### PR TITLE
Create an endpoint for modifying an object's embargo date

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -215,10 +215,11 @@ RSpec/SubjectStub:
   Exclude:
     - 'spec/dor/update_marc_record_service_spec.rb'
 
-# Offense count: 10
+# Offense count: 11
 # Configuration parameters: IgnoreNameless, IgnoreSymbolicNames.
 RSpec/VerifiedDoubles:
   Exclude:
+    - 'spec/controllers/objects_controller_spec.rb'
     - 'spec/dor/service_item_spec.rb'
     - 'spec/dor/update_marc_record_service_spec.rb'
     - 'spec/services/version_service_spec.rb'

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -56,6 +56,16 @@ class ObjectsController < ApplicationController
     head :created
   end
 
+  def update_embargo
+    # validate that the embargo_date and requesting_user parameters were provided
+    params.require([:embargo_date, :requesting_user])
+    Dor::EmbargoService.new(@item).update(params[:embargo_date])
+    @item.events.add_event('Embargo', params[:requesting_user], 'Embargo date modified')
+    head :no_content
+  rescue ArgumentError => e
+    render status: 422, plain: e.message
+  end
+
   # This endpoint is called by the goobi-notify process in the goobiWF (code in https://github.com/sul-dlss/goobi-robot)
   # This proxies a request to the Goobi server and proxies it's response to the client.
   def notify_goobi

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
     resources :objects, only: [:create, :update] do
       member do
         post 'publish'
+        post 'update_embargo'
         post 'update_marc_record'
         post 'notify_goobi'
         post 'release_tags'

--- a/spec/controllers/objects_controller_spec.rb
+++ b/spec/controllers/objects_controller_spec.rb
@@ -71,6 +71,68 @@ RSpec.describe ObjectsController do
     end
   end
 
+  describe '/update_embargo' do
+    let(:mock_embargo_service) { instance_double(Dor::EmbargoService) }
+    let(:events_datastream) { double('events', add_event: true) }
+
+    before do
+      allow(item).to receive(:events).and_return(events_datastream)
+    end
+
+    context 'without the :embargo_date param' do
+      it 'returns HTTP 400' do
+        post :update_embargo, params: { id: item.pid }
+        expect(response.status).to eq(400)
+        expect(response.body).to eq('{"errors":[{"title":"bad request","detail":"param is missing or the value is empty: embargo_date"}]}')
+      end
+    end
+
+    context 'without the :requesting_user param' do
+      it 'returns HTTP 400' do
+        post :update_embargo, params: { id: item.pid, embargo_date: '2100-01-01' }
+        expect(events_datastream).not_to have_received(:add_event)
+        expect(response.status).to eq(400)
+        expect(response.body).to eq('{"errors":[{"title":"bad request","detail":"param is missing or the value is empty: requesting_user"}]}')
+      end
+    end
+
+    context 'when Dor::EmbargoService raises an ArgumentError' do
+      let(:error_message) { 'You cannot change the embargo date of an item that is not embargoed.' }
+
+      before do
+        allow(Dor::EmbargoService).to receive(:new).and_return(mock_embargo_service)
+        allow(mock_embargo_service).to receive(:update).and_raise(ArgumentError, error_message)
+      end
+
+      it 'hits the Dor::EmbargoService and returns HTTP 422' do
+        post :update_embargo, params: { id: item.pid, embargo_date: '2100-01-01', requesting_user: 'mjg' }
+        expect(mock_embargo_service).to have_received(:update).once
+        expect(events_datastream).not_to have_received(:add_event)
+        expect(response.status).to eq(422)
+        expect(response.body).to eq(error_message)
+      end
+    end
+
+    context 'when Dor::EmbargoService succeeds' do
+      before do
+        allow(Dor::EmbargoService).to receive(:new).and_return(mock_embargo_service)
+        allow(mock_embargo_service).to receive(:update)
+        allow(item).to receive(:events).and_return(events_datastream)
+      end
+
+      it 'hits the Dor::EmbargoService and returns HTTP 204' do
+        post :update_embargo, params: { id: item.pid, embargo_date: '2100-01-01', requesting_user: 'mjg' }
+        expect(mock_embargo_service).to have_received(:update).once
+        expect(events_datastream).to have_received(:add_event).with(
+          'Embargo',
+          'mjg',
+          'Embargo date modified'
+        )
+        expect(response.status).to eq(204)
+      end
+    end
+  end
+
   describe '/update_marc_record' do
     it 'updates a marc record' do
       # TODO: add some more expectations


### PR DESCRIPTION
Fixes #353

And create a new event on the object associated with the modification.