### PR TITLE
Update dor-services gem to ~> 5.31

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'net-http-persistent', '~> 2.9'
 gem 'marc'
 
 # DLSS/domain-specific dependencies
-gem 'dor-services', '~> 5.12'
+gem 'dor-services', '~> 5.31'
 gem 'lyber-core', '>= 2.0.2'
 gem 'workflow-archiver', '~> 2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -441,7 +441,7 @@ DEPENDENCIES
   config
   coveralls (~> 0.8)
   dlss-capistrano
-  dor-services (~> 5.12)
+  dor-services (~> 5.31)
   equivalent-xml
   erubis
   fakeweb

--- a/config/initializers/dor_config.rb
+++ b/config/initializers/dor_config.rb
@@ -102,6 +102,10 @@ Dor.configure do
     max_sleep_seconds Settings.GOOBI.MAX_SLEEP_SECONDS # max sleep seconds between tries
     base_sleep_seconds Settings.GOOBI.BASE_SLEEP_SECONDS # base sleep seconds between tries
   end
+
+  purl_services do
+    url Settings.purl_services_url
+  end
 end
 
 Dor::WorkflowArchiver.config.configure do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -66,6 +66,7 @@ SOLRIZER_URL: 'https://solr.example.com/solr/collection'
 STATUS_INDEXER_URL: 'https://status.example.com/render/?format=json&other=params'
 WORKFLOW_URL: 'https://workflow.example.com/workflow'
 SDR_URL: 'http://localhost/sdr'
+purl_services_url: ~
 
 CLEANUP:
   LOCAL_WORKSPACE_ROOT: '/dor/workspace'
@@ -80,7 +81,7 @@ RELEASE:
   SYMPHONY_PATH: './'
   WRITE_MARC_SCRIPT: 'bin/write_marc_record_test'
   PURL_BASE_URI : 'http://purl.stanford.edu'
-  
+
 GOOBI:
   URL: 'http://localhost:9292'
   DPG_WORKFLOW_NAME: 'goobiWF'


### PR DESCRIPTION
So that we can configure the app to notify purl-fetcher using the API
rather than by putting files in a NFS mount.

Also updated other dependencies.