### PR TITLE
make honeybadger notification clear that the deprecation warning for X-Auth header usage is just a warning

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::API
     Honeybadger.context(invoked_by: token[:sub])
     return unless request.headers[OLD_TOKEN_HEADER]
 
-    Honeybadger.notify("Deprecated authorization header '#{OLD_TOKEN_HEADER}' was provided, but '#{TOKEN_HEADER}' is expected")
+    Honeybadger.notify("Warning: Deprecated authorization header '#{OLD_TOKEN_HEADER}' was provided, but '#{TOKEN_HEADER}' is expected")
   end
 
   def decoded_auth_token

--- a/spec/requests/authorization_spec.rb
+++ b/spec/requests/authorization_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Authorization' do
       get '/v1/objects/druid:mk420bs7601/versions/current',
           headers: { 'X-Auth' => "Bearer #{jwt}" }
       expect(response.body).to eq '5'
-      expect(Honeybadger).to have_received(:notify).with("Deprecated authorization header 'X-Auth' was provided, but 'Authorization' is expected")
+      expect(Honeybadger).to have_received(:notify).with("Warning: Deprecated authorization header 'X-Auth' was provided, but 'Authorization' is expected")
       expect(Honeybadger).to have_received(:context).with(invoked_by: 'argo')
     end
   end


### PR DESCRIPTION
## Why was this change made?

the honeybadger alert is useful for letting us know that a deprecated auth header is being used in production.  but it should be clarified to indicate that the notice is just a warning.

## Was the API documentation (openapi.json) updated?

N/A