### PR TITLE
Remove a handler that wasn't ever used

### DIFF
--- a/app/models/dor/goobi.rb
+++ b/app/models/dor/goobi.rb
@@ -4,18 +4,12 @@ module Dor
   # This class passes data to the Goobi server using a custom XML message that was developed by Intranda
   class Goobi < ServiceItem
     def register
-      handler = proc do |exception, attempt_number, _total_delay|
-        if attempt_number >= Dor::Config.goobi.max_tries
-          throw :error, message: "#{exception.class} on goobi notification web service call #{attempt_number} for #{@druid_obj.id}", status: 500
-        end
-      end
-
-      # rubocop:disable Metrics/LineLength
-      with_retries(max_tries: Dor::Config.goobi.max_tries, handler: handler, base_sleep_seconds: Dor::Config.goobi.base_sleep_seconds, max_sleep_seconds: Dor::Config.goobi.max_sleep_seconds) do |_attempt|
-        response = RestClient.post(Dor::Config.goobi.url, xml_request, content_type: 'application/xml') { |resp, _request, _result| resp }
+      with_retries(max_tries: Dor::Config.goobi.max_tries,
+                   base_sleep_seconds: Dor::Config.goobi.base_sleep_seconds,
+                   max_sleep_seconds: Dor::Config.goobi.max_sleep_seconds) do |_attempt|
+        response = RestClient.post(Dor::Config.goobi.url, xml_request, content_type: 'application/xml')
         response
       end
-      # rubocop:enable Metrics/LineLength
     end
 
     def goobi_xml_tags


### PR DESCRIPTION
The handler had a condition to only execute if the attempt_number was greater or equal than max_tries
but the handler only executes before running the retry block (e.g. when attempt_number is less than max tries)