### PR TITLE
Retriable exceptions must be exceptions (not strings)

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -72,7 +72,8 @@ class ObjectsController < ApplicationController
     head :created
   end
 
-  # This endpoint is called by the goobi-notify process in the goobiWF (code in https://github.com/sul-dlss/goobi-robot)
+  # This endpoint is called by the goobi-notify process in the goobiWF
+  # (code in https://github.com/sul-dlss/common-accessioning/blob/master/lib/robots/dor_repo/goobi/goobi_notify.rb)
   # This proxies a request to the Goobi server and proxies it's response to the client.
   def notify_goobi
     response = Dor::Goobi.new(@item).register

--- a/app/models/dor/goobi.rb
+++ b/app/models/dor/goobi.rb
@@ -9,7 +9,6 @@ module Dor
     # Any status that is a 500 or greater and timeouts
     RETRIABLE_EXCEPTIONS = [ServerError,
                             Errno::ETIMEDOUT,
-                            'Timeout::Error',
                             Faraday::TimeoutError,
                             Faraday::RetriableResponse].freeze
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,7 +50,7 @@ release:
   purl_base_url: 'http://purl.stanford.edu'
 
 goobi:
-  url: 'http://goobi-env.stanford.edu:9292'
+  url: 'https://goobi-env.stanford.edu:9292/goobi/api/process/stanfordcreate?token=faketoken'
   dpg_workflow_name: 'goobiWF'
   default_goobi_workflow_name: 'Example_Workflow'
   max_tries: 3


### PR DESCRIPTION
## Why was this change made?

An error was logged:
```
TypeError: class or module required for rescue clause
```

Fixes #404


## Was the API documentation (openapi.json) updated?

not necessary, no API change made