### PR TITLE
Now that we deploy on ruby 2.3.4, drop the 2.2 build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ notifications:
   email: false
 
 rvm:
-  - 2.2.4 # deployed
-  - 2.3.4
+  - 2.3.4 # deployed
 
 bundler_args: --without production


### PR DESCRIPTION
Note that we can't add 2.4+ due to #108