### PR TITLE
Provide significance and description when `ConstituentService` closes versions

### DIFF
--- a/app/services/constituent_service.rb
+++ b/app/services/constituent_service.rb
@@ -6,6 +6,9 @@
 #  2. add isConstituentOf assertions to the RELS-EXT of the children
 #  3. saving the parent and the children
 class ConstituentService
+  VERSION_CLOSE_DESCRIPTION = 'Virtual object created'
+  VERSION_CLOSE_SIGNIFICANCE = :major
+
   # @param [String] parent_druid the identifier of the parent object
   def initialize(parent_druid:)
     @parent_druid = parent_druid
@@ -32,7 +35,7 @@ class ConstituentService
     end
 
     # NOTE: parent object is saved as part of closing the version
-    VersionService.close(parent)
+    VersionService.close(parent, description: VERSION_CLOSE_DESCRIPTION, significance: VERSION_CLOSE_SIGNIFICANCE)
 
     nil
   end
@@ -52,7 +55,7 @@ class ConstituentService
     child.add_relationship :is_constituent_of, parent
 
     # NOTE: child object is saved as part of closing the version
-    VersionService.close(child)
+    VersionService.close(child, description: VERSION_CLOSE_DESCRIPTION, significance: VERSION_CLOSE_SIGNIFICANCE)
   end
 
   def parent

--- a/spec/services/constituent_service_spec.rb
+++ b/spec/services/constituent_service_spec.rb
@@ -94,7 +94,9 @@ RSpec.describe ConstituentService do
         expect(child2.object_relations[:is_constituent_of]).to eq [parent]
         expect(VersionService).to have_received(:open?).exactly(3).times
         expect(VersionService).not_to have_received(:open)
-        expect(VersionService).to have_received(:close).exactly(3).times
+        expect(VersionService).to have_received(:close).with(anything,
+                                                             description: described_class::VERSION_CLOSE_DESCRIPTION,
+                                                             significance: described_class::VERSION_CLOSE_SIGNIFICANCE).exactly(3).times
       end
     end
 


### PR DESCRIPTION
Connects to sul-dlss/argo#1463
Fixes #375 

@andrewjbtw says it's OK to hard-code these, and signed off on using `:major` significance.

## Why was this change made?

To accommodate bulk version closing as part of virtual object creation in Argo.

## Was the API documentation (openapi.json) updated?

No, and it didn't need to be.