### PR TITLE
Allow virtual objects to be created in batches

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -40,6 +40,7 @@ class ObjectsController < ApplicationController
     end
   end
 
+  # TODO: Remove this once Argo, in stage and prod, uses a version of dor-services-client that no longer hits this endpoint
   # Handles updates to the record.
   # Presently this only needs to handle the merge object use case.
   # Do this by providing: constituent_ids => ['druid:123', 'druid:345']

--- a/app/controllers/virtual_objects_controller.rb
+++ b/app/controllers/virtual_objects_controller.rb
@@ -2,27 +2,62 @@
 
 # Create virtual objects
 class VirtualObjectsController < ApplicationController
-  # Create one or more virtual objects represented by JSON:
-  # {
-  #   virtual_objects: [
-  #     { parent_id: '', child_ids: [] }
-  #   ]
-  # }
-  def create
-    # validate that the virtual_objects parameter is an present, raises ActionController::ParameterMissing
-    params.require(:virtual_objects)
-    filtered_params = params.permit(virtual_objects: [:parent_id, child_ids: []])
-    raise ActionController::ParameterMissing, 'virtual_objects must be an array' unless filtered_params[:virtual_objects]
+  before_action :validate_params!, only: :create
 
+  # Create one or more virtual objects represented by JSON (see `#schema` below):
+  def create
     errors = []
 
-    filtered_params[:virtual_objects].each do |virtual_object|
+    create_params[:virtual_objects].each do |virtual_object|
+      parent_id, child_ids = virtual_object.values_at(:parent_id, :child_ids)
       # Update the constituent relationship between the parent and child druids
-      errors << ConstituentService.new(parent_druid: virtual_object[:parent_id]).add(child_druids: virtual_object[:child_ids])
+      errors << ConstituentService.new(parent_druid: parent_id).add(child_druids: child_ids)
+    rescue ActiveFedora::ObjectNotFoundError, Rubydora::FedoraInvalidRequest => e
+      errors << { parent_id => [e.message] }
     end
 
-    return render json: { errors: errors }, status: :unprocessable_entity if errors.any?
+    return render_error(errors: errors, status: :unprocessable_entity) if errors.any?
 
     head :no_content
+  end
+
+  private
+
+  def create_params
+    params.to_unsafe_h
+  end
+
+  # Use dry-validation to validate params instead of Rails strong parameters.
+  # This gives us finer-grained validation.
+  def validate_params!
+    errors = schema.call(create_params).errors(full: true)
+    return render_error(errors: errors, status: :bad_request) if errors.any?
+  end
+
+  def render_error(errors:, status:)
+    render json: { errors: errors }, status: status
+  end
+
+  # {
+  #   virtual_objects: [
+  #     {
+  #       parent_id: 'a-non-empty-string',
+  #       child_ids: [
+  #         'another-non-empty-string',
+  #         ...
+  #       ]
+  #     },
+  #     ...
+  #   ]
+  # }
+  def schema
+    Dry::Schema.JSON do
+      required(:virtual_objects).value(:array, min_size?: 1).each do
+        hash do
+          required(:parent_id).filled(:string)
+          required(:child_ids).value(:array, min_size?: 1).each(:filled?)
+        end
+      end
+    end
   end
 end

--- a/app/controllers/virtual_objects_controller.rb
+++ b/app/controllers/virtual_objects_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Create virtual objects
+class VirtualObjectsController < ApplicationController
+  # Create one or more virtual objects represented by JSON:
+  # {
+  #   virtual_objects: [
+  #     { parent_id: '', child_ids: [] }
+  #   ]
+  # }
+  def create
+    # validate that the virtual_objects parameter is an present, raises ActionController::ParameterMissing
+    params.require(:virtual_objects)
+    filtered_params = params.permit(virtual_objects: [:parent_id, child_ids: []])
+    raise ActionController::ParameterMissing, 'virtual_objects must be an array' unless filtered_params[:virtual_objects]
+
+    errors = []
+
+    filtered_params[:virtual_objects].each do |virtual_object|
+      # Update the constituent relationship between the parent and child druids
+      errors << ConstituentService.new(parent_druid: virtual_object[:parent_id]).add(child_druids: virtual_object[:child_ids])
+    end
+
+    return render json: { errors: errors }, status: :unprocessable_entity if errors.any?
+
+    head :no_content
+  end
+end

--- a/app/services/item_query_service.rb
+++ b/app/services/item_query_service.rb
@@ -11,8 +11,6 @@ class ItemQueryService
     @item_relation = item_relation
   end
 
-  delegate :allows_modification?, to: :item
-
   # @param [String] parent a parent druid
   # @param [Array] children a list of child druids
   # @return [Hash]
@@ -32,7 +30,7 @@ class ItemQueryService
   def self.find_combinable_item(druid)
     query_service = ItemQueryService.new(id: druid)
     query_service.item do |item|
-      raise UncombinableItemError, "Item #{item.pid} is not open for modification" unless query_service.allows_modification?
+      raise UncombinableItemError, "Item #{item.pid} is not open or openable" unless VersionService.open?(item) || VersionService.can_open?(item)
       raise UncombinableItemError, "Item #{item.pid} is dark" if item.rightsMetadata.dra_object.dark?
       raise UncombinableItemError, "Item #{item.pid} is citation_only" if item.rightsMetadata.dra_object.citation_only?
     end

--- a/app/services/item_query_service.rb
+++ b/app/services/item_query_service.rb
@@ -13,14 +13,16 @@ class ItemQueryService
 
   delegate :allows_modification?, to: :item
 
-  # @param [Array] druids a list of druids
-  def self.validate_combinable_items(druids)
-    errors = {}
+  # @param [String] parent a parent druid
+  # @param [Array] children a list of child druids
+  # @return [Hash]
+  def self.validate_combinable_items(parent:, children:)
+    errors = Hash.new { |hash, key| hash[key] = [] }
 
-    druids.each do |druid|
+    ([parent] + children).each do |druid|
       find_combinable_item(druid)
     rescue UncombinableItemError => e
-      errors[druid] = e.message
+      errors[parent] << e.message
     end
 
     errors

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -10,6 +10,10 @@ class VersionService
     new(work).can_open?(opts)
   end
 
+  def self.open?(work)
+    new(work).open_for_versioning?
+  end
+
   def self.close(work, opts = {})
     new(work).close(opts)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,9 @@ Rails.application.routes.draw do
       get 'catkey', to: 'marcxml#catkey'
     end
 
+    resources :virtual_objects, only: [:create]
+
+    # TODO: Remove :update once Argo, in stage and prod, uses a version of dor-services-client that no longer hits this endpoint
     resources :objects, only: [:create, :update, :show] do
       member do
         post 'publish'

--- a/spec/requests/batch_create_virtual_objects_spec.rb
+++ b/spec/requests/batch_create_virtual_objects_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Batch creation of virtual objects' do
+  let(:payload) { { sub: 'argo' } }
+  let(:jwt) { JWT.encode(payload, Settings.dor.hmac_secret, 'HS256') }
+  let(:parent_id) { 'druid:mk420bs7601' }
+  let(:child1_id) { 'druid:child1' }
+  let(:child2_id) { 'druid:child2' }
+
+  let(:object) { Dor::Item.new(pid: parent_id) }
+  let(:service) { instance_double(ConstituentService, add: nil) }
+
+  before do
+    allow(Dor).to receive(:find).and_return(object)
+    allow(ConstituentService).to receive(:new).with(parent_druid: parent_id).and_return(service)
+  end
+
+  context 'when virtual_objects param is provided' do
+    it 'creates a virtual object out of the parent object and all child objects' do
+      post '/v1/virtual_objects',
+           params: { virtual_objects: [{ parent_id: parent_id, child_ids: [child1_id, child2_id] }] },
+           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(service).to have_received(:add).with(child_druids: [child1_id, child2_id])
+      expect(response).to be_successful
+    end
+  end
+
+  context 'when virtual_objects param is not provided' do
+    it 'renders an error' do
+      post '/v1/virtual_objects',
+           params: { title: 'New name' },
+           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(service).not_to have_received(:add)
+      expect(response).to be_bad_request
+      json = JSON.parse(response.body)
+      expect(json['errors'][0]['detail']).to eq 'param is missing or the value is empty: virtual_objects'
+    end
+  end
+
+  context 'when virtual_objects is not an array' do
+    it 'renders an error' do
+      post '/v1/virtual_objects',
+           params: { virtual_objects: child1_id },
+           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(service).not_to have_received(:add)
+      expect(response).to be_bad_request
+      json = JSON.parse(response.body)
+      expect(json['errors'][0]['detail']).to eq 'param is missing or the value is empty: virtual_objects must be an array'
+    end
+  end
+
+  context 'when virtual_objects contain objects that are not combinable' do
+    before do
+      allow(service).to receive(:add).and_return(parent_id => ["Item #{child2_id} is not open for modification"])
+    end
+
+    it 'renders an error' do
+      post '/v1/virtual_objects',
+           params: { virtual_objects: [{ parent_id: parent_id, child_ids: [child1_id, child2_id] }] },
+           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(service).to have_received(:add).with(child_druids: [child1_id, child2_id])
+      expect(response).to be_unprocessable
+      expect(response.body).to eq '{"errors":[{"druid:mk420bs7601":["Item druid:child2 is not open for modification"]}]}'
+    end
+  end
+end

--- a/spec/requests/batch_create_virtual_objects_spec.rb
+++ b/spec/requests/batch_create_virtual_objects_spec.rb
@@ -27,30 +27,6 @@ RSpec.describe 'Batch creation of virtual objects' do
     end
   end
 
-  context 'when virtual_objects param is not provided' do
-    it 'renders an error' do
-      post '/v1/virtual_objects',
-           params: { title: 'New name' },
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
-      expect(service).not_to have_received(:add)
-      expect(response).to be_bad_request
-      json = JSON.parse(response.body)
-      expect(json['errors'][0]['detail']).to eq 'param is missing or the value is empty: virtual_objects'
-    end
-  end
-
-  context 'when virtual_objects is not an array' do
-    it 'renders an error' do
-      post '/v1/virtual_objects',
-           params: { virtual_objects: child1_id },
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
-      expect(service).not_to have_received(:add)
-      expect(response).to be_bad_request
-      json = JSON.parse(response.body)
-      expect(json['errors'][0]['detail']).to eq 'param is missing or the value is empty: virtual_objects must be an array'
-    end
-  end
-
   context 'when virtual_objects contain objects that are not combinable' do
     before do
       allow(service).to receive(:add).and_return(parent_id => ["Item #{child2_id} is not open for modification"])
@@ -63,6 +39,114 @@ RSpec.describe 'Batch creation of virtual objects' do
       expect(service).to have_received(:add).with(child_druids: [child1_id, child2_id])
       expect(response).to be_unprocessable
       expect(response.body).to eq '{"errors":[{"druid:mk420bs7601":["Item druid:child2 is not open for modification"]}]}'
+    end
+  end
+
+  context 'when virtual_objects param is not provided' do
+    it 'renders an error' do
+      post '/v1/virtual_objects',
+           params: { title: 'New name' },
+           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(service).not_to have_received(:add)
+      expect(response).to be_bad_request
+      json = JSON.parse(response.body)
+      expect(json['errors'][0]['text']).to eq 'virtual_objects is missing'
+    end
+  end
+
+  context 'when virtual_objects is not an array' do
+    it 'renders an error' do
+      post '/v1/virtual_objects',
+           params: { virtual_objects: child1_id },
+           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(service).not_to have_received(:add)
+      expect(response).to be_bad_request
+      json = JSON.parse(response.body)
+      expect(json['errors'][0]['text']).to eq 'virtual_objects must be an array'
+    end
+  end
+
+  context 'when virtual_objects is empty array' do
+    it 'renders an error' do
+      post '/v1/virtual_objects',
+           params: { virtual_objects: [] },
+           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(service).not_to have_received(:add)
+      expect(response).to be_bad_request
+      json = JSON.parse(response.body)
+      expect(json['errors'][0]['text']).to eq 'parent_id is missing'
+    end
+  end
+
+  context 'when virtual_objects array lacks hashes defining parent_id' do
+    it 'renders an error' do
+      post '/v1/virtual_objects',
+           params: { virtual_objects: [{ child_ids: ['foo'] }] },
+           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(service).not_to have_received(:add)
+      expect(response).to be_bad_request
+      json = JSON.parse(response.body)
+      expect(json['errors'][0]['text']).to eq 'parent_id is missing'
+    end
+  end
+
+  context 'when virtual_objects array has a hash w/ an empty parent_id' do
+    it 'renders an error' do
+      post '/v1/virtual_objects',
+           params: { virtual_objects: [{ parent_id: '' }] },
+           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(service).not_to have_received(:add)
+      expect(response).to be_bad_request
+      json = JSON.parse(response.body)
+      expect(json['errors'][0]['text']).to eq 'parent_id must be filled'
+    end
+  end
+
+  context 'when virtual_objects array lacks hashes defining child_ids' do
+    it 'renders an error' do
+      post '/v1/virtual_objects',
+           params: { virtual_objects: [{ parent_id: 'foo' }] },
+           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(service).not_to have_received(:add)
+      expect(response).to be_bad_request
+      json = JSON.parse(response.body)
+      expect(json['errors'][0]['text']).to eq 'child_ids is missing'
+    end
+  end
+
+  context 'when virtual_objects array has a hash w/ child_ids not an array' do
+    it 'renders an error' do
+      post '/v1/virtual_objects',
+           params: { virtual_objects: [{ parent_id: 'foo', child_ids: '' }] },
+           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(service).not_to have_received(:add)
+      expect(response).to be_bad_request
+      json = JSON.parse(response.body)
+      expect(json['errors'][0]['text']).to eq 'child_ids must be an array'
+    end
+  end
+
+  context 'when virtual_objects array has a hash w/ child_ids empty' do
+    it 'renders an error' do
+      post '/v1/virtual_objects',
+           params: { virtual_objects: [{ parent_id: 'foo', child_ids: [] }] },
+           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(service).not_to have_received(:add)
+      expect(response).to be_bad_request
+      json = JSON.parse(response.body)
+      expect(json['errors'][0]['text']).to eq '0 must be filled'
+    end
+  end
+
+  context 'when virtual_objects array has a hash w/ child_ids containing empties' do
+    it 'renders an error' do
+      post '/v1/virtual_objects',
+           params: { virtual_objects: [{ parent_id: 'foo', child_ids: ['foo', 'bar', ''] }] },
+           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(service).not_to have_received(:add)
+      expect(response).to be_bad_request
+      json = JSON.parse(response.body)
+      expect(json['errors'][0]['text']).to eq '2 must be filled'
     end
   end
 end

--- a/spec/services/item_query_service_spec.rb
+++ b/spec/services/item_query_service_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe ItemQueryService do
       end
 
       it 'returns a single error if one object does not allow modification' do
-        expect(service.validate_combinable_items(['druid:ab123cd4567', 'druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
-          'druid:ab123cd4567' => 'Item druid:ab123cd4567 is not open for modification'
+        expect(service.validate_combinable_items(parent: 'druid:ab123cd4567', children: ['druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
+          'druid:ab123cd4567' => ['Item druid:ab123cd4567 is not open for modification']
         )
       end
     end
@@ -83,9 +83,8 @@ RSpec.describe ItemQueryService do
       end
 
       it 'returns errors if any objects are dark' do
-        expect(service.validate_combinable_items(['druid:ab123cd4567', 'druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
-          'druid:hj097bm8879' => 'Item druid:hj097bm8879 is dark',
-          'druid:xh235dd9059' => 'Item druid:xh235dd9059 is dark'
+        expect(service.validate_combinable_items(parent: 'druid:ab123cd4567', children: ['druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
+          'druid:ab123cd4567' => ['Item druid:xh235dd9059 is dark', 'Item druid:hj097bm8879 is dark']
         )
       end
     end
@@ -98,9 +97,8 @@ RSpec.describe ItemQueryService do
       end
 
       it 'raises error if any objects are citation_only' do
-        expect(service.validate_combinable_items(['druid:ab123cd4567', 'druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
-          'druid:ab123cd4567' => 'Item druid:ab123cd4567 is citation_only',
-          'druid:hj097bm8879' => 'Item druid:hj097bm8879 is citation_only'
+        expect(service.validate_combinable_items(parent: 'druid:ab123cd4567', children: ['druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
+          'druid:ab123cd4567' => ['Item druid:ab123cd4567 is citation_only', 'Item druid:hj097bm8879 is citation_only']
         )
       end
     end
@@ -113,7 +111,7 @@ RSpec.describe ItemQueryService do
       end
 
       it 'returns an empty hash otherwise' do
-        expect(service.validate_combinable_items(['druid:ab123cd4567', 'druid:xh235dd9059', 'druid:hj097bm8879'])).to eq({})
+        expect(service.validate_combinable_items(parent: 'druid:ab123cd4567', children: ['druid:xh235dd9059', 'druid:hj097bm8879'])).to eq({})
       end
     end
   end

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -18,6 +18,19 @@ RSpec.describe VersionService do
     allow(obj.inner_object).to receive(:repository).and_return(double('frepo').as_null_object)
   end
 
+  describe '.open?' do
+    let(:instance) { instance_double(described_class, open_for_versioning?: true) }
+
+    before do
+      allow(described_class).to receive(:new).and_return(instance)
+    end
+
+    it 'creates a new service instance and sends #open_for_versioning?' do
+      described_class.open?(obj)
+      expect(instance).to have_received(:open_for_versioning?).once
+    end
+  end
+
   describe '.open' do
     subject(:open) { described_class.open(obj) }
 


### PR DESCRIPTION
Connects to #375 
Connects to sul-dlss/argo#1463

Includes:
* Mark `ObjectsController#update` as soon as be removed
* Make clear in `ItemQueryService` which parents are associated with which combination errors
* Add class method for convenience of checking if a work is open for versioning
* Check whether item is open or openable, NOT whether it allows modification, within `ItemQueryService`
* Handle versioning concerns when adding constituents
* Extract `VirtualObjectsController` from `ObjectsController`: it functions identically to the `ObjectsController` implementation except it can create many virtual objects at a time.
* Enhance parameter validation in `VirtualObjectsController` by using dry-schema