### PR TITLE
Move PublishMetadataService in from common-accessioning

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,7 +29,7 @@ Lint/UriEscapeUnescape:
     - 'app/controllers/sdr_controller.rb'
     - 'spec/controllers/sdr_controller_spec.rb'
 
-# Offense count: 15
+# Offense count: 19
 Metrics/AbcSize:
   Max: 119
 
@@ -42,7 +42,7 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 24
 
-# Offense count: 22
+# Offense count: 25
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/MethodLength:
   Max: 58
@@ -78,12 +78,19 @@ Naming/VariableName:
   Exclude:
     - 'spec/rails_helper.rb'
 
-# Offense count: 11
+# Offense count: 26
 RSpec/AnyInstance:
   Exclude:
     - 'spec/controllers/objects_controller_spec.rb'
     - 'spec/dor/update_marc_record_service_spec.rb'
+    - 'spec/services/public_xml_service_spec.rb'
+    - 'spec/services/publish_metadata_service_spec.rb'
     - 'spec/services/registration_service_spec.rb'
+
+# Offense count: 21
+RSpec/Be:
+  Exclude:
+    - 'spec/services/public_xml_service_spec.rb'
 
 # Offense count: 1
 RSpec/BeforeAfterAll:
@@ -93,7 +100,7 @@ RSpec/BeforeAfterAll:
     - 'spec/support/**/*.rb'
     - 'spec/dor/update_marc_record_service_spec.rb'
 
-# Offense count: 20
+# Offense count: 22
 # Configuration parameters: Prefixes.
 # Prefixes: when, with, without
 RSpec/ContextWording:
@@ -101,6 +108,8 @@ RSpec/ContextWording:
     - 'spec/controllers/objects_controller_spec.rb'
     - 'spec/controllers/sdr_controller_spec.rb'
     - 'spec/dor/update_marc_record_service_spec.rb'
+    - 'spec/services/public_xml_service_spec.rb'
+    - 'spec/services/publish_metadata_service_spec.rb'
     - 'spec/services/registration_service_spec.rb'
     - 'spec/services/version_service_spec.rb'
 
@@ -134,7 +143,7 @@ RSpec/EmptyLineAfterSubject:
   Exclude:
     - 'spec/models/symphony_reader_spec.rb'
 
-# Offense count: 34
+# Offense count: 39
 # Configuration parameters: Max.
 RSpec/ExampleLength:
   Exclude:
@@ -144,14 +153,19 @@ RSpec/ExampleLength:
     - 'spec/dor/goobi_spec.rb'
     - 'spec/dor/service_item_spec.rb'
     - 'spec/dor/update_marc_record_service_spec.rb'
+    - 'spec/services/dublin_core_service_spec.rb'
+    - 'spec/services/public_xml_service_spec.rb'
+    - 'spec/services/publish_metadata_service_spec.rb'
     - 'spec/services/registration_service_spec.rb'
     - 'spec/services/release_tags_spec.rb'
     - 'spec/services/version_service_spec.rb'
 
-# Offense count: 4
+# Offense count: 19
 RSpec/ExpectInHook:
   Exclude:
     - 'spec/dor/update_marc_record_service_spec.rb'
+    - 'spec/services/public_xml_service_spec.rb'
+    - 'spec/services/publish_metadata_service_spec.rb'
     - 'spec/services/registration_service_spec.rb'
 
 # Offense count: 146
@@ -163,7 +177,7 @@ RSpec/InstanceVariable:
     - 'spec/dor/update_marc_record_service_spec.rb'
     - 'spec/services/registration_service_spec.rb'
 
-# Offense count: 54
+# Offense count: 56
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: have_received, receive
 RSpec/MessageSpies:
@@ -173,15 +187,17 @@ RSpec/MessageSpies:
     - 'spec/controllers/workflows_controller_spec.rb'
     - 'spec/dor/goobi_spec.rb'
     - 'spec/dor/update_marc_record_service_spec.rb'
+    - 'spec/services/public_xml_service_spec.rb'
+    - 'spec/services/publish_metadata_service_spec.rb'
     - 'spec/services/registration_service_spec.rb'
     - 'spec/services/version_service_spec.rb'
 
-# Offense count: 65
+# Offense count: 75
 # Configuration parameters: AggregateFailuresByDefault.
 RSpec/MultipleExpectations:
   Max: 8
 
-# Offense count: 9
+# Offense count: 17
 RSpec/NestedGroups:
   Max: 5
 
@@ -201,12 +217,18 @@ RSpec/ReturnFromStub:
   Exclude:
     - 'spec/controllers/workflows_controller_spec.rb'
 
-# Offense count: 6
+# Offense count: 1
+RSpec/ScatteredLet:
+  Exclude:
+    - 'spec/services/public_xml_service_spec.rb'
+
+# Offense count: 8
 RSpec/ScatteredSetup:
   Exclude:
     - 'spec/controllers/objects_controller_spec.rb'
     - 'spec/controllers/sdr_controller_spec.rb'
     - 'spec/controllers/versions_controller_spec.rb'
+    - 'spec/services/publish_metadata_service_spec.rb'
 
 # Offense count: 5
 RSpec/SubjectStub:
@@ -252,7 +274,7 @@ Style/ConditionalAssignment:
   Exclude:
     - 'spec/support/foxml_helper.rb'
 
-# Offense count: 12
+# Offense count: 14
 Style/Documentation:
   Exclude:
     - 'spec/**/*'
@@ -265,6 +287,8 @@ Style/Documentation:
     - 'app/models/dor/registration_response.rb'
     - 'app/models/dor/service_item.rb'
     - 'app/models/dor/update_marc_record_service.rb'
+    - 'app/services/dublin_core_service.rb'
+    - 'app/services/public_xml_service.rb'
     - 'app/services/registration_service.rb'
     - 'config/application.rb'
     - 'config/initializers/okcomputer.rb'

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -43,7 +43,7 @@ class ObjectsController < ApplicationController
   end
 
   def publish
-    Dor::PublishMetadataService.publish(@item)
+    PublishMetadataService.publish(@item)
     head :created
   end
 

--- a/app/services/dublin_core_service.rb
+++ b/app/services/dublin_core_service.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class DublinCoreService
+  MODS_TO_DC_XSLT = Nokogiri::XSLT(File.new(File.expand_path(File.dirname(__FILE__) + '/mods2dc.xslt')))
+  XMLNS_OAI_DC = 'http://www.openarchives.org/OAI/2.0/oai_dc/'
+  class CrosswalkError < RuntimeError; end
+
+  def initialize(work, include_collection_as_related_item: true)
+    @work = work
+    @include_collection = include_collection_as_related_item
+  end
+
+  # Generates Dublin Core from the MODS in the descMetadata datastream using the LoC mods2dc stylesheet
+  #    Should not be used for the Fedora DC datastream
+  # @raise [CrosswalkError] Raises an Exception if the generated DC is empty or has no children
+  # @return [Nokogiri::XML::Document] the DublinCore XML document object
+  def ng_xml
+    dc_doc = MODS_TO_DC_XSLT.transform(desc_md)
+    dc_doc.xpath('/oai_dc:dc/*[count(text()) = 0]', oai_dc: XMLNS_OAI_DC).remove # Remove empty nodes
+    raise CrosswalkError, "Dor::Item#generate_dublin_core produced incorrect xml (no root):\n#{dc_doc.to_xml}" if dc_doc.root.nil?
+    raise CrosswalkError, "Dor::Item#generate_dublin_core produced incorrect xml (no children):\n#{dc_doc.to_xml}" if dc_doc.root.children.empty?
+
+    dc_doc
+  end
+
+  # @return [String] the DublinCore XML document object
+  delegate :to_xml, to: :ng_xml
+
+  private
+
+  def desc_md
+    return Dor::PublicDescMetadataService.new(work).ng_xml(include_access_conditions: false) if include_collection?
+
+    work.descMetadata.ng_xml
+  end
+
+  def include_collection?
+    @include_collection
+  end
+  attr_reader :work
+end

--- a/app/services/mods2dc.xslt
+++ b/app/services/mods2dc.xslt
@@ -1,0 +1,474 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:mods="http://www.loc.gov/mods/v3" exclude-result-prefixes="mods"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:srw_dc="info:srw/schema/1/dc-schema"
+	xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<!--
+This stylesheet transforms MODS version 3.2 records and collections of records to simple Dublin Core (DC) records,
+based on the Library of Congress' MODS to simple DC mapping <http://www.loc.gov/standards/mods/mods-dcsimple.html>
+
+The stylesheet will transform a collection of MODS 3.2 records into simple Dublin Core (DC)
+as expressed by the SRU DC schema <http://www.loc.gov/standards/sru/dc-schema.xsd>
+
+The stylesheet will transform a single MODS 3.2 record into simple Dublin Core (DC)
+as expressed by the OAI DC schema <http://www.openarchives.org/OAI/2.0/oai_dc.xsd>
+
+Because MODS is more granular than DC, transforming a given MODS element or subelement to a DC element frequently results in less precise tagging,
+and local customizations of the stylesheet may be necessary to achieve desired results.
+
+This stylesheet makes the following decisions in its interpretation of the MODS to simple DC mapping:
+
+When the roleTerm value associated with a name is creator, then name maps to dc:creator
+When there is no roleTerm value associated with name, or the roleTerm value associated with name is a value other than creator, then name maps to dc:contributor
+Start and end dates are presented as span dates in dc:date and in dc:coverage
+When the first subelement in a subject wrapper is topic, subject subelements are strung together in dc:subject with hyphens separating them
+Some subject subelements, i.e., geographic, temporal, hierarchicalGeographic, and cartographics, are also parsed into dc:coverage
+The subject subelement geographicCode is dropped in the transform
+
+
+Revision 1.1	2007-05-18 <tmee@loc.gov>
+		Added modsCollection conversion to DC SRU
+		Updated introductory documentation
+
+Version 1.0	2007-05-04 Tracy Meehleib <tmee@loc.gov>
+
+-->
+
+	<xsl:output method="xml" indent="yes"/>
+
+	<xsl:template match="/">
+		<xsl:choose>
+		<xsl:when test="//mods:modsCollection">
+			<srw_dc:dcCollection xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xsi:schemaLocation="info:srw/schema/1/dc-schema http://www.loc.gov/standards/sru/dc-schema.xsd">
+				<xsl:apply-templates/>
+			<xsl:for-each select="mods:modsCollection/mods:mods">
+				<srw_dc:dc xsi:schemaLocation="info:srw/schema/1/dc-schema http://www.loc.gov/standards/sru/dc-schema.xsd">
+
+				<xsl:apply-templates/>
+			</srw_dc:dc>
+			</xsl:for-each>
+			</srw_dc:dcCollection>
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:for-each select="mods:mods">
+			<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+				<xsl:apply-templates/>
+
+			</oai_dc:dc>
+			</xsl:for-each>
+		</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<xsl:template match="mods:titleInfo">
+		<dc:title>
+			<xsl:value-of select="mods:nonSort"/>
+			<xsl:if test="mods:nonSort">
+
+				<xsl:text> </xsl:text>
+			</xsl:if>
+			<xsl:value-of select="mods:title"/>
+			<xsl:if test="mods:subTitle">
+				<xsl:text>: </xsl:text>
+				<xsl:value-of select="mods:subTitle"/>
+			</xsl:if>
+			<xsl:if test="mods:partNumber">
+
+				<xsl:text>. </xsl:text>
+				<xsl:value-of select="mods:partNumber"/>
+			</xsl:if>
+			<xsl:if test="mods:partName">
+				<xsl:text>. </xsl:text>
+				<xsl:value-of select="mods:partName"/>
+			</xsl:if>
+		</dc:title>
+
+	</xsl:template>
+
+	<xsl:template match="mods:name">
+		<xsl:choose>
+			<xsl:when
+				test="mods:role/mods:roleTerm[@type='text']='creator' or mods:role/mods:roleTerm[@type='code']='cre' ">
+				<dc:creator>
+					<xsl:call-template name="name"/>
+				</dc:creator>
+			</xsl:when>
+
+			<xsl:otherwise>
+				<dc:contributor>
+					<xsl:call-template name="name"/>
+				</dc:contributor>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<xsl:template match="mods:classification">
+
+		<dc:subject>
+			<xsl:value-of select="."/>
+		</dc:subject>
+	</xsl:template>
+
+	<xsl:template match="mods:subject[mods:topic | mods:name | mods:occupation | mods:geographic | mods:hierarchicalGeographic | mods:cartographics | mods:temporal] ">
+		<dc:subject>
+			<xsl:for-each select="mods:topic">
+				<xsl:value-of select="."/>
+
+				<xsl:if test="position()!=last()">--</xsl:if>
+			</xsl:for-each>
+
+			<xsl:for-each select="mods:occupation">
+				<xsl:value-of select="."/>
+				<xsl:if test="position()!=last()">--</xsl:if>
+			</xsl:for-each>
+
+			<xsl:for-each select="mods:name">
+
+				<xsl:call-template name="name"/>
+			</xsl:for-each>
+		</dc:subject>
+
+		<xsl:for-each select="mods:titleInfo/mods:title">
+			<dc:subject>
+				<xsl:value-of select="mods:titleInfo/mods:title"/>
+			</dc:subject>
+		</xsl:for-each>
+
+		<xsl:for-each select="mods:geographic">
+			<dc:coverage>
+				<xsl:value-of select="."/>
+			</dc:coverage>
+		</xsl:for-each>
+
+		<xsl:for-each select="mods:hierarchicalGeographic">
+			<dc:coverage>
+				<xsl:for-each
+					select="mods:continent|mods:country|mods:provence|mods:region|mods:state|mods:territory|mods:county|mods:city|mods:island|mods:area">
+
+					<xsl:value-of select="."/>
+					<xsl:if test="position()!=last()">--</xsl:if>
+				</xsl:for-each>
+			</dc:coverage>
+		</xsl:for-each>
+
+		<xsl:for-each select="mods:cartographics/*">
+			<dc:coverage>
+				<xsl:value-of select="."/>
+
+			</dc:coverage>
+		</xsl:for-each>
+
+		<xsl:if test="mods:temporal">
+			<dc:coverage>
+				<xsl:for-each select="mods:temporal">
+					<xsl:value-of select="."/>
+					<xsl:if test="position()!=last()">-</xsl:if>
+				</xsl:for-each>
+
+			</dc:coverage>
+		</xsl:if>
+
+		<xsl:if test="*[1][local-name()='topic'] and *[local-name()!='topic']">
+			<dc:subject>
+				<xsl:for-each select="*[local-name()!='cartographics' and local-name()!='geographicCode' and local-name()!='hierarchicalGeographic'] ">
+					<xsl:value-of select="."/>
+					<xsl:if test="position()!=last()">--</xsl:if>
+				</xsl:for-each>
+
+			</dc:subject>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template match="mods:abstract | mods:tableOfContents | mods:note">
+		<dc:description>
+			<xsl:copy-of select="@type"/>
+			<xsl:copy-of select="@displayLabel"/>
+			<xsl:value-of select="."/>
+		</dc:description>
+	</xsl:template>
+
+	<xsl:template match="mods:originInfo">
+		<xsl:apply-templates select="*[@point='start']"/>
+		<xsl:for-each
+			select="mods:dateIssued[(count(@point) = 0) or (@point!='start' and @point!='end')] |mods:dateCreated[(count(@point) = 0) or (@point!='start' and @point!='end')] | mods:dateCaptured[(count(@point) = 0) or (@point!='start' and @point!='end')] | mods:dateOther[(count(@point) = 0) or (@point!='start' and @point!='end')]">
+			<dc:date>
+				<xsl:value-of select="."/>
+			</dc:date>
+		</xsl:for-each>
+
+		<xsl:for-each select="mods:publisher">
+
+			<dc:publisher>
+				<xsl:value-of select="."/>
+			</dc:publisher>
+		</xsl:for-each>
+	</xsl:template>
+
+	<xsl:template match="mods:dateIssued | mods:dateCreated | mods:dateCaptured">
+		<dc:date>
+			<xsl:choose>
+
+				<xsl:when test="@point='start'">
+					<xsl:value-of select="."/>
+					<xsl:text> - </xsl:text>
+				</xsl:when>
+				<xsl:when test="@point='end'">
+					<xsl:value-of select="."/>
+				</xsl:when>
+				<xsl:otherwise>
+
+					<xsl:value-of select="."/>
+				</xsl:otherwise>
+			</xsl:choose>
+		</dc:date>
+	</xsl:template>
+
+	<xsl:template match="mods:genre">
+		<xsl:choose>
+			<xsl:when test="@authority='dct'">
+
+				<dc:type>
+					<xsl:value-of select="."/>
+				</dc:type>
+				<xsl:for-each select="mods:typeOfResource">
+					<dc:type>
+						<xsl:value-of select="."/>
+					</dc:type>
+				</xsl:for-each>
+			</xsl:when>
+
+			<xsl:otherwise>
+				<dc:type>
+					<xsl:value-of select="."/>
+				</dc:type>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<xsl:template match="mods:typeOfResource">
+
+		<xsl:if test="@collection='yes'">
+			<dc:type>Collection</dc:type>
+		</xsl:if>
+		<xsl:if test=". ='software' and ../mods:genre='database'">
+			<dc:type>DataSet</dc:type>
+		</xsl:if>
+		<xsl:if test=".='software' and ../mods:genre='online system or service'">
+			<dc:type>Service</dc:type>
+
+		</xsl:if>
+		<xsl:if test=".='software'">
+			<dc:type>Software</dc:type>
+		</xsl:if>
+		<xsl:if test=".='cartographic material'">
+			<dc:type>Image</dc:type>
+		</xsl:if>
+		<xsl:if test=".='multimedia'">
+
+			<dc:type>InteractiveResource</dc:type>
+		</xsl:if>
+		<xsl:if test=".='moving image'">
+			<dc:type>MovingImage</dc:type>
+		</xsl:if>
+		<xsl:if test=".='three-dimensional object'">
+			<dc:type>PhysicalObject</dc:type>
+
+		</xsl:if>
+		<xsl:if test="starts-with(.,'sound recording')">
+			<dc:type>Sound</dc:type>
+		</xsl:if>
+		<xsl:if test=".='still image'">
+			<dc:type>StillImage</dc:type>
+		</xsl:if>
+		<xsl:if test=". ='text'">
+
+			<dc:type>Text</dc:type>
+		</xsl:if>
+		<xsl:if test=".='notated music'">
+			<dc:type>Text</dc:type>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template match="mods:physicalDescription">
+
+		<xsl:if test="mods:extent">
+			<dc:format>
+				<xsl:value-of select="mods:extent"/>
+			</dc:format>
+		</xsl:if>
+		<xsl:if test="mods:form">
+			<dc:format>
+				<xsl:value-of select="mods:form"/>
+			</dc:format>
+
+		</xsl:if>
+		<xsl:if test="mods:internetMediaType">
+			<dc:format>
+				<xsl:value-of select="mods:internetMediaType"/>
+			</dc:format>
+		</xsl:if>
+	</xsl:template>
+
+	<xsl:template match="mods:mimeType">
+
+		<dc:format>
+			<xsl:value-of select="."/>
+		</dc:format>
+	</xsl:template>
+
+	<xsl:template match="mods:identifier">
+		<xsl:variable name="type" select="translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')"/>
+		<xsl:choose>
+			<xsl:when test="contains ('isbn issn uri doi lccn uri', $type)">
+
+				<dc:identifier>
+					<xsl:value-of select="$type"/>: <xsl:value-of select="."/>
+				</dc:identifier>
+			</xsl:when>
+			<xsl:otherwise>
+				<dc:identifier>
+					<xsl:value-of select="."/>
+				</dc:identifier>
+
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+	<xsl:template match="mods:location[mods:url]">
+		<dc:identifier>
+			<xsl:for-each select="mods:url">
+				<xsl:value-of select="."/>
+			</xsl:for-each>
+
+		</dc:identifier>
+	</xsl:template>
+
+	<xsl:template match="mods:language">
+		<dc:language>
+			<xsl:value-of select="normalize-space(.)"/>
+		</dc:language>
+	</xsl:template>
+
+	<xsl:template match="mods:relatedItem[mods:titleInfo | mods:name | mods:identifier | mods:location]">
+
+		<xsl:choose>
+			<xsl:when test="@type='original'">
+				<dc:source>
+					<xsl:for-each
+						select="mods:titleInfo/mods:title | mods:identifier | mods:location/mods:url">
+						<xsl:if test="normalize-space(.)!= ''">
+							<xsl:value-of select="."/>
+							<xsl:if test="position()!=last()">--</xsl:if>
+						</xsl:if>
+
+					</xsl:for-each>
+				</dc:source>
+			</xsl:when>
+			<xsl:when test="@type='series'"/>
+			<xsl:otherwise>
+				<dc:relation>
+					<xsl:if test="mods:location/mods:url">
+						<xsl:attribute name="type">url</xsl:attribute>
+						<xsl:attribute name="href"><xsl:value-of select="mods:location/mods:url"/></xsl:attribute>
+					</xsl:if>
+					<xsl:for-each
+						select="mods:titleInfo/mods:title | mods:identifier">
+						<xsl:if test="normalize-space(.)!= ''">
+							<xsl:value-of select="."/>
+
+							<xsl:if test="position()!=last()">--</xsl:if>
+						</xsl:if>
+					</xsl:for-each>
+				</dc:relation>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
+
+    <xsl:template match="mods:location[mods:physicalLocation[@type='repository']]">
+        <dc:relation type="repository">
+            <xsl:value-of select="normalize-space(.)"/>
+        </dc:relation>
+    </xsl:template>
+	<xsl:template match="mods:relatedItem[@type='host']">
+      <xsl:choose>
+        <xsl:when test="mods:location/mods:physicalLocation[@type='location']">
+          <dc:relation type="location">
+              <xsl:value-of select="normalize-space(.)"/>
+          </dc:relation>
+        </xsl:when>
+        <xsl:when test="mods:typeOfResource[@collection='yes']">
+          <dc:relation type="collection">
+              <xsl:value-of select="normalize-space(mods:titleInfo/mods:title)"/>
+          </dc:relation>
+        </xsl:when>
+      </xsl:choose>
+    </xsl:template>
+
+	<xsl:template match="mods:accessCondition">
+
+		<dc:rights>
+			<xsl:value-of select="."/>
+		</dc:rights>
+	</xsl:template>
+
+	<xsl:template name="name">
+		<xsl:variable name="name">
+			<xsl:for-each select="mods:namePart[not(@type)]">
+                <xsl:if test="normalize-space(.)!= ''">
+                    <xsl:text> </xsl:text>
+                    <xsl:value-of select="normalize-space(.)"/>
+                    <xsl:text></xsl:text>
+                </xsl:if>
+			</xsl:for-each>
+			<xsl:value-of select="mods:namePart[@type='family']"/>
+			<xsl:if test="mods:namePart[@type='given']">
+				<xsl:text>, </xsl:text>
+				<xsl:value-of select="normalize-space(mods:namePart[@type='given'])"/>
+			</xsl:if>
+			<xsl:if test="mods:namePart[@type='date']">
+				<xsl:text>, </xsl:text>
+				<xsl:value-of select="mods:namePart[@type='date']"/>
+				<xsl:text/>
+			</xsl:if>
+			<xsl:if test="mods:displayForm">
+				<xsl:text> (</xsl:text>
+				<xsl:value-of select="mods:displayForm"/>
+				<xsl:text>) </xsl:text>
+			</xsl:if>
+			<xsl:for-each select="mods:role[mods:roleTerm[@type='text']!='creator']">
+				<xsl:text> (</xsl:text>
+				<xsl:value-of select="normalize-space(.)"/>
+				<xsl:text>) </xsl:text>
+			</xsl:for-each>
+
+		</xsl:variable>
+		<xsl:value-of select="normalize-space($name)"/>
+	</xsl:template>
+
+	<xsl:template match="mods:dateIssued[@point='start'] | mods:dateCreated[@point='start'] | mods:dateCaptured[@point='start'] | mods:dateOther[@point='start'] ">
+		<xsl:variable name="dateName" select="local-name()"/>
+			<dc:date>
+				<xsl:value-of select="."/>-<xsl:value-of select="../*[local-name()=$dateName][@point='end']"/>
+			</dc:date>
+
+	</xsl:template>
+
+	<xsl:template match="mods:temporal[@point='start']  ">
+		<xsl:value-of select="."/>-<xsl:value-of select="../mods:temporal[@point='end']"/>
+	</xsl:template>
+
+	<xsl:template match="mods:temporal[(count(@point) = 0) or (@point!='start' and @point!='end')]  ">
+		<xsl:value-of select="."/>
+	</xsl:template>
+
+	<!-- suppress all else:-->
+
+	<xsl:template match="*"/>
+
+
+
+</xsl:stylesheet>

--- a/app/services/public_xml_service.rb
+++ b/app/services/public_xml_service.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+class PublicXmlService
+  attr_reader :object
+
+  def initialize(object)
+    @object = object
+  end
+
+  def to_xml
+    pub = Nokogiri::XML('<publicObject/>').root
+    pub['id'] = object.pid
+    pub['published'] = Time.now.utc.xmlschema
+    pub['publishVersion'] = 'dor-services/' + Dor::VERSION
+
+    pub.add_child(public_identity_metadata.root) # add in modified identityMetadata datastream
+    pub.add_child(public_content_metadata.root) if public_content_metadata.xpath('//resource').any?
+    pub.add_child(public_rights_metadata.root)
+
+    pub.add_child(public_relationships.root) unless public_relationships.nil? # TODO: Should never be nil in practice; working around an ActiveFedora quirk for testing
+    pub.add_child(DublinCoreService.new(object).ng_xml.root)
+    pub.add_child(Dor::PublicDescMetadataService.new(object).ng_xml.root)
+    pub.add_child(release_xml.root) unless release_xml.xpath('//release').children.empty? # If there are no release_tags, this prevents an empty <releaseData/> from being added
+    # Note we cannot base this on if an individual object has release tags or not, because the collection may cause one to be generated for an item,
+    # so we need to calculate it and then look at the final result.
+
+    thumb = Dor::ThumbnailService.new(object).thumb
+    pub.add_child(Nokogiri("<thumb>#{thumb}</thumb>").root) unless thumb.nil?
+
+    new_pub = Nokogiri::XML(pub.to_xml, &:noblanks)
+    new_pub.encoding = 'UTF-8'
+    new_pub.to_xml
+  end
+
+  # Generate XML structure for inclusion to Purl
+  # @return [String] The XML release node as a string, with ReleaseDigest as the root document
+  def release_xml
+    @release_xml ||= begin
+      builder = Nokogiri::XML::Builder.new do |xml|
+        xml.releaseData do
+          object.released_for.each do |project, released_value|
+            xml.release(released_value['release'], to: project)
+          end
+        end
+      end
+      Nokogiri::XML(builder.to_xml)
+    end
+  end
+
+  def public_relationships
+    @public_relationships ||= object.public_relationships.clone
+  end
+
+  def public_rights_metadata
+    @public_rights_metadata ||= object.datastreams['rightsMetadata'].ng_xml.clone
+  end
+
+  def public_identity_metadata
+    @public_identity_metadata ||= begin
+      im = object.datastreams['identityMetadata'].ng_xml.clone
+      im.search('//release').each(&:remove) # remove any <release> tags from public xml which have full history
+      im
+    end
+  end
+
+  # @return [Nokogiri::XML::Document] sanitized for public consumption
+  def public_content_metadata
+    return Nokogiri::XML::Document.new unless object.datastreams['contentMetadata']
+
+    @public_content_metadata ||= begin
+      result = object.datastreams['contentMetadata'].ng_xml.clone
+
+      # remove any resources or attributes that are not destined for the public XML
+      result.xpath('/contentMetadata/resource[not(file[(@deliver="yes" or @publish="yes")]|externalFile)]').each(&:remove)
+      result.xpath('/contentMetadata/resource/file[not(@deliver="yes" or @publish="yes")]').each(&:remove)
+      result.xpath('/contentMetadata/resource/file').xpath('@preserve|@shelve|@publish|@deliver').each(&:remove)
+      result.xpath('/contentMetadata/resource/file/checksum').each(&:remove)
+
+      # support for dereferencing links via externalFile element(s) to the source (child) item - see JUMBO-19
+      result.xpath('/contentMetadata/resource/externalFile').each do |external_file|
+        add_data_from_src(external_file)
+      end
+
+      result
+    end
+  end
+
+  def add_data_from_src(external_file)
+    # enforce pre-conditions that resourceId, objectId, fileId are required
+    src_resource_id = external_file['resourceId']
+    src_druid = external_file['objectId']
+    src_file_id = external_file['fileId']
+    raise Dor::DataError, "Malformed externalFile data: #{external_file.to_xml}" if [src_resource_id, src_file_id, src_druid].map(&:blank?).any?
+
+    # grab source item
+    src_item = Dor.find(src_druid)
+
+    # locate and extract the resourceId/fileId elements
+    doc = src_item.contentMetadata.ng_xml
+    src_resource = doc.at_xpath("//resource[@id=\"#{src_resource_id}\"]")
+    src_file = src_resource.at_xpath("file[@id=\"#{src_file_id}\"]")
+    raise Dor::DataError, "Unable to find a file node with id=\"#{src_file_id}\" (child of #{object.pid})" unless src_file
+
+    src_image_data = src_file.at_xpath('imageData')
+
+    # always use title regardless of whether a child label is present
+    src_label = doc.create_element('label')
+    src_label.content = src_item.full_title
+
+    # add the extracted label and imageData
+    external_file.add_previous_sibling(src_label)
+    external_file << src_image_data unless src_image_data.nil?
+  end
+end

--- a/app/services/publish_metadata_service.rb
+++ b/app/services/publish_metadata_service.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# Merges contentMetadata from several objects into one and sends it to PURL
+class PublishMetadataService
+  # @param [Dor::Item] item the object to be publshed
+  def self.publish(item)
+    new(item).publish
+  end
+
+  def initialize(item)
+    @item = item
+  end
+
+  # Appends contentMetadata file resources from the source objects to this object
+  def publish
+    return unpublish unless world_discoverable?
+
+    transfer_metadata
+    publish_notify_on_success
+  end
+
+  private
+
+  attr_reader :item
+
+  def transfer_metadata
+    transfer_to_document_store(DublinCoreService.new(item).ng_xml.to_xml(&:no_declaration), 'dc')
+    %w[identityMetadata contentMetadata rightsMetadata].each do |stream|
+      transfer_to_document_store(item.datastreams[stream].content.to_s, stream) if item.datastreams[stream]
+    end
+    transfer_to_document_store(PublicXmlService.new(item).to_xml, 'public')
+    transfer_to_document_store(Dor::PublicDescMetadataService.new(item).to_xml, 'mods')
+  end
+
+  # Clear out the document cache for this item
+  def unpublish
+    purl_druid.prune!
+    publish_delete_on_success
+  end
+
+  def world_discoverable?
+    rights = item.rightsMetadata.ng_xml.clone.remove_namespaces!
+    rights.at_xpath("//rightsMetadata/access[@type='discover']/machine/world")
+  end
+
+  # Create a file inside the content directory under the stacks.local_document_cache_root
+  # @param [String] content The contents of the file to be created
+  # @param [String] filename The name of the file to be created
+  # @return [void]
+  def transfer_to_document_store(content, filename)
+    new_file = File.join(purl_druid.content_dir, filename)
+    File.open(new_file, 'w') { |f| f.write content }
+  end
+
+  def purl_druid
+    @purl_druid ||= DruidTools::PurlDruid.new item.pid, Dor::Config.stacks.local_document_cache_root
+  end
+
+  def prune_purl_dir
+    purl_druid.prune!
+  end
+
+  ##
+  # When publishing a PURL, we notify purl-fetcher of changes.
+  # If the purl service isn't configured, instead we drop a `aa11bb2222` file into the `local_recent_changes` folder
+  # to notify other applications watching the filesystem (i.e., purl-fetcher).
+  # We also remove any .deletes entry that may have left over from a previous removal
+  def publish_notify_on_success
+    id = item.pid.gsub(/^druid:/, '')
+    raise 'You have not configured perl-fetcher (Dor::Config.purl_services.url).' unless Dor::Config.purl_services.url
+
+    purl_services = Dor::Config.purl_services.rest_client
+    purl_services["purls/#{id}"].post ''
+  end
+
+  ##
+  # When publishing a PURL, we notify purl-fetcher of changes.
+  def publish_delete_on_success
+    return unless Dor::Config.purl_services.url
+
+    id = item.pid.gsub(/^druid:/, '')
+
+    purl_services = Dor::Config.purl_services.rest_client
+    purl_services["purls/#{id}"].delete
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,7 +35,7 @@ CONTENT:
 # Stacks
 STACKS:
   DOCUMENT_CACHE_STORAGE_ROOT: '/purl/document_cache'
-  DOCUMENT_CACHE_HOST: 'cache.example.com'
+  DOCUMENT_CACHE_HOST: 'purl-test.stanford.edu'
   DOCUMENT_CACHE_USER: 'user'
   LOCAL_WORKSPACE_ROOT: '/dor/workspace'
   STORAGE_ROOT: '/stacks'

--- a/spec/controllers/objects_controller_spec.rb
+++ b/spec/controllers/objects_controller_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe ObjectsController do
 
   describe '/publish' do
     it 'calls publish metadata' do
-      expect(Dor::PublishMetadataService).to receive(:publish).with(item)
+      expect(PublishMetadataService).to receive(:publish).with(item)
       post :publish, params: { id: item.pid }
       expect(response.status).to eq(201)
     end

--- a/spec/fixtures/ex1_dc.xml
+++ b/spec/fixtures/ex1_dc.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+   <dc:title xmlns:srw_dc="info:srw/schema/1/dc-schema">The complete works of Henry George</dc:title>
+   <dc:creator>George, Henry, 1839-1897</dc:creator>
+   <dc:contributor>George, Henry, 1862-1916</dc:contributor>
+   <dc:type>Text</dc:type>
+   <dc:date>1911</dc:date>
+   <dc:date>1911</dc:date>
+   <dc:publisher>Doubleday, Page</dc:publisher>
+   <dc:language xmlns:srw_dc="info:srw/schema/1/dc-schema">eng</dc:language>
+
+   <dc:format>electronic</dc:format>
+   <dc:description xmlns:srw_dc="info:srw/schema/1/dc-schema">I. Progress and poverty.--II. Social problems.--III. The land question. Property in land. The condition of labor.--IV. Protection or free trade.--V. A perplexed philosopher [Herbert Spencer]--VI. The science of political economy, books I and II.--VII. The science of political economy, books III to V. "Moses": a lecture.--VIII. Our land and land policy.--IX-X. The life of Henry George, by his son Henry George, jr.</dc:description>
+   <dc:description xmlns:srw_dc="info:srw/schema/1/dc-schema">On cover: Complete works of Henry George. Fels fund. Library edition.</dc:description>
+   <dc:subject xmlns:srw_dc="info:srw/schema/1/dc-schema">Economics</dc:subject>
+   <dc:subject>Economics--1800-1900</dc:subject>
+   <dc:coverage>1800-1900</dc:coverage>
+
+   <dc:identifier>druid:pz263ny9658</dc:identifier>
+   <dc:identifier xmlns:srw_dc="info:srw/schema/1/dc-schema">http://purl.stanford.edu/pz263ny9658</dc:identifier>
+</oai_dc:dc>

--- a/spec/fixtures/ex1_mods.xml
+++ b/spec/fixtures/ex1_mods.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods:mods xmlns:mods="http://www.loc.gov/mods/v3"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           version="3.3"
+           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://cosimo.stanford.edu/standards/mods/v3/mods-3-3.xsd">
+   <mods:titleInfo>
+      <mods:nonSort>The</mods:nonSort>
+      <mods:title>complete works of Henry George</mods:title>
+   </mods:titleInfo>
+   <mods:name type="personal">
+      <mods:namePart>George, Henry</mods:namePart>
+
+      <mods:namePart type="date">1839-1897</mods:namePart>
+      <mods:role>
+         <mods:roleTerm authority="marcrelator" type="text">creator</mods:roleTerm>
+      </mods:role>
+   </mods:name>
+   <mods:name type="personal">
+      <mods:namePart>George, Henry</mods:namePart>
+
+      <mods:namePart type="date">1862-1916</mods:namePart>
+   </mods:name>
+   <mods:typeOfResource>text</mods:typeOfResource>
+   <mods:originInfo>
+      <mods:place>
+         <mods:placeTerm type="code" authority="marccountry">xx</mods:placeTerm>
+      </mods:place>
+
+      <mods:place>
+         <mods:placeTerm type="text">Garden City, N. Y</mods:placeTerm>
+      </mods:place>
+      <mods:publisher>Doubleday, Page</mods:publisher>
+      <mods:dateIssued>1911</mods:dateIssued>
+      <mods:dateIssued encoding="marc" keyDate="yes">1911</mods:dateIssued>
+      <mods:edition>[Library ed.]</mods:edition>
+
+      <mods:issuance>monographic</mods:issuance>
+   </mods:originInfo>
+   <mods:language>
+      <mods:languageTerm authority="iso639-2b" type="code">eng</mods:languageTerm>
+   </mods:language>
+   <mods:relatedItem type="original">
+      <mods:physicalDescription>
+         <mods:form authority="marcform">print</mods:form>
+
+         <mods:extent>10 v. fronts (v. 1-9) ports. 21 cm.</mods:extent>
+      </mods:physicalDescription>
+      <mods:recordInfo>
+         <mods:recordContentSource authority="marcorg">YNG</mods:recordContentSource>
+         <mods:recordCreationDate encoding="marc">731210</mods:recordCreationDate>
+         <mods:recordChangeDate encoding="iso8601">19900625062034.0</mods:recordChangeDate>
+         <mods:recordIdentifier source="SUL catalog key">68184</mods:recordIdentifier>
+
+         <mods:recordIdentifier source="oclc">757655</mods:recordIdentifier>
+      </mods:recordInfo>
+   </mods:relatedItem>
+   <mods:physicalDescription>
+      <mods:form authority="marcform">electronic</mods:form>
+      <mods:reformattingQuality>preservation</mods:reformattingQuality>
+      <mods:digitalOrigin>reformatted digital</mods:digitalOrigin>
+
+   </mods:physicalDescription>
+   <mods:tableOfContents>I. Progress and poverty.--II. Social problems.--III. The land question. Property in land. The condition of labor.--IV. Protection or free trade.--V. A perplexed philosopher [Herbert Spencer]--VI. The science of political economy, books I and II.--VII. The science of political economy, books III to V. "Moses": a lecture.--VIII. Our land and land policy.--IX-X. The life of Henry George, by his son Henry George, jr.</mods:tableOfContents>
+   <mods:note>On cover: Complete works of Henry George. Fels fund. Library edition.</mods:note>
+   <mods:subject authority="lcsh">
+      <mods:topic>Economics</mods:topic>
+      <mods:temporal>1800-1900</mods:temporal>
+   </mods:subject>
+   <mods:recordInfo>
+
+      <mods:recordContentSource>DOR_MARC2MODS3-3.xsl Revision 1.1</mods:recordContentSource>
+      <mods:recordCreationDate encoding="iso8601">2011-02-25T18:20:23.132-08:00</mods:recordCreationDate>
+      <mods:recordIdentifier source="Data Provider Digital Object Identifier">36105010700545</mods:recordIdentifier>
+   </mods:recordInfo>
+   <mods:identifier type="local" displayLabel="SUL Resource ID">druid:pz263ny9658</mods:identifier>
+   <mods:location>
+      <mods:physicalLocation>Stanford University Libraries</mods:physicalLocation>
+
+      <mods:url>http://purl.stanford.edu/pz263ny9658</mods:url>
+   </mods:location>
+</mods:mods>

--- a/spec/fixtures/ex2_related_dc.xml
+++ b/spec/fixtures/ex2_related_dc.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>Slides, IA, Geodesic Domes [1 of 2]</dc:title>
+  <dc:relation type="collection">Buckminster Fuller papers, 1920-1983</dc:relation>
+  <dc:type>StillImage</dc:type>
+  <dc:format>photographs, color transparencies</dc:format>
+  <dc:relation type="location">Series 15 | Box 1 | Folder 1</dc:relation>
+  <dc:relation type="repository">Stanford University. Libraries. Dept. of Special Collections and Stanford University Archives.</dc:relation>
+  <dc:identifier>M1090_S15_B01_F01_0055</dc:identifier>
+  <dc:rights>Property rights reside with the repository. Intellectual rights to the images reside with the creators of the images or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections.</dc:rights>
+</oai_dc:dc>

--- a/spec/fixtures/ex2_related_mods.xml
+++ b/spec/fixtures/ex2_related_mods.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<mods:mods xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <mods:titleInfo>
+        <mods:title type="main">Slides, IA, Geodesic Domes [1 of 2]</mods:title>
+    </mods:titleInfo>
+    <mods:relatedItem type="host">
+        <mods:titleInfo>
+            <mods:title>Buckminster Fuller papers, 1920-1983</mods:title>
+        </mods:titleInfo>
+        <mods:typeOfResource collection="yes"/>
+    </mods:relatedItem>
+    <mods:typeOfResource>still image</mods:typeOfResource>
+    <mods:physicalDescription>
+        <mods:form>photographs, color transparencies</mods:form>
+    </mods:physicalDescription>
+    <mods:relatedItem type="host">
+        <mods:location>
+            <mods:physicalLocation type="location">Series 15 | Box 1 | Folder 1</mods:physicalLocation>
+        </mods:location>
+    </mods:relatedItem>
+    <mods:location>
+        <mods:physicalLocation type="repository">Stanford University. Libraries. Dept. of Special Collections and Stanford University Archives.</mods:physicalLocation>
+    </mods:location>
+    <mods:identifier type="local" displayLabel="Image ID">M1090_S15_B01_F01_0055</mods:identifier>
+    <mods:accessCondition>Property rights reside with the repository. Intellectual rights to the images reside with the creators of the images or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections.</mods:accessCondition>
+</mods:mods>

--- a/spec/fixtures/hj097bm8879_contentMetadata.xml
+++ b/spec/fixtures/hj097bm8879_contentMetadata.xml
@@ -1,0 +1,10 @@
+<contentMetadata objectId="hj097bm8879" type="map">
+  <resource id="hj097bm8879_1" sequence="1" type="image">
+    <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1" mimetype="image/jp2"/>
+    <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_2" sequence="2" thumb="yes" type="image">
+    <externalFile fileId="2542B.jp2" objectId="druid:jw923xn5254" resourceId="jw923xn5254_1" mimetype="image/jp2"/>
+    <relationship objectId="druid:jw923xn5254" type="alsoAvailableAs"/>
+  </resource>
+</contentMetadata>        

--- a/spec/fixtures/hj097bm8879_publicObject.xml
+++ b/spec/fixtures/hj097bm8879_publicObject.xml
@@ -1,0 +1,111 @@
+<publicObject id="druid:hj097bm8879" published="2015-09-09T13:33:17-07:00">
+<identityMetadata>
+<sourceId source="Rumsey">2542</sourceId>
+<objectId>druid:hj097bm8879</objectId>
+<objectCreator>DOR</objectCreator>
+<objectLabel>Rumsey Atlas 2542</objectLabel>
+<objectType>item</objectType>
+<otherId name="catkey">10449093</otherId>
+<otherId name="uuid">3526ef90-1f4b-11e5-b0dc-0050569b3c3c</otherId>
+<tag>Project : Rumsey : AtlasProto</tag>
+<tag>Remediated By : 4.21.0</tag>
+<release to="Searchworks">true</release>
+</identityMetadata>
+<contentMetadata objectId="hj097bm8879" type="map">
+  <resource id="hj097bm8879_1" sequence="1" type="image">
+    <label>(Covers to) Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]</label>
+    <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1" mimetype="image/jp2">
+      <imageData width="6475" height="4747"/>
+    </externalFile>
+    <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_2" sequence="2" thumb="yes" type="image">
+    <label>(Title Page to) Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]</label>
+    <externalFile fileId="2542B.jp2" objectId="druid:jw923xn5254" resourceId="jw923xn5254_1" mimetype="image/jp2">
+      <imageData width="3139" height="4675"/>
+    </externalFile>
+    <relationship objectId="druid:jw923xn5254" type="alsoAvailableAs"/>
+  </resource>
+</contentMetadata>
+<rightsMetadata>
+<copyright>
+<human type="copyright">
+Property rights reside with the repository, Copyright © Stanford University. Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license.
+</human>
+</copyright>
+<access type="discover">
+<machine>
+<world/>
+</machine>
+</access>
+<access type="read">
+<machine>
+<world/>
+</machine>
+</access>
+<use>
+<human type="useAndReproduction">
+To obtain permission to publish or reproduce commercially, please contact the Digital &amp; Rare Map Librarian, David Rumsey Map Center at rumseymapcenter@stanford.edu.
+</human>
+</use>
+<use>
+<machine type="creativeCommons">by-nc-sa</machine>
+<human type="creativeCommons">
+Attribution Non-Commercial Share Alike 3.0 Unported
+</human>
+</use>
+</rightsMetadata>
+<rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description rdf:about="info:fedora/druid:hj097bm8879">
+<fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"/>
+<fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"/>
+</rdf:Description>
+</rdf:RDF>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+<dc:title>
+Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]
+</dc:title>
+<dc:contributor>Carey, Mathew.</dc:contributor>
+<dc:contributor>Barker, W.</dc:contributor>
+<dc:contributor>Doolittle, Amos.</dc:contributor>
+<dc:contributor>Harris, Caleb &amp; Harding.</dc:contributor>
+<dc:contributor>Harrison, Junr.</dc:contributor>
+<dc:contributor>Lewis, Samuel.</dc:contributor>
+<dc:contributor>Scott, J.T.</dc:contributor>
+<dc:contributor>Smith, Genl. D.</dc:contributor>
+<dc:contributor>Smither, T.</dc:contributor>
+<dc:contributor>Vallance.</dc:contributor>
+<dc:type>map</dc:type>
+<dc:type>cartographic image</dc:type>
+<dc:type>Atlases.</dc:type>
+<dc:date>1795</dc:date>
+<dc:date>1795.</dc:date>
+<dc:publisher>Mathew Carey,</dc:publisher>
+<dc:language>eng</dc:language>
+<dc:format>1 atlas : 21 maps ; 37 x 24 cm</dc:format>
+<dc:format>cartographic material</dc:format>
+<dc:description>
+First atlas of America printed in America. First edition. These maps were also published in Carey's American edition of Guthrie's Geography (1795) and most of the maps say "engraved for Carey's American edition of Guthrie's Geography improved." The maps were again used for the 1796 edition of Carey's General Atlas, unchanged except for the Tennessee map, which is titled "Tennassee State" instead of "Tennassee Government" which is the title in both the American Atlas and the Guthrie Atlas -see Wheat and Brun, and has several counties delineated in the eastern part of the state which do not show in the 1795 edition of the map. NMM 480 (American Atlas) has "Tennassee State" indicating that Carey was not consistent. This atlas was the model for John Reid's American Atlas of 1796. This copy's maps have very strong impressions. Rebound quarter leather, marbled paper covered boards.
+</dc:description>
+<dc:description>National Atlas.</dc:description>
+<dc:description>References: P1172; Walsh p33; NMM 480; Howes C135.</dc:description>
+<dc:description type="local" displayLabel="Local note">Pub list no.: 2542.000.</dc:description>
+<dc:subject>Maps</dc:subject>
+<dc:coverage>Western Hemisphere</dc:coverage>
+<dc:coverage>North America</dc:coverage>
+<dc:coverage>South America</dc:coverage>
+<dc:coverage>United States</dc:coverage>
+<dc:coverage>Canada</dc:coverage>
+<dc:subject>G1100 1795 .C3 F</dc:subject>
+<dc:identifier>
+http://www.davidrumsey.com/luna/servlet/view/search?QuickSearchA=QuickSearchA&amp;q=2542.000&amp;sort=pub_list_no_initialsort%2Cpub_date%2Cpub_list_no%2Cseries_no&amp;search=Search
+</dc:identifier>
+<dc:relation type="collection">
+David Rumsey Map Collection at Stanford University Libraries
+</dc:relation>
+</oai_dc:dc>
+<releaseData>
+<release to="Searchworks">true</release>
+</releaseData>
+<thumb>jw923xn5254/2542B.jp2</thumb>
+</publicObject>

--- a/spec/fixtures/item_druid_ab123cd4567.xml
+++ b/spec/fixtures/item_druid_ab123cd4567.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foxml:digitalObject xmlns:foxml="info:fedora/fedora-system:def/foxml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PID="druid:ab123cd4567" VERSION="1.1" xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+  <foxml:objectProperties>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="Foxml Test Object"/>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE="DOR"/>
+  </foxml:objectProperties>
+  <foxml:datastream CONTROL_GROUP="X" ID="DC" STATE="A" VERSIONABLE="false">
+    <foxml:datastreamVersion FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" ID="DC1.0" LABEL="Dublin Core Record for this object" MIMETYPE="text/xml">
+      <foxml:xmlContent>
+        <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+          <dc:title>Foxml Test Object</dc:title>
+          <dc:identifier>google:STANFORD_342837261527</dc:identifier>
+          <dc:identifier>barcode:36105049267078</dc:identifier>
+          <dc:identifier>catkey:129483625</dc:identifier>
+          <dc:identifier>uuid:7f3da130-7b02-11de-8a39-0800200c9a66</dc:identifier>
+          <dc:identifier>druid:ab123cd4567</dc:identifier>
+        </oai_dc:dc>
+      </foxml:xmlContent>
+    </foxml:datastreamVersion>
+  </foxml:datastream>
+  <foxml:datastream CONTROL_GROUP="X" ID="identityMetadata" STATE="A" VERSIONABLE="false">
+    <foxml:datastreamVersion ID="identityMetadata.0" LABEL="Identity Metadata" MIMETYPE="text/xml">
+      <foxml:xmlContent>
+        <identityMetadata>
+          <objectId>druid:rt923jk342</objectId>
+          <objectType>item</objectType>
+          <objectLabel>google download barcode 36105049267078</objectLabel>
+          <objectCreator>DOR</objectCreator>
+          <citationTitle>Squirrels of North America</citationTitle>
+          <citationCreator>Eder, Tamara, 1974-</citationCreator>
+          <sourceId source="google">STANFORD_342837261527</sourceId>
+          <otherId name="barcode">36105049267078</otherId>
+          <otherId name="catkey">129483625</otherId>
+          <otherId name="uuid">7f3da130-7b02-11de-8a39-0800200c9a66</otherId>
+          <tag>Google Books : Phase 1</tag>
+          <tag>Google Books : Scan source STANFORD</tag>
+          <tag>Project : Beautiful Books</tag>
+          <tag>Registered By : blalbrit</tag>
+          <tag>DPG : Beautiful Books : Octavo : newpri</tag>
+          <tag>Remediated By : 4.15.4</tag>
+          <release displayType="image" release="true" to="Searchworks" what="self" when="2015-07-27T21:44:26Z" who="lauraw15">true</release>
+          <release displayType="image" release="true" to="Some_special_place" what="self" when="2015-08-31T23:59:59" who="atz">true</release>
+        </identityMetadata>
+      </foxml:xmlContent>
+    </foxml:datastreamVersion>
+  </foxml:datastream>
+  <foxml:datastream CONTROL_GROUP="X" ID="RELS-EXT" STATE="A">
+    <foxml:datastreamVersion FORMAT_URI="info:fedora/fedora-system:FedoraRELSExt-1.0" ID="RELS-EXT.0" LABEL="RDF Statements about this object" MIMETYPE="application/rdf+xml">
+      <foxml:xmlContent>
+        <rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+          xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:hydra="http://projecthydra.org/ns/relations#">
+          <rdf:Description rdf:about="info:fedora/druid:ab123cd4567">
+            <fedora-model:hasModel rdf:resource="info:fedora/testObject"/>
+            <hydra:isGovernedBy rdf:resource="info:fedora/druid:fg890hi1234"/>
+          </rdf:Description>
+        </rdf:RDF>
+      </foxml:xmlContent>
+    </foxml:datastreamVersion>
+  </foxml:datastream>
+</foxml:digitalObject>

--- a/spec/fixtures/item_druid_cg767mn6478.xml
+++ b/spec/fixtures/item_druid_cg767mn6478.xml
@@ -1,0 +1,296 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foxml:digitalObject VERSION="1.1" PID="druid:cg767mn6478"
+xmlns:foxml="info:fedora/fedora-system:def/foxml#"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+<foxml:objectProperties>
+<foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="Cover: Carey&apos;s American atlas."/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE="argo.stanford.edu"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2015-06-30T17:36:16.813Z"/>
+<foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE="2016-06-01T16:02:50.233Z"/>
+</foxml:objectProperties>
+<foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="DC1.0" LABEL="Dublin Core Record for this object" CREATED="2015-06-30T17:36:16.813Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="405">
+<foxml:xmlContent>
+<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>Cover: Carey&apos;s American atlas.</dc:title>
+  <dc:identifier>druid:cg767mn6478</dc:identifier>
+</oai_dc:dc>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="RELS-EXT.1" LABEL="Fedora Object-to-Object Relationship Metadata" CREATED="2015-07-09T21:48:34.182Z" MIMETYPE="application/rdf+xml" SIZE="820">
+<foxml:xmlContent>
+<rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="info:fedora/druid:cg767mn6478">
+    <hydra:isGovernedBy rdf:resource="info:fedora/druid:sq161jk2248"></hydra:isGovernedBy>
+    <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_Item"></fedora-model:hasModel>
+    <fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"></fedora:isMemberOf>
+    <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"></fedora:isMemberOfCollection>
+    <fedora:isConstituentOf rdf:resource="info:fedora/druid:hj097bm8879"></fedora:isConstituentOf>
+  </rdf:Description>
+</rdf:RDF>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="identityMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="identityMetadata.8" LABEL="Identity Metadata" CREATED="2016-06-01T16:02:48.479Z" MIMETYPE="text/xml" SIZE="869">
+<foxml:xmlContent>
+<identityMetadata>
+  <sourceId source="Rumsey">2542A</sourceId>
+  <objectId>druid:cg767mn6478</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>Cover: Carey&apos;s American atlas.</objectLabel>
+  <objectType>item</objectType>
+  <otherId name="label"></otherId>
+  <otherId name="uuid">804cfb1a-1f4e-11e5-b0dc-0050569b3c3c</otherId>
+  <release displayType="image" release="true" to="Searchworks" what="self" when="2016-03-10T02:13:30Z" who="lauraw15">true</release>
+  <displayType>image</displayType>
+  <release displayType="image" release="true" to="Searchworks" what="self" when="2016-03-11T05:56:00Z" who="lauraw15">true</release>
+  <tag>Process : Content Type : Map</tag>
+  <tag>Project : Rumsey Map Collection : Batch 1 : PLN : 2542</tag>
+  <tag>LAB : RUMSEY</tag>
+  <tag>CATKEY : 10449093</tag>
+  <tag>Remediated By : 4.21.4</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="workflows" STATE="A" CONTROL_GROUP="E" VERSIONABLE="true">
+<foxml:datastreamVersion ID="workflows.0" LABEL="Workflows" CREATED="2015-06-30T17:36:17.466Z" MIMETYPE="application/xml">
+<foxml:contentLocation TYPE="URL" REF="https://lyberservices-prod.stanford.edu/workflow/dor/objects/druid:cg767mn6478/workflows"/>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="descMetadata" STATE="A" CONTROL_GROUP="M" VERSIONABLE="true">
+<foxml:datastreamVersion ID="descMetadata.1" LABEL="Descriptive Metadata" CREATED="2015-08-11T19:43:52.155Z" MIMETYPE="text/xml" SIZE="2942">
+<foxml:binaryContent> 
+              PG1vZHMgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOnhzaT0i
+              aHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vd3d3
+              LmxvYy5nb3YvbW9kcy92MyIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vd3d3LmxvYy5nb3YvbW9k
+              cy92MyBodHRwOi8vd3d3LmxvYy5nb3Yvc3RhbmRhcmRzL21vZHMvdjMvbW9kcy0zLTUueHNkIiB2ZXJz
+              aW9uPSIzLjUiPgogICAgICAgIDx0eXBlT2ZSZXNvdXJjZT5jYXJ0b2dyYXBoaWM8L3R5cGVPZlJlc291
+              cmNlPgogICAgICAgIDx0aXRsZUluZm8+CiAgICAgICAgPHRpdGxlPihDb3ZlcnMgdG8pIENhcmV5J3Mg
+              QW1lcmljYW4gQXRsYXM6IENvbnRhaW5pbmcgVHdlbnR5IE1hcHMgQW5kIE9uZSBDaGFydCAuLi4gUGhp
+              bGFkZWxwaGlhOiBFbmdyYXZlZCBGb3IsIEFuZCBQdWJsaXNoZWQgQnksIE1hdGhldyBDYXJleSwgTm8u
+              IDExOCwgTWFya2V0IFN0cmVldC4gTS5EQ0MuWENWLiBbUHJpY2UsIFBsYWluLCBGaXZlIERvbGxhcnMt
+              Q29sb3VyZWQsIFNpeCBEb2xsYXJzLl08L3RpdGxlPgogICAgPC90aXRsZUluZm8+CiAgICA8dGl0bGVJ
+              bmZvIHR5cGU9ImFsdGVybmF0aXZlIiBkaXNwbGF5TGFiZWw9IlNob3J0IHRpdGxlIj4KICAgICAgICA8
+              dGl0bGU+Q292ZXI6IENhcmV5J3MgQW1lcmljYW4gYXRsYXMuPC90aXRsZT4KICAgIDwvdGl0bGVJbmZv
+              PgogICAgPG5hbWUgdHlwZT0icGVyc29uYWwiIHVzYWdlPSJwcmltYXJ5Ij4gICAgICAgIAogICAgICAg
+              IDxuYW1lUGFydD5DYXJleSwgTWF0aGV3PC9uYW1lUGFydD4KICAgICAgICA8cm9sZT4KICAgICAgICAg
+              ICAgPHJvbGVUZXJtIHR5cGU9InRleHQiIGF1dGhvcml0eT0ibWFyY3JlbGF0b3IiPmF1dGhvcjwvcm9s
+              ZVRlcm0+CiAgICAgICAgPC9yb2xlPgogICAgPC9uYW1lPiAgICAKICAgICAgICAgICAgICAgICAgICAg
+              ICAgICAgIDxnZW5yZT5Db3ZlcnM8L2dlbnJlPgogICAgICAgIDxnZW5yZSBhdXRob3JpdHk9ImdtZ3Bj
+              IiB2YWx1ZVVSST0iaHR0cDovL2lkLmxvYy5nb3Yvdm9jYWJ1bGFyeS9ncmFwaGljTWF0ZXJpYWxzL3Rn
+              bTAwMTIwMiI+Qm9vayBjb3ZlcnM8L2dlbnJlPgogICAgICAgIAogICAgPG9yaWdpbkluZm8gZXZlbnRU
+              eXBlPSJwdWJsaWNhdGlvbiI+IAogICAgICAgIDxwbGFjZT4KICAgICAgICAgICAgPHBsYWNlVGVybSB0
+              eXBlPSJ0ZXh0Ij5QaGlsYWRlbHBoaWE8L3BsYWNlVGVybT4KICAgICAgICA8L3BsYWNlPgogICAgICAg
+              IDxwdWJsaXNoZXI+TWF0aGV3IENhcmV5PC9wdWJsaXNoZXI+CiAgICAgICAgPGRhdGVJc3N1ZWQgZW5j
+              b2Rpbmc9InczY2R0ZiIga2V5RGF0ZT0ieWVzIj4xNzk1PC9kYXRlSXNzdWVkPgogICAgPC9vcmlnaW5J
+              bmZvPgogICAgPGxhbmd1YWdlPgogICAgICAgIDxsYW5ndWFnZVRlcm0gdHlwZT0iY29kZSIgYXV0aG9y
+              aXR5PSJpc282MzktMmIiPmVuZzwvbGFuZ3VhZ2VUZXJtPgogICAgPC9sYW5ndWFnZT4KICAgIDxwaHlz
+              aWNhbERlc2NyaXB0aW9uPgogICAgICAgICAgICAgICAgPGV4dGVudD4zNyB4IDI0IGNtPC9leHRlbnQ+
+              CiAgICAgICAgICAgICAgICA8ZGlnaXRhbE9yaWdpbj5yZWZvcm1hdHRlZCBkaWdpdGFsPC9kaWdpdGFs
+              T3JpZ2luPgogICAgICAgIDxpbnRlcm5ldE1lZGlhVHlwZT5pbWFnZS9qcGVnPC9pbnRlcm5ldE1lZGlh
+              VHlwZT4KICAgIDwvcGh5c2ljYWxEZXNjcmlwdGlvbj4KICAgICAgICAgICAgICAgICAgICA8c3ViamVj
+              dCBkaXNwbGF5TGFiZWw9IkNvdW50cnkiPgogICAgICAgIDxnZW9ncmFwaGljPlVuaXRlZCBTdGF0ZXM8
+              L2dlb2dyYXBoaWM+CiAgICA8L3N1YmplY3Q+CiAgICAgICAgICAgICAgICAgICAgPHN1YmplY3Q+CiAg
+              ICAgICAgPGNhcnRvZ3JhcGhpY3M+CiAgICAgICAgICAgIDxjb29yZGluYXRlcz5FMTIwMDAwMCBXMDMw
+              MDAwMCBOMDc2MDAwMCBTMDU5MDAwMDwvY29vcmRpbmF0ZXM+CiAgICAgICAgPC9jYXJ0b2dyYXBoaWNz
+              PgogICAgPC9zdWJqZWN0PgogICAgICAgIDxyZWxhdGVkSXRlbSB0eXBlPSJob3N0IiBkaXNwbGF5TGFi
+              ZWw9IkFwcGVhcnMgaW4iPgogICAgICAgIDx0aXRsZUluZm8+CiAgICAgICAgICAgIDx0aXRsZT5DYXJl
+              eSdzIEFtZXJpY2FuIEF0bGFzOiBDb250YWluaW5nIFR3ZW50eSBNYXBzIEFuZCBPbmUgQ2hhcnQgLi4u
+              IFBoaWxhZGVscGhpYTogRW5ncmF2ZWQgRm9yLCBBbmQgUHVibGlzaGVkIEJ5LCBNYXRoZXcgQ2FyZXks
+              IE5vLiAxMTgsIE1hcmtldCBTdHJlZXQuIE0uRENDLlhDVi4gW1ByaWNlLCBQbGFpbiwgRml2ZSBEb2xs
+              YXJzLUNvbG91cmVkLCBTaXggRG9sbGFycy5dPC90aXRsZT4KICAgICAgICA8L3RpdGxlSW5mbz4KICAg
+              ICAgICA8b3JpZ2luSW5mbyBldmVudFR5cGU9InB1YmxpY2F0aW9uIj4KICAgICAgICAgICAgPGRhdGVJ
+              c3N1ZWQ+MTc5NTwvZGF0ZUlzc3VlZD4KICAgICAgICA8L29yaWdpbkluZm8+CiAgICAgICAgPGlkZW50
+              aWZpZXIgdHlwZT0ibG9jYWwiIGRpc3BsYXlMYWJlbD0iUHViIGxpc3Qgbm8uIj4yNTQyPC9pZGVudGlm
+              aWVyPgogICAgPC9yZWxhdGVkSXRlbT4KICAgIDxpZGVudGlmaWVyIHR5cGU9ImxvY2FsIiBkaXNwbGF5
+              TGFiZWw9Ikxpc3QgbnVtYmVyIj4yNTQyQTwvaWRlbnRpZmllcj4KICAgIDxpZGVudGlmaWVyIHR5cGU9
+              ImxvY2FsIiBkaXNwbGF5TGFiZWw9IkltYWdlIG51bWJlciI+MjU0MkE8L2lkZW50aWZpZXI+CiAgICA8
+              cmVjb3JkSW5mbz4KICAgICAgICA8bGFuZ3VhZ2VPZkNhdGFsb2dpbmc+CiAgICAgICAgICAgIDxsYW5n
+              dWFnZVRlcm0gYXV0aG9yaXR5PSJpc282MzktMmIiPmVuZzwvbGFuZ3VhZ2VUZXJtPgogICAgICAgIDwv
+              bGFuZ3VhZ2VPZkNhdGFsb2dpbmc+CiAgICAgICAgPHJlY29yZENvbnRlbnRTb3VyY2UgYXV0aG9yaXR5
+              PSJtYXJjb3JnIj5DU3Q8L3JlY29yZENvbnRlbnRTb3VyY2U+CiAgICA8L3JlY29yZEluZm8+CjwvbW9k
+              cz4=
+</foxml:binaryContent> 
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="rightsMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="rightsMetadata.0" LABEL="Rights Metadata" CREATED="2015-06-30T17:36:18.124Z" MIMETYPE="text/xml" SIZE="1047">
+<foxml:xmlContent>
+<rightsMetadata>
+  <copyright>
+    <human type="copyright">Property rights reside with the repository, Copyright © Stanford University.  Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license. </human>
+  </copyright>
+  <access type="discover">
+    <machine>
+      <world></world>
+    </machine>
+  </access>
+  <access type="read">
+    <machine>
+      <world></world>
+    </machine>
+  </access>
+  <use>
+    <human type="useAndReproduction">To obtain permission to publish or reproduce commercially, please contact the Digital &amp; Rare Map Librarian, David Rumsey Map Center at rumseymapcenter@stanford.edu. </human>
+  </use>
+  <use>
+    <machine type="creativeCommons">by-nc-sa</machine>
+    <human type="creativeCommons">Attribution Non-Commercial Share Alike 3.0 Unported</human>
+  </use>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="contentMetadata" STATE="A" CONTROL_GROUP="M" VERSIONABLE="true">
+<foxml:datastreamVersion ID="contentMetadata.0" LABEL="Content Metadata" CREATED="2015-06-30T18:22:33.370Z" MIMETYPE="text/xml" SIZE="796">
+<foxml:binaryContent> 
+              PGNvbnRlbnRNZXRhZGF0YSBvYmplY3RJZD0iY2c3NjdtbjY0NzgiIHR5cGU9ImltYWdlIj4KICA8cmVz
+              b3VyY2UgaWQ9ImNnNzY3bW42NDc4XzEiIHNlcXVlbmNlPSIxIiB0eXBlPSJpbWFnZSI+CiAgICA8bGFi
+              ZWw+SW1hZ2UgMTwvbGFiZWw+CiAgICA8ZmlsZSBpZD0iMjU0MkEudGlmIiBwcmVzZXJ2ZT0ieWVzIiBw
+              dWJsaXNoPSJubyIgc2hlbHZlPSJubyIgbWltZXR5cGU9ImltYWdlL3RpZmYiIHNpemU9IjkyMjE3MTI0
+              Ij4KICAgICAgPGNoZWNrc3VtIHR5cGU9Im1kNSI+NWI3OWM4NTcwYjdlZjU4MjczNWY5MTJhYTI0Y2U1
+              ZjI8L2NoZWNrc3VtPgogICAgICA8Y2hlY2tzdW0gdHlwZT0ic2hhMSI+MWYwOWY4Nzk2YmZhNjdkYjk3
+              NTU3ZjNkZTQ4YTk2Yzg3YjI4NmQzMjwvY2hlY2tzdW0+CiAgICAgIDxpbWFnZURhdGEgd2lkdGg9IjY0
+              NzUiIGhlaWdodD0iNDc0NyIvPgogICAgPC9maWxlPgogICAgPGZpbGUgaWQ9IjI1NDJBLmpwMiIgbWlt
+              ZXR5cGU9ImltYWdlL2pwMiIgc2l6ZT0iNTc4OTc2NCIgcHJlc2VydmU9Im5vIiBwdWJsaXNoPSJ5ZXMi
+              IHNoZWx2ZT0ieWVzIj4KICAgICAgPGNoZWNrc3VtIHR5cGU9Im1kNSI+Y2Q1Y2E1YzQ2NjZjZmQ1Y2Uw
+              ZTlkYzhjODM0NjFkN2E8L2NoZWNrc3VtPgogICAgICA8Y2hlY2tzdW0gdHlwZT0ic2hhMSI+MzlmZWVk
+              NmVlMWI3MzRjYWIyZDZhNDQ2ZTkwOWE5ZmM3YWM2ZmQwMTwvY2hlY2tzdW0+CiAgICAgIDxpbWFnZURh
+              dGEgd2lkdGg9IjY0NzUiIGhlaWdodD0iNDc0NyIvPgogICAgPC9maWxlPgogIDwvcmVzb3VyY2U+Cjwv
+              Y29udGVudE1ldGFkYXRhPg==
+</foxml:binaryContent> 
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="technicalMetadata" STATE="A" CONTROL_GROUP="M" VERSIONABLE="true">
+<foxml:datastreamVersion ID="technicalMetadata.3" LABEL="Technical Metadata" CREATED="2015-08-11T19:47:26.203Z" MIMETYPE="text/xml" SIZE="4669">
+<foxml:binaryContent> 
+              PHRlY2huaWNhbE1ldGFkYXRhIHhtbG5zOmpob3ZlPSJodHRwOi8vaHVsLmhhcnZhcmQuZWR1L29pcy94
+              bWwvbnMvamhvdmUiIHhtbG5zOm1peD0iaHR0cDovL3d3dy5sb2MuZ292L21peC92MTAiIHhtbG5zOnRl
+              eHRtZD0iaW5mbzpsYy94bWxucy90ZXh0TUQtdjMiIG9iamVjdElkPSJkcnVpZDpjZzc2N21uNjQ3OCIg
+              ZGF0ZXRpbWU9IjIwMTUtMDYtMzBUMTg6MjI6NTZaIj4KICA8ZmlsZSBpZD0iMjU0MkEudGlmIj4KICAg
+              IDxqaG92ZTpyZXBvcnRpbmdNb2R1bGUgcmVsZWFzZT0iMS43IiBkYXRlPSIyMDEyLTA4LTEyIj5USUZG
+              LWh1bDwvamhvdmU6cmVwb3J0aW5nTW9kdWxlPgogICAgPGpob3ZlOmZvcm1hdD5USUZGPC9qaG92ZTpm
+              b3JtYXQ+CiAgICA8amhvdmU6dmVyc2lvbj42LjA8L2pob3ZlOnZlcnNpb24+CiAgICA8amhvdmU6c3Rh
+              dHVzPldlbGwtRm9ybWVkIGFuZCB2YWxpZDwvamhvdmU6c3RhdHVzPgogICAgPGpob3ZlOnNpZ01hdGNo
+              PgogICAgICA8amhvdmU6bW9kdWxlPlRJRkYtaHVsPC9qaG92ZTptb2R1bGU+CiAgICA8L2pob3ZlOnNp
+              Z01hdGNoPgogICAgPGpob3ZlOm1pbWVUeXBlPmltYWdlL3RpZmY8L2pob3ZlOm1pbWVUeXBlPgogICAg
+              PGpob3ZlOnByb2ZpbGVzPgogICAgICA8amhvdmU6cHJvZmlsZT5CYXNlbGluZSBSR0IgKENsYXNzIFIp
+              PC9qaG92ZTpwcm9maWxlPgogICAgICA8amhvdmU6cHJvZmlsZT5ETEYgQmVuY2htYXJrIGZvciBGYWl0
+              aGZ1bCBEaWdpdGFsIFJlcHJvZHVjdGlvbnMgb2YgTW9ub2dyYXBocyBhbmQgU2VyaWFsczogY29sb3I8
+              L2pob3ZlOnByb2ZpbGU+CiAgICA8L2pob3ZlOnByb2ZpbGVzPgogICAgPGpob3ZlOnByb3BlcnRpZXM+
+              CiAgICAgIDxtaXg6bWl4PgogICAgICAgIDxtaXg6QmFzaWNEaWdpdGFsT2JqZWN0SW5mb3JtYXRpb24+
+              CiAgICAgICAgICA8bWl4OmJ5dGVPcmRlcj5iaWdfZW5kaWFuPC9taXg6Ynl0ZU9yZGVyPgogICAgICAg
+              ICAgPG1peDpDb21wcmVzc2lvbj4KICAgICAgICAgICAgPG1peDpjb21wcmVzc2lvblNjaGVtZT4xPC9t
+              aXg6Y29tcHJlc3Npb25TY2hlbWU+CiAgICAgICAgICA8L21peDpDb21wcmVzc2lvbj4KICAgICAgICA8
+              L21peDpCYXNpY0RpZ2l0YWxPYmplY3RJbmZvcm1hdGlvbj4KICAgICAgICA8bWl4OkJhc2ljSW1hZ2VJ
+              bmZvcm1hdGlvbj4KICAgICAgICAgIDxtaXg6QmFzaWNJbWFnZUNoYXJhY3RlcmlzdGljcz4KICAgICAg
+              ICAgICAgPG1peDppbWFnZVdpZHRoPjY0NzU8L21peDppbWFnZVdpZHRoPgogICAgICAgICAgICA8bWl4
+              OmltYWdlSGVpZ2h0PjQ3NDc8L21peDppbWFnZUhlaWdodD4KICAgICAgICAgICAgPG1peDpQaG90b21l
+              dHJpY0ludGVycHJldGF0aW9uPgogICAgICAgICAgICAgIDxtaXg6Y29sb3JTcGFjZT4yPC9taXg6Y29s
+              b3JTcGFjZT4KICAgICAgICAgICAgICA8bWl4OnJlZmVyZW5jZUJsYWNrV2hpdGU+MCAwIDI1NSAyNTUg
+              MCAwIDI1NSAyNTUgMCAwIDI1NSAyNTU8L21peDpyZWZlcmVuY2VCbGFja1doaXRlPgogICAgICAgICAg
+              ICA8L21peDpQaG90b21ldHJpY0ludGVycHJldGF0aW9uPgogICAgICAgICAgPC9taXg6QmFzaWNJbWFn
+              ZUNoYXJhY3RlcmlzdGljcz4KICAgICAgICA8L21peDpCYXNpY0ltYWdlSW5mb3JtYXRpb24+CiAgICAg
+              ICAgPG1peDpJbWFnZUNhcHR1cmVNZXRhZGF0YT4KICAgICAgICAgIDxtaXg6b3JpZW50YXRpb24+MTwv
+              bWl4Om9yaWVudGF0aW9uPgogICAgICAgIDwvbWl4OkltYWdlQ2FwdHVyZU1ldGFkYXRhPgogICAgICAg
+              IDxtaXg6SW1hZ2VBc3Nlc3NtZW50TWV0YWRhdGE+CiAgICAgICAgICA8bWl4OlNwYXRpYWxNZXRyaWNz
+              PgogICAgICAgICAgICA8bWl4OnNhbXBsaW5nRnJlcXVlbmN5VW5pdD4yPC9taXg6c2FtcGxpbmdGcmVx
+              dWVuY3lVbml0PgogICAgICAgICAgICA8bWl4OnhTYW1wbGluZ0ZyZXF1ZW5jeT4KICAgICAgICAgICAg
+              ICA8bWl4Om51bWVyYXRvcj4zMDAwMDAwPC9taXg6bnVtZXJhdG9yPgogICAgICAgICAgICAgIDxtaXg6
+              ZGVub21pbmF0b3I+MTAwMDA8L21peDpkZW5vbWluYXRvcj4KICAgICAgICAgICAgPC9taXg6eFNhbXBs
+              aW5nRnJlcXVlbmN5PgogICAgICAgICAgICA8bWl4OnlTYW1wbGluZ0ZyZXF1ZW5jeT4KICAgICAgICAg
+              ICAgICA8bWl4Om51bWVyYXRvcj4zMDAwMDAwPC9taXg6bnVtZXJhdG9yPgogICAgICAgICAgICAgIDxt
+              aXg6ZGVub21pbmF0b3I+MTAwMDA8L21peDpkZW5vbWluYXRvcj4KICAgICAgICAgICAgPC9taXg6eVNh
+              bXBsaW5nRnJlcXVlbmN5PgogICAgICAgICAgPC9taXg6U3BhdGlhbE1ldHJpY3M+CiAgICAgICAgICA8
+              bWl4OkltYWdlQ29sb3JFbmNvZGluZz4KICAgICAgICAgICAgPG1peDpiaXRzUGVyU2FtcGxlPgogICAg
+              ICAgICAgICAgIDxtaXg6Yml0c1BlclNhbXBsZVZhbHVlPjgsOCw4PC9taXg6Yml0c1BlclNhbXBsZVZh
+              bHVlPgogICAgICAgICAgICAgIDxtaXg6Yml0c1BlclNhbXBsZVVuaXQ+aW50ZWdlcjwvbWl4OmJpdHNQ
+              ZXJTYW1wbGVVbml0PgogICAgICAgICAgICA8L21peDpiaXRzUGVyU2FtcGxlPgogICAgICAgICAgICA8
+              bWl4OnNhbXBsZXNQZXJQaXhlbD4zPC9taXg6c2FtcGxlc1BlclBpeGVsPgogICAgICAgICAgPC9taXg6
+              SW1hZ2VDb2xvckVuY29kaW5nPgogICAgICAgIDwvbWl4OkltYWdlQXNzZXNzbWVudE1ldGFkYXRhPgog
+              ICAgICA8L21peDptaXg+CiAgICA8L2pob3ZlOnByb3BlcnRpZXM+CiAgPC9maWxlPgogIDxmaWxlIGlk
+              PSIyNTQyQS5qcDIiPgogICAgPGpob3ZlOnJlcG9ydGluZ01vZHVsZSByZWxlYXNlPSIxLjMiIGRhdGU9
+              IjIwMDctMDEtMDgiPkpQRUcyMDAwLWh1bDwvamhvdmU6cmVwb3J0aW5nTW9kdWxlPgogICAgPGpob3Zl
+              OmZvcm1hdD5KUEVHIDIwMDA8L2pob3ZlOmZvcm1hdD4KICAgIDxqaG92ZTpzdGF0dXM+V2VsbC1Gb3Jt
+              ZWQgYW5kIHZhbGlkPC9qaG92ZTpzdGF0dXM+CiAgICA8amhvdmU6c2lnTWF0Y2g+CiAgICAgIDxqaG92
+              ZTptb2R1bGU+SlBFRzIwMDAtaHVsPC9qaG92ZTptb2R1bGU+CiAgICA8L2pob3ZlOnNpZ01hdGNoPgog
+              ICAgPGpob3ZlOm1pbWVUeXBlPmltYWdlL2pwMjwvamhvdmU6bWltZVR5cGU+CiAgICA8amhvdmU6cHJv
+              ZmlsZXM+CiAgICAgIDxqaG92ZTpwcm9maWxlPkpQMjwvamhvdmU6cHJvZmlsZT4KICAgIDwvamhvdmU6
+              cHJvZmlsZXM+CiAgICA8amhvdmU6cHJvcGVydGllcz4KICAgICAgPG1peDptaXg+CiAgICAgICAgPG1p
+              eDpCYXNpY0RpZ2l0YWxPYmplY3RJbmZvcm1hdGlvbj4KICAgICAgICAgIDxtaXg6Ynl0ZU9yZGVyPmJp
+              Z19lbmRpYW48L21peDpieXRlT3JkZXI+CiAgICAgICAgICA8bWl4OkNvbXByZXNzaW9uPgogICAgICAg
+              ICAgICA8bWl4OmNvbXByZXNzaW9uU2NoZW1lPjM0NzEyPC9taXg6Y29tcHJlc3Npb25TY2hlbWU+CiAg
+              ICAgICAgICA8L21peDpDb21wcmVzc2lvbj4KICAgICAgICA8L21peDpCYXNpY0RpZ2l0YWxPYmplY3RJ
+              bmZvcm1hdGlvbj4KICAgICAgICA8bWl4OkJhc2ljSW1hZ2VJbmZvcm1hdGlvbj4KICAgICAgICAgIDxt
+              aXg6QmFzaWNJbWFnZUNoYXJhY3RlcmlzdGljcz4KICAgICAgICAgICAgPG1peDppbWFnZVdpZHRoPjY0
+              NzU8L21peDppbWFnZVdpZHRoPgogICAgICAgICAgICA8bWl4OmltYWdlSGVpZ2h0PjQ3NDc8L21peDpp
+              bWFnZUhlaWdodD4KICAgICAgICAgIDwvbWl4OkJhc2ljSW1hZ2VDaGFyYWN0ZXJpc3RpY3M+CiAgICAg
+              ICAgPC9taXg6QmFzaWNJbWFnZUluZm9ybWF0aW9uPgogICAgICAgIDxtaXg6SW1hZ2VBc3Nlc3NtZW50
+              TWV0YWRhdGE+CiAgICAgICAgICA8bWl4OlNwYXRpYWxNZXRyaWNzPgogICAgICAgICAgICA8bWl4OnNh
+              bXBsaW5nRnJlcXVlbmN5VW5pdD4zPC9taXg6c2FtcGxpbmdGcmVxdWVuY3lVbml0PgogICAgICAgICAg
+              ICA8bWl4OnhTYW1wbGluZ0ZyZXF1ZW5jeT4KICAgICAgICAgICAgICA8bWl4Om51bWVyYXRvcj4zMDAw
+              MDAwPC9taXg6bnVtZXJhdG9yPgogICAgICAgICAgICAgIDxtaXg6ZGVub21pbmF0b3I+MjU0MDA8L21p
+              eDpkZW5vbWluYXRvcj4KICAgICAgICAgICAgPC9taXg6eFNhbXBsaW5nRnJlcXVlbmN5PgogICAgICAg
+              ICAgICA8bWl4OnlTYW1wbGluZ0ZyZXF1ZW5jeT4KICAgICAgICAgICAgICA8bWl4Om51bWVyYXRvcj4z
+              MDAwMDAwPC9taXg6bnVtZXJhdG9yPgogICAgICAgICAgICAgIDxtaXg6ZGVub21pbmF0b3I+MjU0MDA8
+              L21peDpkZW5vbWluYXRvcj4KICAgICAgICAgICAgPC9taXg6eVNhbXBsaW5nRnJlcXVlbmN5PgogICAg
+              ICAgICAgPC9taXg6U3BhdGlhbE1ldHJpY3M+CiAgICAgICAgICA8bWl4OkltYWdlQ29sb3JFbmNvZGlu
+              Zz4KICAgICAgICAgICAgPG1peDpiaXRzUGVyU2FtcGxlPgogICAgICAgICAgICAgIDxtaXg6Yml0c1Bl
+              clNhbXBsZVZhbHVlPjgsOCw4PC9taXg6Yml0c1BlclNhbXBsZVZhbHVlPgogICAgICAgICAgICAgIDxt
+              aXg6Yml0c1BlclNhbXBsZVVuaXQ+aW50ZWdlcjwvbWl4OmJpdHNQZXJTYW1wbGVVbml0PgogICAgICAg
+              ICAgICA8L21peDpiaXRzUGVyU2FtcGxlPgogICAgICAgICAgICA8bWl4OnNhbXBsZXNQZXJQaXhlbD4z
+              PC9taXg6c2FtcGxlc1BlclBpeGVsPgogICAgICAgICAgPC9taXg6SW1hZ2VDb2xvckVuY29kaW5nPgog
+              ICAgICAgIDwvbWl4OkltYWdlQXNzZXNzbWVudE1ldGFkYXRhPgogICAgICA8L21peDptaXg+CiAgICA8
+              L2pob3ZlOnByb3BlcnRpZXM+CiAgPC9maWxlPgo8L3RlY2huaWNhbE1ldGFkYXRhPg==
+</foxml:binaryContent> 
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="provenanceMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="provenanceMetadata.2" LABEL="Provenance Metadata" CREATED="2015-08-11T20:05:51.295Z" MIMETYPE="text/xml" SIZE="265">
+<foxml:xmlContent>
+<provenanceMetadata objectId="druid:cg767mn6478">
+  <agent name="DOR">
+    <what object="druid:cg767mn6478">
+      <event when="2015-08-11T13:05:50-07:00" who="DOR-accessionWF">DOR Common Accessioning completed</event>
+    </what>
+  </agent>
+</provenanceMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="events" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="events.3" LABEL="Events" CREATED="2015-08-11T19:52:17.580Z" MIMETYPE="text/xml" SIZE="485">
+<foxml:xmlContent>
+<events>
+  <event type="remediation" when="2015-06-30T11:23:13-07:00" who="Dor::Identifiable 3.6.1">Record Remediation Version</event>
+  <event type="open" when="2015-07-10T12:13:26-07:00" who="Benjamin L Albritton">Version 2 opened</event>
+  <event type="close" when="2015-07-10T12:14:19-07:00" who="Benjamin L Albritton">Version 2 closed</event>
+  <event type="remediation" when="2015-08-11T12:52:17-07:00" who="Dor::Identifiable 3.6.1">Record Remediation Version</event>
+</events>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="versionMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="versionMetadata.7" LABEL="Version Metadata" CREATED="2016-06-01T16:02:50.233Z" MIMETYPE="text/xml" SIZE="413">
+<foxml:xmlContent>
+<versionMetadata objectId="druid:cg767mn6478">
+  <version tag="1.0.0" versionId="1">
+    <description>Initial Version</description>
+  </version>
+  <version tag="1.0.1" versionId="2">
+    <description>Add rels-ext stanza for constituent parts</description>
+  </version>
+  <version tag="1.0.2" versionId="3">
+    <description>auto remeditation replace_descMetadata.rb</description>
+  </version>
+</versionMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+</foxml:digitalObject>

--- a/spec/fixtures/item_druid_jw923xn5254.xml
+++ b/spec/fixtures/item_druid_jw923xn5254.xml
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foxml:digitalObject VERSION="1.1" PID="druid:jw923xn5254"
+xmlns:foxml="info:fedora/fedora-system:def/foxml#"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+<foxml:objectProperties>
+<foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="Title Page: Carey&apos;s American atlas."/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE="argo.stanford.edu"/>
+<foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2015-06-30T17:36:18.431Z"/>
+<foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE="2016-06-01T16:02:54.004Z"/>
+</foxml:objectProperties>
+<foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="DC1.0" LABEL="Dublin Core Record for this object" CREATED="2015-06-30T17:36:18.431Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="410">
+<foxml:xmlContent>
+<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:title>Title Page: Carey&apos;s American atlas.</dc:title>
+  <dc:identifier>druid:jw923xn5254</dc:identifier>
+</oai_dc:dc>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="RELS-EXT.1" LABEL="Fedora Object-to-Object Relationship Metadata" CREATED="2015-07-09T21:52:48.123Z" MIMETYPE="application/rdf+xml" SIZE="820">
+<foxml:xmlContent>
+<rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="info:fedora/druid:jw923xn5254">
+    <hydra:isGovernedBy rdf:resource="info:fedora/druid:sq161jk2248"></hydra:isGovernedBy>
+    <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_Item"></fedora-model:hasModel>
+    <fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"></fedora:isMemberOf>
+    <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"></fedora:isMemberOfCollection>
+    <fedora:isConstituentOf rdf:resource="info:fedora/druid:hj097bm8879"></fedora:isConstituentOf>
+  </rdf:Description>
+</rdf:RDF>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="identityMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="identityMetadata.8" LABEL="Identity Metadata" CREATED="2016-06-01T16:02:52.925Z" MIMETYPE="text/xml" SIZE="874">
+<foxml:xmlContent>
+<identityMetadata>
+  <sourceId source="Rumsey">2542B</sourceId>
+  <objectId>druid:jw923xn5254</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>Title Page: Carey&apos;s American atlas.</objectLabel>
+  <objectType>item</objectType>
+  <otherId name="label"></otherId>
+  <otherId name="uuid">80698a64-1f4e-11e5-9f88-0050569b3c3c</otherId>
+  <release displayType="image" release="true" to="Searchworks" what="self" when="2016-03-10T02:14:16Z" who="lauraw15">true</release>
+  <displayType>image</displayType>
+  <release displayType="image" release="true" to="Searchworks" what="self" when="2016-03-11T05:56:46Z" who="lauraw15">true</release>
+  <tag>Process : Content Type : Map</tag>
+  <tag>Project : Rumsey Map Collection : Batch 1 : PLN : 2542</tag>
+  <tag>LAB : RUMSEY</tag>
+  <tag>CATKEY : 10449093</tag>
+  <tag>Remediated By : 4.21.4</tag>
+</identityMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="workflows" STATE="A" CONTROL_GROUP="E" VERSIONABLE="true">
+<foxml:datastreamVersion ID="workflows.0" LABEL="Workflows" CREATED="2015-06-30T17:36:18.921Z" MIMETYPE="application/xml">
+<foxml:contentLocation TYPE="URL" REF="https://lyberservices-prod.stanford.edu/workflow/dor/objects/druid:jw923xn5254/workflows"/>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="descMetadata" STATE="A" CONTROL_GROUP="M" VERSIONABLE="true">
+<foxml:datastreamVersion ID="descMetadata.1" LABEL="Descriptive Metadata" CREATED="2015-08-11T19:44:02.087Z" MIMETYPE="text/xml" SIZE="3827">
+<foxml:binaryContent> 
+              PG1vZHMgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOnhzaT0i
+              aHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zPSJodHRwOi8vd3d3
+              LmxvYy5nb3YvbW9kcy92MyIgeHNpOnNjaGVtYUxvY2F0aW9uPSJodHRwOi8vd3d3LmxvYy5nb3YvbW9k
+              cy92MyBodHRwOi8vd3d3LmxvYy5nb3Yvc3RhbmRhcmRzL21vZHMvdjMvbW9kcy0zLTUueHNkIiB2ZXJz
+              aW9uPSIzLjUiPgogICAgICAgIDx0eXBlT2ZSZXNvdXJjZT50ZXh0PC90eXBlT2ZSZXNvdXJjZT4KICAg
+              ICAgICA8dGl0bGVJbmZvPgogICAgICAgIDx0aXRsZT4oVGl0bGUgUGFnZSB0bykgQ2FyZXkncyBBbWVy
+              aWNhbiBBdGxhczogQ29udGFpbmluZyBUd2VudHkgTWFwcyBBbmQgT25lIENoYXJ0IC4uLiBQaGlsYWRl
+              bHBoaWE6IEVuZ3JhdmVkIEZvciwgQW5kIFB1Ymxpc2hlZCBCeSwgTWF0aGV3IENhcmV5LCBOby4gMTE4
+              LCBNYXJrZXQgU3RyZWV0LiBNLkRDQy5YQ1YuIFtQcmljZSwgUGxhaW4sIEZpdmUgRG9sbGFycy1Db2xv
+              dXJlZCwgU2l4IERvbGxhcnMuXTwvdGl0bGU+CiAgICA8L3RpdGxlSW5mbz4KICAgIDx0aXRsZUluZm8g
+              dHlwZT0iYWx0ZXJuYXRpdmUiIGRpc3BsYXlMYWJlbD0iU2hvcnQgdGl0bGUiPgogICAgICAgIDx0aXRs
+              ZT5UaXRsZSBQYWdlOiBDYXJleSdzIEFtZXJpY2FuIGF0bGFzLjwvdGl0bGU+CiAgICA8L3RpdGxlSW5m
+              bz4KICAgIDxuYW1lIHR5cGU9InBlcnNvbmFsIiB1c2FnZT0icHJpbWFyeSI+ICAgICAgICAKICAgICAg
+              ICA8bmFtZVBhcnQ+Q2FyZXksIE1hdGhldzwvbmFtZVBhcnQ+CiAgICAgICAgPHJvbGU+CiAgICAgICAg
+              ICAgIDxyb2xlVGVybSB0eXBlPSJ0ZXh0IiBhdXRob3JpdHk9Im1hcmNyZWxhdG9yIj5hdXRob3I8L3Jv
+              bGVUZXJtPgogICAgICAgIDwvcm9sZT4KICAgIDwvbmFtZT4gICAgCiAgICAgICAgICAgICAgICAgICAg
+              ICAgICAgICA8Z2VucmU+VGl0bGUgUGFnZTwvZ2VucmU+CiAgICAgICAgPGdlbnJlIGF1dGhvcml0eT0i
+              YWF0IiB2YWx1ZVVSST0iaHR0cDovL3ZvY2FiLmdldHR5LmVkdS9hYXQvMzAwMDU1MDMzIj50aXRsZSBw
+              YWdlczwvZ2VucmU+CiAgICAgICAgCiAgICA8b3JpZ2luSW5mbyBldmVudFR5cGU9InB1YmxpY2F0aW9u
+              Ij4gCiAgICAgICAgPHBsYWNlPgogICAgICAgICAgICA8cGxhY2VUZXJtIHR5cGU9InRleHQiPlBoaWxh
+              ZGVscGhpYTwvcGxhY2VUZXJtPgogICAgICAgIDwvcGxhY2U+CiAgICAgICAgPHB1Ymxpc2hlcj5NYXRo
+              ZXcgQ2FyZXk8L3B1Ymxpc2hlcj4KICAgICAgICA8ZGF0ZUlzc3VlZCBlbmNvZGluZz0idzNjZHRmIiBr
+              ZXlEYXRlPSJ5ZXMiPjE3OTU8L2RhdGVJc3N1ZWQ+CiAgICA8L29yaWdpbkluZm8+CiAgICA8bGFuZ3Vh
+              Z2U+CiAgICAgICAgPGxhbmd1YWdlVGVybSB0eXBlPSJjb2RlIiBhdXRob3JpdHk9ImlzbzYzOS0yYiI+
+              ZW5nPC9sYW5ndWFnZVRlcm0+CiAgICA8L2xhbmd1YWdlPgogICAgPHBoeXNpY2FsRGVzY3JpcHRpb24+
+              CiAgICAgICAgICAgICAgICA8ZXh0ZW50PjM3IHggMjMgY208L2V4dGVudD4KICAgICAgICAgICAgICAg
+              IDxkaWdpdGFsT3JpZ2luPnJlZm9ybWF0dGVkIGRpZ2l0YWw8L2RpZ2l0YWxPcmlnaW4+CiAgICAgICAg
+              PGludGVybmV0TWVkaWFUeXBlPmltYWdlL2pwZWc8L2ludGVybmV0TWVkaWFUeXBlPgogICAgPC9waHlz
+              aWNhbERlc2NyaXB0aW9uPgogICAgICAgIDxub3RlPkZpcnN0IGF0bGFzIG9mIEFtZXJpY2EgcHJpbnRl
+              ZCBpbiBBbWVyaWNhLiBGaXJzdCBlZGl0aW9uLiBUaGVzZSBtYXBzIHdlcmUgYWxzbyBwdWJsaXNoZWQg
+              aW4gQ2FyZXkncyBBbWVyaWNhbiBlZGl0aW9uIG9mIEd1dGhyaWUncyBHZW9ncmFwaHkgKDE3OTUpIGFu
+              ZCBtb3N0IG9mIHRoZSBtYXBzIHNheSAiZW5ncmF2ZWQgZm9yIENhcmV5J3MgQW1lcmljYW4gZWRpdGlv
+              biBvZiBHdXRocmllJ3MgaW1wcm92ZWQuIiBUaGUgbWFwcyB3ZXJlIGFnYWluIHVzZWQgZm9yIHRoZSAx
+              Nzk2IGVkaXRpb24gb2YgQ2FyZXkncyBHZW5lcmFsIEF0bGFzLCB1bmNoYW5nZWQgZXhjZXB0IGZvciB0
+              aGUgVGVubmVzc2VlIG1hcCwgd2hpY2ggaXMgdGl0bGVkICJUZW5uYXNzZWUgU3RhdGUiIGluc3RlYWQg
+              b2YgIlRlbm5hc3NlZSBHb3Zlcm5tZW50IiB3aGljaCBpcyB0aGUgdGl0bGUgaW4gYm90aCB0aGUgQW1l
+              cmljYW4gQXRsYXMgYW5kIHRoZSBHdXRocmllIEF0bGFzIC0gc2VlIFdoZWF0IGFuZCBCcnVuLCBhbmQg
+              aGFzIHNldmVyYWwgY291bnRpZXMgZGVsaW5lYXRlZCBpbiB0aGUgZWFzdGVybiBwYXJ0IG9mIHRoZSBz
+              dGF0ZSB3aGljaCBkbyBub3Qgc2hvdyBpbiB0aGUgMTc5NSBlZGl0aW9uIG9mIHRoZSBtYXAuIE5NTSA0
+              ODAgKEFtZXJpY2FuIEF0bGFzKSBoYXMgIlRlbm5hc3NlZSBTdGF0ZSIgaW5kaWNhdGluZyB0aGF0IENh
+              cmV5IHdhcyBub3QgY29uc2lzdGVudC4gVGhpcyBhdGxhcyB3YXMgdGhlIG1vZGVsIGZvciBKb2huIFJl
+              aWQncyBBbWVyaWNhbiBBdGxhcyBvZiAxNzk2LiBUaGlzIGNvcHkncyBtYXBzIGhhdmUgdmVyeSBzdHJv
+              bmcgaW1wcmVzc2lvbnMuIFJlYm91bmQgcXVhcnRlciBsZWF0aGVyLCBtYXJibGVkIHBhcGVyIGNvdmVy
+              ZWQgYm9hcmRzLjwvbm90ZT4KICAgICAgICAgICAgICAgICAgICA8c3ViamVjdCBkaXNwbGF5TGFiZWw9
+              IkNvdW50cnkiPgogICAgICAgIDxnZW9ncmFwaGljPlVuaXRlZCBTdGF0ZXM8L2dlb2dyYXBoaWM+CiAg
+              ICA8L3N1YmplY3Q+CiAgICAgICAgICAgICAgICAgICAgPHN1YmplY3Q+CiAgICAgICAgPGNhcnRvZ3Jh
+              cGhpY3M+CiAgICAgICAgICAgIDxjb29yZGluYXRlcz5FMTIwMDAwMCBXMDMwMDAwMCBOMDc2MDAwMCBT
+              MDU5MDAwMDwvY29vcmRpbmF0ZXM+CiAgICAgICAgPC9jYXJ0b2dyYXBoaWNzPgogICAgPC9zdWJqZWN0
+              PgogICAgICAgIDxyZWxhdGVkSXRlbSB0eXBlPSJob3N0IiBkaXNwbGF5TGFiZWw9IkFwcGVhcnMgaW4i
+              PgogICAgICAgIDx0aXRsZUluZm8+CiAgICAgICAgICAgIDx0aXRsZT5DYXJleSdzIEFtZXJpY2FuIEF0
+              bGFzOiBDb250YWluaW5nIFR3ZW50eSBNYXBzIEFuZCBPbmUgQ2hhcnQgLi4uIFBoaWxhZGVscGhpYTog
+              RW5ncmF2ZWQgRm9yLCBBbmQgUHVibGlzaGVkIEJ5LCBNYXRoZXcgQ2FyZXksIE5vLiAxMTgsIE1hcmtl
+              dCBTdHJlZXQuIE0uRENDLlhDVi4gW1ByaWNlLCBQbGFpbiwgRml2ZSBEb2xsYXJzLUNvbG91cmVkLCBT
+              aXggRG9sbGFycy5dPC90aXRsZT4KICAgICAgICA8L3RpdGxlSW5mbz4KICAgICAgICA8b3JpZ2luSW5m
+              byBldmVudFR5cGU9InB1YmxpY2F0aW9uIj4KICAgICAgICAgICAgPGRhdGVJc3N1ZWQ+MTc5NTwvZGF0
+              ZUlzc3VlZD4KICAgICAgICA8L29yaWdpbkluZm8+CiAgICAgICAgPGlkZW50aWZpZXIgdHlwZT0ibG9j
+              YWwiIGRpc3BsYXlMYWJlbD0iUHViIGxpc3Qgbm8uIj4yNTQyPC9pZGVudGlmaWVyPgogICAgPC9yZWxh
+              dGVkSXRlbT4KICAgIDxpZGVudGlmaWVyIHR5cGU9ImxvY2FsIiBkaXNwbGF5TGFiZWw9Ikxpc3QgbnVt
+              YmVyIj4yNTQyQjwvaWRlbnRpZmllcj4KICAgIDxpZGVudGlmaWVyIHR5cGU9ImxvY2FsIiBkaXNwbGF5
+              TGFiZWw9IkltYWdlIG51bWJlciI+MjU0MkI8L2lkZW50aWZpZXI+CiAgICA8cmVjb3JkSW5mbz4KICAg
+              ICAgICA8bGFuZ3VhZ2VPZkNhdGFsb2dpbmc+CiAgICAgICAgICAgIDxsYW5ndWFnZVRlcm0gYXV0aG9y
+              aXR5PSJpc282MzktMmIiPmVuZzwvbGFuZ3VhZ2VUZXJtPgogICAgICAgIDwvbGFuZ3VhZ2VPZkNhdGFs
+              b2dpbmc+CiAgICAgICAgPHJlY29yZENvbnRlbnRTb3VyY2UgYXV0aG9yaXR5PSJtYXJjb3JnIj5DU3Q8
+              L3JlY29yZENvbnRlbnRTb3VyY2U+CiAgICA8L3JlY29yZEluZm8+CjwvbW9kcz4=
+</foxml:binaryContent> 
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="rightsMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="rightsMetadata.0" LABEL="Rights Metadata" CREATED="2015-06-30T17:36:19.307Z" MIMETYPE="text/xml" SIZE="1047">
+<foxml:xmlContent>
+<rightsMetadata>
+  <copyright>
+    <human type="copyright">Property rights reside with the repository, Copyright © Stanford University.  Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license. </human>
+  </copyright>
+  <access type="discover">
+    <machine>
+      <world></world>
+    </machine>
+  </access>
+  <access type="read">
+    <machine>
+      <world></world>
+    </machine>
+  </access>
+  <use>
+    <human type="useAndReproduction">To obtain permission to publish or reproduce commercially, please contact the Digital &amp; Rare Map Librarian, David Rumsey Map Center at rumseymapcenter@stanford.edu. </human>
+  </use>
+  <use>
+    <machine type="creativeCommons">by-nc-sa</machine>
+    <human type="creativeCommons">Attribution Non-Commercial Share Alike 3.0 Unported</human>
+  </use>
+</rightsMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="contentMetadata" STATE="A" CONTROL_GROUP="M" VERSIONABLE="true">
+<foxml:datastreamVersion ID="contentMetadata.0" LABEL="Content Metadata" CREATED="2015-06-30T18:22:36.390Z" MIMETYPE="text/xml" SIZE="796">
+<foxml:binaryContent> 
+              PGNvbnRlbnRNZXRhZGF0YSBvYmplY3RJZD0ianc5MjN4bjUyNTQiIHR5cGU9ImltYWdlIj4KICA8cmVz
+              b3VyY2UgaWQ9Imp3OTIzeG41MjU0XzEiIHNlcXVlbmNlPSIxIiB0eXBlPSJpbWFnZSI+CiAgICA8bGFi
+              ZWw+SW1hZ2UgMTwvbGFiZWw+CiAgICA8ZmlsZSBpZD0iMjU0MkIudGlmIiBwcmVzZXJ2ZT0ieWVzIiBw
+              dWJsaXNoPSJubyIgc2hlbHZlPSJubyIgbWltZXR5cGU9ImltYWdlL3RpZmYiIHNpemU9IjQ0MDI4ODkw
+              Ij4KICAgICAgPGNoZWNrc3VtIHR5cGU9Im1kNSI+YjVmNmZjZDZlYjBhZDAyODAwYWViODJjYmE2ZDBl
+              ZWQ8L2NoZWNrc3VtPgogICAgICA8Y2hlY2tzdW0gdHlwZT0ic2hhMSI+YTkwYWVhOTgzNjIwMjM4ZDhl
+              MTM4NGQ5YTVjYjY4M2M2YWNkNjk4NDwvY2hlY2tzdW0+CiAgICAgIDxpbWFnZURhdGEgd2lkdGg9IjMx
+              MzkiIGhlaWdodD0iNDY3NSIvPgogICAgPC9maWxlPgogICAgPGZpbGUgaWQ9IjI1NDJCLmpwMiIgbWlt
+              ZXR5cGU9ImltYWdlL2pwMiIgc2l6ZT0iMjc2MjY2OCIgcHJlc2VydmU9Im5vIiBwdWJsaXNoPSJ5ZXMi
+              IHNoZWx2ZT0ieWVzIj4KICAgICAgPGNoZWNrc3VtIHR5cGU9Im1kNSI+YmNjZGJiMjUwMGJiMTM5ZDZk
+              NjIyMzIxYmZkMmFhNTc8L2NoZWNrc3VtPgogICAgICA8Y2hlY2tzdW0gdHlwZT0ic2hhMSI+ODA0NTRj
+              MTExNjc1ZWM3ZTJjNDI1ZTkwOTgxMGM0OWE2OWZmZWYyNjwvY2hlY2tzdW0+CiAgICAgIDxpbWFnZURh
+              dGEgd2lkdGg9IjMxMzkiIGhlaWdodD0iNDY3NSIvPgogICAgPC9maWxlPgogIDwvcmVzb3VyY2U+Cjwv
+              Y29udGVudE1ldGFkYXRhPg==
+</foxml:binaryContent> 
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="technicalMetadata" STATE="A" CONTROL_GROUP="M" VERSIONABLE="true">
+<foxml:datastreamVersion ID="technicalMetadata.3" LABEL="Technical Metadata" CREATED="2015-08-11T19:47:33.072Z" MIMETYPE="text/xml" SIZE="4669">
+<foxml:binaryContent> 
+              PHRlY2huaWNhbE1ldGFkYXRhIHhtbG5zOmpob3ZlPSJodHRwOi8vaHVsLmhhcnZhcmQuZWR1L29pcy94
+              bWwvbnMvamhvdmUiIHhtbG5zOm1peD0iaHR0cDovL3d3dy5sb2MuZ292L21peC92MTAiIHhtbG5zOnRl
+              eHRtZD0iaW5mbzpsYy94bWxucy90ZXh0TUQtdjMiIG9iamVjdElkPSJkcnVpZDpqdzkyM3huNTI1NCIg
+              ZGF0ZXRpbWU9IjIwMTUtMDYtMzBUMTg6MjM6MDFaIj4KICA8ZmlsZSBpZD0iMjU0MkIudGlmIj4KICAg
+              IDxqaG92ZTpyZXBvcnRpbmdNb2R1bGUgcmVsZWFzZT0iMS43IiBkYXRlPSIyMDEyLTA4LTEyIj5USUZG
+              LWh1bDwvamhvdmU6cmVwb3J0aW5nTW9kdWxlPgogICAgPGpob3ZlOmZvcm1hdD5USUZGPC9qaG92ZTpm
+              b3JtYXQ+CiAgICA8amhvdmU6dmVyc2lvbj42LjA8L2pob3ZlOnZlcnNpb24+CiAgICA8amhvdmU6c3Rh
+              dHVzPldlbGwtRm9ybWVkIGFuZCB2YWxpZDwvamhvdmU6c3RhdHVzPgogICAgPGpob3ZlOnNpZ01hdGNo
+              PgogICAgICA8amhvdmU6bW9kdWxlPlRJRkYtaHVsPC9qaG92ZTptb2R1bGU+CiAgICA8L2pob3ZlOnNp
+              Z01hdGNoPgogICAgPGpob3ZlOm1pbWVUeXBlPmltYWdlL3RpZmY8L2pob3ZlOm1pbWVUeXBlPgogICAg
+              PGpob3ZlOnByb2ZpbGVzPgogICAgICA8amhvdmU6cHJvZmlsZT5CYXNlbGluZSBSR0IgKENsYXNzIFIp
+              PC9qaG92ZTpwcm9maWxlPgogICAgICA8amhvdmU6cHJvZmlsZT5ETEYgQmVuY2htYXJrIGZvciBGYWl0
+              aGZ1bCBEaWdpdGFsIFJlcHJvZHVjdGlvbnMgb2YgTW9ub2dyYXBocyBhbmQgU2VyaWFsczogY29sb3I8
+              L2pob3ZlOnByb2ZpbGU+CiAgICA8L2pob3ZlOnByb2ZpbGVzPgogICAgPGpob3ZlOnByb3BlcnRpZXM+
+              CiAgICAgIDxtaXg6bWl4PgogICAgICAgIDxtaXg6QmFzaWNEaWdpdGFsT2JqZWN0SW5mb3JtYXRpb24+
+              CiAgICAgICAgICA8bWl4OmJ5dGVPcmRlcj5iaWdfZW5kaWFuPC9taXg6Ynl0ZU9yZGVyPgogICAgICAg
+              ICAgPG1peDpDb21wcmVzc2lvbj4KICAgICAgICAgICAgPG1peDpjb21wcmVzc2lvblNjaGVtZT4xPC9t
+              aXg6Y29tcHJlc3Npb25TY2hlbWU+CiAgICAgICAgICA8L21peDpDb21wcmVzc2lvbj4KICAgICAgICA8
+              L21peDpCYXNpY0RpZ2l0YWxPYmplY3RJbmZvcm1hdGlvbj4KICAgICAgICA8bWl4OkJhc2ljSW1hZ2VJ
+              bmZvcm1hdGlvbj4KICAgICAgICAgIDxtaXg6QmFzaWNJbWFnZUNoYXJhY3RlcmlzdGljcz4KICAgICAg
+              ICAgICAgPG1peDppbWFnZVdpZHRoPjMxMzk8L21peDppbWFnZVdpZHRoPgogICAgICAgICAgICA8bWl4
+              OmltYWdlSGVpZ2h0PjQ2NzU8L21peDppbWFnZUhlaWdodD4KICAgICAgICAgICAgPG1peDpQaG90b21l
+              dHJpY0ludGVycHJldGF0aW9uPgogICAgICAgICAgICAgIDxtaXg6Y29sb3JTcGFjZT4yPC9taXg6Y29s
+              b3JTcGFjZT4KICAgICAgICAgICAgICA8bWl4OnJlZmVyZW5jZUJsYWNrV2hpdGU+MCAwIDI1NSAyNTUg
+              MCAwIDI1NSAyNTUgMCAwIDI1NSAyNTU8L21peDpyZWZlcmVuY2VCbGFja1doaXRlPgogICAgICAgICAg
+              ICA8L21peDpQaG90b21ldHJpY0ludGVycHJldGF0aW9uPgogICAgICAgICAgPC9taXg6QmFzaWNJbWFn
+              ZUNoYXJhY3RlcmlzdGljcz4KICAgICAgICA8L21peDpCYXNpY0ltYWdlSW5mb3JtYXRpb24+CiAgICAg
+              ICAgPG1peDpJbWFnZUNhcHR1cmVNZXRhZGF0YT4KICAgICAgICAgIDxtaXg6b3JpZW50YXRpb24+MTwv
+              bWl4Om9yaWVudGF0aW9uPgogICAgICAgIDwvbWl4OkltYWdlQ2FwdHVyZU1ldGFkYXRhPgogICAgICAg
+              IDxtaXg6SW1hZ2VBc3Nlc3NtZW50TWV0YWRhdGE+CiAgICAgICAgICA8bWl4OlNwYXRpYWxNZXRyaWNz
+              PgogICAgICAgICAgICA8bWl4OnNhbXBsaW5nRnJlcXVlbmN5VW5pdD4yPC9taXg6c2FtcGxpbmdGcmVx
+              dWVuY3lVbml0PgogICAgICAgICAgICA8bWl4OnhTYW1wbGluZ0ZyZXF1ZW5jeT4KICAgICAgICAgICAg
+              ICA8bWl4Om51bWVyYXRvcj4zMDAwMDAwPC9taXg6bnVtZXJhdG9yPgogICAgICAgICAgICAgIDxtaXg6
+              ZGVub21pbmF0b3I+MTAwMDA8L21peDpkZW5vbWluYXRvcj4KICAgICAgICAgICAgPC9taXg6eFNhbXBs
+              aW5nRnJlcXVlbmN5PgogICAgICAgICAgICA8bWl4OnlTYW1wbGluZ0ZyZXF1ZW5jeT4KICAgICAgICAg
+              ICAgICA8bWl4Om51bWVyYXRvcj4zMDAwMDAwPC9taXg6bnVtZXJhdG9yPgogICAgICAgICAgICAgIDxt
+              aXg6ZGVub21pbmF0b3I+MTAwMDA8L21peDpkZW5vbWluYXRvcj4KICAgICAgICAgICAgPC9taXg6eVNh
+              bXBsaW5nRnJlcXVlbmN5PgogICAgICAgICAgPC9taXg6U3BhdGlhbE1ldHJpY3M+CiAgICAgICAgICA8
+              bWl4OkltYWdlQ29sb3JFbmNvZGluZz4KICAgICAgICAgICAgPG1peDpiaXRzUGVyU2FtcGxlPgogICAg
+              ICAgICAgICAgIDxtaXg6Yml0c1BlclNhbXBsZVZhbHVlPjgsOCw4PC9taXg6Yml0c1BlclNhbXBsZVZh
+              bHVlPgogICAgICAgICAgICAgIDxtaXg6Yml0c1BlclNhbXBsZVVuaXQ+aW50ZWdlcjwvbWl4OmJpdHNQ
+              ZXJTYW1wbGVVbml0PgogICAgICAgICAgICA8L21peDpiaXRzUGVyU2FtcGxlPgogICAgICAgICAgICA8
+              bWl4OnNhbXBsZXNQZXJQaXhlbD4zPC9taXg6c2FtcGxlc1BlclBpeGVsPgogICAgICAgICAgPC9taXg6
+              SW1hZ2VDb2xvckVuY29kaW5nPgogICAgICAgIDwvbWl4OkltYWdlQXNzZXNzbWVudE1ldGFkYXRhPgog
+              ICAgICA8L21peDptaXg+CiAgICA8L2pob3ZlOnByb3BlcnRpZXM+CiAgPC9maWxlPgogIDxmaWxlIGlk
+              PSIyNTQyQi5qcDIiPgogICAgPGpob3ZlOnJlcG9ydGluZ01vZHVsZSByZWxlYXNlPSIxLjMiIGRhdGU9
+              IjIwMDctMDEtMDgiPkpQRUcyMDAwLWh1bDwvamhvdmU6cmVwb3J0aW5nTW9kdWxlPgogICAgPGpob3Zl
+              OmZvcm1hdD5KUEVHIDIwMDA8L2pob3ZlOmZvcm1hdD4KICAgIDxqaG92ZTpzdGF0dXM+V2VsbC1Gb3Jt
+              ZWQgYW5kIHZhbGlkPC9qaG92ZTpzdGF0dXM+CiAgICA8amhvdmU6c2lnTWF0Y2g+CiAgICAgIDxqaG92
+              ZTptb2R1bGU+SlBFRzIwMDAtaHVsPC9qaG92ZTptb2R1bGU+CiAgICA8L2pob3ZlOnNpZ01hdGNoPgog
+              ICAgPGpob3ZlOm1pbWVUeXBlPmltYWdlL2pwMjwvamhvdmU6bWltZVR5cGU+CiAgICA8amhvdmU6cHJv
+              ZmlsZXM+CiAgICAgIDxqaG92ZTpwcm9maWxlPkpQMjwvamhvdmU6cHJvZmlsZT4KICAgIDwvamhvdmU6
+              cHJvZmlsZXM+CiAgICA8amhvdmU6cHJvcGVydGllcz4KICAgICAgPG1peDptaXg+CiAgICAgICAgPG1p
+              eDpCYXNpY0RpZ2l0YWxPYmplY3RJbmZvcm1hdGlvbj4KICAgICAgICAgIDxtaXg6Ynl0ZU9yZGVyPmJp
+              Z19lbmRpYW48L21peDpieXRlT3JkZXI+CiAgICAgICAgICA8bWl4OkNvbXByZXNzaW9uPgogICAgICAg
+              ICAgICA8bWl4OmNvbXByZXNzaW9uU2NoZW1lPjM0NzEyPC9taXg6Y29tcHJlc3Npb25TY2hlbWU+CiAg
+              ICAgICAgICA8L21peDpDb21wcmVzc2lvbj4KICAgICAgICA8L21peDpCYXNpY0RpZ2l0YWxPYmplY3RJ
+              bmZvcm1hdGlvbj4KICAgICAgICA8bWl4OkJhc2ljSW1hZ2VJbmZvcm1hdGlvbj4KICAgICAgICAgIDxt
+              aXg6QmFzaWNJbWFnZUNoYXJhY3RlcmlzdGljcz4KICAgICAgICAgICAgPG1peDppbWFnZVdpZHRoPjMx
+              Mzk8L21peDppbWFnZVdpZHRoPgogICAgICAgICAgICA8bWl4OmltYWdlSGVpZ2h0PjQ2NzU8L21peDpp
+              bWFnZUhlaWdodD4KICAgICAgICAgIDwvbWl4OkJhc2ljSW1hZ2VDaGFyYWN0ZXJpc3RpY3M+CiAgICAg
+              ICAgPC9taXg6QmFzaWNJbWFnZUluZm9ybWF0aW9uPgogICAgICAgIDxtaXg6SW1hZ2VBc3Nlc3NtZW50
+              TWV0YWRhdGE+CiAgICAgICAgICA8bWl4OlNwYXRpYWxNZXRyaWNzPgogICAgICAgICAgICA8bWl4OnNh
+              bXBsaW5nRnJlcXVlbmN5VW5pdD4zPC9taXg6c2FtcGxpbmdGcmVxdWVuY3lVbml0PgogICAgICAgICAg
+              ICA8bWl4OnhTYW1wbGluZ0ZyZXF1ZW5jeT4KICAgICAgICAgICAgICA8bWl4Om51bWVyYXRvcj4zMDAw
+              MDAwPC9taXg6bnVtZXJhdG9yPgogICAgICAgICAgICAgIDxtaXg6ZGVub21pbmF0b3I+MjU0MDA8L21p
+              eDpkZW5vbWluYXRvcj4KICAgICAgICAgICAgPC9taXg6eFNhbXBsaW5nRnJlcXVlbmN5PgogICAgICAg
+              ICAgICA8bWl4OnlTYW1wbGluZ0ZyZXF1ZW5jeT4KICAgICAgICAgICAgICA8bWl4Om51bWVyYXRvcj4z
+              MDAwMDAwPC9taXg6bnVtZXJhdG9yPgogICAgICAgICAgICAgIDxtaXg6ZGVub21pbmF0b3I+MjU0MDA8
+              L21peDpkZW5vbWluYXRvcj4KICAgICAgICAgICAgPC9taXg6eVNhbXBsaW5nRnJlcXVlbmN5PgogICAg
+              ICAgICAgPC9taXg6U3BhdGlhbE1ldHJpY3M+CiAgICAgICAgICA8bWl4OkltYWdlQ29sb3JFbmNvZGlu
+              Zz4KICAgICAgICAgICAgPG1peDpiaXRzUGVyU2FtcGxlPgogICAgICAgICAgICAgIDxtaXg6Yml0c1Bl
+              clNhbXBsZVZhbHVlPjgsOCw4PC9taXg6Yml0c1BlclNhbXBsZVZhbHVlPgogICAgICAgICAgICAgIDxt
+              aXg6Yml0c1BlclNhbXBsZVVuaXQ+aW50ZWdlcjwvbWl4OmJpdHNQZXJTYW1wbGVVbml0PgogICAgICAg
+              ICAgICA8L21peDpiaXRzUGVyU2FtcGxlPgogICAgICAgICAgICA8bWl4OnNhbXBsZXNQZXJQaXhlbD4z
+              PC9taXg6c2FtcGxlc1BlclBpeGVsPgogICAgICAgICAgPC9taXg6SW1hZ2VDb2xvckVuY29kaW5nPgog
+              ICAgICAgIDwvbWl4OkltYWdlQXNzZXNzbWVudE1ldGFkYXRhPgogICAgICA8L21peDptaXg+CiAgICA8
+              L2pob3ZlOnByb3BlcnRpZXM+CiAgPC9maWxlPgo8L3RlY2huaWNhbE1ldGFkYXRhPg==
+</foxml:binaryContent> 
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="provenanceMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+<foxml:datastreamVersion ID="provenanceMetadata.2" LABEL="Provenance Metadata" CREATED="2015-08-11T20:05:57.588Z" MIMETYPE="text/xml" SIZE="265">
+<foxml:xmlContent>
+<provenanceMetadata objectId="druid:jw923xn5254">
+  <agent name="DOR">
+    <what object="druid:jw923xn5254">
+      <event when="2015-08-11T13:05:57-07:00" who="DOR-accessionWF">DOR Common Accessioning completed</event>
+    </what>
+  </agent>
+</provenanceMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="events" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="events.3" LABEL="Events" CREATED="2015-08-11T19:52:21.479Z" MIMETYPE="text/xml" SIZE="485">
+<foxml:xmlContent>
+<events>
+  <event type="remediation" when="2015-06-30T11:23:15-07:00" who="Dor::Identifiable 3.6.1">Record Remediation Version</event>
+  <event type="open" when="2015-07-10T12:13:29-07:00" who="Benjamin L Albritton">Version 2 opened</event>
+  <event type="close" when="2015-07-10T12:14:21-07:00" who="Benjamin L Albritton">Version 2 closed</event>
+  <event type="remediation" when="2015-08-11T12:52:20-07:00" who="Dor::Identifiable 3.6.1">Record Remediation Version</event>
+</events>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="versionMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="false">
+<foxml:datastreamVersion ID="versionMetadata.7" LABEL="Version Metadata" CREATED="2016-06-01T16:02:54.004Z" MIMETYPE="text/xml" SIZE="413">
+<foxml:xmlContent>
+<versionMetadata objectId="druid:jw923xn5254">
+  <version tag="1.0.0" versionId="1">
+    <description>Initial Version</description>
+  </version>
+  <version tag="1.0.1" versionId="2">
+    <description>Add rels-ext stanza for constituent parts</description>
+  </version>
+  <version tag="1.0.2" versionId="3">
+    <description>auto remeditation replace_descMetadata.rb</description>
+  </version>
+</versionMetadata>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+</foxml:digitalObject>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -91,3 +91,7 @@ end
 def fixture_dir
   @fixture_dir ||= File.join(File.dirname(__FILE__), 'fixtures')
 end
+
+def read_fixture(fname)
+  File.read(File.join(fixture_dir, fname))
+end

--- a/spec/services/dublin_core_service_spec.rb
+++ b/spec/services/dublin_core_service_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DublinCoreService do
+  subject(:service) { described_class.new(item) }
+
+  let(:item) { instantiate_fixture('druid:ab123cd4567', Dor::Item) }
+
+  describe '#ng_xml' do
+    subject(:xml) { service.ng_xml }
+
+    it 'produces dublin core from the MODS in the descMetadata datastream' do
+      item.descMetadata.content = read_fixture('ex1_mods.xml')
+      expect(xml).to be_equivalent_to read_fixture('ex1_dc.xml')
+    end
+
+    it 'produces dublin core Stanford-specific mapping for repository, collection and location, from the MODS in the descMetadata datastream' do
+      item.descMetadata.content = read_fixture('ex2_related_mods.xml')
+      expect(xml).to be_equivalent_to read_fixture('ex2_related_dc.xml')
+    end
+
+    it 'throws an exception if the generated dc has only a root element with no children' do
+      mods = <<-EOXML
+      <mods:mods xmlns:mods="http://www.loc.gov/mods/v3"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      version="3.3"
+      xsi:schemaLocation="http://www.loc.gov/mods/v3 http://cosimo.stanford.edu/standards/mods/v3/mods-3-3.xsd" />
+      EOXML
+
+      item.descMetadata.content = mods
+      expect { xml }.to raise_error(DublinCoreService::CrosswalkError)
+    end
+  end
+end

--- a/spec/services/public_xml_service_spec.rb
+++ b/spec/services/public_xml_service_spec.rb
@@ -1,0 +1,319 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PublicXmlService do
+  subject(:service) { described_class.new(item) }
+
+  let(:item) { instantiate_fixture('druid:ab123cd4567', Dor::Item) }
+
+  describe '#to_xml' do
+    subject(:xml) { service.to_xml }
+
+    let(:rels) do
+      <<-EOXML
+            <rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:hydra="http://projecthydra.org/ns/relations#">
+              <rdf:Description rdf:about="info:fedora/druid:ab123cd4567">
+                <hydra:isGovernedBy rdf:resource="info:fedora/druid:789012"></hydra:isGovernedBy>
+                <fedora-model:hasModel rdf:resource="info:fedora/hydra:commonMetadata"></fedora-model:hasModel>
+                <fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"></fedora:isMemberOf>
+                <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"></fedora:isMemberOfCollection>
+                <fedora:isConstituentOf rdf:resource="info:fedora/druid:hj097bm8879"></fedora:isConstituentOf>
+              </rdf:Description>
+            </rdf:RDF>
+      EOXML
+    end
+
+    before do
+      # allow(Dor.config)
+      Dor.configure do
+        stacks do
+          host 'stacks.stanford.edu'
+        end
+      end
+      mods = <<-EOXML
+        <mods:mods xmlns:mods="http://www.loc.gov/mods/v3"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   version="3.3"
+                   xsi:schemaLocation="http://www.loc.gov/mods/v3 http://cosimo.stanford.edu/standards/mods/v3/mods-3-3.xsd">
+          <mods:identifier type="local" displayLabel="SUL Resource ID">druid:ab123cd4567</mods:identifier>
+        </mods:mods>
+      EOXML
+
+      rights = <<-EOXML
+        <rightsMetadata objectId="druid:ab123cd4567">
+          <copyright>
+            <human>(c) Copyright 2010 by Sebastian Jeremias Osterfeld</human>
+          </copyright>
+          </access>
+          <access type="read">
+            <machine>
+              <group>stanford:stanford</group>
+            </machine>
+          </access>
+          <use>
+            <machine type="creativeCommons">by-sa</machine>
+            <human type="creativeCommons">CC Attribution Share Alike license</human>
+          </use>
+        </rightsMetadata>
+      EOXML
+
+      item.contentMetadata.content = '<contentMetadata/>'
+      item.descMetadata.content    = mods
+      item.rightsMetadata.content  = rights
+      item.rels_ext.content        = rels
+      allow_any_instance_of(Dor::PublicDescMetadataService).to receive(:ng_xml).and_return(Nokogiri::XML(mods)) # calls Item.find and not needed in general tests
+      allow(OpenURI).to receive(:open_uri).with('https://purl-test.stanford.edu/ab123cd4567.xml').and_return('<xml/>')
+      WebMock.disable_net_connect!
+    end
+
+    let(:ng_xml) { Nokogiri::XML(xml) }
+
+    context 'when there are no release tags' do
+      before do
+        expect(item).to receive(:released_for).and_return({})
+      end
+
+      it 'does not include a releaseData element and any info in identityMetadata' do
+        expect(ng_xml.at_xpath('/publicObject/releaseData')).to be_nil
+        expect(ng_xml.at_xpath('/publicObject/identityMetadata/release')).to be_nil
+      end
+    end
+
+    context 'produces xml with' do
+      let(:now) { Time.now.utc }
+
+      before do
+        allow(Time).to receive(:now).and_return(now)
+      end
+
+      it 'an encoding of UTF-8' do
+        expect(ng_xml.encoding).to match(/UTF-8/)
+      end
+      it 'an id attribute' do
+        expect(ng_xml.at_xpath('/publicObject/@id').value).to match(/^druid:ab123cd4567/)
+      end
+      it 'a published attribute' do
+        expect(ng_xml.at_xpath('/publicObject/@published').value).to eq(now.xmlschema)
+      end
+      it 'a published version' do
+        expect(ng_xml.at_xpath('/publicObject/@publishVersion').value).to eq('dor-services/' + Dor::VERSION)
+      end
+      it 'identityMetadata' do
+        expect(ng_xml.at_xpath('/publicObject/identityMetadata')).to be
+      end
+      it 'no contentMetadata element' do
+        expect(ng_xml.at_xpath('/publicObject/contentMetadata')).not_to be
+      end
+
+      describe 'with contentMetadata present' do
+        before do
+          item.contentMetadata.content = <<-XML
+            <?xml version="1.0"?>
+            <contentMetadata objectId="druid:ab123cd4567" type="file">
+              <resource id="0001" sequence="1" type="file">
+                <file id="some_file.pdf" mimetype="file/pdf" publish="yes"/>
+              </resource>
+            </contentMetadata>
+          XML
+        end
+
+        it 'include contentMetadata' do
+          expect(ng_xml.at_xpath('/publicObject/contentMetadata')).to be
+        end
+      end
+
+      it 'rightsMetadata' do
+        expect(ng_xml.at_xpath('/publicObject/rightsMetadata')).to be
+      end
+      it 'generated mods' do
+        expect(ng_xml.at_xpath('/publicObject/mods:mods', 'mods' => 'http://www.loc.gov/mods/v3')).to be
+      end
+
+      it 'generated dublin core' do
+        expect(ng_xml.at_xpath('/publicObject/oai_dc:dc', 'oai_dc' => 'http://www.openarchives.org/OAI/2.0/oai_dc/')).to be
+      end
+
+      it 'relationships' do
+        ns = {
+          'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+          'hydra' => 'http://projecthydra.org/ns/relations#',
+          'fedora' => 'info:fedora/fedora-system:def/relations-external#',
+          'fedora-model' => 'info:fedora/fedora-system:def/model#'
+        }
+        expect(ng_xml.at_xpath('/publicObject/rdf:RDF', ns)).to be
+        expect(ng_xml.at_xpath('/publicObject/rdf:RDF/rdf:Description/fedora:isMemberOf', ns)).to be
+        expect(ng_xml.at_xpath('/publicObject/rdf:RDF/rdf:Description/fedora:isMemberOfCollection', ns)).to be
+        expect(ng_xml.at_xpath('/publicObject/rdf:RDF/rdf:Description/fedora:isConstituentOf', ns)).to be
+        expect(ng_xml.at_xpath('/publicObject/rdf:RDF/rdf:Description/fedora-model:hasModel', ns)).not_to be
+        expect(ng_xml.at_xpath('/publicObject/rdf:RDF/rdf:Description/hydra:isGovernedBy', ns)).not_to be
+      end
+
+      it 'clones of the content of the other datastreams, keeping the originals in tact' do
+        expect(item.datastreams['identityMetadata'].ng_xml.at_xpath('/identityMetadata')).to be
+        expect(item.datastreams['contentMetadata'].ng_xml.at_xpath('/contentMetadata')).to be
+        expect(item.datastreams['rightsMetadata'].ng_xml.at_xpath('/rightsMetadata')).to be
+        expect(item.datastreams['RELS-EXT'].content).to be_equivalent_to rels
+      end
+
+      it 'does not add a thumb node if no thumb is present' do
+        expect(ng_xml.at_xpath('/publicObject/thumb')).not_to be
+      end
+
+      it 'include a thumb node if a thumb is present' do
+        item.contentMetadata.content = <<-XML
+          <?xml version="1.0"?>
+          <contentMetadata objectId="druid:ab123cd4567" type="map">
+            <resource id="0001" sequence="1" type="image">
+              <file id="ab123cd4567_05_0001.jp2" mimetype="image/jp2"/>
+            </resource>
+            <resource id="0002" sequence="2" thumb="yes" type="image">
+              <file id="ab123cd4567_05_0002.jp2" mimetype="image/jp2"/>
+            </resource>
+          </contentMetadata>
+        XML
+        expect(ng_xml.at_xpath('/publicObject/thumb').to_xml).to be_equivalent_to('<thumb>ab123cd4567/ab123cd4567_05_0002.jp2</thumb>')
+      end
+
+      it 'includes releaseData element from release tags' do
+        releases = ng_xml.xpath('/publicObject/releaseData/release')
+        expect(releases.map(&:inner_text)).to eq %w[true true]
+        expect(releases.map { |r| r['to'] }).to eq %w[Searchworks Some_special_place]
+      end
+
+      it 'include a releaseData element when there is content inside it, but does not include this release data in identityMetadata' do
+        allow(item).to receive(:released_for).and_return('' => { 'release' => 'foo' })
+        expect(ng_xml.at_xpath('/publicObject/releaseData/release').inner_text).to eq 'foo'
+        expect(ng_xml.at_xpath('/publicObject/identityMetadata/release')).to be_nil
+      end
+    end
+
+    context 'with a collection' do
+      it 'publishes the expected datastreams' do
+        expect(ng_xml.at_xpath('/publicObject/identityMetadata')).to be
+        expect(ng_xml.at_xpath('/publicObject/rightsMetadata')).to be
+        expect(ng_xml.at_xpath('/publicObject/mods:mods', 'mods' => 'http://www.loc.gov/mods/v3')).to be
+        expect(ng_xml.at_xpath('/publicObject/rdf:RDF', 'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#')).to be
+        expect(ng_xml.at_xpath('/publicObject/oai_dc:dc', 'oai_dc' => 'http://www.openarchives.org/OAI/2.0/oai_dc/')).to be
+      end
+    end
+
+    context 'with external references' do
+      it 'handles externalFile references' do
+        correct_content_md = Nokogiri::XML(read_fixture('hj097bm8879_publicObject.xml')).at_xpath('/publicObject/contentMetadata').to_xml
+        item.contentMetadata.content = read_fixture('hj097bm8879_contentMetadata.xml')
+
+        cover_item = instantiate_fixture('druid:cg767mn6478', Dor::Item)
+        allow(Dor).to receive(:find).with(cover_item.pid).and_return(cover_item)
+        title_item = instantiate_fixture('druid:jw923xn5254', Dor::Item)
+        allow(Dor).to receive(:find).with(title_item.pid).and_return(title_item)
+
+        # generate publicObject XML and verify that the content metadata portion is correct and the correct thumb is present
+        expect(ng_xml.at_xpath('/publicObject/contentMetadata').to_xml).to be_equivalent_to(correct_content_md)
+        expect(ng_xml.at_xpath('/publicObject/thumb').to_xml).to be_equivalent_to('<thumb>jw923xn5254/2542B.jp2</thumb>')
+      end
+
+      context 'when the referenced object does not have the referenced image' do
+        let(:cover_item) { instance_double(Dor::Item, pid: 'druid:cg767mn6478', contentMetadata: contentMetadata) }
+        let(:contentMetadata) { instance_double(Dor::ContentMetadataDS, ng_xml: Nokogiri::XML(cm_xml)) }
+        let(:cm_xml) do
+          <<-EOXML
+          <contentMetadata objectId="cg767mn6478" type="map">
+            <resource id="cg767mn6478_1" sequence="1" type="image">
+            </resource>
+          </contentMetadata>
+          EOXML
+        end
+
+        before do
+          item.contentMetadata.content = <<-EOXML
+          <contentMetadata objectId="hj097bm8879" type="map">
+            <resource id="hj097bm8879_1" sequence="1" type="image">
+              <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1" />
+              <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+            </resource>
+          </contentMetadata>
+          EOXML
+
+          allow(Dor).to receive(:find).with(cover_item.pid).and_return(cover_item)
+        end
+
+        it 'raises an error' do
+          expect { xml }.to raise_error(Dor::DataError, 'Unable to find a file node with id="2542A.jp2" (child of druid:ab123cd4567)')
+        end
+      end
+
+      context 'when it is missing resourceId and mimetype attributes' do
+        before do
+          item.contentMetadata.content = <<-EOXML
+          <contentMetadata objectId="hj097bm8879" type="map">
+            <resource id="hj097bm8879_1" sequence="1" type="image">
+              <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478"/>
+              <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+            </resource>
+          </contentMetadata>
+          EOXML
+        end
+
+        it 'raises an error' do
+          # generate publicObject XML and verify that the content metadata portion is invalid
+          expect { xml }.to raise_error(Dor::DataError)
+        end
+      end
+
+      context 'when it has blank resourceId attribute' do
+        before do
+          item.contentMetadata.content = <<-EOXML
+          <contentMetadata objectId="hj097bm8879" type="map">
+            <resource id="hj097bm8879_1" sequence="1" type="image">
+              <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId=" " mimetype="image/jp2"/>
+              <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+            </resource>
+          </contentMetadata>
+          EOXML
+        end
+
+        it 'raises an error' do
+          # generate publicObject XML and verify that the content metadata portion is invalid
+          expect { xml }.to raise_error(Dor::DataError)
+        end
+      end
+
+      context 'when it has blank fileId attribute' do
+        before do
+          item.contentMetadata.content = <<-EOXML
+          <contentMetadata objectId="hj097bm8879" type="map">
+            <resource id="hj097bm8879_1" sequence="1" type="image">
+              <externalFile fileId=" " objectId="druid:cg767mn6478" resourceId="cg767mn6478_1" mimetype="image/jp2"/>
+              <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+            </resource>
+          </contentMetadata>
+          EOXML
+        end
+
+        it 'raises an error' do
+          # generate publicObject XML and verify that the content metadata portion is invalid
+          expect { xml }.to raise_error(Dor::DataError)
+        end
+      end
+
+      context 'when it has blank objectId attribute' do
+        before do
+          item.contentMetadata.content = <<-EOXML
+          <contentMetadata objectId="hj097bm8879" type="map">
+            <resource id="hj097bm8879_1" sequence="1" type="image">
+              <externalFile fileId="2542A.jp2" objectId=" " resourceId="cg767mn6478_1" mimetype="image/jp2"/>
+              <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+            </resource>
+          </contentMetadata>
+          EOXML
+        end
+
+        it 'raises an error' do
+          # generate publicObject XML and verify that the content metadata portion is invalid
+          expect { xml }.to raise_error(Dor::DataError)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/publish_metadata_service_spec.rb
+++ b/spec/services/publish_metadata_service_spec.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PublishMetadataService do
+  let(:item) do
+    instantiate_fixture('druid:ab123cd4567', Dor::Item).tap do |i|
+      i.contentMetadata.content = '<contentMetadata/>'
+      i.rels_ext.content = rels
+    end
+  end
+  let(:service) { described_class.new(item) }
+
+  let(:rels) do
+    <<-EOXML
+      <rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:hydra="http://projecthydra.org/ns/relations#">
+        <rdf:Description rdf:about="info:fedora/druid:ab123cd4567">
+          <hydra:isGovernedBy rdf:resource="info:fedora/druid:789012"></hydra:isGovernedBy>
+          <fedora-model:hasModel rdf:resource="info:fedora/hydra:commonMetadata"></fedora-model:hasModel>
+          <fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"></fedora:isMemberOf>
+          <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"></fedora:isMemberOfCollection>
+          <fedora:isConstituentOf rdf:resource="info:fedora/druid:hj097bm8879"></fedora:isConstituentOf>
+        </rdf:Description>
+      </rdf:RDF>
+    EOXML
+  end
+
+  describe '#publish' do
+    before do
+      allow(OpenURI).to receive(:open_uri).with('https://purl-test.stanford.edu/ab123cd4567.xml').and_return('<xml/>')
+    end
+
+    context 'with no world discover access in rightsMetadata' do
+      let(:purl_root) { Dir.mktmpdir }
+
+      before do
+        item.rightsMetadata.content = <<-EOXML
+          <rightsMetadata objectId="druid:ab123cd4567">
+            <copyright>
+              <human>(c) Copyright 2010 by Sebastian Jeremias Osterfeld</human>
+            </copyright>
+            </access>
+            <access type="read">
+              <machine>
+                <group>stanford:stanford</group>
+              </machine>
+            </access>
+            <use>
+              <machine type="creativeCommons">by-sa</machine>
+              <human type="creativeCommons">CC Attribution Share Alike license</human>
+            </use>
+          </rightsMetadata>
+        EOXML
+
+        Dor::Config.push! do |config|
+          config.stacks.local_document_cache_root purl_root
+          config.purl_services.url 'http://example.com/purl'
+        end
+
+        stub_request(:delete, 'example.com/purl/purls/ab123cd4567')
+      end
+
+      after do
+        FileUtils.remove_entry purl_root
+        Dor::Config.pop!
+      end
+
+      it 'notifies the purl service of the deletion' do
+        service.publish
+        expect(WebMock).to have_requested(:delete, 'example.com/purl/purls/ab123cd4567')
+      end
+
+      it "removes the item's content from the Purl document cache and creates a .delete entry" do
+        # create druid tree and dummy content in purl root
+        druid1 = DruidTools::Druid.new item.pid, purl_root
+        druid1.mkdir
+        expect(druid1).not_to be_deletes_record_exists # deletes record not there yet
+        File.open(File.join(druid1.path, 'tmpfile'), 'w') { |f| f.write 'junk' }
+        service.publish
+        expect(File).not_to exist(druid1.path) # it should now be gone
+        expect(druid1).to be_deletes_record_exists # deletes record created
+      end
+    end
+
+    context 'copies to the document cache' do
+      let(:mods) do
+        <<-EOXML
+          <mods:mods xmlns:mods="http://www.loc.gov/mods/v3"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     version="3.3"
+                     xsi:schemaLocation="http://www.loc.gov/mods/v3 http://cosimo.stanford.edu/standards/mods/v3/mods-3-3.xsd">
+            <mods:identifier type="local" displayLabel="SUL Resource ID">druid:ab123cd4567</mods:identifier>
+          </mods:mods>
+        EOXML
+      end
+      let(:md_service) { instance_double(Dor::PublicDescMetadataService, to_xml: mods, ng_xml: Nokogiri::XML(mods)) }
+      let(:dc_service) { instance_double(DublinCoreService, ng_xml: Nokogiri::XML('<oai_dc:dc></oai_dc:dc>')) }
+      let(:public_service) { instance_double(PublicXmlService, to_xml: '<publicObject></publicObject>') }
+
+      before do
+        allow(DublinCoreService).to receive(:new).and_return(dc_service)
+        allow(PublicXmlService).to receive(:new).and_return(public_service)
+        allow(Dor::PublicDescMetadataService).to receive(:new).and_return(md_service)
+      end
+
+      context 'with an item' do
+        before do
+          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<identityMetadata/, 'identityMetadata')
+          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<contentMetadata/, 'contentMetadata')
+          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<rightsMetadata/, 'rightsMetadata')
+          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<oai_dc:dc/, 'dc')
+          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<publicObject/, 'public')
+          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<mods:mods/, 'mods')
+          expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(no_args)
+        end
+
+        it 'identityMetadta, contentMetadata, rightsMetadata, generated dublin core, and public xml' do
+          item.rightsMetadata.content = "<rightsMetadata><access type='discover'><machine><world/></machine></access></rightsMetadata>"
+          service.publish
+          expect(DublinCoreService).to have_received(:new).with(item)
+          expect(PublicXmlService).to have_received(:new).with(item)
+          expect(Dor::PublicDescMetadataService).to have_received(:new).with(item)
+        end
+
+        it 'even when rightsMetadata uses xml namespaces' do
+          item.rightsMetadata.content = %q(<rightsMetadata xmlns="http://hydra-collab.stanford.edu/schemas/rightsMetadata/v1">
+            <access type='discover'><machine><world/></machine></access></rightsMetadata>)
+          service.publish
+        end
+      end
+
+      context 'with a collection object' do
+        let(:item) { instantiate_fixture('druid:ab123cd4567', Dor::Collection) }
+
+        before do
+          item.descMetadata.content = mods
+          item.rightsMetadata.content = "<rightsMetadata><access type='discover'><machine><world/></machine></access></rightsMetadata>"
+          item.rels_ext.content = rels
+        end
+
+        before do
+          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<identityMetadata/, 'identityMetadata')
+          expect_any_instance_of(described_class).not_to receive(:transfer_to_document_store).with(/<contentMetadata/, 'contentMetadata')
+          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<rightsMetadata/, 'rightsMetadata')
+          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<oai_dc:dc/, 'dc')
+          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<publicObject/, 'public')
+          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<mods:mods/, 'mods')
+          expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(no_args)
+        end
+
+        it 'ignores missing data' do
+          service.publish
+        end
+      end
+    end
+  end
+
+  describe '#publish_notify_on_success' do
+    subject(:notify) { service.send(:publish_notify_on_success) }
+
+    context 'when purl-fetcher is configured' do
+      before do
+        allow(Dor::Config.purl_services).to receive(:url).and_return('http://example.com/purl')
+
+        stub_request(:post, 'example.com/purl/purls/ab123cd4567')
+      end
+
+      it 'notifies the purl service of the update' do
+        notify
+        expect(WebMock).to have_requested(:post, 'example.com/purl/purls/ab123cd4567')
+      end
+    end
+
+    context 'when purl-fetcher is not configured' do
+      let(:purl_root) { Dir.mktmpdir }
+      let(:changes_dir) { Dir.mktmpdir }
+      let(:changes_file) { File.join(changes_dir, item.pid.gsub('druid:', '')) }
+
+      before do
+        allow(Dor::Config.purl_services).to receive(:url).and_return(nil)
+      end
+
+      it 'writes empty notification file' do
+        expect { notify }.to raise_error 'You have not configured perl-fetcher (Dor::Config.purl_services.url).'
+      end
+    end
+  end
+
+  describe '#transfer_to_document_store' do
+    let(:purl_root) { Dir.mktmpdir }
+    let(:workspace_root) { Dir.mktmpdir }
+
+    before do
+      allow(Dor::Config.stacks).to receive(:local_document_cache_root).and_return(purl_root)
+      allow(Dor::Config.stacks).to receive(:local_workspace_root).and_return(workspace_root)
+    end
+
+    after do
+      FileUtils.remove_entry purl_root
+      FileUtils.remove_entry workspace_root
+    end
+
+    it 'copies the given metadata to the document cache in the Digital Stacks' do
+      dr = DruidTools::PurlDruid.new item.pid, purl_root
+      service.send(:transfer_to_document_store, '<xml/>', 'someMd')
+      file_path = dr.find(:content, 'someMd')
+      expect(file_path).to match(%r{4567/someMd$})
+      expect(IO.read(file_path)).to eq('<xml/>')
+    end
+  end
+end


### PR DESCRIPTION
This was previously moved out of dor-services, but it was still being used here.
Once this is here we can refactor the common-accessioning robots to call these
services in dor-services-app.