### PR TITLE
Add new update marc record web service call

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :test, :development do
   gem 'simplecov'
   gem 'equivalent-xml'
   gem 'fakeweb'
+  gem 'rack-console'
 end
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,9 @@ GEM
     rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
+    rack-console (1.3.1)
+      rack (>= 1.1)
+      rack-test
     rack-mount (0.8.3)
       rack (>= 1.0.0)
     rack-test (0.6.3)
@@ -292,6 +295,7 @@ DEPENDENCIES
   fakeweb
   grape (~> 0.14)
   lyber-core (>= 2.0.2)
+  rack-console
   rack-test
   rspec
   ruby-oci8

--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ DOR Services App is based on the [Grape](http://intridea.github.io/grape/) API f
 Because the workflows that the app provides access to use Oracle on the backend, the app requires
 the Oracle client gem, [ruby-oci8](https://github.com/kubo/ruby-oci8). In order to install
 ruby-oci8, you need to go through a couple of hoops to set up an Oracle client. The easiest approach
-is to install the Oracle Instant Client.
+is to install the Oracle Instant Client.   Read detailed instructions for installing with homebrew at
+http://www.rubydoc.info/github/kubo/ruby-oci8/file/docs/install-on-osx.md or follow directions below.
 
 1. Download the "Instant Client Package - Basic" and the "Instant Client Package - SDK" from the
 [Oracle download page](http://www.oracle.com/technetwork/topics/intel-macsoft-096467.html)
 (requires a free Oracle account).
 
-2. Unzip the downloaded zip files into a directory on your computer. For example:
+2. Unzip the downloaded zip files into a directory on your computer. For example (version numbers may be different):
 
         mkdir /opt/oracle_instantclient/
         cd /opt/oracle_instantclient/
@@ -37,8 +38,27 @@ directory:
 
 You should now be ready to run `bundle install`. Note that DOR Services App requires Ruby 2.
 
-To run the tests, use `bundle exec rake`.
+## Running Tests
 
+To run the tests:
+
+  `bundle exec rake`
+
+## Console
+
+To get the rough equivalent of a Rails console:
+
+  `RACK_ENV=local bundle exec rack-console`
+  
+## Development Server
+
+To spin up a local development server (see the output on the console for the exact port #):
+
+  `RACK_ENV=local rackup`
+
+You can also copy the config/environments/local.rb file to create a development.rb or production.rb as needed
+for connecting to actual Fedora servers.  Edit those config files, add certs to a config/certs folder if you need.  
+adjust the RACK_ENV parameter when starting up the server to pick the environment.
 
 ## TODO
 

--- a/bin/write_marc_record_test
+++ b/bin/write_marc_record_test
@@ -1,3 +1,3 @@
-#Do kerbose authentication here if it is required by the server
+#Do kerberos authentication here if it is required by the server
 echo "${1}" >> $2
 

--- a/bin/write_marc_record_test
+++ b/bin/write_marc_record_test
@@ -1,0 +1,3 @@
+#Do kerbose authentication here if it is required by the server
+echo "${1}" >> $2
+

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -10,6 +10,7 @@ $LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib
 require 'grape_overrides'
 require 'dor_services_app'
 require 'registration_response'
+require 'update_marc_record_service'
 
 # Override from lyber-core gem so that we can access the log object in the config.ru
 module LyberCore

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -34,6 +34,7 @@ set :log_level, :info
 set :stages, %w(dev staging production)
 
 set :linked_dirs, %w(log config/environments config/certs)
+set :linked_files, %w{bin/write_marc_record}
 
 set :bundle_env_variables, :ld_library_path => '/usr/lib/oracle/11.2/client64/lib:$LD_LIBRARY_PATH'
 

--- a/config/environments/local.rb
+++ b/config/environments/local.rb
@@ -35,6 +35,13 @@ Dor.configure do
     service_user     'user'
     service_password 'password'
   end
+
+  release do
+    symphony_path './'
+    write_marc_script 'bin/write_marc_record_test'
+    purl_base_uri "http://purl.stanford.edu"
+  end
+    
 end
 
 Dor::WorkflowArchiver.config.configure do

--- a/lib/dor_services_app.rb
+++ b/lib/dor_services_app.rb
@@ -204,7 +204,7 @@ module Dor
           end
         end
 
-        get '/update_marc_record' do
+        post '/update_marc_record' do
           Dor::UpdateMarcRecordService.new(@item).update
         end
         

--- a/lib/dor_services_app.rb
+++ b/lib/dor_services_app.rb
@@ -204,6 +204,10 @@ module Dor
           end
         end
 
+        get '/update_marc_record' do
+          Dor::UpdateMarcRecordService.new(@item).update
+        end
+        
         resource :versions do
           post do
             @item.open_new_version

--- a/lib/update_marc_record_service.rb
+++ b/lib/update_marc_record_service.rb
@@ -175,8 +175,8 @@ module Dor
     end
 
     def released_to_Searchworks
-      rel = @druid_obj.released_for
-      rel.blank? || rel['Searchworks'].blank? || rel['Searchworks']['release'].blank? ? false : rel['Searchworks']['release']
+      rel = @druid_obj.released_for.transform_keys{ |key| key.to_s.upcase } # upcase all release tags to make the check case insensitive
+      rel.blank? || rel['SEARCHWORKS'].blank? || rel['SEARCHWORKS']['release'].blank? ? false : rel['SEARCHWORKS']['release']
     end
 
     private

--- a/lib/update_marc_record_service.rb
+++ b/lib/update_marc_record_service.rb
@@ -176,7 +176,7 @@ module Dor
 
     def released_to_Searchworks
       rel = @druid_obj.released_for
-      rel.blank? || rel['Searchworks'].blank? ? false : rel['Searchworks']['release']
+      rel.blank? || rel['Searchworks'].blank? || rel['Searchworks']['release'].blank? ? false : rel['Searchworks']['release']
     end
 
     private

--- a/lib/update_marc_record_service.rb
+++ b/lib/update_marc_record_service.rb
@@ -1,0 +1,192 @@
+require 'open3'
+
+module Dor
+  class UpdateMarcRecordService
+    def initialize(druid_obj)
+      @druid_obj = druid_obj
+      @druid_id = @druid_obj.id.sub('druid:', '')
+    end
+
+    def update
+      push_symphony_record if ckey(@druid_obj).present?
+    end
+    
+    def push_symphony_record
+      symphony_record = generate_symphony_record
+      write_symphony_record symphony_record
+    end
+
+    def generate_symphony_record
+      druid_ckey = ckey @druid_obj
+      return '' unless druid_ckey.present?
+
+      if released_to_Searchworks
+        purl_uri = get_u_field
+        collection_info = get_x2_collection_info
+        constituent_info = get_x2_constituent_info
+
+        # catkey: the catalog key that associates a DOR object with a specific Symphony record.
+        # druid: the druid
+        # .856. 41
+        # Subfield u (required): the full Purl URL
+        # Subfield x #1 (required): The string SDR-PURL as a marker to identify 856 entries managed through DOR
+        # Subfield x #2 (required): Object type (<identityMetadata><objectType>) – item, collection,
+        #     (future types of sets to describe other aggregations like albums, atlases, etc)
+        # Subfield x #3 (required): The display type of the object.
+        #     use an explicit display type from the object if present (<identityMetadata><displayType>)
+        #     else use the value of the <contentMetadata> "type" attribute if present, e.g., image, book, file
+        #     else use the value “citation"
+        # Subfield x #4 (optional): the barcode if known (<identityMetadata><otherId name="barcode">, recorded as barcode:barcode-value
+        # Subfield x #5 (optional): the file-id to be used as thumb if available, recorded as file:file-id-value
+        # Subfield x #6..n (optional): Collection(s) this object is a member of, recorded as collection:druid-value:ckey-value:title
+        # Subfield x #7..n (optional): Set(s) this object is a member of, recorded as set:druid-value:ckey-value:title
+
+        new856 = "#{druid_ckey}\t#{@druid_id}\t#{get_856_cons} #{get_1st_indicator}#{get_2nd_indicator}#{purl_uri}#{get_x1_sdrpurl_marker}#{object_type}"
+        new856 << barcode unless barcode.nil?
+        new856 << file_id unless file_id.nil?
+        new856 << collection_info unless collection_info.nil?
+        new856 << constituent_info unless constituent_info.nil?
+        new856
+      else
+        "#{druid_ckey}\t#{@druid_id}\t"
+      end
+    end
+
+    def write_symphony_record(symphony_record)
+      return if symphony_record.nil? || symphony_record.length == 0
+      symphony_file_name = "#{Dor::Config.release.symphony_path}/sdr-purl-856s"
+      command = "#{Dor::Config.release.write_marc_script} \'#{symphony_record}\' #{symphony_file_name}"
+      run_write_script(command)
+    end
+
+    def run_write_script(command)
+      Open3.popen3(command) do |_stdin, stdout, stderr, _wait_thr|
+        stdout_text = stdout.read
+        stderr_text = stderr.read
+
+        if stdout_text.length > 0 || stderr_text.length > 0
+          fail "Error in writing marc_record file using the command #{command}\n#{stdout_text}\n#{stderr_text}"
+        end
+      end
+    end
+
+    # @return [String] value with SIRSI/Symphony numeric catkey in it, or nil if none exists
+    # look in identityMetadata/otherId[@name='catkey']
+    def ckey(object)
+      unless object.datastreams.nil? || object.datastreams['identityMetadata'].nil?
+        if object.datastreams['identityMetadata'].ng_xml
+          node = object.identityMetadata.ng_xml.at_xpath("//identityMetadata/otherId[@name='catkey']")
+        end
+      end
+      node.content if node && node.content.present?
+    end
+
+    # @return [String] value with object_type in it, or empty x subfield if none exists
+    # look in identityMetadata/objectType
+    def object_type
+      @object_type ||= begin
+        object_type = ''
+        node = @druid_obj.datastreams['identityMetadata'].ng_xml.at_xpath('//identityMetadata/objectType')
+        object_type = node.content unless node.nil?
+        object_type.prepend('|x')
+      end
+    end
+
+    # @return [String] value with barcode in it, or empty x subfield if none exists
+    # look in identityMetadata/otherId name="barcode"
+    def barcode
+      @barcode ||= begin
+        node = @druid_obj.datastreams['identityMetadata'].ng_xml.at_xpath("//identityMetadata/otherId[@name='barcode']")
+        node.content.prepend('|xbarcode:') unless node.nil?
+      end
+    end
+
+    # the @id attribute of resource/file elements including extension
+    # @return [String] first filename
+    def file_id
+      filename = []
+      unless @druid_obj.datastreams.nil? || @druid_obj.datastreams['contentMetadata'].nil?
+        if @druid_obj.datastreams['contentMetadata'].ng_xml
+          content_md = @druid_obj.datastreams['contentMetadata'].ng_xml.xpath('//contentMetadata')
+          content_md.xpath('//resource[@type="page" or @type="image" or @type="thumb"]').map do |node|
+            filename += node.xpath('./file[@mimetype="image/jp2"]/@id').map { |x| "#{@druid_id}%2F" + x }
+            if filename.empty?
+              filename += node.xpath('./externalFile[@mimetype="image/jp2"]').map do |y| "#{y.attributes['objectId'].text.split(':').last}" + "%2F" + "#{y.attributes['fileId']}" end
+            end
+          end
+        end
+      end
+      filename.detect { |file| file.prepend("|xfile:") unless file.empty? }
+    end
+
+    # It returns 856 constants
+    def get_856_cons
+      '.856.'
+    end
+
+    # It returns First Indicator for HTTP (4)
+    def get_1st_indicator
+      '4'
+    end
+
+    # It returns Second Indicator for Version of resource (1)
+    def get_2nd_indicator
+      '1'
+    end
+
+    # It's a plceholder for the uri label
+    def get_z_field
+      #  Placeholder to be used in the future
+    end
+
+    # It builds the PURL uri based on the druid id
+    def get_u_field
+      "|u#{Dor::Config.release.purl_base_uri}/#{@druid_id}"
+    end
+
+    # It returns the SDR-PURL subfield
+    def get_x1_sdrpurl_marker
+      '|xSDR-PURL'
+    end
+
+    # It returns the collection information subfields if exists
+    # @return [String] the collection information druid-value:catkey-value:title format
+    def get_x2_collection_info
+      collections = @druid_obj.collections
+      coll_info = ''
+
+      if collections.length > 0
+        collections.each do |coll|
+          coll_info << "|xcollection:#{coll.id.sub('druid:', '')}:#{ckey(coll)}:#{coll.label}"
+        end
+      end
+
+      coll_info
+    end
+
+    # It returns the constituent information subfields if exists
+    # @return [String] the constituent information druid-value:catkey-value:title format
+    def get_x2_constituent_info
+      dor_items_for_constituents.map do |cons_obj|
+        cons_obj_id = cons_obj.id.sub('druid:', '')
+        cons_obj_title = cons_obj.datastreams['descMetadata'].ng_xml.xpath('//mods/titleInfo/title').first.content
+        "|xset:#{cons_obj_id}:#{ckey(cons_obj)}:#{cons_obj_title}"
+      end.join('')
+    end
+
+    def released_to_Searchworks
+      rel = @druid_obj.released_for
+      rel.blank? || rel['Searchworks'].blank? ? false : rel['Searchworks']['release']
+    end
+
+    private
+
+    def dor_items_for_constituents
+      return [] unless @druid_obj.relationships(:is_constituent_of)
+      @druid_obj.relationships(:is_constituent_of).map do |cons|
+        cons_druid = cons.sub('info:fedora/', '')
+        Dor::Item.find(cons_druid)
+      end
+    end
+  end
+end

--- a/spec/dor_services_app_spec.rb
+++ b/spec/dor_services_app_spec.rb
@@ -249,6 +249,16 @@ describe Dor::DorServicesApi do
     end
   end
 
+  describe '/update_marc_record' do
+    before(:each) { login }
+
+    it 'updates a marc record' do
+      #TODO add some more expectations
+      post "/v1/objects/#{item.pid}/update_marc_record"
+      expect(last_response.status).to eq(201)
+    end
+  end
+  
   describe 'apo-workflow intialization' do
     before(:each) { login }
 

--- a/spec/fixtures/sdr_purl/.gitignore
+++ b/spec/fixtures/sdr_purl/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,4 +14,17 @@ def login
   authorize Dor::Config.dor.service_user, Dor::Config.dor.service_password
 end
 
+def setup_marc_record(druid,xml)
+  @dor_item=double(Dor::Item)
+  @identityMetadataXML = Dor::IdentityMetadataDS.new
+  allow(@identityMetadataXML).to receive_messages(:ng_xml => Nokogiri::XML(xml))
+  allow(@dor_item).to receive_messages(
+    :id=>druid,
+    :released_for=>{},
+    :datastreams => {"identityMetadata"=>@identityMetadataXML},
+    :identityMetadata => @identityMetadataXML
+  )
+  @umrs=Dor::UpdateMarcRecordService.new @dor_item
+end
+
 require 'fakeweb'

--- a/spec/update_marc_spec.rb
+++ b/spec/update_marc_spec.rb
@@ -454,10 +454,33 @@ describe Dor::UpdateMarcRecordService do
       dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
       release_data = { 'Searchworks' => { 'release' => false } }
       allow(dor_item).to receive(:released_for).and_return(release_data)
-
       updater = Dor::UpdateMarcRecordService.new(dor_item)
       expect(updater.released_to_Searchworks).to be false
     end
+    it 'should return false if release_data tag has release to=SW but no specified release value' do
+      identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_2))
+      dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
+      release_data = { 'Searchworks' => { 'bogus' => 'yup' } }
+      allow(dor_item).to receive(:released_for).and_return(release_data)
+      updater = Dor::UpdateMarcRecordService.new(dor_item)
+      expect(updater.released_to_Searchworks).to be false
+    end       
+    it 'should return false if there are no release tags at all' do
+      identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_2))
+      dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
+      release_data = {}
+      allow(dor_item).to receive(:released_for).and_return(release_data)
+      updater = Dor::UpdateMarcRecordService.new(dor_item)
+      expect(updater.released_to_Searchworks).to be false
+    end    
+    it 'should return false if there are non searchworks related release tags' do
+      identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_2))
+      dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
+      release_data = { 'Revs' => { 'release' => true } }
+      allow(dor_item).to receive(:released_for).and_return(release_data)
+      updater = Dor::UpdateMarcRecordService.new(dor_item)
+      expect(updater.released_to_Searchworks).to be false
+    end       
   end
 
   describe 'dor_items_for_constituents' do

--- a/spec/update_marc_spec.rb
+++ b/spec/update_marc_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe Dor::UpdateMarcRecordService do
+
+  before :all do
+    Dor::Config.release.write_marc_script = 'bin/write_marc_record_test'
+    Dor::Config.release.symphony_path = './spec/fixtures/sdr-purl'
+    Dor::Config.release.purl_base_uri = 'http://purl.stanford.edu'
+  end
+
+  context "for a druid without a catkey" do
+    it 'does nothing' do
+      druid='druid:aa222cc3333'
+      setup_marc_record(druid,build_identity_metadata_without_ckey)
+      expect(@umrs).to receive(:ckey).with(@dor_item).and_return(nil)
+      expect(@umrs).not_to receive(:push_symphony_record)
+      @umrs.update
+    end
+  end
+
+  context "for a druid with a catkey" do
+    it "executes the UpdateMarcRecordService push_symphony_record method" do
+      druid='druid:bb333dd4444'
+      setup_marc_record(druid,build_identity_metadata_with_ckey)
+      expect(@umrs).to receive(:ckey).twice.with(@dor_item).and_return('8832162')
+      expect(@umrs.generate_symphony_record).to eq("8832162\t#{druid.gsub('druid:','')}\t")
+      expect(@umrs).to receive(:push_symphony_record)
+      @umrs.update
+    end
+  end
+end
+
+def build_identity_metadata_with_ckey
+  '<identityMetadata>
+  <sourceId source="sul">36105216275185</sourceId>
+  <objectId>druid:bb333dd4444</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>A  new map of Africa</objectLabel>
+  <objectType>item</objectType>
+  <displayType>image</displayType>
+  <adminPolicy>druid:dd051ys2703</adminPolicy>
+  <otherId name="catkey">8832162</otherId>
+  <otherId name="uuid">ff3ce224-9ffb-11e3-aaf2-0050569b3c3c</otherId>
+  <tag>Process : Content Type : Map</tag>
+  <tag>Project : Batchelor Maps : Batch 1</tag>
+  <tag>LAB : MAPS</tag>
+  <tag>Registered By : dfuzzell</tag>
+  <tag>Remediated By : 4.15.4</tag>
+  </identityMetadata>'
+end
+
+def build_identity_metadata_without_ckey
+  '<identityMetadata>
+  <sourceId source="sul">36105216275185</sourceId>
+  <objectId>druid:aa222cc3333</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>A  new map of Africa</objectLabel>
+  <objectType>item</objectType>
+  <displayType>image</displayType>
+  <adminPolicy>druid:dd051ys2703</adminPolicy>
+  <otherId name="uuid">ff3ce224-9ffb-11e3-aaf2-0050569b3c3c</otherId>
+  <tag>Process : Content Type : Map</tag>
+  <tag>Project : Batchelor Maps : Batch 1</tag>
+  <tag>LAB : MAPS</tag>
+  <tag>Registered By : dfuzzell</tag>
+  <tag>Remediated By : 4.15.4</tag>
+  </identityMetadata>'
+end

--- a/spec/update_marc_spec.rb
+++ b/spec/update_marc_spec.rb
@@ -1,11 +1,13 @@
 require 'spec_helper'
 
 describe Dor::UpdateMarcRecordService do
-
+  
   before :all do
+    Dor::Config.suri = {}
     Dor::Config.release.write_marc_script = 'bin/write_marc_record_test'
     Dor::Config.release.symphony_path = './spec/fixtures/sdr-purl'
     Dor::Config.release.purl_base_uri = 'http://purl.stanford.edu'
+    @fixtures = './spec/fixtures'
   end
 
   context "for a druid without a catkey" do
@@ -28,8 +30,830 @@ describe Dor::UpdateMarcRecordService do
       @umrs.update
     end
   end
+  
+  describe '.push_symphony_record' do
+    pending
+  end
+
+  describe '.generate_symphony_record' do
+    
+    it 'should generate an empty string for a druid object without catkey' do
+      Dor::Config.release.purl_base_uri = 'http://purl.stanford.edu'
+      
+      item = Dor::Item.new
+      collection = Dor::Collection.new
+      identity_metadata_xml = double(String)
+
+      allow(identity_metadata_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_identity_metadata_3)
+      )
+
+      allow(collection).to receive_messages(
+        label: 'Collection label',
+        id: 'cc111cc1111',
+        catkey: '12345678'
+      )
+
+      allow(item).to receive_messages(
+        id: 'aa111aa1111',
+        collections: [collection],
+        datastreams: { 'identityMetadata' => identity_metadata_xml }
+      )
+
+      release_data = { 'Searchworks' => { 'release' => true } }
+      allow(item).to receive(:released_for).and_return(release_data)
+      allow(collection).to receive(:released_for).and_return(release_data)
+
+      updater = Dor::UpdateMarcRecordService.new(item)
+      expect(updater.generate_symphony_record).to eq('')
+    end
+    it 'should generate symphony record for a item object with catkey' do
+      Dor::Config.release.purl_base_uri = 'http://purl.stanford.edu'
+
+      item = Dor::Item.new
+      collection = Dor::Collection.new
+      constituent = Dor::Item.new
+
+      rels_ext_xml = double(String)
+      identity_metadata_xml = double(String)
+      content_metadata_xml = double(String)
+      desc_metadata_xml = double(String)
+
+      allow(identity_metadata_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_identity_metadata_1)
+      )
+
+      allow(content_metadata_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_content_metadata_1)
+      )
+
+      allow(desc_metadata_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_desc_metadata_1)
+      )
+
+      allow(rels_ext_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_rels_ext)
+      )
+
+      allow(collection).to receive_messages(
+        label: 'Collection label',
+        id: 'cc111cc1111'
+      )
+
+      allow(item).to receive_messages(
+        id: 'aa111aa1111',
+        collections: [collection],
+        datastreams: { 'identityMetadata' => identity_metadata_xml, 'contentMetadata' => content_metadata_xml, 'RELS-EXT' => rels_ext_xml }
+      )
+
+      allow(constituent).to receive_messages(
+        id: 'dd111dd1111',
+        datastreams: { 'descMetadata' => desc_metadata_xml }
+      )
+
+      release_data = { 'Searchworks' => { 'release' => true } }
+      allow(item).to receive(:released_for).and_return(release_data)
+
+      allow_any_instance_of(Dor::UpdateMarcRecordService).to receive(:dor_items_for_constituents).and_return([constituent])
+      updater = Dor::UpdateMarcRecordService.new(item)
+      expect(updater.generate_symphony_record).to eq("8832162\taa111aa1111\t.856. 41|uhttp://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label")
+    end
+
+    it 'should generate symphony record for a collection object with catkey' do
+      Dor::Config.release.purl_base_uri = 'http://purl.stanford.edu'
+
+      collection = Dor::Collection.new
+      identity_metadata_xml = double(String)
+      content_metadata_xml = double(String)
+
+      allow(identity_metadata_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_identity_metadata_2)
+      )
+
+      allow(identity_metadata_xml).to receive(:tag).and_return('Project : Batchelor Maps : Batch 1')
+      allow(content_metadata_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_content_metadata_2)
+      )
+
+      allow(collection).to receive_messages(
+        label: 'Collection label',
+        id: 'aa111aa1111',
+        collections: [],
+        datastreams: { 'identityMetadata' => identity_metadata_xml, 'contentMetadata' => content_metadata_xml }
+      )
+
+      release_data = { 'Searchworks' => { 'release' => true } }
+      allow(collection).to receive(:released_for).and_return(release_data)
+
+      updater = Dor::UpdateMarcRecordService.new(collection)
+      expect(updater.generate_symphony_record).to eq("8832162\taa111aa1111\t.856. 41|uhttp://purl.stanford.edu/aa111aa1111|xSDR-PURL|xcollection|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2")
+    end
+  end
+
+  describe '.write_symphony_record' do
+    xit 'should write the symphony record to the symphony directory' do
+      d = Dor::Item.new
+      updater = Dor::UpdateMarcRecordService.new(d)
+      updater.instance_variable_set(:@druid_id, 'aa111aa1111')
+      Dor::Config.release.symphony_path = "#{@fixtures}/sdr-purl"
+      Dor::Config.release.write_marc_script = 'bin/write_marc_record_test'
+      updater.write_symphony_record 'aaa'
+
+      expect(Dir.glob("#{@fixtures}/sdr-purl/sdr-purl-aa111aa1111-??????????????").empty?).to be false
+    end
+
+    it 'should do nothing if the symphony record is empty' do
+      d = double(Dor::Item)
+      expect(d).to receive(:id).and_return('aa111aa1111')
+      updater = Dor::UpdateMarcRecordService.new(d)
+      Dor::Config.release.symphony_path = "#{@fixtures}/sdr-purl"
+      updater.write_symphony_record ''
+
+      expect(Dir.glob("#{@fixtures}/sdr-purl/sdr-purl-aa111aa1111-??????????????").empty?).to be true
+    end
+
+    it 'should do nothing if the symphony record is nil' do
+      d = double(Dor::Item)
+      expect(d).to receive(:id).and_return('aa111aa1111')
+      updater = Dor::UpdateMarcRecordService.new(d)
+      Dor::Config.release.symphony_path = "#{@fixtures}/sdr-purl"
+      updater.write_symphony_record ''
+
+      expect(Dir.glob("#{@fixtures}/sdr-purl/sdr-purl-aa111aa1111-??????????????").empty?).to be true
+    end
+
+    after :each do
+      FileUtils.rm_rf("#{@fixtures}/sdr-purl/.")
+    end
+  end
+
+  describe '.catkey' do
+    it 'should return catkey from a valid identityMetadata' do
+      d = double(Dor::Item)
+      identity_metadata_ng_xml = Nokogiri::XML(build_identity_metadata_1)
+      identity_metadata_ds = double(Dor::IdentityMetadataDS)
+
+      expect(d).to receive(:id).and_return('')
+      expect(d).to receive(:datastreams).exactly(3).times.and_return({'identityMetadata' => identity_metadata_ds})
+      expect(d).to receive(:identityMetadata).and_return(identity_metadata_ds)
+      expect(identity_metadata_ds).to receive(:ng_xml).twice.and_return(identity_metadata_ng_xml)
+
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.ckey(d)).to eq('8832162')
+    end
+
+    it 'should return nil for an identityMetadata without catkey' do
+      d = double(Dor::Item)
+      identity_metadata_ng_xml = Nokogiri::XML(build_identity_metadata_3)
+      identity_metadata_ds = double(Dor::IdentityMetadataDS)
+
+      expect(d).to receive(:id).and_return('')
+      expect(d).to receive(:datastreams).exactly(3).times.and_return({'identityMetadata' => identity_metadata_ds})
+      expect(d).to receive(:identityMetadata).and_return(identity_metadata_ds)
+      expect(identity_metadata_ds).to receive(:ng_xml).twice.and_return(identity_metadata_ng_xml)
+
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.ckey(d)).to be_nil
+    end
+  end
+
+  describe '.object_type' do
+    it 'should return object_type from a valid identityMetadata' do
+      d = double(Dor::Item)
+      identity_metadata_ng_xml = Nokogiri::XML(build_identity_metadata_1)
+      identity_metadata_ds = double(Dor::IdentityMetadataDS)
+
+      expect(d).to receive(:id).and_return('')
+      expect(d).to receive(:datastreams).and_return({'identityMetadata' => identity_metadata_ds})
+      expect(identity_metadata_ds).to receive(:ng_xml).and_return(identity_metadata_ng_xml)
+
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.object_type).to eq('|xitem')
+    end
+
+    it 'should return an empty x subfield for identityMetadata without object_type' do
+      d = double(Dor::Item)
+      identity_metadata_ng_xml = Nokogiri::XML(build_identity_metadata_3)
+      identity_metadata_ds = double(Dor::IdentityMetadataDS)
+
+      expect(d).to receive(:id).and_return('')
+      expect(d).to receive(:datastreams).and_return({'identityMetadata' => identity_metadata_ds})
+      expect(identity_metadata_ds).to receive(:ng_xml).and_return(identity_metadata_ng_xml)
+
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.object_type).to eq('|x')
+    end
+  end
+
+  describe '.barcode' do
+    it 'should return barcode from a valid identityMetadata' do
+      d = double(Dor::Item)
+      identity_metadata_ng_xml = Nokogiri::XML(build_identity_metadata_1)
+      identity_metadata_ds = double(Dor::IdentityMetadataDS)
+
+      expect(d).to receive(:id).and_return('')
+      expect(d).to receive(:datastreams).and_return({'identityMetadata' => identity_metadata_ds})
+      expect(identity_metadata_ds).to receive(:ng_xml).and_return(identity_metadata_ng_xml)
+
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.barcode).to eq('|xbarcode:36105216275185')
+    end
+
+    it 'should return an empty x subfield for identityMetadata without barcode' do
+      d = double(Dor::Item)
+      identity_metadata_ng_xml = Nokogiri::XML(build_identity_metadata_3)
+      identity_metadata_ds = double(Dor::IdentityMetadataDS)
+
+      expect(d).to receive(:id).and_return('')
+      expect(d).to receive(:datastreams).and_return({'identityMetadata' => identity_metadata_ds})
+      expect(identity_metadata_ds).to receive(:ng_xml).and_return(identity_metadata_ng_xml)
+
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.barcode).to be nil
+    end
+  end
+
+  describe '.file_id' do
+    it 'should return file_id from a valid contentMetadata' do
+      d = double(Dor::Item)
+      content_metadata_ng_xml = Nokogiri::XML(build_content_metadata_1)
+      content_metadata_ds = double(Dor::ContentMetadataDS)
+
+      expect(d).to receive(:id).and_return('bb111bb2222')
+      expect(d).to receive(:datastreams).exactly(4).times.and_return({'contentMetadata' => content_metadata_ds})
+      expect(content_metadata_ds).to receive(:ng_xml).twice.and_return(content_metadata_ng_xml)
+
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.file_id).to eq('|xfile:bb111bb2222%2Fwt183gy6220_00_0001.jp2')
+    end
+
+    it 'should return an empty x subfield for contentMetadata without file_id' do
+      d = double(Dor::Item)
+      content_metadata_ng_xml = Nokogiri::XML(build_content_metadata_3)
+      content_metadata_ds = double(Dor::ContentMetadataDS)
+
+      expect(d).to receive(:id).and_return('aa111aa2222')
+      expect(d).to receive(:datastreams).exactly(4).times.and_return({'contentMetadata' => content_metadata_ds})
+      expect(content_metadata_ds).to receive(:ng_xml).twice.and_return(content_metadata_ng_xml)
+
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.file_id).to eq(nil)
+    end
+
+    it 'should return correct file_id from a valid contentMetadata  with resource type = image' do
+      d = double(Dor::Item)
+      content_metadata_ng_xml = Nokogiri::XML(build_content_metadata_4)
+      content_metadata_ds = double(Dor::ContentMetadataDS)
+
+      expect(d).to receive(:id).and_return('bb111bb2222')
+      expect(d).to receive(:datastreams).exactly(4).times.and_return({'contentMetadata' => content_metadata_ds})
+      expect(content_metadata_ds).to receive(:ng_xml).twice.and_return(content_metadata_ng_xml)
+
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.file_id).to eq('|xfile:bb111bb2222%2Fwt183gy6220_00_0001.jp2')
+    end
+
+    it 'should return correct file_id from a valid contentMetadata with resource type = page' do
+      d = double(Dor::Item)
+      content_metadata_ng_xml = Nokogiri::XML(build_content_metadata_5)
+      content_metadata_ds = double(Dor::ContentMetadataDS)
+
+      expect(d).to receive(:id).and_return('aa111aa2222')
+      expect(d).to receive(:datastreams).exactly(4).times.and_return({'contentMetadata' => content_metadata_ds})
+      expect(content_metadata_ds).to receive(:ng_xml).twice.and_return(content_metadata_ng_xml)
+
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.file_id).to eq('|xfile:aa111aa2222%2Fwt183gy6220_00_0002.jp2')
+    end
+
+    # Added thumb based upon recommendation from Lynn McRae for future use
+    it 'should return correct file_id from a valid contentMetadata with resource type = thumb' do
+      d = double(Dor::Item)
+      content_metadata_ng_xml = Nokogiri::XML(build_content_metadata_6)
+      content_metadata_ds = double(Dor::ContentMetadataDS)
+
+      expect(d).to receive(:id).and_return('bb111bb2222')
+      expect(d).to receive(:datastreams).exactly(4).times.and_return({'contentMetadata' => content_metadata_ds})
+      expect(content_metadata_ds).to receive(:ng_xml).twice.and_return(content_metadata_ng_xml)
+
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.file_id).to eq('|xfile:bb111bb2222%2Fwt183gy6220_00_0002.jp2')
+    end
+
+    it 'should return correct file_id from a valid contentMetadata  with resource type = image' do
+      d = double(Dor::Item)
+      content_metadata_ng_xml = Nokogiri::XML(build_content_metadata_7)
+      content_metadata_ds = double(Dor::ContentMetadataDS)
+
+      expect(d).to receive(:id).and_return('hj097bm8879')
+      expect(d).to receive(:datastreams).exactly(4).times.and_return({'contentMetadata' => content_metadata_ds})
+      expect(content_metadata_ds).to receive(:ng_xml).twice.and_return(content_metadata_ng_xml)
+
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.file_id).to eq('|xfile:cg767mn6478%2F2542A.jp2')
+    end
+  end
+
+  describe '.get_856_cons' do
+    it 'should return a valid sdrpurl constant' do
+      d = double(Dor::Item)
+      expect(d).to receive(:id).and_return('')
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.get_856_cons).to eq('.856.')
+    end
+  end
+
+  describe '.get_1st_indicator' do
+    it 'should return 4' do
+      d = double(Dor::Item)
+      expect(d).to receive(:id).and_return('')
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.get_1st_indicator).to eq('4')
+    end
+  end
+
+  describe '.get_2nd_indicator' do
+    it 'should return 1' do
+      d = double(Dor::Item)
+      expect(d).to receive(:id).and_return('')
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.get_2nd_indicator).to eq('1')
+    end
+  end
+
+  describe '.get_u_field' do
+    it 'should return valid purl url' do
+      d = double(Dor::Item)
+      expect(d).to receive(:id).and_return('aa111aa1111')
+      updater = Dor::UpdateMarcRecordService.new(d)
+      Dor::Config.release.purl_base_uri = 'http://purl.stanford.edu'
+      expect(updater.get_u_field).to eq('|uhttp://purl.stanford.edu/aa111aa1111')
+    end
+  end
+
+  describe '.get_x1_sdrpurl_marker' do
+    it 'should return a valid sdrpurl constant' do
+      d = double(Dor::Item)
+      expect(d).to receive(:id).and_return('')
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.get_x1_sdrpurl_marker).to eq('|xSDR-PURL')
+    end
+  end
+
+  describe '.get_x2_collection_info' do
+    it 'should return an empty string for an object without collection' do
+      d = double(Dor::Item)
+      expect(d).to receive(:id).and_return('')
+      expect(d).to receive(:collections).and_return([])
+      updater = Dor::UpdateMarcRecordService.new(d)
+      expect(updater.get_x2_collection_info).to be_empty
+    end
+
+    it 'should return an empty string for a collection object' do
+      c = double(Dor::Collection)
+      expect(c).to receive(:id).and_return('')
+      expect(c).to receive(:collections).and_return([])
+      updater = Dor::UpdateMarcRecordService.new(c)
+      expect(updater.get_x2_collection_info).to be_empty
+    end
+
+    it 'should return the appropriate information for a collection object' do
+      item = double(Dor::Item.new)
+      collection = Dor::Collection.new
+      identity_metadata_xml = String
+
+      allow(identity_metadata_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_identity_metadata_2)
+      )
+
+      allow(collection).to receive_messages(
+        label: 'Collection label',
+        id: 'cc111cc1111',
+        datastreams: { 'identityMetadata' => identity_metadata_xml }
+      )
+      allow(item).to receive_messages(
+        id: 'aa111aa1111',
+        collections: [collection]
+      )
+      updater = Dor::UpdateMarcRecordService.new(item)
+      expect(updater.get_x2_collection_info).to eq('|xcollection:cc111cc1111:8832162:Collection label')
+    end
+  end
+
+  describe 'Released to Searchworks' do
+    it 'should return true if release_data tag has release to=SW and value is true' do
+      identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_1))
+      dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
+      release_data = { 'Searchworks' => { 'release' => true } }
+      allow(dor_item).to receive(:released_for).and_return(release_data)
+      updater = Dor::UpdateMarcRecordService.new(dor_item)
+      expect(updater.released_to_Searchworks).to be true
+    end
+    it 'should return false if release_data tag has release to=SW and value is false' do
+      identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_2))
+      dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
+      release_data = { 'Searchworks' => { 'release' => false } }
+      allow(dor_item).to receive(:released_for).and_return(release_data)
+
+      updater = Dor::UpdateMarcRecordService.new(dor_item)
+      expect(updater.released_to_Searchworks).to be false
+    end
+  end
+
+  describe 'dor_items_for_constituents' do
+    it 'should return empty array if no relationships' do
+      item = double('item', id: '12345', relationships: nil)
+      expect(Dor::UpdateMarcRecordService.new(item).send(:dor_items_for_constituents)).to eq([])
+    end
+    it 'successfully determines constituent druid' do
+      item = double('item', id: '12345', relationships: ['info:fedora/druid:mb062dy1188'])
+      expect(Dor::Item).to receive(:find).with('druid:mb062dy1188')
+      Dor::UpdateMarcRecordService.new(item).send(:dor_items_for_constituents)
+    end
+  end  
 end
 
+
+def build_identity_metadata_1
+    '<identityMetadata>
+  <sourceId source="sul">36105216275185</sourceId>
+  <objectId>druid:bb987ch8177</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>A  new map of Africa</objectLabel>
+  <objectType>item</objectType>
+  <displayType>image</displayType>
+  <adminPolicy>druid:dd051ys2703</adminPolicy>
+  <otherId name="catkey">8832162</otherId>
+  <otherId name="barcode">36105216275185</otherId>
+  <otherId name="uuid">ff3ce224-9ffb-11e3-aaf2-0050569b3c3c</otherId>
+  <tag>Process : Content Type : Map</tag>
+  <tag>Project : Batchelor Maps : Batch 1</tag>
+  <tag>LAB : MAPS</tag>
+  <tag>Registered By : dfuzzell</tag>
+  <tag>Remediated By : 4.15</tag>
+  <release displayType="image" release="true" to="Searchworks" what="self" when="2015-07-27T21:43:27Z" who="lauraw15">true</release>
+</identityMetadata>'
+end
+
+def build_identity_metadata_2
+      '<identityMetadata>
+    <sourceId source="sul">36105216275185</sourceId>
+    <objectId>druid:bb987ch8177</objectId>
+    <objectCreator>DOR</objectCreator>
+    <objectLabel>A  new map of Africa</objectLabel>
+    <objectType>collection</objectType>
+    <displayType>image</displayType>
+    <adminPolicy>druid:dd051ys2703</adminPolicy>
+    <otherId name="catkey">8832162</otherId>
+    <otherId name="uuid">ff3ce224-9ffb-11e3-aaf2-0050569b3c3c</otherId>
+    <tag>Process : Content Type : Map</tag>
+    <tag>Project : Batchelor Maps : Batch 1</tag>
+    <tag>LAB : MAPS</tag>
+    <tag>Registered By : dfuzzell</tag>
+    <tag>Remediated By : 4.15.4</tag>
+    <release displayType="image" release="false" to="Searchworks" what="collection" when="2015-07-27T21:43:27Z" who="lauraw15">false</release>
+    </identityMetadata>'
+end
+
+def build_identity_metadata_3
+      '<identityMetadata>
+    <sourceId source="sul">36105216275185</sourceId>
+    <objectId>druid:bb987ch8177</objectId>
+    <objectCreator>DOR</objectCreator>
+    <objectLabel>A  new map of Africa</objectLabel>
+    <adminPolicy>druid:dd051ys2703</adminPolicy>
+    <otherId name="uuid">ff3ce224-9ffb-11e3-aaf2-0050569b3c3c</otherId>
+    <tag>Process : Content Type : Map</tag>
+    <tag>Project : Batchelor Maps : Batch 1</tag>
+    <tag>LAB : MAPS</tag>
+    <tag>Registered By : dfuzzell</tag>
+    <tag>Remediated By : 4.15.4</tag>
+  </identityMetadata>'
+end
+
+def build_identity_metadata_4
+      '<identityMetadata>
+    <sourceId source="sul">36105216275185</sourceId>
+    <objectId>druid:bb987ch8177</objectId>
+    <objectCreator>DOR</objectCreator>
+    <objectLabel>A  new map of Africa</objectLabel>
+    <objectType>item</objectType>
+    <displayType>image</displayType>
+    <adminPolicy>druid:dd051ys2703</adminPolicy>
+    <otherId name="catkey">8832162</otherId>
+    <otherId name="barcode">36105216275185</otherId>
+    <otherId name="uuid">ff3ce224-9ffb-11e3-aaf2-0050569b3c3c</otherId>
+    <tag>Process : Content Type : Map</tag>
+    <tag>Project : Batchelor Maps : Batch 1</tag>
+    <tag>LAB : MAPS</tag>
+    <tag>Registered By : dfuzzell</tag>
+    <tag>Remediated By : 4.1</tag>
+    <release displayType="image" release="false" to="Searchworks" what="self" when="2015-07-27T21:43:27Z" who="lauraw15">false</release>
+  </identityMetadata>'
+end
+
+def build_release_data_1
+      '<release_data>
+  <release to="Searchworks">true</release>
+  </release_data>'
+end
+
+def build_release_data_2
+    '<release_data>
+    <release to="Searchworks">false</release>
+    </release_data>'
+end
+
+def build_content_metadata_1
+  '<contentMetadata objectId="wt183gy6220" type="map">
+  <resource id="wt183gy6220_1" sequence="1" type="image">
+  <label>Image 1</label>
+  <file id="wt183gy6220_00_0001.jp2" mimetype="image/jp2" size="3182927">
+  <imageData width="4531" height="3715"/>
+  </file>
+  </resource>
+  </contentMetadata>'
+end
+
+def build_content_metadata_2
+    '<contentMetadata objectId="wt183gy6220">
+  <resource id="wt183gy6220_1" sequence="1" type="image">
+  <label>Image 1</label>
+  <file id="wt183gy6220_00_0001.jp2" mimetype="image/jp2" size="3182927">
+  <imageData width="4531" height="3715"/>
+  </file>
+  </resource>
+  <resource id="wt183gy6220_2" sequence="2" type="image">
+  <label>Image 2</label>
+  <file id="wt183gy6220_00_0002.jp2" mimetype="image/jp2" size="3182927">
+  <imageData width="4531" height="3715"/>
+  </file>
+  </resource>
+  </contentMetadata>'
+end
+
+def build_content_metadata_3
+    '<contentMetadata objectId="wt183gy6220">
+    </contentMetadata>'
+end
+
+def build_content_metadata_4
+      '<contentMetadata objectId="wt183gy6220">
+  <resource id="wt183gy6220_1" sequence="1" type="image">
+  <label>PDF 1</label>
+  <file id="wt183gy6220.pdf" mimetype="application/pdf" size="3182927">
+  <imageData width="4531" height="3715"/>
+  </file>
+  </resource>
+  <resource id="wt183gy6220_1" sequence="2" type="image">
+  <label>Image 1</label>
+  <file id="wt183gy6220_00_0001.jp2" mimetype="image/jp2" size="3182927">
+  <imageData width="4531" height="3715"/>
+  </file>
+  </resource>
+  <resource id="wt183gy6220_2" sequence="3" type="image">
+  <label>Image 2</label>
+  <file id="wt183gy6220_00_0002.jp2" mimetype="image/jp2" size="3182927">
+  <imageData width="4531" height="3715"/>
+  </file>
+  </resource>
+  </contentMetadata>'
+end
+
+def build_content_metadata_5
+      '<contentMetadata objectId="wt183gy6220">
+  <resource id="wt183gy6220_1" sequence="1" type="image">
+  <label>PDF 1</label>
+  <file id="wt183gy6220.pdf" mimetype="application/pdf" size="3182927">
+  <imageData width="4531" height="3715"/>
+  </file>
+  </resource>
+  <resource id="wt183gy6220_2" sequence="2" type="page">
+  <label>Page 1</label>
+  <file id="wt183gy6220_00_0002.jp2" mimetype="image/jp2" size="3182927">
+  <imageData width="4531" height="3715"/>
+  </file>
+  </resource>
+  <resource id="wt183gy6220_1" sequence="3" type="page">
+  <label>Page 2</label>
+  <file id="wt183gy6220_00_0001.jp2" mimetype="image/jp2" size="3182927">
+  <imageData width="4531" height="3715"/>
+  </file>
+  </resource>
+  </contentMetadata>'
+end
+
+  # Added thumb based upon recommendation from Lynn McRae for future use
+def build_content_metadata_6
+      '<contentMetadata objectId="wt183gy6220">
+  <resource id="wt183gy6220_1" sequence="1" type="image">
+  <label>PDF 1</label>
+  <file id="wt183gy6220.pdf" mimetype="application/pdf" size="3182927">
+  <imageData width="4531" height="3715"/>
+  </file>
+  </resource>
+  <resource id="wt183gy6220_2" sequence="2" type="thumb">
+  <label>Page 1</label>
+  <file id="wt183gy6220_00_0002.jp2" mimetype="image/jp2" size="3182927">
+  <imageData width="4531" height="3715"/>
+  </file>
+  </resource>
+  <resource id="wt183gy6220_1" sequence="3" type="page">
+  <label>Page 2</label>
+  <file id="wt183gy6220_00_0001.jp2" mimetype="image/jp2" size="3182927">
+  <imageData width="4531" height="3715"/>
+  </file>
+  </resource>
+  </contentMetadata>'
+end
+
+def build_content_metadata_7
+    '<contentMetadata objectId="hj097bm8879" type="image">
+  <resource id="hj097bm8879_1" sequence="1" type="image">
+  <label>Cover: Carey\'s American atlas.</label>
+  <externalFile fileId="2542A.jp2" mimetype="image/jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1">
+  <imageData width="6475" height="4747"/>
+  </externalFile>
+  <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_2" sequence="2" thumb="yes" type="image">
+  <label>Title Page: Carey\'s American atlas.</label>
+  <externalFile fileId="2542B.jp2" mimetype="image/jp2" objectId="druid:jw923xn5254" resourceId="jw923xn5254_1">
+  <imageData width="3139" height="4675"/>
+  </externalFile>
+  <relationship objectId="druid:jw923xn5254" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_3" sequence="3" type="image">
+  <label>British Possessions in North America.</label>
+  <externalFile fileId="2542001.jp2" mimetype="image/jp2" objectId="druid:wn461xh4882" resourceId="wn461xh4882_1">
+  <imageData width="6633" height="5305"/>
+  </externalFile>
+  <relationship objectId="druid:wn461xh4882" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_4" sequence="4" type="image">
+  <label>Province of Maine.</label>
+  <externalFile fileId="2542002.jp2" mimetype="image/jp2" objectId="druid:fh193nf4583" resourceId="fh193nf4583_1">
+  <imageData width="4761" height="6117"/>
+  </externalFile>
+  <relationship objectId="druid:fh193nf4583" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_5" sequence="5" type="image">
+  <label>State of New Hampshire.</label>
+  <externalFile fileId="2542003.jp2" mimetype="image/jp2" objectId="druid:zm141bz6672" resourceId="zm141bz6672_1">
+  <imageData width="4761" height="6721"/>
+  </externalFile>
+  <relationship objectId="druid:zm141bz6672" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_6" sequence="6" type="image">
+  <label>Vermont.</label>
+  <externalFile fileId="2542004.jp2" mimetype="image/jp2" objectId="druid:ty335fg4673" resourceId="ty335fg4673_1">
+  <imageData width="4689" height="6065"/>
+  </externalFile>
+  <relationship objectId="druid:ty335fg4673" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_7" sequence="7" type="image">
+  <label>State of Massachusetts.</label>
+  <externalFile fileId="2542005.jp2" mimetype="image/jp2" objectId="druid:cb783jw9314" resourceId="cb783jw9314_1">
+  <imageData width="7073" height="5553"/>
+  </externalFile>
+  <relationship objectId="druid:cb783jw9314" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_8" sequence="8" type="image">
+  <label>Connecticut.</label>
+  <externalFile fileId="2542006.jp2" mimetype="image/jp2" objectId="druid:yr145dc7638" resourceId="yr145dc7638_1">
+  <imageData width="6161" height="4801"/>
+  </externalFile>
+  <relationship objectId="druid:yr145dc7638" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_9" sequence="9" type="image">
+  <label>State of Rhode Island.</label>
+  <externalFile fileId="2542007.jp2" mimetype="image/jp2" objectId="druid:qw237mm1478" resourceId="qw237mm1478_1">
+  <imageData width="4657" height="6065"/>
+  </externalFile>
+  <relationship objectId="druid:qw237mm1478" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_10" sequence="10" type="image">
+  <label>State of New York.</label>
+  <externalFile fileId="2542008.jp2" mimetype="image/jp2" objectId="druid:bv599bt4452" resourceId="bv599bt4452_1">
+  <imageData width="7577" height="5900"/>
+  </externalFile>
+  <relationship objectId="druid:bv599bt4452" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_11" sequence="11" type="image">
+  <label>State of New Jersey.</label>
+  <externalFile fileId="2542009.jp2" mimetype="image/jp2" objectId="druid:nb435pz3288" resourceId="nb435pz3288_1">
+  <imageData width="4681" height="6817"/>
+  </externalFile>
+  <relationship objectId="druid:nb435pz3288" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_12" sequence="12" type="image">
+  <label>State of Pennsylvania.</label>
+  <externalFile fileId="2542010.jp2" mimetype="image/jp2" objectId="druid:sc006nj1332" resourceId="sc006nj1332_1">
+  <imageData width="6805" height="4675"/>
+  </externalFile>
+  <relationship objectId="druid:sc006nj1332" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_13" sequence="13" type="image">
+  <label>Delaware.</label>
+  <externalFile fileId="2542011.jp2" mimetype="image/jp2" objectId="druid:mk475my0384" resourceId="mk475my0384_1">
+  <imageData width="4737" height="6121"/>
+  </externalFile>
+  <relationship objectId="druid:mk475my0384" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_14" sequence="14" type="image">
+  <label>State of Maryland.</label>
+  <externalFile fileId="2542012.jp2" mimetype="image/jp2" objectId="druid:wp257mm9313" resourceId="wp257mm9313_1">
+  <imageData width="6145" height="4741"/>
+  </externalFile>
+  <relationship objectId="druid:wp257mm9313" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_15" sequence="15" type="image">
+  <label>State of Virginia.</label>
+  <externalFile fileId="2542013.jp2" mimetype="image/jp2" objectId="druid:pw121jd8972" resourceId="pw121jd8972_1">
+  <imageData width="7321" height="5251"/>
+  </externalFile>
+  <relationship objectId="druid:pw121jd8972" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_16" sequence="16" type="image">
+  <label>State of North Carolina.</label>
+  <externalFile fileId="2542014.jp2" mimetype="image/jp2" objectId="druid:dh865cc1881" resourceId="dh865cc1881_1">
+  <imageData width="6793" height="4669"/>
+  </externalFile>
+  <relationship objectId="druid:dh865cc1881" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_17" sequence="17" type="image">
+  <label>State of South Carolina.</label>
+  <externalFile fileId="2542015.jp2" mimetype="image/jp2" objectId="druid:xt213gh5830" resourceId="xt213gh5830_1">
+  <imageData width="7159" height="5890"/>
+  </externalFile>
+  <relationship objectId="druid:xt213gh5830" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_18" sequence="18" type="image">
+  <label>Georgia.</label>
+  <externalFile fileId="2542016.jp2" mimetype="image/jp2" objectId="druid:xw455fd1110" resourceId="xw455fd1110_1">
+  <imageData width="6129" height="4729"/>
+  </externalFile>
+  <relationship objectId="druid:xw455fd1110" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_19" sequence="19" type="image">
+  <label>Kentucky.</label>
+  <externalFile fileId="2542017.jp2" mimetype="image/jp2" objectId="druid:pk237jz4413" resourceId="pk237jz4413_1">
+  <imageData width="7553" height="4729"/>
+  </externalFile>
+  <relationship objectId="druid:pk237jz4413" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_20" sequence="20" type="image">
+  <label>Map of The Tennassee (sic) Government.</label>
+  <externalFile fileId="2542018.jp2" mimetype="image/jp2" objectId="druid:jp652gk0604" resourceId="jp652gk0604_1">
+  <imageData width="7483" height="4657"/>
+  </externalFile>
+  <relationship objectId="druid:jp652gk0604" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_21" sequence="21" type="image">
+  <label>South America.</label>
+  <externalFile fileId="2542019.jp2" mimetype="image/jp2" objectId="druid:cs003qk0166" resourceId="cs003qk0166_1">
+  <imageData width="6091" height="4693"/>
+  </externalFile>
+  <relationship objectId="druid:cs003qk0166" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_22" sequence="22" type="image">
+  <label>
+  Map of the Discoveries made by Capts. Cook & Clerk.
+  </label>
+  <externalFile fileId="2542020.jp2" mimetype="image/jp2" objectId="druid:th862dp3538" resourceId="th862dp3538_1">
+  <imageData width="4615" height="3107"/>
+  </externalFile>
+  <relationship objectId="druid:th862dp3538" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_23" sequence="23" type="image">
+  <label>Chart of the West Indies.</label>
+  <externalFile fileId="2542021.jp2" mimetype="image/jp2" objectId="druid:wq036fq6080" resourceId="wq036fq6080_1">
+  <imageData width="6091" height="4699"/>
+  </externalFile>
+  <relationship objectId="druid:wq036fq6080" type="alsoAvailableAs"/>
+  </resource>
+  </contentMetadata>'
+end
+
+def build_rels_ext
+    '<rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="info:fedora/druid:cs003qk0166">
+    <hydra:isGovernedBy rdf:resource="info:fedora/druid:sq161jk2248"/>
+    <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_Item"/>
+    <fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"/>
+    <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"/>
+    <fedora:isConstituentOf rdf:resource="info:fedora/druid:hj097bm8879"/>
+  </rdf:Description>
+</rdf:RDF>'
+end
+
+def build_desc_metadata_1
+    '<mods>
+  <titleInfo>
+    <title>Constituent label</title>
+  </titleInfo></mods>'
+end
+  
 def build_identity_metadata_with_ckey
   '<identityMetadata>
   <sourceId source="sul">36105216275185</sourceId>

--- a/spec/update_marc_spec.rb
+++ b/spec/update_marc_spec.rb
@@ -441,7 +441,7 @@ describe Dor::UpdateMarcRecordService do
   end
 
   describe 'Released to Searchworks' do
-    it 'should return true if release_data tag has release to=SW and value is true' do
+    it 'should return true if release_data tag has release to=Searchworks and value is true' do
       identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_1))
       dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
       release_data = { 'Searchworks' => { 'release' => true } }
@@ -449,7 +449,23 @@ describe Dor::UpdateMarcRecordService do
       updater = Dor::UpdateMarcRecordService.new(dor_item)
       expect(updater.released_to_Searchworks).to be true
     end
-    it 'should return false if release_data tag has release to=SW and value is false' do
+    it 'should return true if release_data tag has release to=searchworks (all lowercase) and value is true' do
+      identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_1))
+      dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
+      release_data = { 'searchworks' => { 'release' => true } }
+      allow(dor_item).to receive(:released_for).and_return(release_data)
+      updater = Dor::UpdateMarcRecordService.new(dor_item)
+      expect(updater.released_to_Searchworks).to be true
+    end
+    it 'should return true if release_data tag has release to=SearchWorks (camcelcase) and value is true' do
+      identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_1))
+      dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
+      release_data = { 'SearchWorks' => { 'release' => true } }
+      allow(dor_item).to receive(:released_for).and_return(release_data)
+      updater = Dor::UpdateMarcRecordService.new(dor_item)
+      expect(updater.released_to_Searchworks).to be true
+    end
+    it 'should return false if release_data tag has release to=Searchworks and value is false' do
       identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_2))
       dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
       release_data = { 'Searchworks' => { 'release' => false } }
@@ -457,14 +473,14 @@ describe Dor::UpdateMarcRecordService do
       updater = Dor::UpdateMarcRecordService.new(dor_item)
       expect(updater.released_to_Searchworks).to be false
     end
-    it 'should return false if release_data tag has release to=SW but no specified release value' do
+    it 'should return false if release_data tag has release to=Searchworks but no specified release value' do
       identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_2))
       dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
       release_data = { 'Searchworks' => { 'bogus' => 'yup' } }
       allow(dor_item).to receive(:released_for).and_return(release_data)
       updater = Dor::UpdateMarcRecordService.new(dor_item)
       expect(updater.released_to_Searchworks).to be false
-    end       
+    end   
     it 'should return false if there are no release tags at all' do
       identity_metadata_xml = double('Identity Metadata', ng_xml: Nokogiri::XML(build_identity_metadata_2))
       dor_item = double('Dor Item', id: 'aa111aa1111', identityMetadata: identity_metadata_xml)
@@ -480,7 +496,7 @@ describe Dor::UpdateMarcRecordService do
       allow(dor_item).to receive(:released_for).and_return(release_data)
       updater = Dor::UpdateMarcRecordService.new(dor_item)
       expect(updater.released_to_Searchworks).to be false
-    end       
+    end      
   end
 
   describe 'dor_items_for_constituents' do


### PR DESCRIPTION
Implements a new method called "update_marc_record" which will write out a marc record for syncing up with symphony.  The logic used to be in the item-release robot suite, but it is being extracted here so that it can be called directly without having to invoke a workflow.  The robot will simply call the web service now.  See https://github.com/sul-dlss/item-release/pull/64

fixes sul-dlss/discovery-indexing#1