### PR TITLE
no activerecord check necessary for okcomputer

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -5,6 +5,7 @@ require 'okcomputer'
 # /status/<name-of-check> for a specific check (e.g. for nagios warning)
 OkComputer.mount_at = 'status'
 OkComputer.check_in_parallel = true
+OkComputer::Registry.deregister "database" # no database in this app
 
 class CustomAppVersionCheck < OkComputer::AppVersionCheck
   def version


### PR DESCRIPTION
ActiveRecord check fails currently, which is expected since there is no database used or configured:
https://dor-services-prod.stanford.edu/status/all
