### PR TITLE
Correct parameter location

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -146,6 +146,9 @@
             "in": "path",
             "description": "ID of the datastream",
             "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ]
       }
@@ -178,6 +181,9 @@
             "in": "path",
             "description": "ID of the datastream",
             "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ]
       }
@@ -210,6 +216,9 @@
             "in": "path",
             "description": "name of the file",
             "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ]
       }
@@ -233,12 +242,18 @@
             "in": "query",
             "description": "barcode of an item",
             "required": false,
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "catkey",
             "in": "query",
             "description": "catalog identifier of an item",
             "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ]
       }
@@ -262,12 +277,18 @@
             "in": "query",
             "description": "barcode of an item",
             "required": false,
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "catkey",
             "in": "query",
             "description": "catalog identifier of an item",
             "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ]
       }
@@ -291,6 +312,9 @@
             "in": "query",
             "description": "barcode of an item",
             "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ]
       }

--- a/openapi.json
+++ b/openapi.json
@@ -230,13 +230,13 @@
         "parameters": [
           {
             "name": "barcode",
-            "in": "body",
+            "in": "query",
             "description": "barcode of an item",
             "required": false,
           },
           {
             "name": "catkey",
-            "in": "body",
+            "in": "query",
             "description": "catalog identifier of an item",
             "required": false,
           }
@@ -259,13 +259,13 @@
         "parameters": [
           {
             "name": "barcode",
-            "in": "body",
+            "in": "query",
             "description": "barcode of an item",
             "required": false,
           },
           {
             "name": "catkey",
-            "in": "body",
+            "in": "query",
             "description": "catalog identifier of an item",
             "required": false,
           }
@@ -288,7 +288,7 @@
         "parameters": [
           {
             "name": "barcode",
-            "in": "body",
+            "in": "query",
             "description": "barcode of an item",
             "required": false,
           }


### PR DESCRIPTION
These are in the query not the body

## Why was this change made?

`body` is not valid in OAS 3.0 and furthermore these parameters are in the query.


## Was the API documentation (openapi.json) updated?


yes