### PR TITLE
Switch from fakeweb to webmock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,11 +49,11 @@ group :test, :development do
   gem 'coveralls', '~> 0.8', require: false
   gem 'simplecov'
   gem 'equivalent-xml'
-  gem 'fakeweb'
   gem 'rack-console'
   gem 'rubocop', '~> 0.57.1'
   gem 'rubocop-rspec'
   gem 'capybara'
+  gem 'webmock'
 end
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.4)
       tins (~> 1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     daemons (1.2.6)
     deep_merge (1.2.1)
@@ -181,7 +183,6 @@ GEM
       nokogiri (>= 1.4.3)
     erubi (1.7.1)
     erubis (2.7.0)
-    fakeweb (1.3.0)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
@@ -189,6 +190,7 @@ GEM
       activesupport (>= 4.2.0)
     haml (4.0.7)
       tilt
+    hashdiff (0.3.7)
     honeybadger (3.3.0)
     hooks (0.4.1)
       uber (~> 0.0.14)
@@ -367,6 +369,7 @@ GEM
       mime-types
       nokogiri
       rest-client
+    safe_yaml (1.0.4)
     scrub_rb (1.0.1)
     sequel (5.9.0)
     simplecov (0.14.1)
@@ -416,6 +419,10 @@ GEM
     unf_ext (0.0.7.5)
     unicode-display_width (1.4.0)
     uuidtools (2.1.5)
+    webmock (3.4.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -444,7 +451,6 @@ DEPENDENCIES
   dor-services (~> 5.31)
   equivalent-xml
   erubis
-  fakeweb
   faraday
   honeybadger
   listen (~> 3.0.5)
@@ -465,6 +471,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
+  webmock
   workflow-archiver (~> 2.0)
 
 BUNDLED WITH

--- a/spec/controllers/marcxml_controller_spec.rb
+++ b/spec/controllers/marcxml_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe MarcxmlController do
     end
 
     it 'looks up an item by barcode' do
-      FakeWeb.register_uri(:get, Settings.CATALOG.SOLR_URL + 'barcode?wt=json&n=98765', body: { response: { docs: [{ id: '12345' }] } }.to_json)
+      stub_request(:get, Settings.CATALOG.SOLR_URL + 'barcode?wt=json&n=98765').to_return(body: { response: { docs: [{ id: '12345' }] } }.to_json)
       get :catkey, params: { barcode: '98765' }
       expect(response.body).to eq '12345'
     end
@@ -22,7 +22,7 @@ RSpec.describe MarcxmlController do
 
   describe 'GET marcxml' do
     it 'retrieves MARCXML' do
-      FakeWeb.register_uri(:get, Settings.CATALOG.SYMPHONY.JSON_URL % { catkey: resource.catkey }, body: '{}')
+      stub_request(:get, Settings.CATALOG.SYMPHONY.JSON_URL % { catkey: resource.catkey }).to_return(body: '{}')
 
       get :marcxml, params: { catkey: '12345' }
       expect(response.body).to start_with '<record'
@@ -31,7 +31,7 @@ RSpec.describe MarcxmlController do
 
   describe 'GET mods' do
     it 'transforms the MARCXML into MODS' do
-      FakeWeb.register_uri(:get, Settings.CATALOG.SYMPHONY.JSON_URL % { catkey: resource.catkey }, body: '{}')
+      stub_request(:get, Settings.CATALOG.SYMPHONY.JSON_URL % { catkey: resource.catkey }).to_return(body: '{}')
 
       get :mods, params: { catkey: '12345' }
       expect(response.body).to match(/mods/)

--- a/spec/controllers/objects_controller_spec.rb
+++ b/spec/controllers/objects_controller_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe ObjectsController do
   describe '/notify_goobi' do
     it 'notifies goobi of a new registration by making a web service call' do
       fake_request = "<stanfordCreationRequest><objectId>#{item.pid}</objectId></stanfordCreationRequest>"
-      FakeWeb.register_uri(:post, Dor::Config.goobi.url, body: fake_request, content_type: 'application/xml', status: 201)
+      stub_request(:post, Dor::Config.goobi.url).to_return(body: fake_request, headers: { 'Content-Type' => 'application/xml' }, status: 201)
       allow_any_instance_of(Dor::Goobi).to receive(:xml_request).and_return(fake_request)
       fake_response = double(RestClient::Response, headers: { content_type: 'text/xml' }, code: 201, body: '')
       expect_any_instance_of(Dor::Goobi).to receive(:register).once.and_return(fake_response)

--- a/spec/controllers/sdr_controller_spec.rb
+++ b/spec/controllers/sdr_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SdrController do
     let(:mock_response) { '<currentVersion>1</currentVersion>' }
 
     it 'retrieves the current version from SDR' do
-      FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/current_version", body: mock_response, content_type: 'application/xml')
+      stub_request(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/current_version").to_return(body: mock_response, headers: { 'Content-Type' => 'application/xml' })
 
       get :current_version, params: { druid: item.pid }
 
@@ -25,7 +25,7 @@ RSpec.describe SdrController do
     end
 
     it 'passes through error codes' do
-      FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/current_version", status: 404, body: '')
+      stub_request(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/current_version").to_return(status: 404, body: '')
 
       get :current_version, params: { druid: item.pid }
 
@@ -40,8 +40,8 @@ RSpec.describe SdrController do
     let(:mock_response_txt) { 'some file content' }
 
     it 'passes through errors' do
-      FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/content/no_such_file?version=2", status: 404)
-      FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/content/unexpected_error?version=2", status: 500)
+      stub_request(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/content/no_such_file?version=2").to_return(status: 404)
+      stub_request(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/content/unexpected_error?version=2").to_return(status: 500)
 
       get :file_content, params: { druid: item.pid, filename: 'no_such_file', version: 2 }
       expect(response.status).to eq 404
@@ -55,8 +55,9 @@ RSpec.describe SdrController do
       let(:uri_encoded_filename) { URI.encode(filename_with_spaces) }
 
       it 'handles file names with characters that need URI encoding' do
-        FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/content/#{uri_encoded_filename}?version=#{item_version}", body: mock_response_txt, content_type: content_type_txt)
-        
+        stub_request(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/content/#{uri_encoded_filename}?version=#{item_version}")
+          .to_return(body: mock_response_txt, headers: { 'Content-Type' => content_type_txt })
+
         get :file_content, params: { druid: item.pid, filename: filename_with_spaces, version: item_version }
 
         expect(response.status).to eq 200
@@ -67,8 +68,9 @@ RSpec.describe SdrController do
 
     context 'text file type' do
       it 'retrieves the content for a version of a text file from SDR' do
-        FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/content/#{content_file_name_txt}?version=#{item_version}", body: mock_response_txt, content_type: content_type_txt)
-        
+        stub_request(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/content/#{content_file_name_txt}?version=#{item_version}")
+          .to_return(body: mock_response_txt, headers: { 'Content-Type' => content_type_txt })
+
         get :file_content, params: { druid: item.pid, filename: content_file_name_txt, version: item_version }
 
         expect(response.status).to eq 200
@@ -85,8 +87,9 @@ RSpec.describe SdrController do
       let(:mock_response_jpg) { URI.encode_www_form_component(File.binread(img_fixture_filename)) }
 
       it 'retrieves the content for a version of a text file from SDR' do
-        FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/content/#{content_file_name_jpg}?version=#{item_version}", body: mock_response_jpg, content_type: content_type_jpg)
-        
+        stub_request(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/content/#{content_file_name_jpg}?version=#{item_version}")
+          .to_return(body: mock_response_jpg, headers: { 'Content-Type' => content_type_jpg })
+
         get :file_content, params: { druid: item.pid, filename: content_file_name_jpg, version: item_version }
 
         expect(response.status).to eq 200
@@ -108,8 +111,9 @@ RSpec.describe SdrController do
 
     context 'with an explicit version' do
       it 'passes the version to SDR' do
-        FakeWeb.register_uri(:post, "#{Dor::Config.sdr.url}/objects/#{item.pid}/cm-inv-diff?subset=all&version=5", body: mock_response, content_type: 'application/xml')
-        
+        stub_request(:post, "#{Dor::Config.sdr.url}/objects/#{item.pid}/cm-inv-diff?subset=all&version=5")
+          .to_return(body: mock_response, headers: { 'Content-Type' => 'application/xml' })
+
         post :cm_inv_diff, params: { druid: item.pid, subset: 'all', version: 5 }
         expect(response.status).to eq 200
         expect(response.body).to eq mock_response
@@ -118,8 +122,9 @@ RSpec.describe SdrController do
     end
 
     it 'retrieves the diff from SDR' do
-      FakeWeb.register_uri(:post, "#{Dor::Config.sdr.url}/objects/#{item.pid}/cm-inv-diff?subset=all", body: mock_response, content_type: 'application/xml')
-      
+      stub_request(:post, "#{Dor::Config.sdr.url}/objects/#{item.pid}/cm-inv-diff?subset=all")
+        .to_return(body: mock_response, headers: { 'Content-Type' => 'application/xml' })
+
       post :cm_inv_diff, params: { druid: item.pid, subset: 'all' }
       expect(response.status).to eq 200
       expect(response.body).to eq mock_response
@@ -129,7 +134,8 @@ RSpec.describe SdrController do
 
   describe 'signatureCatalog' do
     it 'retrieves the catalog from SDR' do
-      FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/manifest/signatureCatalog.xml", body: '<catalog />', content_type: 'application/xml')
+      stub_request(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/manifest/signatureCatalog.xml")
+        .to_return(body: '<catalog />', headers: { 'Content-Type' => 'application/xml' })
 
       get :ds_manifest, params: { druid: item.pid, dsname: 'signatureCatalog.xml' }
 
@@ -139,7 +145,8 @@ RSpec.describe SdrController do
     end
 
     it 'passes through errors' do
-      FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/manifest/signatureCatalog.xml", status: 428)
+      stub_request(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/manifest/signatureCatalog.xml")
+        .to_return(status: 428)
 
       get :ds_manifest, params: { druid: item.pid, dsname: 'signatureCatalog.xml' }
 
@@ -149,8 +156,9 @@ RSpec.describe SdrController do
 
   describe 'metadata services' do
     it 'retrieves the datastream from SDR' do
-      FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/metadata/whatever", body: 'content', content_type: 'application/xml')
-      
+      stub_request(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/metadata/whatever")
+        .to_return(body: 'content', headers: { 'Content-Type' => 'application/xml' })
+
       get :ds_metadata, params: { druid: item.pid, dsname: 'whatever' }
 
       expect(response.status).to eq 200
@@ -159,7 +167,8 @@ RSpec.describe SdrController do
     end
 
     it 'passes through errors' do
-      FakeWeb.register_uri(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/metadata/whatever", status: 428)
+      stub_request(:get, "#{Dor::Config.sdr.url}/objects/#{item.pid}/metadata/whatever")
+        .to_return(status: 428)
 
       get :ds_metadata, params: { druid: item.pid, dsname: 'whatever' }
 

--- a/spec/goobi_spec.rb
+++ b/spec/goobi_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Dor::Goobi do
   end
 
   it 'makes a call to the goobi server with the appropriate xml params' do
-    FakeWeb.register_uri(:post, Dor::Config.goobi.url, body: '<somexml/>', content_type: 'text/xml')
+    stub_request(:post, Dor::Config.goobi.url).to_return(body: '<somexml/>', headers: { 'Content-Type' => 'text/xml' })
     expect(@goobi).to receive(:xml_request)
     response = @goobi.register
     expect(response.code).to eq(200)

--- a/spec/models/symphony_reader_spec.rb
+++ b/spec/models/symphony_reader_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SymphonyReader do
 
   describe '#to_marc' do
     before do
-      FakeWeb.register_uri(:get, Settings.CATALOG.SYMPHONY.JSON_URL % { catkey: catkey }, body: body.to_json)
+      stub_request(:get, Settings.CATALOG.SYMPHONY.JSON_URL % { catkey: catkey }).to_return(body: body.to_json)
     end
 
     let(:body) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,7 +11,7 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 require 'rack/test'
-require 'fakeweb'
+require 'webmock/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -50,6 +50,10 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include AuthHelper
+
+  config.before :suite do
+    WebMock.disable_net_connect!(allow_localhost: true)
+  end
 end
 
 TEST_WORKSPACE = (Dor::Config.stacks.local_workspace_root = 'tmp/dor/workspace')


### PR DESCRIPTION
Fakeweb is no longer maintained (last release 2010) and doesn't support
ruby > 2.4+

Fixes #108