### PR TITLE
surface Faraday::Timeout errors for Symphony response

### DIFF
--- a/app/models/symphony_reader.rb
+++ b/app/models/symphony_reader.rb
@@ -47,12 +47,18 @@ class SymphonyReader
       validate_response(resp)
       return resp
     elsif resp.status == 404
+      # 404 received here is for the catkey, but this app cares about the druid
+      #   for the DOR object, hence raising 404 from here could be misleading
       errmsg = "Record not found in Symphony: #{@catkey}"
     else
       errmsg = "Got HTTP Status-Code #{resp.status} retrieving #{@catkey} from Symphony: #{resp.body}"
       Honeybadger.notify(errmsg)
     end
 
+    raise ResponseError, errmsg
+  rescue Faraday::TimeoutError => e
+    errmsg = "Timeout for Symphony response for catkey #{@catkey}: #{e}"
+    Honeybadger.notify(errmsg)
     raise ResponseError, errmsg
   end
 


### PR DESCRIPTION
## Why was this change made?

A timeout for a Symphony request should get a specific error message to the end user (e.g. in Argo registration or in Argo refresh_metadata).

Fixes #377

## Was the API documentation (openapi.json) updated?

- no change to API (we aren't currently documenting error codes for requests)