### PR TITLE
Validate OpenAPI specification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
     - image: circleci/postgres:10
       environment:
         POSTGRES_USER: postgres
-        POSTGRES_DB: dor_services_test
+        POSTGRES_DB: dor_services
         POSTGRES_PASSWORD: ""
     steps:
     - checkout
@@ -79,6 +79,19 @@ jobs:
                             --out test_results/rspec.xml \
                             --format progress \
                             $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+
+    - run:
+        name: Validate API specification
+        command: |
+          npm install openapi-enforcer-cli
+          result=$(node_modules/.bin/openapi-enforcer validate openapi.json)
+          [[ $result == $'\nDocument is valid' ]] && {
+          exit 0
+          } || {
+          echo $result
+          exit 1
+          }
+
     # Save test results for timing analysis
     - store_test_results:
         path: test_results

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/sul-dlss/dor-services-app/badge.svg?branch=master)](https://coveralls.io/github/sul-dlss/dor-services-app?branch=master)
 [![GitHub version](https://badge.fury.io/gh/sul-dlss%2Fdor-services-app.svg)](https://badge.fury.io/gh/sul-dlss%2Fdor-services-app)
 [![Docker image](https://images.microbadger.com/badges/image/suldlss/dor-services-app.svg)](https://microbadger.com/images/suldlss/dor-services-app "Get your own image badge on microbadger.com")
+[![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/dor-services-app/master/openapi.json)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/dor-services-app/master/openapi.json)
 
 # DOR Services App
 

--- a/app/controllers/shelves_controller.rb
+++ b/app/controllers/shelves_controller.rb
@@ -7,7 +7,7 @@ class ShelvesController < ApplicationController
   def create
     if @item.is_a?(Dor::Item)
       ShelvingService.shelve(@item)
-      head :created
+      head :no_content
     else
       render json: {
         errors: [

--- a/openapi.json
+++ b/openapi.json
@@ -304,11 +304,10 @@
           "201": {
             "description": "background job for creation of virtual object created",
             "headers": {
-              "Location": {
+              "location": {
                 "schema": {
                   "type": "string",
                   "description": "URI at which the client can expect updates on the virtual object creation job",
-                  "format": "uri",
                   "pattern": "^\\w+:(\\/?\\/?)[^\\s]+$"
                 }
               }
@@ -639,7 +638,7 @@
         "description": "",
         "operationId": "shelves#create",
         "responses": {
-          "201": {
+          "204": {
             "description": "The object was shelved"
           },
           "422": {

--- a/spec/requests/shelving_spec.rb
+++ b/spec/requests/shelving_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Shelve object' do
 
     it 'returns a 422 error' do
       post '/v1/objects/druid:1234/shelve', headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response.status).to eq(422)
+      expect(response).to have_http_status(:unprocessable_entity)
       json = JSON.parse(response.body)
       expect(json['errors'].first['detail']).to eq("A Dor::Item is required but you provided 'Dor::Collection'")
       expect(ShelvingService).not_to have_received(:shelve)
@@ -26,10 +26,10 @@ RSpec.describe 'Shelve object' do
   context 'when the request is successful' do
     let(:object) { Dor::Item.new(pid: 'druid:1234') }
 
-    it 'calls ShelvingService and returns 201' do
+    it 'calls ShelvingService and returns 204' do
       post '/v1/objects/druid:1234/shelve', headers: { 'Authorization' => "Bearer #{jwt}" }
 
-      expect(response.status).to eq(201)
+      expect(response).to have_http_status(:no_content)
       expect(ShelvingService).to have_received(:shelve)
     end
   end


### PR DESCRIPTION
Includes:
* Add validation step to CI build
* Add validator badge to README
* Prefer HTTP 204 over 201 when not creating a new resource

## Why was this change made?

To make our spec validation more transparent and more robust.

## Was the API documentation (openapi.json) updated?

Yes.