### PR TITLE
The can_open_version? returns false when open_version would fail

### DIFF
--- a/app/services/sdr_client.rb
+++ b/app/services/sdr_client.rb
@@ -6,6 +6,8 @@ class SdrClient
     RestClient::Resource.new(Settings.sdr_url, {})
   end
 
+  # @raises [RestClient::NotFound] if SDR doesn't know about the object (i.e. 404 response code)
+  # @raises [StandardError] if the response from SDR can't be parsed
   def self.current_version(druid)
     xml = create["objects/#{druid}/current_version"].get
 

--- a/spec/services/sdr_client_spec.rb
+++ b/spec/services/sdr_client_spec.rb
@@ -4,18 +4,20 @@ require 'rails_helper'
 
 RSpec.describe SdrClient do
   describe '.current_version' do
+    subject(:current_version) { described_class.current_version('druid:ab123cd4567') }
+
     it 'returns the current of the object from SDR' do
       stub_request(:get, 'http://sdr-services.example.com/sdr/objects/druid:ab123cd4567/current_version')
         .to_return(body: '<currentVersion>2</currentVersion>')
-      expect(described_class.current_version('druid:ab123cd4567')).to eq 2
+      expect(current_version).to eq 2
     end
 
     context 'when it has the wrong root element' do
       it 'raises an exception' do
         stub_request(:get, 'http://sdr-services.example.com/sdr/objects/druid:ab123cd4567/current_version')
           .to_return(body: '<wrongRoot>2</wrongRoot>')
-        expect { described_class.current_version('druid:ab123cd4567') }
-          .to raise_error(Exception, 'Unable to parse XML from SDR current_version API call: <wrongRoot>2</wrongRoot>')
+        expect { current_version }.to raise_error(Exception,
+                                                  'Unable to parse XML from SDR current_version API call: <wrongRoot>2</wrongRoot>')
       end
     end
 
@@ -23,8 +25,19 @@ RSpec.describe SdrClient do
       it 'raises an exception' do
         stub_request(:get, 'http://sdr-services.example.com/sdr/objects/druid:ab123cd4567/current_version')
           .to_return(body: '<currentVersion>two</currentVersion>')
-        expect { described_class.current_version('druid:ab123cd4567') }
-          .to raise_error(Exception, 'Unable to parse XML from SDR current_version API call: <currentVersion>two</currentVersion>')
+        expect { current_version }.to raise_error(Exception,
+                                                  'Unable to parse XML from SDR current_version API call: <currentVersion>two</currentVersion>')
+      end
+    end
+
+    context "when sdr-services-app doesn't know about the object" do
+      before do
+        stub_request(:get, 'http://sdr-services.example.com/sdr/objects/druid:ab123cd4567/current_version')
+          .to_return(status: 404, body: '')
+      end
+
+      it 'raises an error' do
+        expect { current_version }.to raise_error RestClient::NotFound
       end
     end
   end


### PR DESCRIPTION
This would happen in the case when the object has been transfered to
sdr, but sdr-services-app is not yet acknowledging queries for this
object.

Fixes #292 