### PR TITLE
Add missing `capistrano-sidekiq` dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,5 +60,6 @@ group :deployment do
   gem 'capistrano-bundler'
   gem 'capistrano-passenger'
   gem 'capistrano-shared_configs'
+  gem 'capistrano-sidekiq'
   gem 'dlss-capistrano'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,9 @@ GEM
     capistrano-passenger (0.2.0)
       capistrano (~> 3.0)
     capistrano-shared_configs (0.2.2)
+    capistrano-sidekiq (1.0.3)
+      capistrano (>= 3.9.0)
+      sidekiq (>= 3.4, < 6.0)
     cocina-models (0.1.2)
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -476,6 +479,7 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-passenger
   capistrano-shared_configs
+  capistrano-sidekiq
   cocina-models (~> 0.1.0)
   config
   coveralls (~> 0.8)


### PR DESCRIPTION
## Why was this change made?

To make `capistrano-sidekiq` work, restarting sidekiq on a successful deployment.

## Was the API documentation (openapi.json) updated?

Nope, not needed.