### PR TITLE
Pass optional version params to Dor::VersionService

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -2,7 +2,7 @@ class VersionsController < ApplicationController
   before_action :load_item
 
   def create
-    Dor::VersionService.open(@item)
+    Dor::VersionService.open(@item, open_params)
     render plain: @item.current_version
   end
 
@@ -11,18 +11,33 @@ class VersionsController < ApplicationController
   end
 
   def close_current
-    request.body.rewind
-    body = request.body.read
-    if body.strip.empty?
-      sym_params = nil
-    else
-      raw_params = JSON.parse body
-      sym_params = Hash[raw_params.map { |(k, v)| [k.to_sym, v] }]
-      if sym_params[:significance]
-        sym_params[:significance] = sym_params[:significance].to_sym
-      end
-    end
-    Dor::VersionService.close(@item, sym_params)
+    Dor::VersionService.close(@item, close_params)
     render plain: "version #{@item.current_version} closed"
+  end
+
+  private
+
+  def open_params
+    params.permit(
+      :assume_accessioned,
+      :create_workflows_ds,
+      vers_md_upd_info: [
+        :description,
+        :opening_user_name,
+        :significance
+      ]
+    ).to_h.deep_symbolize_keys
+  end
+
+  def close_params
+    symbolized_hash = params.permit(
+      :description,
+      :significance,
+      :start_accession,
+      :version_num
+    ).to_h.symbolize_keys
+    # Downstream code expects the significance value to be a symbol
+    symbolized_hash[:significance] = symbolized_hash[:significance].to_sym if symbolized_hash.key?(:significance)
+    symbolized_hash
   end
 end

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -21,26 +21,61 @@ RSpec.describe VersionsController do
   describe '/versions/current/close' do
     it 'closes the current version when posted to' do
       expect(Dor::VersionService).to receive(:close)
-      post :close_current, params: { object_id: item.pid }
+      post :close_current, params: { object_id: item.pid }, as: :json
       expect(response.body).to match(/version 1 closed/)
     end
 
     it 'forwards optional params to the Dor::VersionService#close method' do
       expect(Dor::VersionService).to receive(:close).with(item, description: 'some text', significance: :major)
-      post :close_current, params: { object_id: item.pid }, body: %( {"description": "some text", "significance": "major"} )
+      post :close_current, params: { object_id: item.pid }, body: %( {"description": "some text", "significance": "major"} ), as: :json
       expect(response.body).to match(/version 1 closed/)
     end
   end
 
   describe '/versions' do
-    it 'opens a new object version when posted to' do
+    # rubocop:disable RSpec/VerifiedDoubles
+    let(:fake_events_ds) { double('events') }
+    # rubocop:enable RSpec/VerifiedDoubles
+    let(:open_params) do
+      {
+        assume_accessioned: false,
+        create_workflows_ds: false,
+        vers_md_upd_info: {
+          significance: 'minor',
+          description: 'bar',
+          opening_user_name: opening_user_name
+        }
+      }
+    end
+    let(:opening_user_name) { 'foo' }
+
+    # rubocop:disable RSpec/ExpectInHook
+    before do
       expect(Dor::Config.workflow.client).to receive(:get_lifecycle).with('dor', item.pid, 'accessioned').and_return(true)
       expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', item.pid, 'submitted').and_return(nil)
       expect(Dor::Config.workflow.client).to receive(:get_active_lifecycle).with('dor', item.pid, 'opened').and_return(nil)
       expect(Sdr::Client).to receive(:current_version).and_return(1)
+
+      allow(fake_events_ds).to receive(:add_event)
+      allow(item).to receive(:events).and_return(fake_events_ds)
+      allow(item).to receive(:save)
       # Do not test workflow side effects in dor-services-app; that is dor-services' responsibility
       allow(Dor::CreateWorkflowService).to receive(:create_workflow)
-      post :create, params: { object_id: item.pid }
+    end
+    # rubocop:enable RSpec/ExpectInHook
+
+    it 'opens a new object version when posted to' do
+      post :create, params: { object_id: item.pid }, as: :json
+      expect(response.body).to eq('2')
+    end
+
+    it 'forwards optional params to the Dor::VersionService#open method' do
+      expect(Dor::VersionService).to receive(:open).with(
+        item,
+        open_params
+      ).and_call_original
+      post :create, params: { object_id: item.pid }, body: open_params.to_json, as: :json
+      expect(fake_events_ds).to have_received(:add_event).with('open', opening_user_name, 'Version 2 opened')
       expect(response.body).to eq('2')
     end
   end


### PR DESCRIPTION
* Pass POSTed version params on to `Dor::VersionService`.
* Remove custom param-handling behavior around parsing POSTed JSON bodies to
  params hashes, since Rails already does this for us now.

Refs sul-dlss/argo#1277