### PR TITLE
Add SDR service gateway endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :test, :development do
   gem 'rspec'
   gem 'simplecov'
   gem 'equivalent-xml'
+  gem 'fakeweb'
 end
 
 group :deployment do

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'grape', '~> 0.14'
 gem 'rack-test'
 
 # DLSS/domain-specific dependencies
-gem 'dor-services', '~> 5.3'
+gem 'dor-services', '~> 5.4'
 gem 'lyber-core', '>= 2.0.2'
 gem 'workflow-archiver', '~> 2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
     equalizer (0.0.11)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
+    fakeweb (1.3.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
@@ -293,6 +294,7 @@ DEPENDENCIES
   dlss-capistrano
   dor-services (~> 5.3)
   equivalent-xml
+  fakeweb
   grape (~> 0.14)
   lyber-core (>= 2.0.2)
   rack-test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,10 +11,10 @@ GEM
       rdf-rdfxml (= 1.0.1)
       rsolr
       rubydora (~> 1.6, >= 1.6.5)
-    activemodel (4.2.5)
-      activesupport (= 4.2.5)
+    activemodel (4.2.5.1)
+      activesupport (= 4.2.5.1)
       builder (~> 3.1)
-    activesupport (4.2.5)
+    activesupport (4.2.5.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -58,29 +58,29 @@ GEM
       capistrano-releaseboard
     docile (1.1.5)
     docopt (0.5.0)
-    domain_name (0.5.25)
+    domain_name (0.5.20160128)
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.0.2)
       nokogiri
-    dor-services (5.3.0)
+    dor-services (5.4.0)
       active-fedora (~> 6.0)
       activesupport (>= 3.2.18)
       confstruct (~> 0.2.7)
       dor-rights-auth (~> 1.0, >= 1.0.2)
-      dor-workflow-service (~> 1.8, >= 1.8.0)
+      dor-workflow-service (~> 1.8)
       druid-tools (~> 0.4, >= 0.4.1)
       equivalent-xml (~> 0.5, >= 0.5.1)
       json (~> 1.8.1)
       lyber-utils (~> 0.1.2)
-      moab-versioning (~> 1.4.4)
+      moab-versioning (~> 2.0)
       modsulator (~> 0.0.7)
       net-sftp (~> 2.1.2)
       net-ssh (~> 2.6.5)
-      nokogiri (~> 1.6.0)
-      nokogiri-pretty (~> 0.1.0)
+      nokogiri (~> 1.6)
+      nokogiri-pretty (~> 0.1)
       om (~> 3.0)
       osullivan (~> 0.0.3)
-      progressbar (~> 0.21.0)
+      progressbar (~> 0.21)
       rdf (~> 1.1.7)
       rest-client (~> 1.7)
       retries
@@ -89,8 +89,8 @@ GEM
       ruby-graphviz
       rubydora (~> 1.6.5)
       solrizer (~> 3.0)
-      stanford-mods (~> 1.1)
-      systemu (~> 2.6.0)
+      stanford-mods (= 1.5.3)
+      systemu (~> 2.6)
       uuidtools (~> 2.1.4)
     dor-workflow-service (1.8.0)
       activesupport (>= 3.2.1, < 5)
@@ -138,8 +138,8 @@ GEM
     mediashelf-loggable (0.4.10)
     mime-types (2.99)
     mini_portile2 (2.0.0)
-    minitest (5.8.3)
-    moab-versioning (1.4.4)
+    minitest (5.8.4)
+    moab-versioning (2.0.0)
       confstruct
       json
       nokogiri
@@ -164,7 +164,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (2.6.8)
     netrc (0.11.0)
-    nokogiri (1.6.7.1)
+    nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)
@@ -206,7 +206,7 @@ GEM
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     retries (0.0.5)
-    roo (2.3.1)
+    roo (2.3.2)
       nokogiri (~> 1)
       rubyzip (~> 1.1, < 2.0.0)
     rsolr (1.0.13)
@@ -239,7 +239,7 @@ GEM
       mime-types
       nokogiri
       rest-client
-    rubyzip (1.1.7)
+    rubyzip (1.2.0)
     sequel (4.31.0)
     simplecov (0.10.0)
       docile (~> 1.1.0)
@@ -257,7 +257,7 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh
       term-ansicolor
-    stanford-mods (1.4.0)
+    stanford-mods (1.5.3)
       activesupport
       mods (~> 2.0.2)
     stomp (1.3.4)
@@ -272,7 +272,7 @@ GEM
     uber (0.0.15)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     uuidtools (2.1.5)
     validatable (1.6.7)
     virtus (1.0.5)
@@ -292,7 +292,7 @@ PLATFORMS
 
 DEPENDENCIES
   dlss-capistrano
-  dor-services (~> 5.3)
+  dor-services (~> 5.4)
   equivalent-xml
   fakeweb
   grape (~> 0.14)

--- a/config/environments/local.rb
+++ b/config/environments/local.rb
@@ -17,6 +17,10 @@ Dor.configure do
     pass 'password'
   end
 
+  sdr do
+    url 'http://localhost/sdr'
+  end
+
   metadata do
     exist.url   'http://localhost/exist/rest/'
     catalog.url 'http://localhost/catalog/mods'

--- a/config/environments/local.rb
+++ b/config/environments/local.rb
@@ -26,11 +26,7 @@ Dor.configure do
     catalog.url 'http://localhost/catalog/mods'
   end
 
-  gsearch do
-    rest_url 'http://localhost/gsearch/rest'
-    url      'http://localhost/solr/argo_dev'
-  end
-  solrizer.url 'https://localhost/solr/argo_dev'
+  solr.url 'https://localhost/solr/argo_dev'
   workflow.url 'http://localhost/workflow/'
 
   stacks.local_workspace_root '/my/workspace'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,3 +13,5 @@ end
 def login
   authorize Dor::Config.dor.service_user, Dor::Config.dor.service_password
 end
+
+require 'fakeweb'


### PR DESCRIPTION
This allows the dor-services-app to mediate requests to the SDR services, instead of requiring all dor-services consumers to get special access to SDR. There will be a corresponding change in dor-services to consume these endpoints instead of accessing SDR directly.