### PR TITLE
surface better error message in ObjectsController

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -3,6 +3,10 @@
 class ObjectsController < ApplicationController
   before_action :load_item, except: [:create]
 
+  rescue_from(ActiveFedora::ObjectNotFoundError) do |e|
+    render status: :not_found, plain: e.message
+  end
+
   rescue_from(Dor::ParameterError) do |e|
     render status: :bad_request, plain: e.message
   end

--- a/spec/controllers/objects_controller_spec.rb
+++ b/spec/controllers/objects_controller_spec.rb
@@ -48,6 +48,13 @@ RSpec.describe ObjectsController do
         expect(response.status).to eq(500)
         expect(response.body).to eq(errmsg)
       end
+
+      it 'returns a 404 error for ActiveFedora::ObjectNotFoundError' do
+        allow(RegistrationService).to receive(:register_object).and_raise(ActiveFedora::ObjectNotFoundError.new(errmsg))
+        post :create
+        expect(response.status).to eq(404)
+        expect(response.body).to eq(errmsg)
+      end
     end
 
     it 'registers the object with the registration service' do


### PR DESCRIPTION
Fixes #346 

If, say, a collection or APO object is missing when registering an item, we get 

```
ActiveFedora::ObjectNotFoundError (Unable to find 'druid:bh738rc3225' in fedora. See logger for details.):
```

in logs for dor-services-app.

This PR will ensure the useful "Unable to find 'druid:bh738rc3225' in fedora" part is shared with dor-services-client, instead of:

```
Dor::Services::Client::UnexpectedResponse: Not Found: 404 ({"status":404,"error":"Not Found"})
```

