### PR TITLE
Add embargoReleaseDate to the show route

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'sidekiq-statistic'
 gem 'uuidtools', '~> 2.1.4'
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.1.0'
+gem 'cocina-models', '~> 0.3.0'
 gem 'dor-services', '~> 8.0'
 gem 'marc'
 gem 'moab-versioning', '~> 4.0', require: 'moab/stanford'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     capistrano-sidekiq (1.0.3)
       capistrano (>= 3.9.0)
       sidekiq (>= 3.4, < 6.0)
-    cocina-models (0.1.2)
+    cocina-models (0.3.0)
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
@@ -472,7 +472,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-shared_configs
   capistrano-sidekiq
-  cocina-models (~> 0.1.0)
+  cocina-models (~> 0.3.0)
   config
   coveralls (~> 0.8)
   dlss-capistrano

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -12,9 +12,19 @@ module Cocina
     end
 
     def build
-      Cocina::Models::DRO.new(externalIdentifier: item.pid,
-                              type: type,
-                              label: item.label)
+      props = {
+        externalIdentifier: item.pid,
+        type: type,
+        label: item.label
+      }
+
+      # Collections don't have embargoMetadata
+      if type == 'object' && item.embargoMetadata.release_date
+        props[:access] = {
+          embargoReleaseDate: item.embargoMetadata.release_date.iso8601
+        }
+      end
+      Cocina::Models::DRO.new(props)
     end
 
     private

--- a/openapi.json
+++ b/openapi.json
@@ -849,6 +849,17 @@
       "Druid": {
         "type": "string"
       },
+      "Access": {
+        "type": "object",
+        "properties": {
+          "embargoReleaseDate": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2029-06-22T07:00:00.000+00:00"
+          }
+        },
+        "required": ["externalIdentifier", "label", "type"]
+      },
       "DRO": {
         "type": "object",
         "properties": {
@@ -861,6 +872,9 @@
           },
           "label": {
             "type": "string"
+          },
+          "access": {
+            "$ref": "#/components/schemas/Access"
           }
         },
         "required": ["externalIdentifier", "label", "type"]

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Get the object' do
     allow(Dor).to receive(:find).and_return(object)
   end
 
-  context 'when the object exists' do
+  context 'when the object exists with minimal metadata' do
     before do
       object.descMetadata.title_info.main_title = 'Hello'
       object.label = 'foo'
@@ -18,8 +18,24 @@ RSpec.describe 'Get the object' do
     it 'returns the object' do
       get '/v1/objects/druid:mk420bs7601',
           headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response).to be_successful
+      expect(response).to have_http_status(:ok)
       expect(response.body).to eq '{"externalIdentifier":"druid:1234","type":"object","label":"foo"}'
+    end
+  end
+
+  context 'when the object exists with full metadata' do
+    before do
+      object.descMetadata.title_info.main_title = 'Hello'
+      object.label = 'foo'
+      object.embargoMetadata.release_date = DateTime.parse '2019-09-26T07:00:00Z'
+    end
+
+    it 'returns the object' do
+      get '/v1/objects/druid:mk420bs7601',
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq '{"externalIdentifier":"druid:1234","type":"object","label":"foo",' \
+        '"access":{"embargoReleaseDate":"2019-09-26T07:00:00.000+00:00"}}'
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

So we have a way of getting the embargo date for the object


## Was the API documentation (openapi.json) updated?

yes