### PR TITLE
Create an event when closing a version

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -58,6 +58,7 @@ class VersionsController < ApplicationController
       :description,
       :significance,
       :start_accession,
+      :user_name,
       :version_num
     ).to_h.symbolize_keys
   end


### PR DESCRIPTION
This means the consumers won't have to do two steps. Fixes #351 