### PR TITLE
Create empty records for previous catkeys

### DIFF
--- a/app/models/dor/service_item.rb
+++ b/app/models/dor/service_item.rb
@@ -3,12 +3,13 @@ module Dor
     # @return [String] value with SIRSI/Symphony numeric catkey in it for specified object, or nil if none exists
     # look in identityMetadata/otherId[@name='catkey']
     def self.get_ckey(object)
-      unless object.datastreams.nil? || object.datastreams['identityMetadata'].nil?
-        if object.datastreams['identityMetadata'].ng_xml
-          node = object.identityMetadata.ng_xml.at_xpath("//identityMetadata/otherId[@name='catkey']")
-        end
-      end
+      return nil unless identity_metadata?(object)
+      node = object.identityMetadata.ng_xml.at_xpath("//identityMetadata/otherId[@name='catkey']")
       node.content if node && node.content.present?
+    end
+
+    def self.identity_metadata?(object)
+      object.datastreams && object.datastreams['identityMetadata'] && object.datastreams['identityMetadata'].ng_xml
     end
 
     def initialize(druid_obj)
@@ -20,10 +21,20 @@ module Dor
     # the ckey for the current object
     # @return [String] value with SIRSI/Symphony numeric catkey in it for specified object, or nil if none exists
     def ckey
-      self.class.get_ckey(@druid_obj)
+      @ckey ||= self.class.get_ckey(@druid_obj)
     end
 
-    # @return [String] value with object_type in it, or empty x subfield if none exists
+    # the previous ckeys for the current object
+    # @return [Array] previous catkeys for the object in an array, empty array if none exist
+    def previous_ckeys
+      @previous_ckeys ||= if self.class.identity_metadata?(@druid_obj)
+                            @druid_obj.identityMetadata.ng_xml.xpath("//identityMetadata/otherId[@name='previous_catkey']").map(&:content).reject(&:empty?)
+                          else
+                            []
+                          end
+    end
+
+    # @return [String] value with object_type in it (nil if none found)
     # look in identityMetadata/objectType
     def object_type
       @object_type ||= begin
@@ -33,7 +44,7 @@ module Dor
     end
 
     # the barcode
-    # @return [String] value with barcode in it, or empty x subfield if none exists
+    # @return [String] value with barcode in it (nil if none found)
     # look in identityMetadata/otherId name="barcode"
     def barcode
       @barcode ||= begin

--- a/app/models/dor/service_item.rb
+++ b/app/models/dor/service_item.rb
@@ -1,6 +1,7 @@
 module Dor
   class ServiceItem
     # @return [String] value with SIRSI/Symphony numeric catkey in it for specified object, or nil if none exists
+    # this is a class level method so it can be used on aribtrary druids (e.g. collection the item is associated with) without having to instantiate the object
     # look in identityMetadata/otherId[@name='catkey']
     def self.get_ckey(object)
       return nil unless identity_metadata?(object)
@@ -56,47 +57,51 @@ module Dor
     # the @id attribute of resource/file elements including extension
     # @return [String] thumbnail filename (nil if none found)
     def thumb
-      @druid_obj.encoded_thumb unless @druid_obj.datastreams.nil?
+      @thumb ||= @druid_obj.encoded_thumb unless @druid_obj.datastreams.nil?
     end
 
     # returns the first collection_id the object is contained in (if any)
     # @return [String] collection druid the item is in (blank if none)
     def collection_id
-      @druid_obj.collections.empty? ? '' : @druid_obj.collections.first.id
+      @collection_id ||= @druid_obj.collections.empty? ? '' : @druid_obj.collections.first.id
     end
 
     # returns the name of the first collection the object is contained in (if any)
     # @return [String] first collection name the item is in (blank if none)
     def collection_name
-      @druid_obj.collections.empty? ? '' : @druid_obj.collections.first.label
+      @collection_name ||= @druid_obj.collections.empty? ? '' : @druid_obj.collections.first.label
     end
 
     # returns the value of the content_type_tag from dor services if it exists, else returns the value from contentMetadata object type
     # note, the content_type_tag comes from value of the tag called "Process : Content Type"
     # @return [String] first collection name the item is in (blank if none)
     def content_type
-      if @druid_obj.content_type_tag.empty?
-        node = @druid_obj.datastreams['contentMetadata'].ng_xml.at_xpath('//contentMetadata/@type')
-        node.blank? ? '' : node.content
-      else
-        @druid_obj.content_type_tag
-      end
+      @content_type ||= if @druid_obj.content_type_tag.empty?
+                          node = @druid_obj.datastreams['contentMetadata'].ng_xml.at_xpath('//contentMetadata/@type')
+                          node.blank? ? '' : node.content
+                        else
+                          @druid_obj.content_type_tag
+                        end
     end
 
     # returns the name of the project by examining the objects tags
     # @return [String] first project tag value if one exists (blank if none)
     def project_name
-      project_tag_id = 'Project : '
-      content_tag = @druid_obj.tags.select { |tag| tag.include?(project_tag_id) }
-      content_tag.empty? ? '' : content_tag[0].gsub(project_tag_id, '').strip
+      @project_name ||= begin
+        project_tag_id = 'Project : '
+        content_tag = @druid_obj.tags.select { |tag| tag.include?(project_tag_id) }
+        content_tag.empty? ? '' : content_tag[0].gsub(project_tag_id, '').strip
+      end
     end
 
     # returns the name of the goobiworkflow in the object by examining the objects tags
     # @return [String] first goobi workflow tag value if one exists (default from config if none)
     def goobi_workflow_name
-      dpg_workflow_tag_id = 'DPG : Workflow : '
-      content_tag = @druid_obj.tags.select { |tag| tag.include?(dpg_workflow_tag_id) }
-      content_tag.empty? ? Dor::Config.goobi.default_goobi_workflow_name : content_tag[0].split(':').last.strip
+      @goobi_workflow_name ||= begin
+        dpg_workflow_tag_id = 'DPG : Workflow : '
+        content_tag = @druid_obj.tags.select { |tag| tag.include?(dpg_workflow_tag_id) }
+        content_tag.empty? ? Dor::Config.goobi.default_goobi_workflow_name : content_tag[0].split(':').last.strip
+      end
     end
   end
 end

--- a/spec/service_item_spec.rb
+++ b/spec/service_item_spec.rb
@@ -12,11 +12,12 @@ RSpec.describe Dor::ServiceItem do
       allow(identity_metadata_ds).to receive(:ng_xml).and_return(identity_metadata_ng_xml)
 
       expect(@si.ckey).to eq('8832162')
+      expect(@si.previous_ckeys).to eq([])
     end
 
-    it 'should return nil for an identityMetadata without catkey' do
+    it 'should return nil for current catkey but values for previous catkeys in identityMetadata' do
       setup_test_objects('druid:aa111aa1111', '')
-      identity_metadata_ng_xml = Nokogiri::XML(build_identity_metadata_3)
+      identity_metadata_ng_xml = Nokogiri::XML(build_identity_metadata_5)
       identity_metadata_ds = double(Dor::IdentityMetadataDS)
 
       allow(@dor_item).to receive(:datastreams).times.and_return('identityMetadata' => identity_metadata_ds)
@@ -24,6 +25,20 @@ RSpec.describe Dor::ServiceItem do
       allow(identity_metadata_ds).to receive(:ng_xml).and_return(identity_metadata_ng_xml)
 
       expect(@si.ckey).to be_nil
+      expect(@si.previous_ckeys).to eq(%w(123 456))
+    end
+
+    it 'should return nil for current catkey and empty array for previous catkeys in identityMetadata without either' do
+      setup_test_objects('druid:aa111aa1111', '')
+      identity_metadata_ng_xml = Nokogiri::XML(build_identity_metadata_4)
+      identity_metadata_ds = double(Dor::IdentityMetadataDS)
+
+      allow(@dor_item).to receive(:datastreams).times.and_return('identityMetadata' => identity_metadata_ds)
+      allow(@dor_item).to receive(:identityMetadata).and_return(identity_metadata_ds)
+      allow(identity_metadata_ds).to receive(:ng_xml).and_return(identity_metadata_ng_xml)
+
+      expect(@si.ckey).to be_nil
+      expect(@si.previous_ckeys).to eq([])
     end
   end
 
@@ -77,7 +92,7 @@ RSpec.describe Dor::ServiceItem do
 
     it 'should return a blank object type for identityMetadata without object_type' do
       setup_test_objects('druid:aa111aa1111', '')
-      identity_metadata_ng_xml = Nokogiri::XML(build_identity_metadata_3)
+      identity_metadata_ng_xml = Nokogiri::XML(build_identity_metadata_6)
       identity_metadata_ds = double(Dor::IdentityMetadataDS)
 
       allow(@dor_item).to receive(:datastreams).and_return('identityMetadata' => identity_metadata_ds)
@@ -217,7 +232,7 @@ RSpec.describe Dor::ServiceItem do
     it 'should return an empty string for contentMetadata without thumb' do
       druid = 'aa111aa2222'
       d = Dor::Item.new(:pid => druid)
-      content_metadata_ng_xml = Nokogiri::XML(build_content_metadata_3)
+      content_metadata_ng_xml = Nokogiri::XML(build_content_metadata_2)
       content_metadata_ds = double(Dor::ContentMetadataDS)
       rights_metadata_ng_xml = Nokogiri::XML(build_rights_metadata_1)
       rights_metadata_ds = double(Dor::RightsMetadataDS)

--- a/spec/support/datastreams.rb
+++ b/spec/support/datastreams.rb
@@ -46,9 +46,14 @@ def build_identity_metadata_3
     <sourceId source="sul">36105216275185</sourceId>
     <objectId>druid:bb987ch8177</objectId>
     <objectCreator>DOR</objectCreator>
+    <objectType>item</objectType>
     <objectLabel>A  new map of Africa</objectLabel>
     <adminPolicy>druid:dd051ys2703</adminPolicy>
     <otherId name="uuid">ff3ce224-9ffb-11e3-aaf2-0050569b3c3c</otherId>
+    <otherId name="catkey">8832162</otherId>
+    <otherId name="previous_catkey">123</otherId>
+    <otherId name="previous_catkey">456</otherId>
+    <otherId name="previous_catkey"/>
     <tag>Process : Content Type : Map</tag>
     <tag>Project : Batchelor Maps : Batch 1</tag>
     <tag>LAB : MAPS</tag>
@@ -66,7 +71,6 @@ def build_identity_metadata_4
     <objectType>item</objectType>
     <displayType>image</displayType>
     <adminPolicy>druid:dd051ys2703</adminPolicy>
-    <otherId name="catkey">8832162</otherId>
     <otherId name="barcode">36105216275185</otherId>
     <otherId name="uuid">ff3ce224-9ffb-11e3-aaf2-0050569b3c3c</otherId>
     <tag>Process : Content Type : Map</tag>
@@ -78,16 +82,42 @@ def build_identity_metadata_4
   </identityMetadata>'
 end
 
-def build_release_data_1
-  '<release_data>
-  <release to="Searchworks">true</release>
-  </release_data>'
+def build_identity_metadata_5
+  '<identityMetadata>
+    <sourceId source="sul">36105216275185</sourceId>
+    <objectId>druid:bb987ch8177</objectId>
+    <objectCreator>DOR</objectCreator>
+    <objectLabel>A  new map of Africa</objectLabel>
+    <objectType>item</objectType>
+    <displayType>image</displayType>
+    <adminPolicy>druid:dd051ys2703</adminPolicy>
+    <otherId name="previous_catkey">123</otherId>
+    <otherId name="previous_catkey">456</otherId>
+    <otherId name="barcode">36105216275185</otherId>
+    <otherId name="uuid">ff3ce224-9ffb-11e3-aaf2-0050569b3c3c</otherId>
+    <tag>Process : Content Type : Map</tag>
+    <tag>Project : Batchelor Maps : Batch 1</tag>
+    <tag>LAB : MAPS</tag>
+    <tag>Registered By : dfuzzell</tag>
+    <tag>Remediated By : 4.1</tag>
+    <release displayType="image" release="false" to="Searchworks" what="self" when="2015-07-27T21:43:27Z" who="lauraw15">false</release>
+  </identityMetadata>'
 end
 
-def build_release_data_2
-  '<release_data>
-  <release to="Searchworks">false</release>
-  </release_data>'
+def build_identity_metadata_6
+  '<identityMetadata>
+    <sourceId source="sul">36105216275185</sourceId>
+    <objectId>druid:bb987ch8177</objectId>
+    <objectCreator>DOR</objectCreator>
+    <objectLabel>A  new map of Africa</objectLabel>
+    <adminPolicy>druid:dd051ys2703</adminPolicy>
+    <otherId name="uuid">ff3ce224-9ffb-11e3-aaf2-0050569b3c3c</otherId>
+    <tag>Process : Content Type : Map</tag>
+    <tag>Project : Batchelor Maps : Batch 1</tag>
+    <tag>LAB : MAPS</tag>
+    <tag>Registered By : dfuzzell</tag>
+    <tag>Remediated By : 4.15.4</tag>
+  </identityMetadata>'
 end
 
 def build_content_metadata_1
@@ -103,261 +133,6 @@ end
 
 def build_content_metadata_2
   '<contentMetadata objectId="wt183gy6220">
-  <resource id="wt183gy6220_1" sequence="1" type="image">
-  <label>Image 1</label>
-  <file id="wt183gy6220_00_0001.jp2" mimetype="image/jp2" size="3182927">
-  <imageData width="4531" height="3715"/>
-  </file>
-  </resource>
-  <resource id="wt183gy6220_2" sequence="2" type="image">
-  <label>Image 2</label>
-  <file id="wt183gy6220_00_0002.jp2" mimetype="image/jp2" size="3182927">
-  <imageData width="4531" height="3715"/>
-  </file>
-  </resource>
-  </contentMetadata>'
-end
-
-def build_content_metadata_3
-  '<contentMetadata objectId="wt183gy6220">
-  </contentMetadata>'
-end
-
-def build_content_metadata_4
-  '<contentMetadata objectId="wt183gy6220">
-  <resource id="wt183gy6220_1" sequence="1" type="image">
-  <label>PDF 1</label>
-  <file id="wt183gy6220.pdf" mimetype="application/pdf" size="3182927">
-  <imageData width="4531" height="3715"/>
-  </file>
-  </resource>
-  <resource id="wt183gy6220_1" sequence="2" type="image">
-  <label>Image 1</label>
-  <file id="wt183gy6220_00_0001.jp2" mimetype="image/jp2" size="3182927">
-  <imageData width="4531" height="3715"/>
-  </file>
-  </resource>
-  <resource id="wt183gy6220_2" sequence="3" type="image">
-  <label>Image 2</label>
-  <file id="wt183gy6220_00_0002.jp2" mimetype="image/jp2" size="3182927">
-  <imageData width="4531" height="3715"/>
-  </file>
-  </resource>
-  </contentMetadata>'
-end
-
-def build_content_metadata_5
-  '<contentMetadata objectId="wt183gy6220">
-  <resource id="wt183gy6220_1" sequence="1" type="image">
-  <label>PDF 1</label>
-  <file id="wt183gy6220.pdf" mimetype="application/pdf" size="3182927">
-  <imageData width="4531" height="3715"/>
-  </file>
-  </resource>
-  <resource id="wt183gy6220_2" sequence="2" type="page">
-  <label>Page 1</label>
-  <file id="wt183gy6220_00_0002.jp2" mimetype="image/jp2" size="3182927">
-  <imageData width="4531" height="3715"/>
-  </file>
-  </resource>
-  <resource id="wt183gy6220_1" sequence="3" type="page">
-  <label>Page 2</label>
-  <file id="wt183gy6220_00_0001.jp2" mimetype="image/jp2" size="3182927">
-  <imageData width="4531" height="3715"/>
-  </file>
-  </resource>
-  </contentMetadata>'
-end
-
-# Added thumb based upon recommendation from Lynn McRae for future use
-def build_content_metadata_6
-  '<contentMetadata objectId="wt183gy6220">
-  <resource id="wt183gy6220_1" sequence="1" type="image">
-  <label>PDF 1</label>
-  <file id="wt183gy6220.pdf" mimetype="application/pdf" size="3182927">
-  <imageData width="4531" height="3715"/>
-  </file>
-  </resource>
-  <resource id="wt183gy6220_2" sequence="2" type="thumb">
-  <label>Page 1</label>
-  <file id="wt183gy6220_00_0002.jp2" mimetype="image/jp2" size="3182927">
-  <imageData width="4531" height="3715"/>
-  </file>
-  </resource>
-  <resource id="wt183gy6220_1" sequence="3" type="page">
-  <label>Page 2</label>
-  <file id="wt183gy6220_00_0001.jp2" mimetype="image/jp2" size="3182927">
-  <imageData width="4531" height="3715"/>
-  </file>
-  </resource>
-  </contentMetadata>'
-end
-
-def build_content_metadata_7
-  '<contentMetadata objectId="hj097bm8879" type="image">
-  <resource id="hj097bm8879_1" sequence="1" type="image">
-  <label>Cover: Carey\'s American atlas.</label>
-  <externalFile fileId="2542A.jp2" mimetype="image/jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1">
-  <imageData width="6475" height="4747"/>
-  </externalFile>
-  <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_2" sequence="2" thumb="yes" type="image">
-  <label>Title Page: Carey\'s American atlas.</label>
-  <externalFile fileId="2542B.jp2" mimetype="image/jp2" objectId="druid:jw923xn5254" resourceId="jw923xn5254_1">
-  <imageData width="3139" height="4675"/>
-  </externalFile>
-  <relationship objectId="druid:jw923xn5254" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_3" sequence="3" type="image">
-  <label>British Possessions in North America.</label>
-  <externalFile fileId="2542001.jp2" mimetype="image/jp2" objectId="druid:wn461xh4882" resourceId="wn461xh4882_1">
-  <imageData width="6633" height="5305"/>
-  </externalFile>
-  <relationship objectId="druid:wn461xh4882" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_4" sequence="4" type="image">
-  <label>Province of Maine.</label>
-  <externalFile fileId="2542002.jp2" mimetype="image/jp2" objectId="druid:fh193nf4583" resourceId="fh193nf4583_1">
-  <imageData width="4761" height="6117"/>
-  </externalFile>
-  <relationship objectId="druid:fh193nf4583" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_5" sequence="5" type="image">
-  <label>State of New Hampshire.</label>
-  <externalFile fileId="2542003.jp2" mimetype="image/jp2" objectId="druid:zm141bz6672" resourceId="zm141bz6672_1">
-  <imageData width="4761" height="6721"/>
-  </externalFile>
-  <relationship objectId="druid:zm141bz6672" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_6" sequence="6" type="image">
-  <label>Vermont.</label>
-  <externalFile fileId="2542004.jp2" mimetype="image/jp2" objectId="druid:ty335fg4673" resourceId="ty335fg4673_1">
-  <imageData width="4689" height="6065"/>
-  </externalFile>
-  <relationship objectId="druid:ty335fg4673" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_7" sequence="7" type="image">
-  <label>State of Massachusetts.</label>
-  <externalFile fileId="2542005.jp2" mimetype="image/jp2" objectId="druid:cb783jw9314" resourceId="cb783jw9314_1">
-  <imageData width="7073" height="5553"/>
-  </externalFile>
-  <relationship objectId="druid:cb783jw9314" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_8" sequence="8" type="image">
-  <label>Connecticut.</label>
-  <externalFile fileId="2542006.jp2" mimetype="image/jp2" objectId="druid:yr145dc7638" resourceId="yr145dc7638_1">
-  <imageData width="6161" height="4801"/>
-  </externalFile>
-  <relationship objectId="druid:yr145dc7638" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_9" sequence="9" type="image">
-  <label>State of Rhode Island.</label>
-  <externalFile fileId="2542007.jp2" mimetype="image/jp2" objectId="druid:qw237mm1478" resourceId="qw237mm1478_1">
-  <imageData width="4657" height="6065"/>
-  </externalFile>
-  <relationship objectId="druid:qw237mm1478" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_10" sequence="10" type="image">
-  <label>State of New York.</label>
-  <externalFile fileId="2542008.jp2" mimetype="image/jp2" objectId="druid:bv599bt4452" resourceId="bv599bt4452_1">
-  <imageData width="7577" height="5900"/>
-  </externalFile>
-  <relationship objectId="druid:bv599bt4452" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_11" sequence="11" type="image">
-  <label>State of New Jersey.</label>
-  <externalFile fileId="2542009.jp2" mimetype="image/jp2" objectId="druid:nb435pz3288" resourceId="nb435pz3288_1">
-  <imageData width="4681" height="6817"/>
-  </externalFile>
-  <relationship objectId="druid:nb435pz3288" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_12" sequence="12" type="image">
-  <label>State of Pennsylvania.</label>
-  <externalFile fileId="2542010.jp2" mimetype="image/jp2" objectId="druid:sc006nj1332" resourceId="sc006nj1332_1">
-  <imageData width="6805" height="4675"/>
-  </externalFile>
-  <relationship objectId="druid:sc006nj1332" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_13" sequence="13" type="image">
-  <label>Delaware.</label>
-  <externalFile fileId="2542011.jp2" mimetype="image/jp2" objectId="druid:mk475my0384" resourceId="mk475my0384_1">
-  <imageData width="4737" height="6121"/>
-  </externalFile>
-  <relationship objectId="druid:mk475my0384" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_14" sequence="14" type="image">
-  <label>State of Maryland.</label>
-  <externalFile fileId="2542012.jp2" mimetype="image/jp2" objectId="druid:wp257mm9313" resourceId="wp257mm9313_1">
-  <imageData width="6145" height="4741"/>
-  </externalFile>
-  <relationship objectId="druid:wp257mm9313" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_15" sequence="15" type="image">
-  <label>State of Virginia.</label>
-  <externalFile fileId="2542013.jp2" mimetype="image/jp2" objectId="druid:pw121jd8972" resourceId="pw121jd8972_1">
-  <imageData width="7321" height="5251"/>
-  </externalFile>
-  <relationship objectId="druid:pw121jd8972" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_16" sequence="16" type="image">
-  <label>State of North Carolina.</label>
-  <externalFile fileId="2542014.jp2" mimetype="image/jp2" objectId="druid:dh865cc1881" resourceId="dh865cc1881_1">
-  <imageData width="6793" height="4669"/>
-  </externalFile>
-  <relationship objectId="druid:dh865cc1881" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_17" sequence="17" type="image">
-  <label>State of South Carolina.</label>
-  <externalFile fileId="2542015.jp2" mimetype="image/jp2" objectId="druid:xt213gh5830" resourceId="xt213gh5830_1">
-  <imageData width="7159" height="5890"/>
-  </externalFile>
-  <relationship objectId="druid:xt213gh5830" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_18" sequence="18" type="image">
-  <label>Georgia.</label>
-  <externalFile fileId="2542016.jp2" mimetype="image/jp2" objectId="druid:xw455fd1110" resourceId="xw455fd1110_1">
-  <imageData width="6129" height="4729"/>
-  </externalFile>
-  <relationship objectId="druid:xw455fd1110" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_19" sequence="19" type="image">
-  <label>Kentucky.</label>
-  <externalFile fileId="2542017.jp2" mimetype="image/jp2" objectId="druid:pk237jz4413" resourceId="pk237jz4413_1">
-  <imageData width="7553" height="4729"/>
-  </externalFile>
-  <relationship objectId="druid:pk237jz4413" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_20" sequence="20" type="image">
-  <label>Map of The Tennassee (sic) Government.</label>
-  <externalFile fileId="2542018.jp2" mimetype="image/jp2" objectId="druid:jp652gk0604" resourceId="jp652gk0604_1">
-  <imageData width="7483" height="4657"/>
-  </externalFile>
-  <relationship objectId="druid:jp652gk0604" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_21" sequence="21" type="image">
-  <label>South America.</label>
-  <externalFile fileId="2542019.jp2" mimetype="image/jp2" objectId="druid:cs003qk0166" resourceId="cs003qk0166_1">
-  <imageData width="6091" height="4693"/>
-  </externalFile>
-  <relationship objectId="druid:cs003qk0166" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_22" sequence="22" type="image">
-  <label>
-  Map of the Discoveries made by Capts. Cook & Clerk.
-  </label>
-  <externalFile fileId="2542020.jp2" mimetype="image/jp2" objectId="druid:th862dp3538" resourceId="th862dp3538_1">
-  <imageData width="4615" height="3107"/>
-  </externalFile>
-  <relationship objectId="druid:th862dp3538" type="alsoAvailableAs"/>
-  </resource>
-  <resource id="hj097bm8879_23" sequence="23" type="image">
-  <label>Chart of the West Indies.</label>
-  <externalFile fileId="2542021.jp2" mimetype="image/jp2" objectId="druid:wq036fq6080" resourceId="wq036fq6080_1">
-  <imageData width="6091" height="4699"/>
-  </externalFile>
-  <relationship objectId="druid:wq036fq6080" type="alsoAvailableAs"/>
-  </resource>
   </contentMetadata>'
 end
 

--- a/spec/update_marc_spec.rb
+++ b/spec/update_marc_spec.rb
@@ -14,196 +14,278 @@ RSpec.describe Dor::UpdateMarcRecordService do
       druid = 'druid:aa222cc3333'
       setup_test_objects(druid, build_identity_metadata_without_ckey)
       expect(@umrs).to receive(:ckey).and_return(nil)
-      expect(@umrs).not_to receive(:push_symphony_record)
+      expect(@umrs).not_to receive(:push_symphony_records)
       @umrs.update
     end
   end
 
   context 'for a druid with a catkey' do
-    it 'executes the UpdateMarcRecordService push_symphony_record method' do
+    it 'executes the UpdateMarcRecordService push_symphony_records method' do
       druid = 'druid:bb333dd4444'
       setup_test_objects(druid, build_identity_metadata_with_ckey)
-      expect(@umrs).to receive(:ckey).exactly(3).times.and_return('8832162')
-      expect(@umrs.generate_symphony_record).to eq("8832162\t#{druid.gsub('druid:', '')}\t")
-      expect(@umrs).to receive(:push_symphony_record)
+      expect(@umrs).to receive(:ckey).exactly(4).times.and_return('8832162')
+      expect(@umrs.generate_symphony_records).to eq(["8832162\t#{druid.gsub('druid:', '')}\t"])
+      expect(@umrs).to receive(:push_symphony_records)
       @umrs.update
     end
   end
 
-  describe '.push_symphony_record' do
+  describe '.push_symphony_records' do
     it 'should call the relevant methods' do
       setup_test_objects('druid:aa111aa1111', '')
-      expect(@umrs).to receive(:generate_symphony_record).once
-      expect(@umrs).to receive(:write_symphony_record).once
-      @umrs.push_symphony_record
+      expect(@umrs).to receive(:generate_symphony_records).once
+      expect(@umrs).to receive(:write_symphony_records).once
+      @umrs.push_symphony_records
     end
   end
 
-  describe '.generate_symphony_record' do
+  describe '.generate_symphony_records' do
+    let(:item) { Dor::Item.new }
+    let(:collection) { Dor::Collection.new }
+    let(:constituent) { Dor::Item.new }
+
+    let(:rels_ext_xml) { double(String) }
+    let(:identity_metadata_xml) { double(String) }
+    let(:content_metadata_xml) { double(String) }
+    let(:desc_metadata_xml) { double(String) }
+    let(:rights_metadata_xml) { double(String) }
+    let(:release_data) { { 'Searchworks' => { 'release' => true } } }
+
     before :each do
-      Dor::Config.release.purl_base_uri = 'http://purl.stanford.edu'
-      @item = Dor::Item.new
-      @collection = Dor::Collection.new
-      @constituent = Dor::Item.new
-      @identity_metadata_xml = double(String)
-      @rights_metadata_xml = double(String)
-      @rels_ext_xml = double(String)
-      @content_metadata_xml = double(String)
-      @desc_metadata_xml = double(String)
+      allow(item).to receive(:released_for).and_return(release_data)
+      allow(collection).to receive(:released_for).and_return(release_data)
     end
-    it 'should generate an empty string for a druid object without catkey' do
+
+    it 'should generate an empty array for a druid object without catkey or previous catkeys' do
       rights_metadata_ng_xml = Nokogiri::XML(build_rights_metadata_1)
-      allow(@rights_metadata_xml).to receive_messages(
+      allow(rights_metadata_xml).to receive_messages(
         ng_xml: rights_metadata_ng_xml,
         dra_object: Dor::RightsAuth.parse(rights_metadata_ng_xml, true)
       )
 
-      allow(@identity_metadata_xml).to receive_messages(
-        ng_xml: Nokogiri::XML(build_identity_metadata_3)
+      allow(identity_metadata_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_identity_metadata_4)
       )
 
-      allow(@collection).to receive_messages(
+      allow(collection).to receive_messages(
         label: 'Collection label',
         id: 'cc111cc1111',
         catkey: '12345678'
       )
 
-      allow(@item).to receive_messages(
+      allow(item).to receive_messages(
         id: 'aa111aa1111',
-        collections: [@collection],
-        datastreams: { 'identityMetadata' => @identity_metadata_xml, 'rightsMetadata' => @rights_metadata_xml }
+        collections: [collection],
+        datastreams: { 'identityMetadata' => identity_metadata_xml, 'rightsMetadata' => rights_metadata_xml }
       )
 
-      release_data = { 'Searchworks' => { 'release' => true } }
-      allow(@item).to receive(:released_for).and_return(release_data)
-      allow(@collection).to receive(:released_for).and_return(release_data)
-
-      updater = Dor::UpdateMarcRecordService.new(@item)
-      expect(updater.generate_symphony_record).to eq('')
+      updater = Dor::UpdateMarcRecordService.new(item)
+      expect(updater.generate_symphony_records).to eq([])
     end
-    it 'should generate symphony record for a item object with catkey' do
-      allow(@identity_metadata_xml).to receive_messages(
+
+    it 'should generate a single symphony record for an item object with a catkey' do
+      allow(identity_metadata_xml).to receive_messages(
         ng_xml: Nokogiri::XML(build_identity_metadata_1)
       )
 
-      allow(@content_metadata_xml).to receive_messages(
+      allow(content_metadata_xml).to receive_messages(
         ng_xml: Nokogiri::XML(build_content_metadata_1)
       )
 
-      allow(@desc_metadata_xml).to receive_messages(
+      allow(desc_metadata_xml).to receive_messages(
         ng_xml: Nokogiri::XML(build_desc_metadata_1)
       )
 
-      allow(@rels_ext_xml).to receive_messages(
+      allow(rels_ext_xml).to receive_messages(
         ng_xml: Nokogiri::XML(build_rels_ext)
       )
 
       rights_metadata_ng_xml = Nokogiri::XML(build_rights_metadata_1)
-      allow(@rights_metadata_xml).to receive_messages(
+      allow(rights_metadata_xml).to receive_messages(
         ng_xml: rights_metadata_ng_xml,
         dra_object: Dor::RightsAuth.parse(rights_metadata_ng_xml, true)
       )
 
-      allow(@collection).to receive_messages(
+      allow(collection).to receive_messages(
         label: 'Collection label',
         id: 'cc111cc1111'
       )
 
-      allow(@item).to receive_messages(
+      allow(item).to receive_messages(
         id: 'aa111aa1111',
-        collections: [@collection],
-        datastreams: { 'rightsMetadata' => @rights_metadata_xml, 'identityMetadata' => @identity_metadata_xml, 'contentMetadata' => @content_metadata_xml, 'RELS-EXT' => @rels_ext_xml }
+        collections: [collection],
+        datastreams: { 'rightsMetadata' => rights_metadata_xml, 'identityMetadata' => identity_metadata_xml, 'contentMetadata' => content_metadata_xml, 'RELS-EXT' => rels_ext_xml }
       )
 
-      allow(@constituent).to receive_messages(
+      allow(constituent).to receive_messages(
         id: 'dd111dd1111',
-        datastreams: { 'descMetadata' => @desc_metadata_xml }
+        datastreams: { 'descMetadata' => desc_metadata_xml }
       )
 
-      release_data = { 'Searchworks' => { 'release' => true } }
-      allow(@item).to receive(:released_for).and_return(release_data)
-
-      allow_any_instance_of(Dor::UpdateMarcRecordService).to receive(:dor_items_for_constituents).and_return([@constituent])
-      updater = Dor::UpdateMarcRecordService.new(@item)
+      allow_any_instance_of(Dor::UpdateMarcRecordService).to receive(:dor_items_for_constituents).and_return([constituent])
+      updater = Dor::UpdateMarcRecordService.new(item)
       # rubocop:disable Metrics/LineLength
-      expect(updater.generate_symphony_record).to eq("8832162\taa111aa1111\t.856. 41|uhttp://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label")
+      expect(updater.generate_symphony_records).to eq(["8832162\taa111aa1111\t.856. 41|uhttp://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label"])
       # rubocop:enble Metrics/LineLength
     end
 
     it 'should generate symphony record with a z subfield for a stanford only item object with catkey' do
-      allow(@identity_metadata_xml).to receive_messages(
+      allow(identity_metadata_xml).to receive_messages(
         ng_xml: Nokogiri::XML(build_identity_metadata_1)
       )
 
-      allow(@content_metadata_xml).to receive_messages(
+      allow(content_metadata_xml).to receive_messages(
         ng_xml: Nokogiri::XML(build_content_metadata_1)
       )
 
-      allow(@desc_metadata_xml).to receive_messages(
+      allow(desc_metadata_xml).to receive_messages(
         ng_xml: Nokogiri::XML(build_desc_metadata_1)
       )
 
-      allow(@rels_ext_xml).to receive_messages(
+      allow(rels_ext_xml).to receive_messages(
         ng_xml: Nokogiri::XML(build_rels_ext)
       )
 
       rights_metadata_ng_xml = Nokogiri::XML(build_rights_metadata_2)
-      allow(@rights_metadata_xml).to receive_messages(
+      allow(rights_metadata_xml).to receive_messages(
         ng_xml: rights_metadata_ng_xml,
         dra_object: Dor::RightsAuth.parse(rights_metadata_ng_xml, true)
       )
 
-      allow(@collection).to receive_messages(
+      allow(collection).to receive_messages(
         label: 'Collection label',
         id: 'cc111cc1111'
       )
 
-      allow(@item).to receive_messages(
+      allow(item).to receive_messages(
         id: 'aa111aa1111',
-        collections: [@collection],
-        datastreams: { 'rightsMetadata' => @rights_metadata_xml, 'identityMetadata' => @identity_metadata_xml, 'contentMetadata' => @content_metadata_xml, 'RELS-EXT' => @rels_ext_xml }
+        collections: [collection],
+        datastreams: { 'rightsMetadata' => rights_metadata_xml, 'identityMetadata' => identity_metadata_xml, 'contentMetadata' => content_metadata_xml, 'RELS-EXT' => rels_ext_xml }
       )
 
-      allow(@constituent).to receive_messages(
+      allow(constituent).to receive_messages(
         id: 'dd111dd1111',
-        datastreams: { 'descMetadata' => @desc_metadata_xml }
+        datastreams: { 'descMetadata' => desc_metadata_xml }
       )
 
-      release_data = { 'Searchworks' => { 'release' => true } }
-      allow(@item).to receive(:released_for).and_return(release_data)
-      allow_any_instance_of(Dor::UpdateMarcRecordService).to receive(:dor_items_for_constituents).and_return([@constituent])
-      updater = Dor::UpdateMarcRecordService.new(@item)
-      expect(updater.generate_symphony_record).to eq("8832162\taa111aa1111\t.856. 41|zAvailable to Stanford-affiliated users.|uhttp://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label")
+      allow_any_instance_of(Dor::UpdateMarcRecordService).to receive(:dor_items_for_constituents).and_return([constituent])
+      updater = Dor::UpdateMarcRecordService.new(item)
+      expect(updater.generate_symphony_records).to match_array(["8832162\taa111aa1111\t.856. 41|zAvailable to Stanford-affiliated users.|uhttp://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label"])
     end
 
-    it 'should generate symphony record for a collection object with catkey' do
+    it 'should generate blank symphony records and a regular symphony record for an item object with both previous and current catkeys' do
+      allow(identity_metadata_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_identity_metadata_3)
+      )
+
+      allow(content_metadata_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_content_metadata_1)
+      )
+
+      allow(desc_metadata_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_desc_metadata_1)
+      )
+
+      allow(rels_ext_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_rels_ext)
+      )
+
       rights_metadata_ng_xml = Nokogiri::XML(build_rights_metadata_1)
-      allow(@rights_metadata_xml).to receive_messages(
+      allow(rights_metadata_xml).to receive_messages(
         ng_xml: rights_metadata_ng_xml,
         dra_object: Dor::RightsAuth.parse(rights_metadata_ng_xml, true)
       )
 
-      allow(@identity_metadata_xml).to receive_messages(
+      allow(collection).to receive_messages(
+        label: 'Collection label',
+        id: 'cc111cc1111'
+      )
+
+      allow(item).to receive_messages(
+        id: 'aa111aa1111',
+        collections: [collection],
+        datastreams: { 'rightsMetadata' => rights_metadata_xml, 'identityMetadata' => identity_metadata_xml, 'contentMetadata' => content_metadata_xml, 'RELS-EXT' => rels_ext_xml }
+      )
+
+      allow(constituent).to receive_messages(
+        id: 'dd111dd1111',
+        datastreams: { 'descMetadata' => desc_metadata_xml }
+      )
+
+      allow_any_instance_of(Dor::UpdateMarcRecordService).to receive(:dor_items_for_constituents).and_return([constituent])
+      updater = Dor::UpdateMarcRecordService.new(item)
+      expect(updater.generate_symphony_records).to match_array(["123\taa111aa1111\t", "456\taa111aa1111\t", "8832162\taa111aa1111\t.856. 41|uhttp://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label"])
+    end
+
+    it 'should generate blank symphony records for an item object with only previous catkeys' do
+      allow(identity_metadata_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_identity_metadata_5)
+      )
+
+      allow(content_metadata_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_content_metadata_1)
+      )
+
+      allow(desc_metadata_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_desc_metadata_1)
+      )
+
+      allow(rels_ext_xml).to receive_messages(
+        ng_xml: Nokogiri::XML(build_rels_ext)
+      )
+
+      rights_metadata_ng_xml = Nokogiri::XML(build_rights_metadata_1)
+      allow(rights_metadata_xml).to receive_messages(
+        ng_xml: rights_metadata_ng_xml,
+        dra_object: Dor::RightsAuth.parse(rights_metadata_ng_xml, true)
+      )
+
+      allow(collection).to receive_messages(
+        label: 'Collection label',
+        id: 'cc111cc1111'
+      )
+
+      allow(item).to receive_messages(
+        id: 'aa111aa1111',
+        collections: [collection],
+        datastreams: { 'rightsMetadata' => rights_metadata_xml, 'identityMetadata' => identity_metadata_xml, 'contentMetadata' => content_metadata_xml, 'RELS-EXT' => rels_ext_xml }
+      )
+
+      allow(constituent).to receive_messages(
+        id: 'dd111dd1111',
+        datastreams: { 'descMetadata' => desc_metadata_xml }
+      )
+
+      allow_any_instance_of(Dor::UpdateMarcRecordService).to receive(:dor_items_for_constituents).and_return([constituent])
+      updater = Dor::UpdateMarcRecordService.new(item)
+      expect(updater.generate_symphony_records).to match_array(%W(123\taa111aa1111\t 456\taa111aa1111\t))
+    end
+
+    it 'should generate a single symphony record for a collection object with a catkey' do
+      rights_metadata_ng_xml = Nokogiri::XML(build_rights_metadata_1)
+      allow(rights_metadata_xml).to receive_messages(
+        ng_xml: rights_metadata_ng_xml,
+        dra_object: Dor::RightsAuth.parse(rights_metadata_ng_xml, true)
+      )
+
+      allow(identity_metadata_xml).to receive_messages(
         ng_xml: Nokogiri::XML(build_identity_metadata_2)
       )
 
-      allow(@identity_metadata_xml).to receive(:tag).and_return('Project : Batchelor Maps : Batch 1')
-      allow(@collection).to receive_messages(
+      allow(identity_metadata_xml).to receive(:tag).and_return('Project : Batchelor Maps : Batch 1')
+      allow(collection).to receive_messages(
         label: 'Collection label',
         id: 'aa111aa1111',
         collections: [],
-        datastreams: { 'identityMetadata' => @identity_metadata_xml, 'rightsMetadata' => @rights_metadata_xml }
+        datastreams: { 'rightsMetadata' => rights_metadata_xml, 'identityMetadata' => identity_metadata_xml }
       )
 
-      release_data = { 'Searchworks' => { 'release' => true } }
-      allow(@collection).to receive(:released_for).and_return(release_data)
-
-      updater = Dor::UpdateMarcRecordService.new(@collection)
-      expect(updater.generate_symphony_record).to eq("8832162\taa111aa1111\t.856. 41|uhttp://purl.stanford.edu/aa111aa1111|xSDR-PURL|xcollection")
+      updater = Dor::UpdateMarcRecordService.new(collection)
+      expect(updater.generate_symphony_records).to match_array(["8832162\taa111aa1111\t.856. 41|uhttp://purl.stanford.edu/aa111aa1111|xSDR-PURL|xcollection"])
     end
   end
 
-  describe '.write_symphony_record' do
+  describe '.write_symphony_records' do
     before :each do
       Dor::Config.release.symphony_path = "#{@fixtures}/sdr_purl"
       Dor::Config.release.write_marc_script = 'bin/write_marc_record_test'
@@ -213,25 +295,50 @@ RSpec.describe Dor::UpdateMarcRecordService do
       expect(File.exist?(@output_file)).to be_falsey
     end
 
-    it 'should write the symphony record to the symphony directory' do
-      marc_record = 'abcdef'
-      @updater.write_symphony_record marc_record
+    it 'should write the symphony record to the symphony directory for a single record' do
+      marc_records = ['abcdef']
+      @updater.write_symphony_records marc_records
       expect(File.exist?(@output_file)).to be_truthy
-      expect(File.read(@output_file)).to eq "#{marc_record}\n"
+      expect(File.read(@output_file)).to eq "#{marc_records.first}\n"
     end
 
-    it 'should do nothing if the symphony record is empty' do
-      @updater.write_symphony_record ''
+    it 'should write the symphony record to the symphony directory for multiple records' do
+      marc_records = %w(abcdef 12345)
+      @updater.write_symphony_records marc_records
+      expect(File.exist?(@output_file)).to be_truthy
+      expect(File.read(@output_file)).to eq "#{marc_records[0]}\n#{marc_records[1]}\n"
+    end
+
+    it 'should do nothing if the symphony record is an empty array' do
+      @updater.write_symphony_records []
       expect(File.exist?(@output_file)).to be_falsey
     end
 
     it 'should do nothing if the symphony record is nil' do
-      @updater.write_symphony_record nil
+      @updater.write_symphony_records nil
       expect(File.exist?(@output_file)).to be_falsey
     end
 
     after :each do
       FileUtils.rm_f(@output_file)
+    end
+  end
+
+  describe '.get_z_field' do
+    it 'should return a blank z message' do
+      setup_test_objects('druid:aa111aa1111', '', build_rights_metadata_1)
+      updater = Dor::UpdateMarcRecordService.new(@dor_item)
+      expect(updater.get_z_field).to eq('')
+    end
+    it 'should return a non-blank z message for a stanford only object' do
+      setup_test_objects('druid:aa111aa1111', '', build_rights_metadata_2)
+      updater = Dor::UpdateMarcRecordService.new(@dor_item)
+      expect(updater.get_z_field).to eq('|zAvailable to Stanford-affiliated users.')
+    end
+    it 'should return a non-blank z message for a location restricted object' do
+      setup_test_objects('druid:aa111aa1111', '', build_rights_metadata_3)
+      updater = Dor::UpdateMarcRecordService.new(@dor_item)
+      expect(updater.get_z_field).to eq('|zAvailable to Stanford-affiliated users.')
     end
   end
 
@@ -278,24 +385,6 @@ RSpec.describe Dor::UpdateMarcRecordService do
       updater = Dor::UpdateMarcRecordService.new(@dor_item)
       Dor::Config.release.purl_base_uri = 'http://purl.stanford.edu'
       expect(updater.get_u_field).to eq('|uhttp://purl.stanford.edu/aa111aa1111')
-    end
-  end
-
-  describe '.get_z_field' do
-    it 'should return a blank z message' do
-      setup_test_objects('druid:aa111aa1111', '', build_rights_metadata_1)
-      updater = Dor::UpdateMarcRecordService.new(@dor_item)
-      expect(updater.get_z_field).to eq('')
-    end
-    it 'should return a non-blank z message for a stanford only object' do
-      setup_test_objects('druid:aa111aa1111', '', build_rights_metadata_2)
-      updater = Dor::UpdateMarcRecordService.new(@dor_item)
-      expect(updater.get_z_field).to eq('|zAvailable to Stanford-affiliated users.')
-    end
-    it 'should return a non-blank z message for a location restricted object' do
-      setup_test_objects('druid:aa111aa1111', '', build_rights_metadata_3)
-      updater = Dor::UpdateMarcRecordService.new(@dor_item)
-      expect(updater.get_z_field).to eq('|zAvailable to Stanford-affiliated users.')
     end
   end
 
@@ -352,43 +441,43 @@ RSpec.describe Dor::UpdateMarcRecordService do
       setup_test_objects('druid:aa111aa1111', build_identity_metadata_1)
       release_data = { 'Searchworks' => { 'release' => true } }
       allow(@dor_item).to receive(:released_for).and_return(release_data)
-      expect(@umrs.released_to_searchworks).to be true
+      expect(@umrs.released_to_searchworks?).to be true
     end
     it 'should return true if release_data tag has release to=searchworks (all lowercase) and value is true' do
       setup_test_objects('druid:aa111aa1111', build_identity_metadata_1)
       release_data = { 'searchworks' => { 'release' => true } }
       allow(@dor_item).to receive(:released_for).and_return(release_data)
-      expect(@umrs.released_to_searchworks).to be true
+      expect(@umrs.released_to_searchworks?).to be true
     end
     it 'should return true if release_data tag has release to=SearchWorks (camcelcase) and value is true' do
       setup_test_objects('druid:aa111aa1111', build_identity_metadata_1)
       release_data = { 'SearchWorks' => { 'release' => true } }
       allow(@dor_item).to receive(:released_for).and_return(release_data)
-      expect(@umrs.released_to_searchworks).to be true
+      expect(@umrs.released_to_searchworks?).to be true
     end
     it 'should return false if release_data tag has release to=Searchworks and value is false' do
       setup_test_objects('druid:aa111aa1111', build_identity_metadata_2)
       release_data = { 'Searchworks' => { 'release' => false } }
       allow(@dor_item).to receive(:released_for).and_return(release_data)
-      expect(@umrs.released_to_searchworks).to be false
+      expect(@umrs.released_to_searchworks?).to be false
     end
     it 'should return false if release_data tag has release to=Searchworks but no specified release value' do
       setup_test_objects('druid:aa111aa1111', build_identity_metadata_2)
       release_data = { 'Searchworks' => { 'bogus' => 'yup' } }
       allow(@dor_item).to receive(:released_for).and_return(release_data)
-      expect(@umrs.released_to_searchworks).to be false
+      expect(@umrs.released_to_searchworks?).to be false
     end
     it 'should return false if there are no release tags at all' do
       setup_test_objects('druid:aa111aa1111', build_identity_metadata_2)
       release_data = {}
       allow(@dor_item).to receive(:released_for).and_return(release_data)
-      expect(@umrs.released_to_searchworks).to be false
+      expect(@umrs.released_to_searchworks?).to be false
     end
     it 'should return false if there are non searchworks related release tags' do
       setup_test_objects('druid:aa111aa1111', build_identity_metadata_1)
       release_data = { 'Revs' => { 'release' => true } }
       allow(@dor_item).to receive(:released_for).and_return(release_data)
-      expect(@umrs.released_to_searchworks).to be false
+      expect(@umrs.released_to_searchworks?).to be false
     end
   end
 


### PR DESCRIPTION
when writing out catkeys, cycle through all previous catkeys and write out a simple blank record for each before writing out the actual record

refactored to allow for multiple rows to be written out per object

some other refactoring and new tests

closes #73