### PR TITLE
slightly relax condition for writing z subfield to marc record

### DIFF
--- a/app/models/dor/update_marc_record_service.rb
+++ b/app/models/dor/update_marc_record_service.rb
@@ -80,7 +80,9 @@ module Dor
 
     # It returns text in the z field based on permissions
     def get_z_field
-      if @dra_object.stanford_only_unrestricted? || @dra_object.stanford_only_downloadable?
+      # @dra_object.stanford_only_rights returns a 2 element list where presence of first element indicates stanford
+      # only read restriction, and second element indicates the rule on the restriction, if any (e.g. 'no-download')
+      if @dra_object.stanford_only_rights.first.present? || @dra_object.restricted_by_location?
         '|zAvailable to Stanford-affiliated users.'
       else
         ''

--- a/spec/support/datastreams.rb
+++ b/spec/support/datastreams.rb
@@ -448,8 +448,7 @@ def build_rights_metadata_2
    </access>
    <access type="read">
     <machine>
-      <group>Stanford</group>
-      <world rule="no-download"/>
+      <group rule="no-download">stanford</group>
     </machine>
    </access>
    <use>
@@ -459,6 +458,28 @@ def build_rights_metadata_2
     <human type="creativeCommons"/>
     <machine type="creativeCommons"/>
    </use>
+  </rightsMetadata>
+  '
+end
+
+def build_rights_metadata_3
+  '<rightsMetadata>
+    <access type="discover">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <access type="read">
+      <machine>
+        <location>spec</location>
+      </machine>
+    </access>
+    <use>
+      <human type="useAndReproduction">While Special Collections is the owner of the physical and digital items, permission to examine collection materials is not an authorization to publish. These materials are made available for use in research, teaching, and private study. Any transmission or reproduction beyond that allowed by fair use requires permission from the owners of rights, heir(s) or assigns. See: http://library.stanford.edu/spc/using-collections/permission-publish. Access Condition: Content is available for access via the Special Collections Reading Room.</human>
+    </use>
+    <copyright>
+      <human>Materials may be subject to copyright.</human>
+    </copyright>
   </rightsMetadata>
   '
 end

--- a/spec/update_marc_spec.rb
+++ b/spec/update_marc_spec.rb
@@ -279,6 +279,11 @@ RSpec.describe Dor::UpdateMarcRecordService do
       updater = Dor::UpdateMarcRecordService.new(@dor_item)
       expect(updater.get_z_field).to eq('|zAvailable to Stanford-affiliated users.')
     end
+    it 'should return a non-blank z message for a location restricted object' do
+      setup_test_objects('druid:aa111aa1111', '', build_rights_metadata_3)
+      updater = Dor::UpdateMarcRecordService.new(@dor_item)
+      expect(updater.get_z_field).to eq('|zAvailable to Stanford-affiliated users.')
+    end
   end
 
   describe '.get_x1_sdrpurl_marker' do


### PR DESCRIPTION
so that all stanford restricted and location restricted objects get the field.  fixup fixture to put no-download rule on stanford object, add location restricted fixture, add location restricted test.