### PR TITLE
add workspace service for creating workspaces

### DIFF
--- a/app/services/workspace_service.rb
+++ b/app/services/workspace_service.rb
@@ -1,0 +1,11 @@
+# Creates workspaces.  This replaces https://github.com/sul-dlss/dor-services/blob/master/lib/dor/models/concerns/assembleable.rb
+class WorkspaceService
+  # @param [Dor::Item] work the work to create the workspace for
+  # @param [String] source the path to create
+  def self.create(work, source)
+    druid = DruidTools::Druid.new(work.pid, Dor::Config.stacks.local_workspace_root)
+    return druid.mkdir if source.nil?
+
+    druid.mkdir_with_final_link(source)
+  end
+end

--- a/spec/services/workspace_service_spec.rb
+++ b/spec/services/workspace_service_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe WorkspaceService do
+  let(:temp_workspace) { '/tmp/dor_ws' }
+
+  before do
+    FileUtils.rm_rf(temp_workspace)
+
+    Dor::Config.push! do |config|
+      config.suri.mint_ids false
+      config.solr.url 'http://solr.edu/solrizer'
+      config.fedora.url 'http://fedora.edu'
+      config.stacks.local_workspace_root temp_workspace
+    end
+
+    FileUtils.mkdir_p(temp_workspace)
+  end
+
+  after do
+    Dor::Config.pop!
+    FileUtils.rm_rf(temp_workspace)
+  end
+
+  describe '.create' do
+    let(:druid_path) { File.join(temp_workspace, 'aa', '123', 'bb', '7890', 'aa123bb7890') }
+    let(:work) { AssembleableVersionableItem.new.tap { |x| x.pid = 'druid:aa123bb7890' } }
+
+    before do
+      FileUtils.rm_rf(File.join(temp_workspace, 'aa'))
+    end
+
+    it 'creates a plain directory in the workspace when passed no source directory' do
+      described_class.create(work, nil)
+      expect(File).to be_directory(druid_path)
+      expect(File).not_to be_symlink(druid_path)
+    end
+
+    it 'creates a link in the workspace to a passed in source directory' do
+      source_dir = '/tmp/content_dir'
+      FileUtils.mkdir_p(source_dir)
+      described_class.create(work, source_dir)
+
+      expect(File).to be_symlink(druid_path)
+      expect(File.readlink(druid_path)).to eq(source_dir)
+    end
+  end
+end


### PR DESCRIPTION
This will enable us to remove the `Dor::Assemblable` concern from dor-services.
Since dor-services-app is the only one to call that function, it makes sense to remove it
from the library and keep the code close to the caller.

See https://github.com/sul-dlss/dor-services/blob/master/lib/dor/models/concerns/assembleable.rb