### PR TITLE
alert honeybadger for incomplete response from Symphony

### DIFF
--- a/app/models/symphony_reader.rb
+++ b/app/models/symphony_reader.rb
@@ -50,6 +50,7 @@ class SymphonyReader
     return resp if actual_content_length == exp_content_length
 
     errmsg = "Incomplete response received from Symphony for #{@catkey} - expected #{exp_content_length} bytes but got #{actual_content_length}"
+    Honeybadger.notify(errmsg)
     raise RecordIncompleteError, errmsg
   end
 

--- a/spec/models/symphony_reader_spec.rb
+++ b/spec/models/symphony_reader_spec.rb
@@ -63,8 +63,12 @@ RSpec.describe SymphonyReader do
 
     context 'when wrong number of bytes received from Symphony' do
       let(:headers) { { 'Content-Length': 268 } }
-      it 'raises RecordIncompleteError' do
-        expect { reader.to_marc }.to raise_error(SymphonyReader::RecordIncompleteError, 'Incomplete response received from Symphony for catkey - expected 268 bytes but got 394')
+
+      it 'raises RecordIncompleteError and notifies Honeybadger' do
+        msg = 'Incomplete response received from Symphony for catkey - expected 268 bytes but got 394'
+        allow(Honeybadger).to receive(:notify)
+        expect { reader.to_marc }.to raise_error(SymphonyReader::RecordIncompleteError, msg)
+        expect(Honeybadger).to have_received(:notify).with(msg)
       end
     end
   end


### PR DESCRIPTION
Fixes #362

FYI:

For Argo registration, we will now see this error in honeybadger.  Yay!

For Argo "refresh metadata", we will now see each of these errors twice in honeybadger:
- from the notification here in dor-services-app
- from the notification in argo due to 500 from dor-service-client

