### PR TITLE
Symphony responses aren't always status 200

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,11 +29,11 @@ class ApplicationController < ActionController::API
 
   def decoded_auth_token
     @decoded_auth_token ||= begin
-     body = JWT.decode(http_auth_header, Settings.dor.hmac_secret, true, algorithm: 'HS256').first
-     HashWithIndifferentAccess.new body
+      body = JWT.decode(http_auth_header, Settings.dor.hmac_secret, true, algorithm: 'HS256').first
+      HashWithIndifferentAccess.new body
                             rescue StandardError
                               nil
-   end
+    end
   end
 
   def http_auth_header

--- a/app/controllers/marcxml_controller.rb
+++ b/app/controllers/marcxml_controller.rb
@@ -3,7 +3,7 @@
 class MarcxmlController < ApplicationController #:nodoc:
   before_action :set_marcxml_resource
 
-  rescue_from(SymphonyReader::RecordIncompleteError) do |e|
+  rescue_from(SymphonyReader::ResponseError) do |e|
     render status: :internal_server_error, plain: e.message
   end
 

--- a/app/controllers/metadata_refresh_controller.rb
+++ b/app/controllers/metadata_refresh_controller.rb
@@ -4,7 +4,7 @@
 class MetadataRefreshController < ApplicationController
   before_action :load_item
 
-  rescue_from(SymphonyReader::RecordIncompleteError) do |e|
+  rescue_from(SymphonyReader::ResponseError) do |e|
     render status: :internal_server_error, plain: e.message
   end
 

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -19,7 +19,7 @@ class ObjectsController < ApplicationController
     render status: :internal_server_error, plain: e.message
   end
 
-  rescue_from(SymphonyReader::RecordIncompleteError) do |e|
+  rescue_from(SymphonyReader::ResponseError) do |e|
     render status: :internal_server_error, plain: e.message
   end
 

--- a/spec/requests/register_object_spec.rb
+++ b/spec/requests/register_object_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Register object' do
     let(:errmsg) { 'my unique snowflake error message' }
 
     before do
-      allow(RegistrationService).to receive(:register_object).and_raise(SymphonyReader::RecordIncompleteError.new(errmsg))
+      allow(RegistrationService).to receive(:register_object).and_raise(SymphonyReader::ResponseError.new(errmsg))
     end
 
     it 'returns a 500 error' do


### PR DESCRIPTION
The bulk of this is "d'oh" -- we need to check the HTTP status code of the response from Symphony and surface the right info. 