### PR TITLE
Upgrade druid-tools to 2.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
       faraday (~> 0.9, >= 0.9.2)
       faraday_middleware
       nokogiri (~> 1.6)
-    druid-tools (1.0.0)
+    druid-tools (2.0.0)
     dry-configurable (0.8.2)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.7)

--- a/spec/services/publish_metadata_service_spec.rb
+++ b/spec/services/publish_metadata_service_spec.rb
@@ -62,20 +62,14 @@ RSpec.describe PublishMetadataService do
         FileUtils.remove_entry purl_root
       end
 
-      it 'notifies the purl service of the deletion' do
-        service.publish
-        expect(WebMock).to have_requested(:delete, 'example.com/purl/purls/ab123cd4567')
-      end
-
-      it "removes the item's content from the Purl document cache and creates a .delete entry" do
+      it "removes the item's content from the Purl document cache and notifies the purl service of the deletion" do
         # create druid tree and dummy content in purl root
         druid1 = DruidTools::Druid.new item.pid, purl_root
         druid1.mkdir
-        expect(druid1).not_to be_deletes_record_exists # deletes record not there yet
         File.open(File.join(druid1.path, 'tmpfile'), 'w') { |f| f.write 'junk' }
         service.publish
         expect(File).not_to exist(druid1.path) # it should now be gone
-        expect(druid1).to be_deletes_record_exists # deletes record created
+        expect(WebMock).to have_requested(:delete, 'example.com/purl/purls/ab123cd4567')
       end
     end
 


### PR DESCRIPTION
This stops from writing deletes to the filesystem log.

Fixes #285 