### PR TITLE
Move mkdir_with_final_link from DruidTools

### DIFF
--- a/app/services/workspace_service.rb
+++ b/app/services/workspace_service.rb
@@ -3,11 +3,19 @@
 # Creates workspaces.  This replaces https://github.com/sul-dlss/dor-services/blob/master/lib/dor/models/concerns/assembleable.rb
 class WorkspaceService
   # @param [Dor::Item] work the work to create the workspace for
-  # @param [String] source the path to create
+  # @param [String, nil] source the path to create
   def self.create(work, source)
     druid = DruidTools::Druid.new(work.pid, Settings.stacks.local_workspace_root)
-    return druid.mkdir if source.nil?
-
-    druid.mkdir_with_final_link(source)
+    source ? mkdir_with_final_link(druid: druid, source: source) : druid.mkdir
   end
+
+  def self.mkdir_with_final_link(druid:, source:)
+    new_path = druid.path
+    raise DruidTools::DifferentContentExistsError, "Unable to create link, directory already exists: #{new_path}" if File.directory?(new_path) && !File.symlink?(new_path)
+
+    real_path = File.expand_path('..', new_path)
+    FileUtils.mkdir_p(real_path)
+    FileUtils.ln_s(source, new_path, force: true)
+  end
+  private_class_method :mkdir_with_final_link
 end

--- a/spec/services/prune_service_spec.rb
+++ b/spec/services/prune_service_spec.rb
@@ -53,7 +53,8 @@ RSpec.describe PruneService do
       # Nil the create records for this test
       source_dir = File.join workspace, 'src_dir'
       FileUtils.mkdir_p(source_dir)
-      dr2.mkdir_with_final_link(source_dir)
+      WorkspaceService.send(:mkdir_with_final_link, druid: dr2, source: source_dir)
+
       described_class.new(druid: dr2).prune!
 
       expect(File).not_to exist(dr2.path)

--- a/spec/services/workspace_service_spec.rb
+++ b/spec/services/workspace_service_spec.rb
@@ -3,34 +3,30 @@
 require 'rails_helper'
 
 RSpec.describe WorkspaceService do
-  let(:temp_workspace) { '/tmp/dor_ws' }
-
-  before do
-    FileUtils.rm_rf(temp_workspace)
-
-    Dor::Config.push! do |config|
-      config.suri.mint_ids false
-      config.solr.url 'http://solr.edu/solrizer'
-      config.fedora.url 'http://fedora.edu'
-    end
-
-    allow(Settings.stacks).to receive(:local_workspace_root).and_return(temp_workspace)
-
-    FileUtils.mkdir_p(temp_workspace)
-  end
-
-  after do
-    Dor::Config.pop!
-    FileUtils.rm_rf(temp_workspace)
-  end
-
   describe '.create' do
-    let(:druid_path) { File.join(temp_workspace, 'aa', '123', 'bb', '7890', 'aa123bb7890') }
-    let(:work) { Dor::Item.new(pid: 'druid:aa123bb7890') }
-
     before do
+      FileUtils.rm_rf(temp_workspace)
+
+      Dor::Config.push! do |config|
+        config.suri.mint_ids false
+        config.solr.url 'http://solr.edu/solrizer'
+        config.fedora.url 'http://fedora.edu'
+      end
+
+      allow(Settings.stacks).to receive(:local_workspace_root).and_return(temp_workspace)
+
+      FileUtils.mkdir_p(temp_workspace)
       FileUtils.rm_rf(File.join(temp_workspace, 'aa'))
     end
+
+    after do
+      Dor::Config.pop!
+      FileUtils.rm_rf(temp_workspace)
+    end
+
+    let(:temp_workspace) { '/tmp/dor_ws' }
+    let(:druid_path) { File.join(temp_workspace, 'aa', '123', 'bb', '7890', 'aa123bb7890') }
+    let(:work) { Dor::Item.new(pid: 'druid:aa123bb7890') }
 
     it 'creates a plain directory in the workspace when passed no source directory' do
       described_class.create(work, nil)
@@ -45,6 +41,32 @@ RSpec.describe WorkspaceService do
 
       expect(File).to be_symlink(druid_path)
       expect(File.readlink(druid_path)).to eq(source_dir)
+    end
+  end
+
+  describe '.mkdir_with_final_link' do
+    let(:strictly_valid_druid_str) { 'druid:cd456gh1234' }
+    let(:tree) { File.join(fixture_dir, 'cd/456/gh/1234/cd456gh1234') }
+    let(:source_dir) { '/tmp/content_dir' }
+    let(:druid_obj) { DruidTools::Druid.new(strictly_valid_druid_str, fixture_dir) }
+
+    before do
+      FileUtils.mkdir_p(source_dir)
+    end
+
+    after do
+      FileUtils.rm_rf(File.join(fixture_dir, 'cd'))
+    end
+
+    it 'creates a druid tree in the workspace with the final directory being a link to the passed in source' do
+      described_class.send(:mkdir_with_final_link, druid: druid_obj, source: source_dir)
+      expect(File).to be_symlink(druid_obj.path)
+      expect(File.readlink(tree)).to eq(source_dir)
+    end
+
+    it 'raises DifferentContentExistsError if a directory already exists in the workspace for this druid' do
+      druid_obj.mkdir(fixture_dir)
+      expect { described_class.send(:mkdir_with_final_link, druid: druid_obj, source: source_dir) }.to raise_error(DruidTools::DifferentContentExistsError)
     end
   end
 end


### PR DESCRIPTION
Because dor-services-app is the only consumer of that method