### PR TITLE
Move DruidTools::Druid#prune! and #prune_ancestors from druid-tools

### DIFF
--- a/app/services/cleanup_reset_service.rb
+++ b/app/services/cleanup_reset_service.rb
@@ -36,7 +36,7 @@ class CleanupResetService
     reset_directories.each do |path|
       FileUtils.rm_rf(path)
     end
-    base_druid.prune_ancestors(base_druid.pathname.parent)
+    PruneService.new(druid: base_druid).prune_ancestors(base_druid.pathname.parent)
   end
 
   # @param [String] base_druid_tree The base directory to delete from
@@ -92,10 +92,11 @@ class CleanupResetService
     reset_bags
   end
 
+  # TODO: This is exactly the same as CleanupService#cleanup_workspace_content
   # @param [String] druid The identifier for the object whose data is to be removed
   # @param [String] base The base directory to delete from
   # @return [void] remove the object's data files from the assembly area
   def self.cleanup_assembly_content(druid, base)
-    DruidTools::Druid.new(druid, base).prune!
+    PruneService.new(druid: DruidTools::Druid.new(druid, base)).prune!
   end
 end

--- a/app/services/cleanup_service.rb
+++ b/app/services/cleanup_service.rb
@@ -14,7 +14,7 @@ class CleanupService
   # @param [String] base The base directory to delete from
   # @return [void] remove the object's data files from the workspace area
   def self.cleanup_workspace_content(druid, base)
-    DruidTools::Druid.new(druid, base).prune!
+    PruneService.new(druid: DruidTools::Druid.new(druid, base)).prune!
   end
   private_class_method :cleanup_workspace_content
 

--- a/app/services/delete_service.rb
+++ b/app/services/delete_service.rb
@@ -33,11 +33,13 @@ class DeleteService
   attr_reader :druid
 
   def cleanup_stacks
-    DruidTools::StacksDruid.new(druid, Dor::Config.stacks.local_stacks_root).prune!
+    stacks_druid = DruidTools::StacksDruid.new(druid, Dor::Config.stacks.local_stacks_root)
+    PruneService.new(druid: stacks_druid).prune!
   end
 
   def cleanup_purl_doc_cache
-    DruidTools::PurlDruid.new(druid, Dor::Config.stacks.local_document_cache_root).prune!
+    purl_druid = DruidTools::PurlDruid.new(druid, Dor::Config.stacks.local_document_cache_root)
+    PruneService.new(druid: purl_druid).prune!
   end
 
   def remove_active_workflows

--- a/app/services/prune_service.rb
+++ b/app/services/prune_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Removes the druid path from the filesystem
+class PruneService
+  # @param [DruidTools::Druid] druid
+  def initialize(druid:)
+    @druid = druid
+  end
+
+  def prune!
+    this_path = druid.pathname
+    parent = this_path.parent
+    parent.rmtree if parent.exist? && parent != druid.base_pathname
+    prune_ancestors parent.parent
+  end
+
+  # @param [Pathname] outermost_branch The branch at which pruning begins
+  # @return [void] Ascend the druid tree and prune empty branches
+  def prune_ancestors(outermost_branch)
+    while outermost_branch.exist? && outermost_branch.children.empty?
+      outermost_branch.rmdir
+      outermost_branch = outermost_branch.parent
+      break if outermost_branch == druid.base_pathname
+    end
+  end
+
+  private
+
+  attr_reader :druid
+end

--- a/app/services/publish_metadata_service.rb
+++ b/app/services/publish_metadata_service.rb
@@ -34,7 +34,7 @@ class PublishMetadataService
 
   # Clear out the document cache for this item
   def unpublish
-    purl_druid.prune!
+    PruneService.new(druid: purl_druid).prune!
     publish_delete_on_success
   end
 

--- a/spec/services/prune_service_spec.rb
+++ b/spec/services/prune_service_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PruneService do
+  let(:druid_str) { 'druid:cd456ef7890' }
+  let(:strictly_valid_druid_str) { 'druid:cd456gh1234' }
+
+  describe '#prune!' do
+    let(:workspace) { Dir.mktmpdir }
+    let(:dr1) { DruidTools::Druid.new(druid_str, workspace) }
+    let(:dr2) { DruidTools::Druid.new(strictly_valid_druid_str, workspace) }
+    let(:pathname1) { dr1.pathname }
+
+    after do
+      FileUtils.remove_entry workspace
+    end
+
+    context 'when there is a shared ancestor' do
+      before do
+        # Nil the create records for this context because we're in a known read only one
+        dr1.mkdir
+        dr2.mkdir
+        described_class.new(druid: dr1).prune!
+      end
+
+      it 'deletes the outermost directory' do
+        expect(File).not_to exist(dr1.path)
+      end
+
+      it 'deletes empty ancestor directories' do
+        expect(File).not_to exist(pathname1.parent)
+        expect(File).not_to exist(pathname1.parent.parent)
+      end
+
+      it 'stops at ancestor directories that have children' do
+        # 'cd/456' should still exist because of druid2
+        shared_ancestor = pathname1.parent.parent.parent
+        expect(shared_ancestor.to_s).to match(%r{cd/456$})
+        expect(File).to exist(shared_ancestor)
+      end
+    end
+
+    it 'removes all directories up to the base path when there are no common ancestors' do
+      # Nil the create records for this test
+      dr1.mkdir
+      described_class.new(druid: dr1).prune!
+      expect(File).not_to exist(File.join(workspace, 'cd'))
+      expect(File).to exist(workspace)
+    end
+
+    it 'removes directories with symlinks' do
+      # Nil the create records for this test
+      source_dir = File.join workspace, 'src_dir'
+      FileUtils.mkdir_p(source_dir)
+      dr2.mkdir_with_final_link(source_dir)
+      described_class.new(druid: dr2).prune!
+
+      expect(File).not_to exist(dr2.path)
+      expect(File).not_to exist(File.join(workspace, 'cd'))
+    end
+  end
+end


### PR DESCRIPTION
This will allow the methods in druid-tools to be deprecated because dor-services-app is the only place they are used

Fixes #327