### PR TITLE
Set the honeybadger_env to the capistrano deployment stage

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -34,5 +34,8 @@ set :log_level, :info
 set :linked_dirs, %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle config/certs config/settings)
 set :linked_files, %w(bin/write_marc_record config/secrets.yml config/honeybadger.yml config/newrelic.yml)
 
+# honeybadger_env otherwise defaults to rails_env
+set :honeybadger_env, fetch(:stage)
+
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'


### PR DESCRIPTION
This prevents both stage and prod from reporting as "production" and
provides consistency across dlss projects.