### PR TITLE
Remove /objects/{id} PATCH from API specification

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -868,31 +868,6 @@
             }
           }
         ]
-      },
-      "patch": {
-        "tags": [
-          "objects"
-        ],
-        "summary": "Update the object metadata",
-        "description": "[DEPRECATED] Currently this handles the create virtual object use case. Use POST /virtual_objects instead",
-        "deprecated": true,
-        "operationId": "objects#update",
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        },
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of object",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/Druid"
-            }
-          }
-        ]
       }
     }
   },


### PR DESCRIPTION
This endpoint was removed in the prior commit, and I missed this.

## Why was this change made?

To correct a prior PR.

## Was the API documentation (openapi.json) updated?

This time, yeah! Thanks, @jcoyne 
