### PR TITLE
Accept the Authorization header

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -890,6 +890,16 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
     }
+  },
+  "security": {
+    "bearerAuth": []
   }
 }

--- a/spec/requests/add_release_tags_spec.rb
+++ b/spec/requests/add_release_tags_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Add release tags' do
     it 'adds a release tag' do
       post '/v1/objects/druid:1234/release_tags',
            params: %( {"to":"searchworks","who":"carrickr","what":"self","release":false} ),
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
 
       expect(ReleaseTags).to have_received(:create)
         .with(Dor::Item, release: false, to: 'searchworks', who: 'carrickr', what: 'self')
@@ -31,7 +31,7 @@ RSpec.describe 'Add release tags' do
     it 'adds a release tag' do
       post '/v1/objects/druid:1234/release_tags',
            params: %( {"to":"searchworks","who":"carrickr","what":"self","release":true} ),
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
 
       expect(ReleaseTags).to have_received(:create)
         .with(Dor::Item, release: true, to: 'searchworks', who: 'carrickr', what: 'self')
@@ -44,7 +44,7 @@ RSpec.describe 'Add release tags' do
     it 'returns an error' do
       post '/v1/objects/druid:1234/release_tags',
            params: %( {"to":"searchworks","who":"carrickr","what":"self","release":"seven"} ),
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.status).to eq(400)
     end
   end
@@ -53,7 +53,7 @@ RSpec.describe 'Add release tags' do
     it 'returns an error' do
       post '/v1/objects/druid:1234/release_tags',
            params: %( {"to":"searchworks","who":"carrickr","what":"self"} ),
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.status).to eq(400)
     end
   end

--- a/spec/requests/authorization_spec.rb
+++ b/spec/requests/authorization_spec.rb
@@ -20,13 +20,26 @@ RSpec.describe 'Authorization' do
     end
   end
 
-  context 'with a bearer token' do
+  context 'with a bearer token in the old field' do
     let(:payload) { { sub: 'argo' } }
     let(:jwt) { JWT.encode(payload, Settings.dor.hmac_secret, 'HS256') }
 
     it 'Logs tokens to honeybadger' do
       get '/v1/objects/druid:mk420bs7601/versions/current',
           headers: { 'X-Auth' => "Bearer #{jwt}" }
+      expect(response.body).to eq '5'
+      expect(Honeybadger).to have_received(:notify).with("Deprecated authorization header 'X-Auth' was provided, but 'Authorization' is expected")
+      expect(Honeybadger).to have_received(:context).with(invoked_by: 'argo')
+    end
+  end
+
+  context 'with a bearer token' do
+    let(:payload) { { sub: 'argo' } }
+    let(:jwt) { JWT.encode(payload, Settings.dor.hmac_secret, 'HS256') }
+
+    it 'Logs tokens to honeybadger' do
+      get '/v1/objects/druid:mk420bs7601/versions/current',
+          headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.body).to eq '5'
       expect(Honeybadger).not_to have_received(:notify)
       expect(Honeybadger).to have_received(:context).with(invoked_by: 'argo')

--- a/spec/requests/batch_create_virtual_objects_spec.rb
+++ b/spec/requests/batch_create_virtual_objects_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Batch creation of virtual objects' do
     it 'creates a virtual object out of the parent object and all child objects' do
       post '/v1/virtual_objects',
            params: { virtual_objects: [{ parent_id: parent_id, child_ids: [child1_id, child2_id] }] },
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).to have_received(:add).with(child_druids: [child1_id, child2_id])
       expect(response).to be_successful
     end
@@ -35,7 +35,7 @@ RSpec.describe 'Batch creation of virtual objects' do
     it 'renders an error' do
       post '/v1/virtual_objects',
            params: { virtual_objects: [{ parent_id: parent_id, child_ids: [child1_id, child2_id] }] },
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).to have_received(:add).with(child_druids: [child1_id, child2_id])
       expect(response).to be_unprocessable
       expect(response.body).to eq '{"errors":[{"druid:mk420bs7601":["versioning is messed up"]}]}'
@@ -50,7 +50,7 @@ RSpec.describe 'Batch creation of virtual objects' do
     it 'renders an error' do
       post '/v1/virtual_objects',
            params: { virtual_objects: [{ parent_id: parent_id, child_ids: [child1_id, child2_id] }] },
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).to have_received(:add).with(child_druids: [child1_id, child2_id])
       expect(response).to be_unprocessable
       expect(response.body).to eq '{"errors":[{"druid:mk420bs7601":["Item druid:child2 is not open for modification"]}]}'
@@ -61,7 +61,7 @@ RSpec.describe 'Batch creation of virtual objects' do
     it 'renders an error' do
       post '/v1/virtual_objects',
            params: { title: 'New name' },
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).not_to have_received(:add)
       expect(response).to be_bad_request
       json = JSON.parse(response.body)
@@ -73,7 +73,7 @@ RSpec.describe 'Batch creation of virtual objects' do
     it 'renders an error' do
       post '/v1/virtual_objects',
            params: { virtual_objects: child1_id },
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).not_to have_received(:add)
       expect(response).to be_bad_request
       json = JSON.parse(response.body)
@@ -85,7 +85,7 @@ RSpec.describe 'Batch creation of virtual objects' do
     it 'renders an error' do
       post '/v1/virtual_objects',
            params: { virtual_objects: [] },
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).not_to have_received(:add)
       expect(response).to be_bad_request
       json = JSON.parse(response.body)
@@ -97,7 +97,7 @@ RSpec.describe 'Batch creation of virtual objects' do
     it 'renders an error' do
       post '/v1/virtual_objects',
            params: { virtual_objects: [{ child_ids: ['foo'] }] },
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).not_to have_received(:add)
       expect(response).to be_bad_request
       json = JSON.parse(response.body)
@@ -109,7 +109,7 @@ RSpec.describe 'Batch creation of virtual objects' do
     it 'renders an error' do
       post '/v1/virtual_objects',
            params: { virtual_objects: [{ parent_id: '' }] },
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).not_to have_received(:add)
       expect(response).to be_bad_request
       json = JSON.parse(response.body)
@@ -121,7 +121,7 @@ RSpec.describe 'Batch creation of virtual objects' do
     it 'renders an error' do
       post '/v1/virtual_objects',
            params: { virtual_objects: [{ parent_id: 'foo' }] },
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).not_to have_received(:add)
       expect(response).to be_bad_request
       json = JSON.parse(response.body)
@@ -133,7 +133,7 @@ RSpec.describe 'Batch creation of virtual objects' do
     it 'renders an error' do
       post '/v1/virtual_objects',
            params: { virtual_objects: [{ parent_id: 'foo', child_ids: '' }] },
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).not_to have_received(:add)
       expect(response).to be_bad_request
       json = JSON.parse(response.body)
@@ -145,7 +145,7 @@ RSpec.describe 'Batch creation of virtual objects' do
     it 'renders an error' do
       post '/v1/virtual_objects',
            params: { virtual_objects: [{ parent_id: 'foo', child_ids: [] }] },
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).not_to have_received(:add)
       expect(response).to be_bad_request
       json = JSON.parse(response.body)
@@ -157,7 +157,7 @@ RSpec.describe 'Batch creation of virtual objects' do
     it 'renders an error' do
       post '/v1/virtual_objects',
            params: { virtual_objects: [{ parent_id: 'foo', child_ids: ['foo', 'bar', ''] }] },
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).not_to have_received(:add)
       expect(response).to be_bad_request
       json = JSON.parse(response.body)

--- a/spec/requests/collections_for_object_spec.rb
+++ b/spec/requests/collections_for_object_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Get the object' do
   describe 'as used by WAS crawl seed registration' do
     it 'returns (at a minimum) the identifiers of the collections ' do
       get '/v1/objects/druid:mk420bs7601/query/collections',
-          headers: { 'X-Auth' => "Bearer #{jwt}" }
+          headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
       expect(response.body).to eq '{"collections":[{"externalIdentifier":"druid:999123","type":"collection","label":"collection #1"}]}'
     end

--- a/spec/requests/metadata_refresh_spec.rb
+++ b/spec/requests/metadata_refresh_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Refresh metadata' do
 
     it 'updates the metadata and saves the changes' do
       post '/v1/objects/druid:mk420bs7601/refresh_metadata',
-           headers: { 'X-Auth' => "Bearer #{jwt}" }
+           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
       expect(RefreshMetadataAction).to have_received(:run).with(object)
       expect(object).to have_received(:save)
@@ -38,7 +38,7 @@ RSpec.describe 'Refresh metadata' do
 
       it 'returns a 500 error' do
         post '/v1/objects/druid:mk420bs7601/refresh_metadata',
-             headers: { 'X-Auth' => "Bearer #{jwt}" }
+             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response.status).to eq(500)
         expect(response.body).to eq('Incomplete response received from Symphony for 666 - expected 0 bytes but got 2')
       end
@@ -51,7 +51,7 @@ RSpec.describe 'Refresh metadata' do
 
       it 'returns a 500 error' do
         post '/v1/objects/druid:mk420bs7601/refresh_metadata',
-             headers: { 'X-Auth' => "Bearer #{jwt}" }
+             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response.status).to eq(500)
         expect(response.body).to eq('Record not found in Symphony: 666')
       end
@@ -75,7 +75,7 @@ RSpec.describe 'Refresh metadata' do
 
       it 'returns a 500 error' do
         post '/v1/objects/druid:mk420bs7601/refresh_metadata',
-             headers: { 'X-Auth' => "Bearer #{jwt}" }
+             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response.status).to eq(500)
         expect(response.body).to match(/^Got HTTP Status-Code 403 retrieving 666 from Symphony:.*Something somewhere went wrong./)
       end

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Display metadata' do
   describe 'dublin core' do
     it 'returns the DC xml' do
       get '/v1/objects/druid:mk420bs7601/metadata/dublin_core',
-          headers: { 'X-Auth' => "Bearer #{jwt}" }
+          headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
       expect(response.body).to include '<dc:title>Hello</dc:title>'
     end
@@ -24,7 +24,7 @@ RSpec.describe 'Display metadata' do
   describe 'descriptive' do
     it 'returns the DC xml' do
       get '/v1/objects/druid:mk420bs7601/metadata/descriptive',
-          headers: { 'X-Auth' => "Bearer #{jwt}" }
+          headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
       expect(response.body).to be_equivalent_to <<~XML
         <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">

--- a/spec/requests/notify_goobi_spec.rb
+++ b/spec/requests/notify_goobi_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Notify Goobi' do
     end
 
     it 'notifies goobi of a new registration by making a web service call' do
-      post '/v1/objects/druid:1234/notify_goobi', headers: { 'X-Auth' => "Bearer #{jwt}" }
+      post '/v1/objects/druid:1234/notify_goobi', headers: { 'Authorization' => "Bearer #{jwt}" }
 
       expect(response.status).to eq(201)
     end
@@ -36,7 +36,7 @@ RSpec.describe 'Notify Goobi' do
     end
 
     it 'returns the conflict code' do
-      post '/v1/objects/druid:1234/notify_goobi', headers: { 'X-Auth' => "Bearer #{jwt}" }
+      post '/v1/objects/druid:1234/notify_goobi', headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.status).to eq(409)
       expect(response.body).to eq('conflict')
     end

--- a/spec/requests/publish_object_spec.rb
+++ b/spec/requests/publish_object_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Publish object' do
     end
 
     it 'returns a 409 error with location header' do
-      post '/v1/objects/druid:1234/publish', headers: { 'X-Auth' => "Bearer #{jwt}" }
+      post '/v1/objects/druid:1234/publish', headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.status).to eq(500)
       expect(response.body).to eq(error_message)
     end
@@ -31,7 +31,7 @@ RSpec.describe 'Publish object' do
     end
 
     it 'calls PublishMetadataService and returns 201' do
-      post '/v1/objects/druid:1234/publish', headers: { 'X-Auth' => "Bearer #{jwt}" }
+      post '/v1/objects/druid:1234/publish', headers: { 'Authorization' => "Bearer #{jwt}" }
 
       expect(PublishMetadataService).to have_received(:publish)
       expect(response.status).to eq(201)

--- a/spec/requests/register_object_spec.rb
+++ b/spec/requests/register_object_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Register object' do
     end
 
     it 'returns a 409 error with location header' do
-      post '/v1/objects', headers: { 'X-Auth' => "Bearer #{jwt}" }
+      post '/v1/objects', headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.status).to eq(409)
       expect(response.headers['Location']).to match(%r{/fedora/objects/druid:existing123obj})
     end
@@ -31,7 +31,7 @@ RSpec.describe 'Register object' do
     end
 
     it 'returns a 422 error' do
-      post '/v1/objects', headers: { 'X-Auth' => "Bearer #{jwt}" }
+      post '/v1/objects', headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.status).to eq(422)
       expect(response.body).to eq(errmsg)
     end
@@ -45,7 +45,7 @@ RSpec.describe 'Register object' do
     end
 
     it 'returns a 500 error' do
-      post '/v1/objects', headers: { 'X-Auth' => "Bearer #{jwt}" }
+      post '/v1/objects', headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.status).to eq(500)
       expect(response.body).to eq(errmsg)
     end
@@ -59,7 +59,7 @@ RSpec.describe 'Register object' do
     end
 
     it 'returns a 404 error' do
-      post '/v1/objects', headers: { 'X-Auth' => "Bearer #{jwt}" }
+      post '/v1/objects', headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.status).to eq(404)
       expect(response.body).to eq(errmsg)
     end
@@ -71,7 +71,7 @@ RSpec.describe 'Register object' do
     end
 
     it 'registers the object with the registration service' do
-      post '/v1/objects', headers: { 'X-Auth' => "Bearer #{jwt}" }
+      post '/v1/objects', headers: { 'Authorization' => "Bearer #{jwt}" }
 
       expect(response.body).to eq 'druid:xyz'
       expect(RegistrationService).to have_received(:create_from_request)

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Get the object' do
 
     it 'returns the object' do
       get '/v1/objects/druid:mk420bs7601',
-          headers: { 'X-Auth' => "Bearer #{jwt}" }
+          headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
       expect(response.body).to eq '{"externalIdentifier":"druid:1234","type":"object","label":"foo"}'
     end

--- a/spec/requests/update_embargo_spec.rb
+++ b/spec/requests/update_embargo_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Update embargo' do
   context 'without the :embargo_date param' do
     it 'returns HTTP 400' do
       patch '/v1/objects/druid:mk420bs7601/embargo',
-            headers: { 'X-Auth' => "Bearer #{jwt}" }
+            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.status).to eq(400)
       expect(response.body).to eq('{"errors":[{"title":"bad request","detail":"param is missing or the value is empty: embargo_date"}]}')
     end
@@ -27,7 +27,7 @@ RSpec.describe 'Update embargo' do
     it 'returns HTTP 400' do
       patch '/v1/objects/druid:mk420bs7601/embargo',
             params: { embargo_date: '2100-01-01' },
-            headers: { 'X-Auth' => "Bearer #{jwt}" }
+            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(events_datastream).not_to have_received(:add_event)
       expect(response.status).to eq(400)
       expect(response.body).to eq('{"errors":[{"title":"bad request","detail":"param is missing or the value is empty: requesting_user"}]}')
@@ -45,7 +45,7 @@ RSpec.describe 'Update embargo' do
     it 'hits the Dor::EmbargoService and returns HTTP 422' do
       patch '/v1/objects/druid:mk420bs7601/embargo',
             params: { embargo_date: '2100-01-01', requesting_user: 'mjg' },
-            headers: { 'X-Auth' => "Bearer #{jwt}" }
+            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(mock_embargo_service).to have_received(:update).once
       expect(events_datastream).not_to have_received(:add_event)
       expect(response.status).to eq(422)
@@ -62,7 +62,7 @@ RSpec.describe 'Update embargo' do
     it 'hits the Dor::EmbargoService and returns HTTP 204' do
       patch '/v1/objects/druid:mk420bs7601/embargo',
             params: { embargo_date: '2100-01-01', requesting_user: 'mjg' },
-            headers: { 'X-Auth' => "Bearer #{jwt}" }
+            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(mock_embargo_service).to have_received(:update).with(Date.parse('2100-01-01'))
       expect(events_datastream).to have_received(:add_event).with(
         'Embargo',

--- a/spec/requests/update_marc_record_spec.rb
+++ b/spec/requests/update_marc_record_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Update MARC record' do
 
   context 'when the request is successful' do
     it 'returns a 201 response' do
-      post '/v1/objects/druid:1234/update_marc_record', headers: { 'X-Auth' => "Bearer #{jwt}" }
+      post '/v1/objects/druid:1234/update_marc_record', headers: { 'Authorization' => "Bearer #{jwt}" }
 
       expect(response.status).to eq(201)
     end

--- a/spec/requests/virtual_merge_spec.rb
+++ b/spec/requests/virtual_merge_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Virtual merge of objects' do
     it 'merges the objects' do
       put "/v1/objects/#{parent_id}",
           params: { constituent_ids: [child1_id, child2_id] },
-          headers: { 'X-Auth' => "Bearer #{jwt}" }
+          headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).to have_received(:add).with(child_druids: [child1_id, child2_id])
       expect(response).to be_successful
     end
@@ -31,7 +31,7 @@ RSpec.describe 'Virtual merge of objects' do
     it 'renders an error' do
       put "/v1/objects/#{parent_id}",
           params: { title: 'New name' },
-          headers: { 'X-Auth' => "Bearer #{jwt}" }
+          headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).not_to have_received(:add)
       expect(response).to be_bad_request
       json = JSON.parse(response.body)
@@ -43,7 +43,7 @@ RSpec.describe 'Virtual merge of objects' do
     it 'renders an error' do
       put "/v1/objects/#{parent_id}",
           params: { constituent_ids: child1_id },
-          headers: { 'X-Auth' => "Bearer #{jwt}" }
+          headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).not_to have_received(:add)
       expect(response).to be_bad_request
       json = JSON.parse(response.body)
@@ -59,7 +59,7 @@ RSpec.describe 'Virtual merge of objects' do
     it 'renders an error' do
       put "/v1/objects/#{parent_id}",
           params: { constituent_ids: [child1_id, child2_id] },
-          headers: { 'X-Auth' => "Bearer #{jwt}" }
+          headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(service).to have_received(:add).with(child_druids: [child1_id, child2_id])
       expect(response).to be_unprocessable
       expect(response.body).to eq '{"errors":{"druid:child2":"Item druid:child2 is not open for modification"}}'


### PR DESCRIPTION
Log a honeybadger notification when we get the old X-Auth header
Fixes #320

## Why was this change made?

We want to be able to accept the standard Authorization header rather than our custom X-Auth header.

## Was the API documentation (openapi.json) updated?

Yes!