### PR TITLE
dor-services v5.21.1 - allow colons in source_id and other_id values

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.3.0)
       nokogiri
-    dor-services (5.20.0)
+    dor-services (5.21.1)
       active-fedora (>= 6.0, < 9.a)
       activesupport (>= 3.2.18)
       confstruct (~> 0.2.7)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Build Status](https://travis-ci.org/sul-dlss/dor-services-app.png?branch=master)](https://travis-ci.org/sul-dlss/dor-services-app)
 [![Coverage Status](https://coveralls.io/repos/github/sul-dlss/dor-services-app/badge.svg?branch=master)](https://coveralls.io/github/sul-dlss/dor-services-app?branch=master)
+[![Dependency Status](https://gemnasium.com/badges/github.com/sul-dlss/dor-services-app.svg)](https://gemnasium.com/github.com/sul-dlss/dor-services-app)
+[![GitHub version](https://badge.fury.io/gh/sul-dlss%2Fdor-services-app.svg)](https://badge.fury.io/gh/sul-dlss%2Fdor-services-app)
 
 # DOR Services App
 


### PR DESCRIPTION
Motivated by errors thrown when registering web archive seed objects with source_id values of the form sul:SOMETHING-http://www.foo.org

Also add Gemnasium and version badges to README