### PR TITLE
Tweak to cleaning and loading seeds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ This will use the HMAC secret to sign the token. It will ask you to submit a val
 
 ## Seeding the staging environment
 
-It's possible to clear out and re-seed the staging environment by using the following rake tasks:
+It's possible to clear out and re-seed the staging environment by using the following rake task:
 
 ```
 ./bin/rake delete_all_objects
-./bin/rake seed
 ```
 
 This will load all the FOXML from https://github.com/sul-dlss/dor-services-app/blob/master/lib/tasks/seeds/

--- a/lib/tasks/seeds/druids
+++ b/lib/tasks/seeds/druids
@@ -10,4 +10,3 @@ druid:zw306xn5593 Hydrus Ur-APO
 druid:wr005wn5739 Web Archive Crawl Object Public APO
 druid:xt299pt7593 Web Archive Seed Object APO
 druid:yf700yh0557 Web Archive Crawl Object Dark APO
-


### PR DESCRIPTION
Because:
1. Blank line in `druids` file was causing an error.
2. `delete_all_objects` calls `seed`.