### PR TITLE
allow druids to be passed in via :id or :object_id

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,12 +4,12 @@ class ApplicationController < ActionController::API
   http_basic_authenticate_with name: Dor::Config.dor.service_user, password: Dor::Config.dor.service_password
 
   protected
-  
+
   def proxy_rest_client_response(response)
     render status: response.code, content_type: response.headers[:content_type], body: response.body
   end
 
   def load_item
-    @item = Dor.find(params[:id])
+    @item = Dor.find(params[:id] || params[:object_id])
   end
 end


### PR DESCRIPTION
The Rails routes provide for the item druid to be passed in via `:id` or `:object_id`