### PR TITLE
Return HTTP 400 with an informative message when metadata to be published

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -11,6 +11,10 @@ class ObjectsController < ApplicationController
     render status: 409, plain: e.message, location: object_location(e.pid)
   end
 
+  rescue_from(DublinCoreService::CrosswalkError) do |e|
+    render status: 400, plain: e.message
+  end
+
   # Register new objects in DOR
   def create
     Rails.logger.info(params.inspect)

--- a/spec/controllers/objects_controller_spec.rb
+++ b/spec/controllers/objects_controller_spec.rb
@@ -53,10 +53,21 @@ RSpec.describe ObjectsController do
   end
 
   describe '/publish' do
-    it 'calls publish metadata' do
+    it 'calls PublishMetadataService and returns 201' do
       expect(PublishMetadataService).to receive(:publish).with(item)
       post :publish, params: { id: item.pid }
       expect(response.status).to eq(201)
+    end
+
+    context 'with bad metadata' do
+      let(:error_message) { "DublinCoreService#ng_xml produced incorrect xml (no children):\n<xml/>" }
+
+      it 'returns a 400 error' do
+        allow(PublishMetadataService).to receive(:publish).and_raise(DublinCoreService::CrosswalkError, error_message)
+        post :publish, params: { id: item.pid }
+        expect(response.status).to eq(400)
+        expect(response.body).to eq(error_message)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #331

@ndushay This is a very specific fix to #331. I'm not sure if you were hoping for a more general (across-the-board) fix. I'm probably inclined to fix the narrowest case and add more error handling as we find other exceptions that don't bubble up useful information, but I am open to pushback on this if you think it's too short-sighted.