### PR TITLE
Fix security syntax in openapi.json

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -899,7 +899,9 @@
       }
     }
   },
-  "security": {
-    "bearerAuth": []
-  }
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ]
 }


### PR DESCRIPTION
## Why was this change made?
The openapi specification was incorrectly specifying the authentication


## Was the API documentation (openapi.json) updated?
Yes