### PR TITLE
Do not allow objects to have multiple parents

### DIFF
--- a/app/services/constituent_service.rb
+++ b/app/services/constituent_service.rb
@@ -52,6 +52,8 @@ class ConstituentService
     child.contentMetadata.ng_xml.search('//resource').each do |resource|
       parent.contentMetadata.add_virtual_resource(child.id, resource)
     end
+
+    child.clear_relationship :is_constituent_of
     child.add_relationship :is_constituent_of, parent
 
     # NOTE: child object is saved as part of closing the version

--- a/spec/services/constituent_service_spec.rb
+++ b/spec/services/constituent_service_spec.rb
@@ -75,6 +75,8 @@ RSpec.describe ConstituentService do
         allow(VersionService).to receive(:open?).and_return(true)
         allow(VersionService).to receive(:open)
         allow(VersionService).to receive(:close)
+        allow(child1).to receive(:clear_relationship)
+        allow(child2).to receive(:clear_relationship)
         add
       end
 
@@ -90,6 +92,8 @@ RSpec.describe ConstituentService do
             </resource>
           </contentMetadata>
         XML
+        expect(child1).to have_received(:clear_relationship).once
+        expect(child2).to have_received(:clear_relationship).once
         expect(child1.object_relations[:is_constituent_of]).to eq [parent]
         expect(child2.object_relations[:is_constituent_of]).to eq [parent]
         expect(VersionService).to have_received(:open?).exactly(3).times


### PR DESCRIPTION
When creating a virtual object, child objects must first be disassociated from other virtual objects before being "merged" into a new virtual object. I discussed this requirement with @andrewjbtw yesterday and he requested and signed off on this change.

Connects to sul-dlss/argo#1463
