### PR TITLE
upgrade to dor-services 8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'uuidtools', '~> 2.1.4'
 
 # DLSS/domain-specific dependencies
 gem 'cocina-models', '~> 0.1.0'
-gem 'dor-services', '~> 7.0'
+gem 'dor-services', '~> 8.0'
 gem 'marc'
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,6 @@ GEM
       activesupport (>= 4.2)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-schema (~> 1.0)
-    confstruct (0.2.7)
     connection_pool (2.2.2)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
@@ -119,14 +118,12 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.4.0)
       nokogiri
-    dor-services (7.2.4)
+    dor-services (8.0.0)
       active-fedora (>= 8.7.0, < 9)
       activesupport (~> 5.1)
-      confstruct (~> 0.2.7)
       deprecation (~> 0)
       dor-rights-auth (~> 1.0, >= 1.2.0)
-      dor-services-client (>= 1.5.0, < 3.0.0)
-      dor-workflow-client (~> 3.0)
+      dor-workflow-client (~> 3.3)
       druid-tools (>= 0.4.1)
       json (>= 1.8.1)
       nokogiri (~> 1.6)
@@ -135,19 +132,11 @@ GEM
       rest-client (>= 1.7, < 3)
       retries (~> 0.0.5)
       rsolr (>= 1.0.3, < 3)
-      ruby-cache (~> 0.3.0)
       rubydora (~> 2.1)
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (2.6.2)
-      activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.1.0)
-      faraday (~> 0.15)
-      moab-versioning (~> 4.0)
-      nokogiri (~> 1.8)
-      zeitwerk (~> 2.1)
-    dor-workflow-client (3.6.0)
+    dor-workflow-client (3.7.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (~> 0.9, >= 0.9.2)
@@ -191,8 +180,8 @@ GEM
       dry-equalizer (~> 0.2, >= 0.2.2)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    edtf (3.0.4)
-      activesupport (>= 3.0, < 6.0)
+    edtf (3.0.5)
+      activesupport (>= 3.0, < 7.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubi (1.8.0)
@@ -245,12 +234,6 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    moab-versioning (4.2.2)
-      confstruct
-      druid-tools (>= 1.0.0)
-      json
-      nokogiri
-      nokogiri-happymapper
     mods (2.4.1)
       edtf
       iso-639
@@ -265,8 +248,6 @@ GEM
     nio4r (2.5.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
-    nokogiri-happymapper (0.8.1)
-      nokogiri (~> 1.5)
     nom-xml (1.1.0)
       activesupport (>= 3.2.18)
       i18n
@@ -473,7 +454,7 @@ DEPENDENCIES
   config
   coveralls (~> 0.8)
   dlss-capistrano
-  dor-services (~> 7.0)
+  dor-services (~> 8.0)
   dry-struct
   dry-types
   equivalent-xml

--- a/spec/dor/update_marc_record_service_spec.rb
+++ b/spec/dor/update_marc_record_service_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
   before do
     allow(Dor::ReleaseTagService).to receive(:for).and_return(release_service)
-  end
-
-  before :all do
-    Dor::Config.suri = {}
     Settings.release.write_marc_script = 'bin/write_marc_record_test'
     Settings.release.symphony_path = './spec/fixtures/sdr-purl'
     Settings.release.purl_base_url = 'http://purl.stanford.edu'

--- a/spec/services/constituent_service_spec.rb
+++ b/spec/services/constituent_service_spec.rb
@@ -52,8 +52,6 @@ RSpec.describe ConstituentService do
       described_class.new(parent_druid: parent.id)
     end
     let(:namespaceless) { parent.id.sub('druid:', '') }
-    let(:client) { instance_double(Dor::Services::Client::Object, version: version_client) }
-    let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, close: true) }
 
     before do
       allow(parent).to receive_messages(id: 'druid:parent1', save!: true)
@@ -66,8 +64,6 @@ RSpec.describe ConstituentService do
       allow(ItemQueryService).to receive(:find_combinable_item).with('druid:parent1').and_return(parent)
       allow(ItemQueryService).to receive(:find_combinable_item).with('druid:child1').and_return(child1)
       allow(ItemQueryService).to receive(:find_combinable_item).with('druid:child2').and_return(child2)
-
-      allow(Dor::Services::Client).to receive(:object).and_return(client)
     end
 
     context 'when the parent is open for modification' do

--- a/spec/services/public_xml_service_spec.rb
+++ b/spec/services/public_xml_service_spec.rb
@@ -25,12 +25,6 @@ RSpec.describe PublicXmlService do
     end
 
     before do
-      # allow(Dor.config)
-      Dor.configure do
-        stacks do
-          host 'stacks.stanford.edu'
-        end
-      end
       mods = <<-EOXML
         <mods:mods xmlns:mods="http://www.loc.gov/mods/v3"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/spec/services/workspace_service_spec.rb
+++ b/spec/services/workspace_service_spec.rb
@@ -6,13 +6,6 @@ RSpec.describe WorkspaceService do
   describe '.create' do
     before do
       FileUtils.rm_rf(temp_workspace)
-
-      Dor::Config.push! do |config|
-        config.suri.mint_ids false
-        config.solr.url 'http://solr.edu/solrizer'
-        config.fedora.url 'http://fedora.edu'
-      end
-
       allow(Settings.stacks).to receive(:local_workspace_root).and_return(temp_workspace)
 
       FileUtils.mkdir_p(temp_workspace)
@@ -20,7 +13,6 @@ RSpec.describe WorkspaceService do
     end
 
     after do
-      Dor::Config.pop!
       FileUtils.rm_rf(temp_workspace)
     end
 


### PR DESCRIPTION
## Why was this change made?

To keep dor-services-app consistent with other Dor projects.

## Was the API documentation (openapi.json) updated?
n/a