### PR TITLE
Avoid calling active_lifecycle

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-workflow-client (3.7.0)
+    dor-workflow-client (3.8.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (~> 0.9, >= 0.9.2)

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -109,7 +109,7 @@ class VersionService
   # Checks if current version has any incomplete wf steps and there is a versionWF
   # @return [Boolean] true if object is open for versioning
   def open_for_versioning?
-    return true if Dor::Config.workflow.client.active_lifecycle('dor', work.pid, 'opened')
+    return true if Dor::Config.workflow.client.lifecycle('dor', work.pid, 'opened', version: work.current_version)
 
     false
   end
@@ -117,7 +117,7 @@ class VersionService
   # Checks if the current version has any incomplete wf steps and there is an accessionWF.
   # @return [Boolean] true if object is currently being accessioned
   def accessioning?
-    return true if Dor::Config.workflow.client.active_lifecycle('dor', work.pid, 'submitted')
+    return true if Dor::Config.workflow.client.lifecycle('dor', work.pid, 'submitted', version: work.current_version)
 
     false
   end


### PR DESCRIPTION
## Why was this change made?

Because that method calls the workflow service, which ends up calling back to dor-services-app to get the current version


## Was the API documentation (openapi.json) updated?
n/a