### PR TITLE
Make plain text output the default response format for registering objects

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -18,11 +18,11 @@ class ObjectsController < ApplicationController
     Rails.logger.info(params.inspect)
     reg_response = Dor::RegistrationService.create_from_request(create_params)
     Rails.logger.info(reg_response)
-    pid = reg_response['pid']
+    pid = reg_response[:pid]
 
     respond_to do |format|
-      format.json { render status: 201, location: object_location(pid), json: Dor::RegistrationResponse.new(reg_response) }
       format.all { render status: 201, location: object_location(pid), plain: Dor::RegistrationResponse.new(reg_response).to_txt }
+      format.json { render status: 201, location: object_location(pid), json: Dor::RegistrationResponse.new(reg_response) }
     end
   end     
   

--- a/spec/controllers/objects_controller_spec.rb
+++ b/spec/controllers/objects_controller_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe ObjectsController do
   end
 
   describe 'object registration' do
+    render_views
+
     context 'error handling' do
       it 'returns a 409 error with location header when an object already exists' do
         allow(Dor::RegistrationService).to receive(:register_object).and_raise(Dor::DuplicateIdError.new('druid:existing123obj'))
@@ -23,10 +25,11 @@ RSpec.describe ObjectsController do
     end
     
     it 'registers the object with the registration service' do
-      allow(Dor::RegistrationService).to receive(:create_from_request).and_return('pid' => 'druid:xyz')
+      allow(Dor::RegistrationService).to receive(:create_from_request).and_return(pid: 'druid:xyz')
       
-      post :create, format: :json
-      
+      post :create
+
+      expect(response.body).to eq 'druid:xyz'
       expect(Dor::RegistrationService).to have_received(:create_from_request)
       expect(response.status).to eq(201)
       expect(response.location).to end_with '/fedora/objects/druid:xyz'


### PR DESCRIPTION
Fixes #53.