### PR TITLE
bump to dor-services 4.22 and dor-workflow-service to 1.7.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-notifications:
-  email: false
-
-rvm:
-  - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+notifications:
+  email: false
+
+rvm:
+  - 1.9.3

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "grape", "0.2.1"
-gem "dor-services", "~> 4.21"
+gem "dor-services", "~> 4.22"
 gem "lyber-core", ">= 2.0.2", :require => 'lyber_core'
 gem "workflow-archiver", "~> 1.3"
 gem "rubydora", "1.6.5"
@@ -16,7 +16,7 @@ group :test do
 end
 
 group :development do
-  gem "pry-debugger"
+  gem 'pry-debugger', '0.2.2', :platform => :ruby_19
   gem "capistrano", '~> 3.0'
   gem 'capistrano-bundler', '~> 1.1'
   gem "lyberteam-capistrano-devel"

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :test do
 end
 
 group :development do
-  gem 'pry-debugger', '0.2.2', :platform => :ruby_19
+  # gem 'pry-debugger' # only supported on 1.9.3, use gem v0.2.2
   gem "capistrano", '~> 3.0'
   gem 'capistrano-bundler', '~> 1.1'
   gem "lyberteam-capistrano-devel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,16 +46,8 @@ GEM
       capistrano (~> 3.0)
     capistrano-releaseboard (0.0.1)
       faraday
-    coderay (1.1.0)
-    columnize (0.9.0)
     confstruct (0.2.7)
     daemons (1.2.3)
-    debugger (1.6.8)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.5)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.8)
     deprecation (0.2.2)
       activesupport
     diff-lcs (1.2.5)
@@ -131,7 +123,6 @@ GEM
       capistrano-one_time_key
       capistrano-releaseboard
     mediashelf-loggable (0.4.10)
-    method_source (0.8.2)
     mime-types (2.6.1)
     mini_portile (0.6.2)
     moab-versioning (1.4.4)
@@ -172,13 +163,6 @@ GEM
       faraday (~> 0.9.0)
       json
     progressbar (0.21.0)
-    pry (0.9.12.6)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
-      slop (~> 3.4)
-    pry-debugger (0.2.2)
-      debugger (~> 1.3)
-      pry (~> 0.9.10)
     rack (1.6.4)
     rack-mount (0.8.3)
       rack (>= 1.0.0)
@@ -233,7 +217,6 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    slop (3.6.0)
     solrizer (2.2.0)
       activesupport
       daemons
@@ -280,7 +263,6 @@ DEPENDENCIES
   grape (= 0.2.1)
   lyber-core (>= 2.0.2)
   lyberteam-capistrano-devel
-  pry-debugger (= 0.2.2)
   rack-test
   rspec
   rubydora (= 1.6.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     docopt (0.5.0)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
-    dor-services (4.21.4)
+    dor-services (4.22.0)
       active-fedora (~> 5.7.1)
       activesupport (~> 3.2, >= 3.2.18)
       addressable (= 2.3.5)
@@ -92,11 +92,12 @@ GEM
       systemu (~> 2.6.0)
       uuidtools (~> 2.1.4)
       validatable (~> 1.6.7)
-    dor-workflow-service (1.7.6)
+    dor-workflow-service (1.7.7)
       activesupport (>= 3.2.1, < 5)
       confstruct (>= 0.2.7, < 2)
       nokogiri (~> 1.6.0)
       rest-client (~> 1.7)
+      retries
     druid-tools (0.4.1)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
@@ -171,13 +172,13 @@ GEM
       faraday (~> 0.9.0)
       json
     progressbar (0.21.0)
-    pry (0.10.1)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
+    pry (0.9.12.6)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
       slop (~> 3.4)
-    pry-debugger (0.2.3)
+    pry-debugger (0.2.2)
       debugger (~> 1.3)
-      pry (>= 0.9.10, < 0.11.0)
+      pry (~> 0.9.10)
     rack (1.6.4)
     rack-mount (0.8.3)
       rack (>= 1.0.0)
@@ -253,7 +254,7 @@ GEM
       tins (~> 1.0)
     thor (0.19.1)
     tins (1.5.4)
-    uber (0.0.13)
+    uber (0.0.15)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
@@ -274,12 +275,12 @@ DEPENDENCIES
   awesome_print
   capistrano (~> 3.0)
   capistrano-bundler (~> 1.1)
-  dor-services (~> 4.21)
+  dor-services (~> 4.22)
   equivalent-xml
   grape (= 0.2.1)
   lyber-core (>= 2.0.2)
   lyberteam-capistrano-devel
-  pry-debugger
+  pry-debugger (= 0.2.2)
   rack-test
   rspec
   rubydora (= 1.6.5)
@@ -287,4 +288,4 @@ DEPENDENCIES
   workflow-archiver (~> 1.3)
 
 BUNDLED WITH
-   1.10.5
+   1.10.6


### PR DESCRIPTION
Note that you have to install oracle for this to install. the dev box already has it installed (see config/deploy.rb). I added a .travis.yml, but it doesn't work because travis does not support Oracle.