### PR TITLE
Validate constituents before creating virtual object

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -42,7 +42,10 @@ class ObjectsController < ApplicationController
     raise ActionController::ParameterMissing, 'constituent_ids must be an array' unless filtered_params[:constituent_ids]
 
     # Update the constituent relationship
-    ConstituentService.new(parent_druid: params[:id]).add(child_druids: filtered_params[:constituent_ids])
+    errors = ConstituentService.new(parent_druid: params[:id]).add(child_druids: filtered_params[:constituent_ids])
+
+    return render json: { errors: errors.to_json }, status: 422 if errors
+
     head :no_content
   end
 

--- a/app/services/constituent_service.rb
+++ b/app/services/constituent_service.rb
@@ -15,13 +15,21 @@ class ConstituentService
   # Typically this is only called one time (with a list of all the pids) because
   # subsequent calls will erase the previous changes.
   # @param [Array<String>] child_druids the identifiers of the child objects
+  # @raises ActiveFedora::RecordInvalid if AF object validations fail on #save!
+  # @returns [NilClass, Hash] true if successful, hash of errors otherwise (if combinable validation fails)
   def add(child_druids:)
+    errors = ItemQueryService.validate_combinable_items([parent_druid] + child_druids)
+
+    return errors if errors.any?
+
     ResetContentMetadataService.new(item: parent).reset
 
     child_druids.each do |child_druid|
       add_constituent(child_druid: child_druid)
     end
     parent.save!
+
+    nil
   end
 
   private

--- a/spec/services/item_query_service_spec.rb
+++ b/spec/services/item_query_service_spec.rb
@@ -15,28 +15,106 @@ RSpec.describe ItemQueryService do
   describe '.find_combinable_item' do
     it 'raises error if object does not allow modification' do
       allow(item).to receive(:allows_modification?).and_return(false)
-      expect { service.find_combinable_item('ab123cd4567') }.to raise_error(RuntimeError, 'Item druid:ab123cd4567 is not open for modification')
+      expect { service.find_combinable_item('ab123cd4567') }.to raise_error(described_class::UncombinableItemError, 'Item druid:ab123cd4567 is not open for modification')
     end
+
     it 'raises error if object is dark' do
       dra = instance_double(Dor::RightsAuth, dark?: true, citation_only?: false)
       rights_ds = instance_double(Dor::RightsMetadataDS, dra_object: dra)
       allow(item).to receive(:rightsMetadata).and_return(rights_ds)
       allow(item).to receive(:allows_modification?).and_return(true)
-      expect { service.find_combinable_item('ab123cd4567') }.to raise_error(RuntimeError, 'Item druid:ab123cd4567 is dark')
+      expect { service.find_combinable_item('ab123cd4567') }.to raise_error(described_class::UncombinableItemError, 'Item druid:ab123cd4567 is dark')
     end
+
     it 'raises error if object is citation_only' do
       dra = instance_double(Dor::RightsAuth, dark?: false, citation_only?: true)
       rights_ds = instance_double(Dor::RightsMetadataDS, dra_object: dra)
       allow(item).to receive(:rightsMetadata).and_return(rights_ds)
       allow(item).to receive(:allows_modification?).and_return(true)
-      expect { service.find_combinable_item('ab123cd4567') }.to raise_error(RuntimeError, 'Item druid:ab123cd4567 is citation_only')
+      expect { service.find_combinable_item('ab123cd4567') }.to raise_error(described_class::UncombinableItemError, 'Item druid:ab123cd4567 is citation_only')
     end
+
     it 'returns item otherwise' do
       dra = instance_double(Dor::RightsAuth, dark?: false, citation_only?: false)
       rights_ds = instance_double(Dor::RightsMetadataDS, dra_object: dra)
       allow(item).to receive(:rightsMetadata).and_return(rights_ds)
       allow(item).to receive(:allows_modification?).and_return(true)
       service.find_combinable_item('ab123cd4567')
+    end
+  end
+
+  describe '.validate_combinable_items' do
+    let(:item2) { instantiate_fixture('druid:xh235dd9059', Dor::Item) }
+    let(:item3) { instantiate_fixture('druid:hj097bm8879', Dor::Item) }
+    let(:dark_rights) { instance_double(Dor::RightsAuth, dark?: true, citation_only?: false) }
+    let(:citation_only_rights) { instance_double(Dor::RightsAuth, dark?: false, citation_only?: true) }
+    let(:permissive_rights) { instance_double(Dor::RightsAuth, dark?: false, citation_only?: false) }
+    let(:dark_rights_ds) { instance_double(Dor::RightsMetadataDS, dra_object: dark_rights) }
+    let(:citation_only_rights_ds) { instance_double(Dor::RightsMetadataDS, dra_object: citation_only_rights) }
+    let(:permissive_rights_ds) { instance_double(Dor::RightsMetadataDS, dra_object: permissive_rights) }
+
+    # Set defaults on all fixture objects and avoid making HTTP calls. Set defaults to the non-error cases.
+    before do
+      allow(Dor::Item).to receive(:find).with('druid:xh235dd9059').and_return(item2)
+      allow(Dor::Item).to receive(:find).with('druid:hj097bm8879').and_return(item3)
+      [item, item2, item3].each do |i|
+        allow(i).to receive(:allows_modification?).and_return(true)
+        allow(i).to receive(:rightsMetadata).and_return(permissive_rights_ds)
+      end
+    end
+
+    context 'when any objects do not allow modification' do
+      before do
+        allow(item).to receive(:allows_modification?).and_return(false)
+      end
+
+      it 'returns a single error if one object does not allow modification' do
+        expect(service.validate_combinable_items(['druid:ab123cd4567', 'druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
+          'druid:ab123cd4567' => 'Item druid:ab123cd4567 is not open for modification'
+        )
+      end
+    end
+
+    context 'when any objects are dark' do
+      before do
+        [item2, item3].each do |i|
+          allow(i).to receive(:rightsMetadata).and_return(dark_rights_ds)
+        end
+      end
+
+      it 'returns errors if any objects are dark' do
+        expect(service.validate_combinable_items(['druid:ab123cd4567', 'druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
+          'druid:hj097bm8879' => 'Item druid:hj097bm8879 is dark',
+          'druid:xh235dd9059' => 'Item druid:xh235dd9059 is dark'
+        )
+      end
+    end
+
+    context 'when any objects are citation-only' do
+      before do
+        [item, item3].each do |i|
+          allow(i).to receive(:rightsMetadata).and_return(citation_only_rights_ds)
+        end
+      end
+
+      it 'raises error if any objects are citation_only' do
+        expect(service.validate_combinable_items(['druid:ab123cd4567', 'druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
+          'druid:ab123cd4567' => 'Item druid:ab123cd4567 is citation_only',
+          'druid:hj097bm8879' => 'Item druid:hj097bm8879 is citation_only'
+        )
+      end
+    end
+
+    context 'when none of the error conditions exist' do
+      before do
+        [item, item2, item3].each do |i|
+          allow(i).to receive(:rightsMetadata).and_return(permissive_rights_ds)
+        end
+      end
+
+      it 'returns an empty hash otherwise' do
+        expect(service.validate_combinable_items(['druid:ab123cd4567', 'druid:xh235dd9059', 'druid:hj097bm8879'])).to eq({})
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #365 

Includes:
* Add `ItemQueryService.validate_combinable_items`. This new class method takes an array of druids and makes sure each is combinable. If any are not, a hash of errors is created and returned.
* Validate all items to be combined before modifying any of them.
* Raise exception from objects controller when constituent service raises.