### PR TITLE
[mistake - do not merge] SymphonyReader validates num bytes in resp body

### DIFF
--- a/app/models/symphony_reader.rb
+++ b/app/models/symphony_reader.rb
@@ -36,8 +36,21 @@ class SymphonyReader
     self.class.client
   end
 
+  def symphony_response
+    resp = client.get(Settings.catalog.symphony.json_url % { catkey: catkey })
+    validate_response(resp)
+  end
+
+  def validate_response(resp)
+    exp_content_length = resp.headers['Content-Length'].to_i
+    actual_content_length = resp.body.length
+    errmsg = "Incomplete response received from Symphony - expected #{exp_content_length} bytes but got #{actual_content_length}"
+    raise errmsg unless actual_content_length == exp_content_length
+    resp
+  end
+
   def json
-    @json ||= JSON.parse(client.get(Settings.catalog.symphony.json_url % { catkey: catkey }).body)
+    @json ||= JSON.parse(symphony_response.body)
   end
 
   def bib_record

--- a/spec/models/symphony_reader_spec.rb
+++ b/spec/models/symphony_reader_spec.rb
@@ -8,17 +8,22 @@ RSpec.describe SymphonyReader do
 
   describe '#to_marc' do
     before do
-      stub_request(:get, Settings.catalog.symphony.json_url % { catkey: catkey }).to_return(body: body.to_json)
+      stub_request(:get, Settings.catalog.symphony.json_url % { catkey: catkey }).to_return(body: body.to_json, headers: headers)
     end
 
     let(:body) do
       {
+        resource: "/catalog/bib",
+        key: "111",
         fields: {
           bib: {
+            standard: "MARC21",
+            type: "BIB",
             leader: '00956cem 2200229Ma 4500',
             fields: [
               { tag: '001', subfields: [{ code: '_', data: 'some data' }] },
-              { tag: '001', subfields: [{ code: '_', data: 'some data' }] },
+              { tag: '001', subfields: [{ code: '_', data: 'some other data' }] },
+              { tag: '009', subfields: [{ code: '_', data: 'whatever' }] },
               {
                 tag: '245',
                 inds: '41',
@@ -29,6 +34,8 @@ RSpec.describe SymphonyReader do
         }
       }
     end
+    let(:headers) { { 'Content-Length': 394 } }
+
     it 'converts symphony json to marc records' do
       expect(reader.to_marc).to be_a_kind_of MARC::Record
     end
@@ -38,11 +45,12 @@ RSpec.describe SymphonyReader do
     end
 
     it 'parses control fields' do
-      expect(reader.to_marc.fields('001').first.value).to eq 'acatkey'
+      expect(reader.to_marc.fields('009').first.value).to eq 'whatever'
     end
 
-    it 'removes duplicate fields' do
+    it 'removes original 001 fields and puts catkey in 001 field' do
       expect(reader.to_marc.fields('001').length).to eq 1
+      expect(reader.to_marc.fields('001').first.value).to eq 'acatkey'
     end
 
     it 'parses data fields' do
@@ -51,6 +59,13 @@ RSpec.describe SymphonyReader do
       expect(field.indicator2).to eq '1'
       expect(field.subfields.first.code).to eq 'a'
       expect(field.subfields.first.value).to eq 'some data'
+    end
+
+    context 'wrong number of bytes from Symphony' do
+      let(:headers) { { 'Content-Length': 268 } }
+      it 'raises RuntimeError when response contains wrong number of bytes' do
+        expect { reader.to_marc }.to raise_error(RuntimeError, 'Incomplete response received from Symphony - expected 268 bytes but got 394')
+      end
     end
   end
 end


### PR DESCRIPTION
part of #348

This has been tested on stage by changing the new code to ensure the error was raised.

TODO (another PR, perhaps): surface the details of the 500 error in the message

### After:

![image](https://user-images.githubusercontent.com/96775/63986572-582a2c80-ca89-11e9-8b17-0a8ded9d0ca6.png)

Note the registration was NOT completed, and we have a tooltip showing the error.  

Here is what was in the Rails logs:

```
I, [2019-08-29T18:13:49.079568 #80392]  INFO -- : [23fc77af-ab6f-4190-beb4-5dcfef495f5a] Started POST "/v1/objects" for 171.67.35.209 at 2019-08-29 18:13:49 -0700
I, [2019-08-29T18:13:49.081030 #80392]  INFO -- : [23fc77af-ab6f-4190-beb4-5dcfef495f5a] Processing by ObjectsController#create as JSON
I, [2019-08-29T18:13:49.081130 #80392]  INFO -- : [23fc77af-ab6f-4190-beb4-5dcfef495f5a]   Parameters: {"object_type"=>"item", "admin_policy"=>"druid:sc012gz0974", "rights"=>"default", "other_id"=>"symphony:9999999", "tag"=>["Process : Content Type : Book (ltr)", "Registered By : ndushay"], "source_id"=>"naomi:test5-no-label", "label"=>":auto", "object"=>{"object_type"=>"item", "admin_policy"=>"druid:sc012gz0974", "rights"=>"default", "other_id"=>"symphony:9999999", "tag"=>["Process : Content Type : Book (ltr)", "Registered By : ndushay"], "source_id"=>"naomi:test5-no-label", "label"=>":auto"}}
I, [2019-08-29T18:13:49.081809 #80392]  INFO -- : [23fc77af-ab6f-4190-beb4-5dcfef495f5a] <ActionController::Parameters {"object_type"=>"item", "admin_policy"=>"druid:sc012gz0974", "rights"=>"default", "other_id"=>"symphony:9999999", "tag"=>["Process : Content Type : Book (ltr)", "Registered By : ndushay"], "source_id"=>"naomi:test5-no-label", "label"=>":auto", "controller"=>"objects", "action"=>"create", "object"=>{"object_type"=>"item", "admin_policy"=>"druid:sc012gz0974", "rights"=>"default", "other_id"=>"symphony:9999999", "tag"=>["Process : Content Type : Book (ltr)", "Registered By : ndushay"], "source_id"=>"naomi:test5-no-label", "label"=>":auto"}} permitted: false>
I, [2019-08-29T18:13:49.182750 #80392]  INFO -- : [23fc77af-ab6f-4190-beb4-5dcfef495f5a] Completed 500 Internal Server Error in 101ms
F, [2019-08-29T18:13:49.183428 #80392] FATAL -- : [23fc77af-ab6f-4190-beb4-5dcfef495f5a]   
F, [2019-08-29T18:13:49.183487 #80392] FATAL -- : [23fc77af-ab6f-4190-beb4-5dcfef495f5a] RuntimeError (Incomplete response received from Symphony - expected 2813 bytes but got 2813):
F, [2019-08-29T18:13:49.183576 #80392] FATAL -- : [23fc77af-ab6f-4190-beb4-5dcfef495f5a]   
F, [2019-08-29T18:13:49.183634 #80392] FATAL -- : [23fc77af-ab6f-4190-beb4-5dcfef495f5a] app/models/symphony_reader.rb:48:in `validate_response'
[23fc77af-ab6f-4190-beb4-5dcfef495f5a] app/models/symphony_reader.rb:41:in `symphony_response'
[23fc77af-ab6f-4190-beb4-5dcfef495f5a] app/models/symphony_reader.rb:53:in `json'
[23fc77af-ab6f-4190-beb4-5dcfef495f5a] app/models/symphony_reader.rb:57:in `bib_record'
[23fc77af-ab6f-4190-beb4-5dcfef495f5a] app/models/symphony_reader.rb:63:in `leader'
[23fc77af-ab6f-4190-beb4-5dcfef495f5a] app/models/symphony_reader.rb:18:in `to_marc'
[23fc77af-ab6f-4190-beb4-5dcfef495f5a] app/models/marcxml_resource.rb:40:in `marc_record'
[23fc77af-ab6f-4190-beb4-5dcfef495f5a] app/models/marcxml_resource.rb:30:in `marcxml'
[23fc77af-ab6f-4190-beb4-5dcfef495f5a] app/models/marcxml_resource.rb:26:in `mods'
[23fc77af-ab6f-4190-beb4-5dcfef495f5a] app/services/catalog_handler.rb:6:in `fetch'
[23fc77af-ab6f-4190-beb4-5dcfef495f5a] app/services/metadata_service.rb:35:in `label_for'
[23fc77af-ab6f-4190-beb4-5dcfef495f5a] app/services/registration_service.rb:40:in `handle_auto_label'
[23fc77af-ab6f-4190-beb4-5dcfef495f5a] app/services/registration_service.rb:23:in `registration_request_params'
[23fc77af-ab6f-4190-beb4-5dcfef495f5a] app/services/registration_service.rb:9:in `create_from_request'
[23fc77af-ab6f-4190-beb4-5dcfef495f5a] app/controllers/objects_controller.rb:22:in `create'
I, [2019-08-29T18:13:49.184680 #80392]  INFO -- honeybadger: ** [Honeybadger] Reporting error id=6da03e1c-959a-46de-8a44-91bee968ad0a level=1 pid=80392
I, [2019-08-29T18:13:49.455499 #80392]  INFO -- honeybadger: ** [Honeybadger] Success ⚡ https://app.honeybadger.io/notice/6da03e1c-959a-46de-8a44-91bee968ad0a id=6da03e1c-959a-46de-8a44-91bee968ad0a code=201 level=1 pid=80392
```