### PR TITLE
Rescue versioning exceptions and provide more context

### DIFF
--- a/app/controllers/virtual_objects_controller.rb
+++ b/app/controllers/virtual_objects_controller.rb
@@ -12,7 +12,7 @@ class VirtualObjectsController < ApplicationController
       parent_id, child_ids = virtual_object.values_at(:parent_id, :child_ids)
       # Update the constituent relationship between the parent and child druids
       errors << ConstituentService.new(parent_druid: parent_id).add(child_druids: child_ids)
-    rescue ActiveFedora::ObjectNotFoundError, Rubydora::FedoraInvalidRequest => e
+    rescue ActiveFedora::ObjectNotFoundError, Rubydora::FedoraInvalidRequest, Dor::Exception => e
       errors << { parent_id => [e.message] }
     end
 

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -75,9 +75,9 @@ class VersionService
       work.versionMetadata.save
     end
 
-    raise Dor::Exception, 'latest version in versionMetadata requires tag and description before it can be closed' unless work.versionMetadata.current_version_closeable?
-    raise Dor::Exception, 'Trying to close version on an object not opened for versioning' unless open_for_versioning?
-    raise Dor::Exception, 'accessionWF already created for versioned object' if accessioning?
+    raise Dor::Exception, "latest version in versionMetadata for #{work.pid} requires tag and description before it can be closed" unless work.versionMetadata.current_version_closeable?
+    raise Dor::Exception, "Trying to close version on #{work.pid} which is not opened for versioning" unless open_for_versioning?
+    raise Dor::Exception, "accessionWF already created for versioned object #{work.pid}" if accessioning?
 
     Dor::Config.workflow.client.close_version 'dor', work.pid, opts.fetch(:start_accession, true) # Default to creating accessionWF when calling close_version
     work.events.add_event('close', opts[:user_name], "Version #{work.current_version} closed") if opts[:user_name]

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe VersionService do
     context 'when the object has not been opened for versioning' do
       it 'raises an exception' do
         expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'opened').and_return(nil)
-        expect { close }.to raise_error(Dor::Exception, 'Trying to close version on an object not opened for versioning')
+        expect { close }.to raise_error(Dor::Exception, 'Trying to close version on druid:ab12cd3456 which is not opened for versioning')
       end
     end
 
@@ -243,14 +243,14 @@ RSpec.describe VersionService do
       it 'raises an exception' do
         expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'opened').and_return(Time.new)
         expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'submitted').and_return(true)
-        expect { close }.to raise_error(Dor::Exception, 'accessionWF already created for versioned object')
+        expect { close }.to raise_error(Dor::Exception, 'accessionWF already created for versioned object druid:ab12cd3456')
       end
     end
 
     context 'when the latest version does not have a tag and a description' do
       it 'raises an exception' do
         vmd_ds.increment_version
-        expect { close }.to raise_error(Dor::Exception, 'latest version in versionMetadata requires tag and description before it can be closed')
+        expect { close }.to raise_error(Dor::Exception, 'latest version in versionMetadata for druid:ab12cd3456 requires tag and description before it can be closed')
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

To provide more information to downstream consumers why operations fail and for which objects.

## Was the API documentation (openapi.json) updated?

No, and it didn't need to be.