### PR TITLE
Backport SDR endpoints into dor-services 4.x branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem "rspec"
 end
 
-group :development do
+group :deployment do
   gem "capistrano", '~> 3.0'
   gem 'capistrano-bundler', '~> 1.1'
   gem "lyberteam-capistrano-devel"

--- a/Gemfile
+++ b/Gemfile
@@ -7,12 +7,14 @@ gem "workflow-archiver", "~> 1.3"
 gem "rubydora", "1.6.5"
 gem "rack-test", :require => "rack/test"
 gem "addressable", '2.3.5'
+gem "rest-client"
 
 group :test do
   gem "awesome_print"
   gem "equivalent-xml"
   gem "simplecov"
   gem "rspec"
+  gem "fakeweb"
 end
 
 group :deployment do

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "grape", "0.2.1"
+gem "grape", "0.14.0"
 gem "dor-services", "~> 4.22"
 gem "lyber-core", ">= 2.0.2", :require => 'lyber_core'
 gem "workflow-archiver", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,10 @@ GEM
       multi_json (~> 1.0)
     addressable (2.3.5)
     awesome_print (1.6.1)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     bagit (0.3.2)
       docopt (~> 0.5.0)
       validatable (~> 1.6)
@@ -46,10 +50,14 @@ GEM
       capistrano (~> 3.0)
     capistrano-releaseboard (0.0.1)
       faraday
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     confstruct (0.2.7)
     daemons (1.2.3)
     deprecation (0.2.2)
       activesupport
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
     docopt (0.5.0)
@@ -91,23 +99,29 @@ GEM
       rest-client (~> 1.7)
       retries
     druid-tools (0.4.1)
+    equalizer (0.0.11)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
-    grape (0.2.1)
-      hashie (~> 1.2)
-      multi_json
-      multi_xml
-      rack
+    grape (0.14.0)
+      activesupport
+      builder
+      hashie (>= 2.1.0)
+      multi_json (>= 1.3.2)
+      multi_xml (>= 0.5.2)
+      rack (>= 1.3.0)
+      rack-accept
       rack-mount
-    hashie (1.2.0)
+      virtus (>= 1.0.0)
+    hashie (3.4.3)
     hooks (0.3.6)
       uber (~> 0.0.4)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
+    ice_nine (0.11.2)
     iso-639 (0.2.5)
     json (1.8.3)
     lyber-core (3.3.0)
@@ -164,6 +178,8 @@ GEM
       json
     progressbar (0.21.0)
     rack (1.6.4)
+    rack-accept (0.4.5)
+      rack (>= 0.4)
     rack-mount (0.8.3)
       rack (>= 1.0.0)
     rack-test (0.6.3)
@@ -236,6 +252,7 @@ GEM
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     thor (0.19.1)
+    thread_safe (0.3.5)
     tins (1.6.0)
     uber (0.0.15)
     unf (0.1.4)
@@ -243,6 +260,11 @@ GEM
     unf_ext (0.0.7.2)
     uuidtools (2.1.5)
     validatable (1.6.7)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     workflow-archiver (1.3.0)
       confstruct
       lyber-core
@@ -260,7 +282,7 @@ DEPENDENCIES
   capistrano-bundler (~> 1.1)
   dor-services (~> 4.22)
   equivalent-xml
-  grape (= 0.2.1)
+  grape (= 0.14.0)
   lyber-core (>= 2.0.2)
   lyberteam-capistrano-devel
   rack-test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
     equalizer (0.0.11)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
+    fakeweb (1.3.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
@@ -282,10 +283,12 @@ DEPENDENCIES
   capistrano-bundler (~> 1.1)
   dor-services (~> 4.22)
   equivalent-xml
+  fakeweb
   grape (= 0.14.0)
   lyber-core (>= 2.0.2)
   lyberteam-capistrano-devel
   rack-test
+  rest-client
   rspec
   rubydora (= 1.6.5)
   simplecov

--- a/config/environments/local.rb
+++ b/config/environments/local.rb
@@ -16,7 +16,11 @@ Dor.configure do
     user 'user'
     pass 'password'
   end
-  
+
+  sdr do
+    url 'http://localhost/sdr'
+  end
+
   metadata do
     exist.url 'http://localhost/exist/rest/'
     catalog.url 'http://localhost/catalog/mods'

--- a/lib/dor_services_app.rb
+++ b/lib/dor_services_app.rb
@@ -51,6 +51,15 @@ module Dor
         @archiver ||= create_archiver
       end
 
+      def sdr_client
+        RestClient::Resource.new(Dor::Config.sdr.url)
+      end
+
+      def proxy_rest_client_response(response)
+        content_type response.headers[:content_type]
+        status response.code
+        response
+      end
     end
 
     resource :about do
@@ -58,6 +67,43 @@ module Dor
       get do
         @version ||= IO.readlines('VERSION').first
         "ok\nversion: #{@version} dor-services/#{Dor::VERSION}"
+      end
+    end
+
+    resource :sdr do
+      post '/objects/:druid/cm-inv-diff' do
+        unless %w(all shelve preserve publish).include?(params[:subset].to_s)
+          status 400
+          return "Invalid subset value: #{params[:subset]}"
+        end
+
+        request.body.rewind
+        current_content = request.body.read
+
+        query_params = { :subset => params[:subset].to_s }
+        query_params[:version] = params[:version].to_s unless params[:version].nil?
+        query_string = URI.encode_www_form(query_params)
+        sdr_query = "objects/#{params[:druid]}/cm-inv-diff?#{query_string}"
+
+        sdr_response = sdr_client[sdr_query].post(current_content, content_type: 'application/xml') { |response, _request, _result| response }
+        proxy_rest_client_response(sdr_response)
+      end
+
+      get '/objects/:druid/manifest/:dsname', requirements: { dsname: /.*/ } do
+        url = "objects/#{params[:druid]}/manifest/#{params[:dsname]}"
+        sdr_response = sdr_client[url].get { |response, _request, _result| response }
+        proxy_rest_client_response(sdr_response)
+      end
+
+      get '/objects/:druid/metadata/:dsname', requirements: { dsname: /.*/ } do
+        url = "objects/#{params[:druid]}/metadata/#{params[:dsname]}"
+        sdr_response = sdr_client[url].get { |response, _request, _result| response }
+        proxy_rest_client_response(sdr_response)
+      end
+
+      get '/objects/:druid/current_version' do
+        sdr_response = sdr_client["objects/#{params[:druid]}/current_version"].get { |response, _request, _result| response }
+        proxy_rest_client_response(sdr_response)
       end
     end
 

--- a/spec/dor_services_app_spec.rb
+++ b/spec/dor_services_app_spec.rb
@@ -123,7 +123,7 @@ describe Dor::DorServicesApi do
       end
 
       it "logs all unhandled exceptions" do
-        allow(Dor::RegistrationService).to receive(:register_object).and_raise(Exception.new("Testing Exception Logging"))
+        allow(Dor::RegistrationService).to receive(:register_object).and_raise(StandardError.new("Testing Exception Logging"))
         expect(LyberCore::Log).to receive(:exception)
 
         post "/v1/objects", :some => 'param'

--- a/spec/dor_services_app_spec.rb
+++ b/spec/dor_services_app_spec.rb
@@ -28,8 +28,105 @@ describe Dor::DorServicesApi do
     expect(last_response.body).to match(/version: \d\..*$/)
   end
 
+  describe 'sdr' do
+    before(:each) { login }
+
+    describe 'current_version' do
+      let(:mock_response) { '<currentVersion>1</currentVersion>' }
+
+      it 'retrieves the current version from SDR' do
+        FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/current_version", body: mock_response, content_type: 'application/xml')
+
+        get "/v1/sdr/objects/#{item.pid}/current_version"
+
+        expect(last_response.status).to eq 200
+        expect(last_response.body).to eq mock_response
+        expect(last_response.content_type).to eq 'application/xml'
+      end
+
+      it 'passes through error codes' do
+        FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/current_version", status: 404, body: '')
+
+        get "/v1/sdr/objects/#{item.pid}/current_version"
+
+        expect(last_response.status).to eq 404
+      end
+    end
+
+    describe 'cm-inv-diff' do
+      let(:mock_response) { 'cm-inv-diff' }
+      context 'with an invalid subset value' do
+        it 'fails as a bad request' do
+          post "/v1/sdr/objects/#{item.pid}/cm-inv-diff?subset=wrong"
+
+          expect(last_response.status).to eq 400
+        end
+      end
+
+      context 'with an explicit version' do
+        it 'passes the version to SDR' do
+          FakeWeb.register_uri(:post, "#{Dor::Config.sdr.url}/objects/#{item.pid}/cm-inv-diff?subset=all&version=5", body: mock_response, content_type: 'application/xml')
+
+          post "/v1/sdr/objects/#{item.pid}/cm-inv-diff?subset=all&version=5"
+          expect(last_response.status).to eq 200
+          expect(last_response.body).to eq mock_response
+          expect(last_response.content_type).to eq 'application/xml'
+        end
+      end
+
+      it 'retrieves the diff from SDR' do
+        FakeWeb.register_uri(:post, "#{Dor::Config.sdr.url}/objects/#{item.pid}/cm-inv-diff?subset=all", body: mock_response, content_type: 'application/xml')
+
+        post "/v1/sdr/objects/#{item.pid}/cm-inv-diff?subset=all"
+        expect(last_response.status).to eq 200
+        expect(last_response.body).to eq mock_response
+        expect(last_response.content_type).to eq 'application/xml'
+      end
+    end
+
+    describe 'signatureCatalog' do
+      it 'retrieves the catalog from SDR' do
+        FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/manifest/signatureCatalog.xml", body: '<catalog />', content_type: 'application/xml')
+
+        get "/v1/sdr/objects/#{item.pid}/manifest/signatureCatalog.xml"
+
+        expect(last_response.status).to eq 200
+        expect(last_response.body).to eq '<catalog />'
+        expect(last_response.content_type).to eq 'application/xml'
+      end
+
+      it 'passes through errors' do
+        FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/manifest/signatureCatalog.xml", status: 428)
+
+        get "/v1/sdr/objects/#{item.pid}/manifest/signatureCatalog.xml"
+
+        expect(last_response.status).to eq 428
+      end
+    end
+
+    describe 'metadata services' do
+      it 'retrieves the datastream from SDR' do
+        FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/metadata/whatever", body: 'content', content_type: 'application/xml')
+
+        get "/v1/sdr/objects/#{item.pid}/metadata/whatever"
+
+        expect(last_response.status).to eq 200
+        expect(last_response.body).to eq 'content'
+        expect(last_response.content_type).to eq 'application/xml'
+      end
+
+      it 'passes through errors' do
+        FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/metadata/whatever", status: 428)
+
+        get "/v1/sdr/objects/#{item.pid}/metadata/whatever"
+
+        expect(last_response.status).to eq 428
+      end
+    end
+  end
+
   describe "initialize_workspace" do
-    before(:each) {login}
+    before(:each) { login }
 
     it "creates a druid tree in the dor workspace for the passed in druid" do
       post "/v1/objects/#{item.pid}/initialize_workspace"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,3 +13,5 @@ end
 def login
   authorize Dor::Config.dor.service_user, Dor::Config.dor.service_password
 end
+
+require 'fakeweb'


### PR DESCRIPTION
This backports #18 to the dor-services-4.x branch, allowing us to deploy a new version of `dor-services-app` to production that supports https://github.com/sul-dlss/dor-services/pull/164.

