### PR TITLE
Remove outdated per-test JWT cruft

### DIFF
--- a/spec/requests/shelving_spec.rb
+++ b/spec/requests/shelving_spec.rb
@@ -3,9 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Shelve object' do
-  let(:payload) { { sub: 'argo' } }
-  let(:jwt) { JWT.encode(payload, Settings.dor.hmac_secret, 'HS256') }
-
   before do
     allow(Dor).to receive(:find).and_return(object)
     allow(ShelvingService).to receive(:shelve)


### PR DESCRIPTION
This is now done in the `AuthHelper`

## Why was this change made?

To remove cruft.

## Was the API documentation (openapi.json) updated?

n/a