### PR TITLE
Require JWT token authorization

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,8 +42,6 @@ cleanup:
   local_export_home: '/dor/export'
 
 dor:
-  service_user: 'user'
-  service_password: 'password'
   hmac_secret: 'my$ecretK3y'
 
 release:

--- a/spec/requests/metadata_refresh_spec.rb
+++ b/spec/requests/metadata_refresh_spec.rb
@@ -3,9 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Refresh metadata' do
-  let(:user) { Settings.dor.service_user }
-  let(:password) { Settings.dor.service_password }
-  let(:basic_auth) { ActionController::HttpAuthentication::Basic.encode_credentials(user, password) }
+  let(:payload) { { sub: 'argo' } }
+  let(:jwt) { JWT.encode(payload, Settings.dor.hmac_secret, 'HS256') }
   let(:object) { Dor::Item.new(pid: 'druid:1234') }
 
   before do
@@ -16,7 +15,7 @@ RSpec.describe 'Refresh metadata' do
 
   it 'updates the metadata and saves the changes' do
     post '/v1/objects/druid:mk420bs7601/refresh_metadata',
-         headers: { 'Authorization' => basic_auth }
+         headers: { 'X-Auth' => "Bearer #{jwt}" }
     expect(response).to be_successful
     expect(RefreshMetadataAction).to have_received(:run).with(object)
     expect(object).to have_received(:save)

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -3,9 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Display metadata' do
-  let(:user) { Settings.dor.service_user }
-  let(:password) { Settings.dor.service_password }
-  let(:basic_auth) { ActionController::HttpAuthentication::Basic.encode_credentials(user, password) }
+  let(:payload) { { sub: 'argo' } }
+  let(:jwt) { JWT.encode(payload, Settings.dor.hmac_secret, 'HS256') }
   let(:object) { Dor::Item.new(pid: 'druid:1234') }
 
   before do
@@ -16,7 +15,7 @@ RSpec.describe 'Display metadata' do
   describe 'dublin core' do
     it 'returns the DC xml' do
       get '/v1/objects/druid:mk420bs7601/metadata/dublin_core',
-          headers: { 'Authorization' => basic_auth }
+          headers: { 'X-Auth' => "Bearer #{jwt}" }
       expect(response).to be_successful
       expect(response.body).to include '<dc:title>Hello</dc:title>'
     end
@@ -25,7 +24,7 @@ RSpec.describe 'Display metadata' do
   describe 'descriptive' do
     it 'returns the DC xml' do
       get '/v1/objects/druid:mk420bs7601/metadata/descriptive',
-          headers: { 'Authorization' => basic_auth }
+          headers: { 'X-Auth' => "Bearer #{jwt}" }
       expect(response).to be_successful
       expect(response.body).to be_equivalent_to <<~XML
         <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -2,8 +2,6 @@
 
 module AuthHelper
   def login
-    user = Settings.dor.service_user
-    pass = Settings.dor.service_password
-    request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(user, pass)
+    allow(controller).to receive(:check_auth_token)
   end
 end


### PR DESCRIPTION
Drop basic authorization.

This can't be deployed until Hydrus is deployed (with JWT support)