### PR TITLE
Dump poorly named and unnecessary hash arg when opening versions

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -47,23 +47,18 @@ class VersionsController < ApplicationController
   def open_params
     params.permit(
       :assume_accessioned,
-      vers_md_upd_info: [
-        :description,
-        :opening_user_name,
-        :significance
-      ]
-    ).to_h.deep_symbolize_keys
+      :description,
+      :opening_user_name,
+      :significance
+    ).to_h.symbolize_keys
   end
 
   def close_params
-    symbolized_hash = params.permit(
+    params.permit(
       :description,
       :significance,
       :start_accession,
       :version_num
     ).to_h.symbolize_keys
-    # Downstream code expects the significance value to be a symbol
-    symbolized_hash[:significance] = symbolized_hash[:significance].to_sym if symbolized_hash.key?(:significance)
-    symbolized_hash
   end
 end

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe VersionsController do
       it 'forwards optional params to the VersionService#close method' do
         post :close_current, params: { object_id: item.pid }, body: %( {"description": "some text", "significance": "major"} ), as: :json
         expect(response.body).to match(/version 1 closed/)
-        expect(VersionService).to have_received(:close).with(item, description: 'some text', significance: :major)
+        expect(VersionService).to have_received(:close).with(item, description: 'some text', significance: 'major')
       end
     end
 
@@ -63,11 +63,9 @@ RSpec.describe VersionsController do
     let(:open_params) do
       {
         assume_accessioned: false,
-        vers_md_upd_info: {
-          significance: 'minor',
-          description: 'bar',
-          opening_user_name: opening_user_name
-        }
+        significance: 'minor',
+        description: 'bar',
+        opening_user_name: opening_user_name
       }
     end
     let(:opening_user_name) { 'foo' }

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -48,23 +48,23 @@ RSpec.describe VersionService do
         expect(workflow_client).to have_received(:create_workflow_by_name).with(obj.pid, 'versioningWF')
       end
 
-      it 'includes vers_md_upd_info' do
-        vers_md_upd_info = { significance: 'real_major', description: 'same as it ever was', opening_user_name: 'sunetid' }
+      it 'includes options' do
+        options = { significance: 'real_major', description: 'same as it ever was', opening_user_name: 'sunetid' }
         cur_vers = '2'
         allow(vmd_ds).to receive(:current_version).and_return(cur_vers)
-        allow(obj).to receive(:save)
+        allow(obj).to receive(:save!)
 
-        expect(ev_ds).to receive(:add_event).with('open', vers_md_upd_info[:opening_user_name], "Version #{cur_vers} opened")
-        expect(vmd_ds).to receive(:update_current_version).with(description: vers_md_upd_info[:description], significance: vers_md_upd_info[:significance].to_sym)
-        expect(obj).to receive(:save)
+        expect(ev_ds).to receive(:add_event).with('open', options[:opening_user_name], "Version #{cur_vers} opened")
+        expect(vmd_ds).to receive(:update_current_version).with(description: options[:description], significance: options[:significance].to_sym)
+        expect(obj).to receive(:save!)
 
-        described_class.open(obj, vers_md_upd_info: vers_md_upd_info)
+        described_class.open(obj, **options)
       end
 
-      it "doesn't include vers_md_upd_info" do
+      it "doesn't include options" do
         expect(ev_ds).not_to receive(:add_event)
         expect(vmd_ds).not_to receive(:update_current_version)
-        expect(obj).not_to receive(:save)
+        expect(obj).not_to receive(:save!)
 
         open
       end


### PR DESCRIPTION
Includes:
* Move version open params nested in hash up a level so they are top-level params
* Avoid coercing significance value to a symbol in `VersionsController`; this is already coerced in `VersionService`, and brings symmetry to `#open_params` and `#close_params`
* Prefer `#symbolize_keys` to `#deep_symbolize_keys` when not working with a nested hash structure
* Update YARD documentation in `VersionService` now that the open params have been promoted to top-level
* Prefer `#save!` to `#save` for ActiveFedora objects (do not hide errors)