### PR TITLE
 Bump dor-services and use services for versioning and workspace creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,6 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
 # Ruby general dependencies
 gem 'okcomputer'
 gem 'config'

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'net-http-persistent', '~> 2.9'
 gem 'marc'
 
 # DLSS/domain-specific dependencies
-gem 'dor-services', '~> 6.0'
+gem 'dor-services', '~> 6.1'
 gem 'lyber-core', '>= 2.0.2'
 gem 'workflow-archiver', '~> 3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -480,9 +480,8 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
-  tzinfo-data
   webmock
   workflow-archiver (~> 3.0)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    active-fedora (8.6.0)
+    active-fedora (8.7.0)
       active-triples (~> 0.4.0)
       activesupport (>= 4.2.10)
       deprecation
@@ -108,7 +108,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
-    daemons (1.2.6)
+    daemons (1.3.1)
     deep_merge (1.2.1)
     deprecation (0.99.0)
       activesupport
@@ -123,12 +123,13 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.3.0)
       nokogiri
-    dor-services (6.0.5)
-      active-fedora (>= 7.0, < 9.a)
+    dor-services (6.1.6)
+      active-fedora (>= 8.7.0, < 9)
       activesupport (>= 4.2.10, < 6.0.0)
       confstruct (~> 0.2.7)
       deprecation (~> 0)
       dor-rights-auth (~> 1.0, >= 1.2.0)
+      dor-services-client (~> 0.4)
       dor-workflow-service (~> 2.0, >= 2.0.1)
       druid-tools (>= 0.4.1)
       equivalent-xml (~> 0.5, >= 0.5.1)
@@ -148,6 +149,10 @@ GEM
       stanford-mods-normalizer (~> 0.1)
       systemu (~> 2.6)
       uuidtools (~> 2.1.4)
+    dor-services-client (0.7.0)
+      activesupport (>= 4.2, < 6)
+      faraday (~> 0.15)
+      nokogiri (~> 1.8)
     dor-workflow-service (2.3.0)
       activesupport (>= 3.2.1, < 6)
       confstruct (>= 0.2.7, < 2)
@@ -239,10 +244,10 @@ GEM
       json
       nokogiri
       nokogiri-happymapper
-    mods (2.4.0)
+    mods (2.4.1)
       edtf
       iso-639
-      nokogiri
+      nokogiri (>= 1.6.6)
       nom-xml (~> 1.0)
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
@@ -257,7 +262,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     nokogiri-happymapper (0.8.0)
       nokogiri (~> 1.5)
-    nom-xml (1.0.0)
+    nom-xml (1.1.0)
       activesupport (>= 3.2.18)
       i18n
       nokogiri
@@ -316,7 +321,7 @@ GEM
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (1.99.0)
       rdf (~> 1.99)
-    rdf-rdfa (1.99.2)
+    rdf-rdfa (1.99.3)
       haml (>= 4.0, < 6.0)
       htmlentities (~> 4.3)
       rdf (~> 1.99)
@@ -413,7 +418,7 @@ GEM
       mods (~> 2.2)
     stanford-mods-normalizer (0.1.0)
       nokogiri (~> 1.8)
-    stomp (1.4.6)
+    stomp (1.4.8)
     systemu (2.6.5)
     temple (0.8.0)
     term-ansicolor (1.7.0)
@@ -459,7 +464,7 @@ DEPENDENCIES
   config
   coveralls (~> 0.8)
   dlss-capistrano
-  dor-services (~> 6.0)
+  dor-services (~> 6.1)
   equivalent-xml
   faraday
   honeybadger

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -26,14 +26,13 @@ class ObjectsController < ApplicationController
     end
   end
 
-  # The param, source, can be passed as apended parameter to url:
+  # The param, source, can be passed as appended parameter to url:
   #  http://lyberservices-dev/dor/v1/objects/{druid}/initialize_workspace?source=/path/to/content/dir/for/druid
   # or
   # It can be passed in the body of the request as application/x-www-form-urlencoded parameters, as if submitted from a form
   # TODO: We could get away with loading a simple object that mixes in Dor::Assembleable.  It just needs to implement #pid
   def initialize_workspace
     WorkspaceService.create(@item, params[:source])
-    @item.initialize_workspace(params[:source])
     head :created
   end
 

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -2,8 +2,7 @@ class VersionsController < ApplicationController
   before_action :load_item
 
   def create
-    @item.open_new_version
-    @item.save
+    Dor::VersionService.open(@item)
     render plain: @item.current_version
   end
 
@@ -23,7 +22,7 @@ class VersionsController < ApplicationController
         sym_params[:significance] = sym_params[:significance].to_sym
       end
     end
-    @item.close_version sym_params
+    Dor::VersionService.close(@item, sym_params)
     render plain: "version #{@item.current_version} closed"
   end
 end

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -20,13 +20,13 @@ RSpec.describe VersionsController do
 
   describe '/versions/current/close' do
     it 'closes the current version when posted to' do
-      expect(item).to receive(:close_version)
+      expect(Dor::VersionService).to receive(:close)
       post :close_current, params: { object_id: item.pid }
       expect(response.body).to match(/version 1 closed/)
     end
 
-    it 'forwards optional params to the Dor::Item#close_version method' do
-      expect(item).to receive(:close_version).with(:description => 'some text', :significance => :major)
+    it 'forwards optional params to the Dor::VersionService#close method' do
+      expect(Dor::VersionService).to receive(:close).with(item, description: 'some text', significance: :major)
       post :close_current, params: { object_id: item.pid }, body: %( {"description": "some text", "significance": "major"} )
       expect(response.body).to match(/version 1 closed/)
     end
@@ -38,8 +38,8 @@ RSpec.describe VersionsController do
       expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', item.pid, 'submitted').and_return(nil)
       expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', item.pid, 'opened').and_return(nil)
       expect(Sdr::Client).to receive(:current_version).and_return(1)
-      expect(item).to receive(:create_workflow).with('versioningWF')
-      allow(item).to receive(:save)
+      # Do not test workflow side effects in dor-services-app; that is dor-services' responsibility
+      allow(Dor::CreateWorkflowService).to receive(:create_workflow)
       post :create, params: { object_id: item.pid }
       expect(response.body).to eq('2')
     end


### PR DESCRIPTION
Refs sul-dlss/argo#1277

Also, remove unnecessary tzinfo-data dependency, as this is only included in the bundle on environments we do not deploy in (Windows and JRuby), and in the meantime, its presence in the bundle causes every bundle command to include a warning message. This message can trip up shell aliases and functions that use bundler, such as grepping the bundle to sleuth out behavior within dependencies.


