### PR TITLE
Return title instead of label in Goobi XML

### DIFF
--- a/app/models/dor/goobi.rb
+++ b/app/models/dor/goobi.rb
@@ -26,7 +26,7 @@ module Dor
             <objectId>#{@druid_obj.id}</objectId>
             <objectType>#{object_type}</objectType>
             <sourceID>#{@druid_obj.source_id.encode(:xml => :text)}</sourceID>
-            <title>#{@druid_obj.label.encode(:xml => :text)}</title>
+            <title>#{title_or_label}</title>
             <contentType>#{content_type}</contentType>
             <project>#{project_name.encode(:xml => :text)}</project>
             <catkey>#{ckey}</catkey>

--- a/app/models/dor/service_item.rb
+++ b/app/models/dor/service_item.rb
@@ -122,5 +122,23 @@ module Dor
         GoobiTag.new(name: tag_split[0], value: tag_split[1])
       end
     end
+
+    private
+
+    def title_or_label
+      title_element = primary_mods_title_info_element
+      return title_element.content.strip if title_element.respond_to?(:content) && title_element.content.present?
+      @druid_obj.label.encode(xml: :text)
+    end
+
+    def primary_mods_title_info_element
+      return nil unless @druid_obj.datastreams['descMetadata']
+
+      title_info = @druid_obj.datastreams['descMetadata'].ng_xml.xpath('//mods:mods/mods:titleInfo[not(@type)]', mods: 'http://www.loc.gov/mods/v3').first
+      title_info ||= @druid_obj.datastreams['descMetadata'].ng_xml.xpath('//mods:mods/mods:titleInfo[@usage="primary"]', mods: 'http://www.loc.gov/mods/v3').first
+      title_info ||= @druid_obj.datastreams['descMetadata'].ng_xml.xpath('//mods:mods/mods:titleInfo', mods: 'http://www.loc.gov/mods/v3').first
+
+      title_info
+    end
   end
 end

--- a/app/models/dor/update_marc_record_service.rb
+++ b/app/models/dor/update_marc_record_service.rb
@@ -180,16 +180,6 @@ module Dor
       end
     end
 
-    def primary_mods_title_info_element
-      return nil unless @druid_obj.datastreams['descMetadata']
-
-      title_info = @druid_obj.datastreams['descMetadata'].ng_xml.xpath('//mods:mods/mods:titleInfo[not(@type)]', mods: 'http://www.loc.gov/mods/v3').first
-      title_info ||= @druid_obj.datastreams['descMetadata'].ng_xml.xpath('//mods:mods/mods:titleInfo[@usage="primary"]', mods: 'http://www.loc.gov/mods/v3').first
-      title_info ||= @druid_obj.datastreams['descMetadata'].ng_xml.xpath('//mods:mods/mods:titleInfo', mods: 'http://www.loc.gov/mods/v3').first
-
-      title_info
-    end
-
     # adapted from mods_display
     def parts_delimiter(elements)
       # index will retun nil which is not comparable so we call 100

--- a/spec/dor/goobi_spec.rb
+++ b/spec/dor/goobi_spec.rb
@@ -1,9 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Dor::Goobi do
+  subject(:goobi) { Dor::Goobi.new(item) }
+
   let(:pid) { 'druid:aa123bb4567' }
   let(:item) { Dor::Item.new(pid: pid) }
 
+  # rubocop:disable RSpec/SubjectStub
   before do
     # all of the methods we are stubbing out below are tested elsewhere,
     #  this just lets us test the methods in goobi.rb without doing a lot of setup
@@ -11,20 +14,40 @@ RSpec.describe Dor::Goobi do
     allow(item).to receive(:source_id).and_return('some_source_id')
     allow(item).to receive(:label).and_return('Object Title')
     allow(item).to receive(:content_type_tag).and_return('book')
-    @goobi = Dor::Goobi.new(item)
-    allow(@goobi).to receive(:project_name).and_return('Project Name')
-    allow(@goobi).to receive(:object_type).and_return('item')
-    allow(@goobi).to receive(:ckey).and_return('ckey_12345')
-    allow(@goobi).to receive(:goobi_workflow_name).and_return('goobi_workflow')
-    allow(@goobi).to receive(:barcode).and_return('barcode_12345')
-    allow(@goobi).to receive(:collection_id).and_return('druid:oo000oo0001')
-    allow(@goobi).to receive(:collection_name).and_return('collection name')
+    allow(goobi).to receive(:project_name).and_return('Project Name')
+    allow(goobi).to receive(:object_type).and_return('item')
+    allow(goobi).to receive(:ckey).and_return('ckey_12345')
+    allow(goobi).to receive(:goobi_workflow_name).and_return('goobi_workflow')
+    allow(goobi).to receive(:barcode).and_return('barcode_12345')
+    allow(goobi).to receive(:collection_id).and_return('druid:oo000oo0001')
+    allow(goobi).to receive(:collection_name).and_return('collection name')
+  end
+  # rubocop:enable RSpec/SubjectStub
+
+  describe '#title_or_label' do
+    subject(:xml) { Nokogiri::XML(goobi.xml_request).xpath('//title').first.content }
+
+    context 'when MODS title is present' do
+      before do
+        item.datastreams['descMetadata'].ng_xml = build_desc_metadata_1
+      end
+
+      it 'returns title text' do
+        expect(xml).to eq 'Constituent label'
+      end
+    end
+
+    context 'when MODS title is absent or empty' do
+      it 'returns object label' do
+        expect(xml).to eq 'Object Title'
+      end
+    end
   end
 
   it 'creates the correct xml request without ocr tag present' do
     allow(item).to receive(:tags).and_return(['DPG : Workflow : book_workflow & stuff', 'Process : Content Type : Book', 'LAB : MAPS'])
-    expect(@goobi.goobi_xml_tags).to eq('<tag name="DPG" value="Workflow : book_workflow &amp; stuff"/><tag name="Process" value="Content Type : Book"/><tag name="LAB" value="MAPS"/>')
-    expect(@goobi.xml_request).to be_equivalent_to <<-END
+    expect(goobi.goobi_xml_tags).to eq('<tag name="DPG" value="Workflow : book_workflow &amp; stuff"/><tag name="Process" value="Content Type : Book"/><tag name="LAB" value="MAPS"/>')
+    expect(goobi.xml_request).to be_equivalent_to <<-END
       <stanfordCreationRequest>
         <objectId>#{pid}</objectId>
         <objectType>item</objectType>
@@ -50,8 +73,8 @@ RSpec.describe Dor::Goobi do
 
   it 'creates the correct xml request with ocr tag present' do
     allow(item).to receive(:tags).and_return(['DPG : Workflow : book_workflow', 'DPG : OCR : TRUE'])
-    expect(@goobi.goobi_xml_tags).to eq('<tag name="DPG" value="Workflow : book_workflow"/><tag name="DPG" value="OCR : TRUE"/>')
-    expect(@goobi.xml_request).to be_equivalent_to <<-END
+    expect(goobi.goobi_xml_tags).to eq('<tag name="DPG" value="Workflow : book_workflow"/><tag name="DPG" value="OCR : TRUE"/>')
+    expect(goobi.xml_request).to be_equivalent_to <<-END
       <stanfordCreationRequest>
         <objectId>#{pid}</objectId>
         <objectType>item</objectType>
@@ -76,14 +99,16 @@ RSpec.describe Dor::Goobi do
 
   it 'creates the correct xml request with no tags present' do
     allow(item).to receive(:tags).and_return([])
-    expect(@goobi.goobi_xml_tags).to eq('')
-    expect(@goobi.xml_request).to include('<tags></tags>')
+    expect(goobi.goobi_xml_tags).to eq('')
+    expect(goobi.xml_request).to include('<tags></tags>')
   end
 
+  # rubocop:disable RSpec/SubjectStub
   it 'makes a call to the goobi server with the appropriate xml params' do
     stub_request(:post, Dor::Config.goobi.url).to_return(body: '<somexml/>', headers: { 'Content-Type' => 'text/xml' })
-    expect(@goobi).to receive(:xml_request)
-    response = @goobi.register
+    expect(goobi).to receive(:xml_request)
+    response = goobi.register
     expect(response.code).to eq(200)
   end
+  # rubocop:enable RSpec/SubjectStub
 end


### PR DESCRIPTION
Fixes sul-dlss/goobi-robot#30

When the Goobi XML is created, use the text of the first MODS title for the document title if present. If not present, use the object label. Prior to this change, the object label was always used in this context, but the label is not always present, requiring downstream failure and manual remediation.