### PR TITLE
SymphonyReader validates num bytes in resp body

### DIFF
--- a/app/controllers/marcxml_controller.rb
+++ b/app/controllers/marcxml_controller.rb
@@ -3,6 +3,10 @@
 class MarcxmlController < ApplicationController #:nodoc:
   before_action :set_marcxml_resource
 
+  rescue_from(SymphonyReader::RecordIncompleteError) do |e|
+    render status: :internal_server_error, plain: e.message
+  end
+
   def catkey
     render plain: @marcxml.catkey
   end

--- a/app/controllers/metadata_refresh_controller.rb
+++ b/app/controllers/metadata_refresh_controller.rb
@@ -4,6 +4,10 @@
 class MetadataRefreshController < ApplicationController
   before_action :load_item
 
+  rescue_from(SymphonyReader::RecordIncompleteError) do |e|
+    render status: :internal_server_error, plain: e.message
+  end
+
   def refresh
     status = RefreshMetadataAction.run(@item)
     @item.save if status

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -15,6 +15,10 @@ class ObjectsController < ApplicationController
     render status: :internal_server_error, plain: e.message
   end
 
+  rescue_from(SymphonyReader::RecordIncompleteError) do |e|
+    render status: :internal_server_error, plain: e.message
+  end
+
   # Register new objects in DOR
   def create
     Rails.logger.info(params.inspect)

--- a/app/models/symphony_reader.rb
+++ b/app/models/symphony_reader.rb
@@ -17,7 +17,8 @@ class SymphonyReader
   def to_marc
     record = MARC::Record.new
 
-    record.leader = leader if leader
+    # note that new record already has default leader, but we don't want it unless it's from Symphony
+    record.leader = leader
 
     fields.uniq.each do |field|
       record << marc_field(field) unless %w[001 003].include? field['tag'] # explicitly remove all 001 and 003 fields from the record

--- a/spec/controllers/marcxml_controller_spec.rb
+++ b/spec/controllers/marcxml_controller_spec.rb
@@ -8,6 +8,29 @@ RSpec.describe MarcxmlController do
   end
 
   let(:resource) { MarcxmlResource.new(catkey: '12345') }
+  let(:body) do
+    {
+      resource: '/catalog/bib',
+      key: '111',
+      fields: {
+        bib: {
+          standard: 'MARC21',
+          type: 'BIB',
+          leader: '00956cem 2200229Ma 4500',
+          fields: [
+            { tag: '001', subfields: [{ code: '_', data: 'some data' }] },
+            { tag: '001', subfields: [{ code: '_', data: 'some other data' }] },
+            { tag: '009', subfields: [{ code: '_', data: 'whatever' }] },
+            {
+              tag: '245',
+              inds: '41',
+              subfields: [{ code: 'a', data: 'some data' }]
+            }
+          ]
+        }
+      }
+    }
+  end
 
   describe 'GET catkey' do
     it 'returns the provided catkey' do
@@ -24,7 +47,7 @@ RSpec.describe MarcxmlController do
 
   describe 'GET marcxml' do
     it 'retrieves MARCXML' do
-      stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: resource.catkey)).to_return(body: '{}', headers: { 'Content-Length': 2 })
+      stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: resource.catkey)).to_return(body: body.to_json, headers: { 'Content-Length': 394 })
       get :marcxml, params: { catkey: '12345' }
       expect(response.body).to start_with '<record'
     end
@@ -44,7 +67,7 @@ RSpec.describe MarcxmlController do
 
   describe 'GET mods' do
     it 'transforms the MARCXML into MODS' do
-      stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: resource.catkey)).to_return(body: '{}', headers: { 'Content-Length': 2 })
+      stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: resource.catkey)).to_return(body: body.to_json, headers: { 'Content-Length': 394 })
       get :mods, params: { catkey: '12345' }
       expect(response.body).to match(/mods/)
     end

--- a/spec/controllers/marcxml_controller_spec.rb
+++ b/spec/controllers/marcxml_controller_spec.rb
@@ -24,18 +24,41 @@ RSpec.describe MarcxmlController do
 
   describe 'GET marcxml' do
     it 'retrieves MARCXML' do
-      stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: resource.catkey)).to_return(body: '{}')
-
+      stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: resource.catkey)).to_return(body: '{}', headers: { 'Content-Length': 2 })
       get :marcxml, params: { catkey: '12345' }
       expect(response.body).to start_with '<record'
+    end
+
+    context 'when incomplete response from Symphony' do
+      before do
+        stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: resource.catkey)).to_return(body: '{}', headers: { 'Content-Length': 0 })
+      end
+
+      it 'returns a 500 error' do
+        get :marcxml, params: { catkey: '12345' }
+        expect(response.status).to eq(500)
+        expect(response.body).to eq('Incomplete response received from Symphony for 12345 - expected 0 bytes but got 2')
+      end
     end
   end
 
   describe 'GET mods' do
     it 'transforms the MARCXML into MODS' do
-      stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: resource.catkey)).to_return(body: '{}')
+      stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: resource.catkey)).to_return(body: '{}', headers: { 'Content-Length': 2 })
       get :mods, params: { catkey: '12345' }
       expect(response.body).to match(/mods/)
+    end
+
+    context 'when incomplete response from Symphony' do
+      before do
+        stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: resource.catkey)).to_return(body: '{}', headers: { 'Content-Length': 0 })
+      end
+
+      it 'returns a 500 error' do
+        get :mods, params: { catkey: '12345' }
+        expect(response.status).to eq(500)
+        expect(response.body).to eq('Incomplete response received from Symphony for 12345 - expected 0 bytes but got 2')
+      end
     end
   end
 end

--- a/spec/requests/metadata_refresh_spec.rb
+++ b/spec/requests/metadata_refresh_spec.rb
@@ -9,15 +9,34 @@ RSpec.describe 'Refresh metadata' do
 
   before do
     allow(Dor).to receive(:find).and_return(object)
-    allow(RefreshMetadataAction).to receive(:run).and_return('<xml />')
     allow(object).to receive(:save)
   end
 
-  it 'updates the metadata and saves the changes' do
-    post '/v1/objects/druid:mk420bs7601/refresh_metadata',
-         headers: { 'X-Auth' => "Bearer #{jwt}" }
-    expect(response).to be_successful
-    expect(RefreshMetadataAction).to have_received(:run).with(object)
-    expect(object).to have_received(:save)
+  context 'when happy path' do
+    before do
+      allow(RefreshMetadataAction).to receive(:run).and_return('<xml />')
+    end
+
+    it 'updates the metadata and saves the changes' do
+      post '/v1/objects/druid:mk420bs7601/refresh_metadata',
+           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(response).to be_successful
+      expect(RefreshMetadataAction).to have_received(:run).with(object)
+      expect(object).to have_received(:save)
+    end
+  end
+
+  context 'when incomplete response from Symphony' do
+    before do
+      allow(object.identityMetadata).to receive(:otherId).and_return(['catkey:666'])
+      stub_request(:get, Settings.catalog.symphony.json_url % { catkey: '666' }).to_return(body: '{}', headers: { 'Content-Length': 0 })
+    end
+
+    it 'returns a 500 error' do
+      post '/v1/objects/druid:mk420bs7601/refresh_metadata',
+           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(response.status).to eq(500)
+      expect(response.body).to eq('Incomplete response received from Symphony for 666 - expected 0 bytes but got 2')
+    end
   end
 end

--- a/spec/requests/metadata_refresh_spec.rb
+++ b/spec/requests/metadata_refresh_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Refresh metadata' do
   context 'when incomplete response from Symphony' do
     before do
       allow(object.identityMetadata).to receive(:otherId).and_return(['catkey:666'])
-      stub_request(:get, Settings.catalog.symphony.json_url % { catkey: '666' }).to_return(body: '{}', headers: { 'Content-Length': 0 })
+      stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: '666')).to_return(body: '{}', headers: { 'Content-Length': 0 })
     end
 
     it 'returns a 500 error' do


### PR DESCRIPTION
part of #348

~~DO NOT MERGE without PO approval.~~   Per storytime 2019-09-03, this is approved by Andrew.
~~- is the registration form tiny errors adequate notice?~~

This has been tested on stage by changing the new code to ensure the error was raised.

- Created #362 re:  honeybadger errors (currently inconsistent between registration and refresh metadata)
- Created sul-dlss/argo/issues/1545 re: better user experience for errors when refreshing metadata.

##  With This Change: Registration

after filling in registration form for one item and submitting it.

### Argo UI:

![image](https://user-images.githubusercontent.com/96775/63987831-6fb7e400-ca8e-11e9-90a3-8e11d07f3717.png)

Note the registration was NOT completed (see the red circle in the column), and we have a tooltip showing the error.  (Pay no attention to the actual numbers in the error message - I faked the failure)  

### Argo log

```
I, [2019-08-30T12:00:05.535674 #9693]  INFO -- : [e2054910-ed7a-456b-9ad4-3379dd84cf33] [2019-08-30 19:00:05.535] Started POST "/dor/objects" for 171.66.20.81 at 2019-08-30 12:00:05 -0700
I, [2019-08-30T12:00:05.536758 #9693]  INFO -- : [e2054910-ed7a-456b-9ad4-3379dd84cf33] [2019-08-30 19:00:05.535] Processing by Dor::ObjectsController#create as JSON
I, [2019-08-30T12:00:05.536817 #9693]  INFO -- : [e2054910-ed7a-456b-9ad4-3379dd84cf33] [2019-08-30 19:00:05.535]   Parameters: {"object_type"=>"item", "admin_policy"=>"druid:yf700yh0557", "workflow_id"=>"registrationWF", "seed_datastream"=>["descMetadata"], "label"=>":auto", "tag"=>["Process : Content Type : Book (ltr)", "Registered By : ndushay"], "rights"=>"default", "collection"=>"", "source_id"=>"naomi:testreg-incompleteSymphResponse", "other_id"=>"symphony:666"}
D, [2019-08-30T12:00:05.540767 #9693] DEBUG -- : [e2054910-ed7a-456b-9ad4-3379dd84cf33] [2019-08-30 19:00:05.535]   User Load (1.5ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` = 21 ORDER BY `users`.`id` ASC LIMIT 1
I, [2019-08-30T12:00:05.736912 #9693]  INFO -- : [e2054910-ed7a-456b-9ad4-3379dd84cf33] [2019-08-30 19:00:05.535]   Rendering text template
I, [2019-08-30T12:00:05.737056 #9693]  INFO -- : [e2054910-ed7a-456b-9ad4-3379dd84cf33] [2019-08-30 19:00:05.535]   Rendered text template (0.0ms)
I, [2019-08-30T12:00:05.737262 #9693]  INFO -- : [e2054910-ed7a-456b-9ad4-3379dd84cf33] [2019-08-30 19:00:05.535] Completed 400 Bad Request in 200ms (Views: 0.6ms | ActiveRecord: 1.5ms)
```

### Honeybadger:

not surfaced.
- dor-services-app handles the raise and sends 500 to (argo)
- argo - handles the UnexpectedResponse error; not sent to honeybadger 

We are surfacing the real error to the user via javascript ... but **what if it's the first item in a long list?  would the user see it?**

### Dor Services App

Rails log:

```
I, [2019-08-29T18:58:12.307435 #101633]  INFO -- : [7374ea33-9c76-4c24-973d-a415a33a58f1] Started POST "/v1/objects" for 171.67.35.209 at 2019-08-29 18:58:12 -0700
I, [2019-08-29T18:58:12.308295 #101633]  INFO -- : [7374ea33-9c76-4c24-973d-a415a33a58f1] Processing by ObjectsController#create as JSON
I, [2019-08-29T18:58:12.308373 #101633]  INFO -- : [7374ea33-9c76-4c24-973d-a415a33a58f1]   Parameters: {"object_type"=>"item", "admin_policy"=>"druid:yf700yh0557", "rights"=>"default", "other_id"=>"symphony:9999999", "tag"=>["Process : Content Type : Book (ltr)", "Registered By : ndushay"], "source_id"=>"naomi:test7", "label"=>":auto", "object"=>{"object_type"=>"item", "admin_policy"=>"druid:yf700yh0557", "rights"=>"default", "other_id"=>"symphony:9999999", "tag"=>["Process : Content Type : Book (ltr)", "Registered By : ndushay"], "source_id"=>"naomi:test7", "label"=>":auto"}}
I, [2019-08-29T18:58:12.308937 #101633]  INFO -- : [7374ea33-9c76-4c24-973d-a415a33a58f1] <ActionController::Parameters {"object_type"=>"item", "admin_policy"=>"druid:yf700yh0557", "rights"=>"default", "other_id"=>"symphony:9999999", "tag"=>["Process : Content Type : Book (ltr)", "Registered By : ndushay"], "source_id"=>"naomi:test7", "label"=>":auto", "controller"=>"objects", "action"=>"create", "object"=>{"object_type"=>"item", "admin_policy"=>"druid:yf700yh0557", "rights"=>"default", "other_id"=>"symphony:9999999", "tag"=>["Process : Content Type : Book (ltr)", "Registered By : ndushay"], "source_id"=>"naomi:test7", "label"=>":auto"}} permitted: false>
I, [2019-08-29T18:58:12.391926 #101633]  INFO -- : [7374ea33-9c76-4c24-973d-a415a33a58f1] Completed 500 Internal Server Error in 83ms (Views: 0.1ms)
```

## With This Change: Refresh Metadata

after hitting "Refresh Metadata" button in left "nav" for an existing item:

### Argo UI:

![image](https://user-images.githubusercontent.com/96775/64038464-f0b5c080-cb0c-11e9-831f-ce8a7274fa69.png)

### Honeybadger 

got the error!

![image](https://user-images.githubusercontent.com/96775/64045102-55791700-cb1d-11e9-82b6-8fdd911dc38b.png)

### Argo logs:

```
I, [2019-08-30T11:50:59.226534 #9693]  INFO -- : [17cae624-7764-49fa-b0d4-f85921ffc780] [2019-08-30 18:50:59.226] Started GET "/items/druid:wg314mv5625/refresh_metadata" for 171.66.20.81 at 2019-08-30 11:50:59 -0700
I, [2019-08-30T11:50:59.227569 #9693]  INFO -- : [17cae624-7764-49fa-b0d4-f85921ffc780] [2019-08-30 18:50:59.226] Processing by ItemsController#refresh_metadata as HTML
I, [2019-08-30T11:50:59.227612 #9693]  INFO -- : [17cae624-7764-49fa-b0d4-f85921ffc780] [2019-08-30 18:50:59.226]   Parameters: {"id"=>"druid:wg314mv5625"}
D, [2019-08-30T11:50:59.229580 #9693] DEBUG -- : [17cae624-7764-49fa-b0d4-f85921ffc780] [2019-08-30 18:50:59.226]   ESC[1mESC[36mUser Load (0.4ms)ESC[0m  ESC[1mESC[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 21 ORDER BY `users`.`id` ASC LIMIT 1ESC[0m
D, [2019-08-30T11:50:59.377154 #11050] DEBUG -- :   ESC[1mESC[35m (0.5ms)ESC[0m  ESC[1mESC[34mSELECT COUNT(*) FROM `delayed_jobs` WHERE (failed_at is not NULL)ESC[0m
D, [2019-08-30T11:50:59.377780 #11050] DEBUG -- :   ESC[1mESC[35m (0.2ms)ESC[0m  ESC[1mESC[34mSELECT COUNT(*) FROM `delayed_jobs` WHERE (locked_by is not NULL)ESC[0m
D, [2019-08-30T11:50:59.378974 #11050] DEBUG -- :   ESC[1mESC[35m (0.5ms)ESC[0m  ESC[1mESC[34mSELECT COUNT(*) AS count_all, `delayed_jobs`.`priority` AS delayed_jobs_priority FROM `delayed_jobs` WHERE (run_at <= '2019-08-30 18:50:59' and failed_at is NULL) GROUP BY `delayed_jobs`.`priority`ESC[0m
I, [2019-08-30T11:50:59.543730 #9693]  INFO -- : [17cae624-7764-49fa-b0d4-f85921ffc780] [2019-08-30 18:50:59.226] Completed 500 Internal Server Error in 316ms (ActiveRecord: 0.4ms)
F, [2019-08-30T11:50:59.544512 #9693] FATAL -- : [17cae624-7764-49fa-b0d4-f85921ffc780] [2019-08-30 18:50:59.226]   
F, [2019-08-30T11:50:59.544549 #9693] FATAL -- : [17cae624-7764-49fa-b0d4-f85921ffc780] [2019-08-30 18:50:59.226] Dor::Services::Client::UnexpectedResponse (Internal Server Error: 500 (Incomplete response received from Symphony for 111 - expected 1960 bytes but got 1965)):
F, [2019-08-30T11:50:59.544568 #9693] FATAL -- : [17cae624-7764-49fa-b0d4-f85921ffc780] [2019-08-30 18:50:59.226]   
F, [2019-08-30T11:50:59.544587 #9693] FATAL -- : [17cae624-7764-49fa-b0d4-f85921ffc780] [2019-08-30 18:50:59.226] app/controllers/items_controller.rb:326:in `refresh_metadata'
I, [2019-08-30T11:50:59.545318 #9693]  INFO -- honeybadger: ** [Honeybadger] Reporting error id=dd245602-631d-4521-8a80-5150d372e603 level=1 pid=9693
I, [2019-08-30T11:50:59.816109 #9693]  INFO -- honeybadger: ** [Honeybadger] Success ⚡ https://app.honeybadger.io/notice/dd245602-631d-4521-8a80-5150d372e603 id=dd245602-631d-4521-8a80-5150d372e603 code=201 level=1 pid=9693
```

### Dor Services App

Rails log (not much):

```
I, [2019-08-30T11:50:59.417649 #5205]  INFO -- : [00238ac2-122a-4887-aa98-955218bcf217] Started POST "/v1/objects/druid:wg314mv5625/refresh_metadata" for 171.67.35.209 at 2019-08-30 11:50:59 -0700
I, [2019-08-30T11:50:59.423613 #5205]  INFO -- : [00238ac2-122a-4887-aa98-955218bcf217] Processing by MetadataRefreshController#refresh as */*
I, [2019-08-30T11:50:59.423678 #5205]  INFO -- : [00238ac2-122a-4887-aa98-955218bcf217]   Parameters: {"id"=>"druid:wg314mv5625"}
I, [2019-08-30T11:50:59.541792 #5205]  INFO -- : [00238ac2-122a-4887-aa98-955218bcf217] Completed 500 Internal Server Error in 118ms (Views: 0.2ms)
```

