### PR TITLE
Do not double-escape JSON

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,7 +40,3 @@ RSpec/MultipleExpectations:
 RSpec/ExpectActual:
   Exclude:
     - 'spec/routing/**'
-
-RSpec/DescribeClass:
-  Exclude:
-    - 'spec/requests/**'

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -44,7 +44,7 @@ class ObjectsController < ApplicationController
     # Update the constituent relationship
     errors = ConstituentService.new(parent_druid: params[:id]).add(child_druids: filtered_params[:constituent_ids])
 
-    return render json: { errors: errors.to_json }, status: :unprocessable_entity if errors
+    return render json: { errors: errors }, status: :unprocessable_entity if errors
 
     head :no_content
   end

--- a/spec/requests/virtual_merge_spec.rb
+++ b/spec/requests/virtual_merge_spec.rb
@@ -62,8 +62,7 @@ RSpec.describe 'Virtual merge of objects' do
           headers: { 'X-Auth' => "Bearer #{jwt}" }
       expect(service).to have_received(:add).with(child_druids: [child1_id, child2_id])
       expect(response).to be_unprocessable
-      json = JSON.parse(response.body)
-      expect(json['errors']).to eq '{"druid:child2":"Item druid:child2 is not open for modification"}'
+      expect(response.body).to eq '{"errors":{"druid:child2":"Item druid:child2 is not open for modification"}}'
     end
   end
 end


### PR DESCRIPTION
Refs sul-dlss/argo#1463

Calling `#to_json` on a string before rendering it with the built-in JSON renderer causes a double-escaping to happen.

Also, remove duplicate rubocop exception