### PR TITLE
Object#show now returns releaseTags and current_version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'sidekiq-statistic'
 gem 'uuidtools', '~> 2.1.4'
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.3.0'
+gem 'cocina-models', '~> 0.4.0'
 gem 'dor-services', '~> 8.0'
 gem 'marc'
 gem 'moab-versioning', '~> 4.0', require: 'moab/stanford'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     capistrano-sidekiq (1.0.3)
       capistrano (>= 3.9.0)
       sidekiq (>= 3.4, < 6.0)
-    cocina-models (0.3.0)
+    cocina-models (0.4.0)
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
@@ -478,7 +478,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-shared_configs
   capistrano-sidekiq
-  cocina-models (~> 0.3.0)
+  cocina-models (~> 0.4.0)
   config
   coveralls (~> 0.8)
   dlss-capistrano

--- a/app/services/release_tags.rb
+++ b/app/services/release_tags.rb
@@ -13,7 +13,7 @@ class ReleaseTags
   # @raise [ArgumentError] Raised if attributes are improperly supplied
   #
   # @example
-  #  ReleaseTags.create(item, release: true, what: 'self', to: 'Searchworks', who: 'petucket'})
+  #  ReleaseTags.create(item, release: true, what: 'self', to: 'Searchworks', who: 'petucket')
   def self.create(work, attrs)
     release = attrs.delete(:release)
     attrs[:when] ||= Time.now.utc.iso8601 # add the timestamp

--- a/openapi.json
+++ b/openapi.json
@@ -899,7 +899,17 @@
             "example": "2029-06-22T07:00:00.000+00:00"
           }
         },
-        "required": ["externalIdentifier", "label", "type"]
+      },
+      "Administrative": {
+        "type": "object",
+        "properties": {
+          "releaseTags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReleaseTag"
+            }
+          }
+        },
       },
       "DRO": {
         "type": "object",
@@ -914,11 +924,23 @@
           "label": {
             "type": "string"
           },
+          "version": {
+            "type": "integer"
+          },
           "access": {
             "$ref": "#/components/schemas/Access"
-          }
+          },
+          "administrative": {
+            "$ref": "#/components/schemas/Administrative"
+          },
+          "identification": {
+            "$ref": "#/components/schemas/Identification"
+          },
+          "structural": {
+            "$ref": "#/components/schemas/Structural"
+          },
         },
-        "required": ["externalIdentifier", "label", "type"]
+        "required": ["externalIdentifier", "label", "type", "version", "access", "administrative", "identification", "structural"]
       },
       "BackgroundJobResultResponse": {
         "type": "object",
@@ -969,6 +991,40 @@
             }
           }
         }
+      },
+      "Identification": {
+        "type": "object",
+        "properties": { },
+      },
+      "ReleaseTag": {
+        "type": "object",
+        "properties": {
+          "who": {
+            "type": "string",
+            "example": "petucket"
+          },
+          "what": {
+            "type": "string",
+            "enum": ["self", "collection"],
+            "example": "self"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "to": {
+            "type": "string",
+            "example": "Searchworks"
+          },
+          "release": {
+            "type": "boolean"
+          }
+
+        },
+      },
+      "Structural": {
+        "type": "object",
+        "properties": { },
       },
       "VirtualObjectRequest": {
         "type": "object",

--- a/spec/requests/collections_for_object_spec.rb
+++ b/spec/requests/collections_for_object_spec.rb
@@ -3,22 +3,41 @@
 require 'rails_helper'
 
 RSpec.describe 'Get the object' do
+  before do
+    allow(Dor).to receive(:find).and_return(object)
+  end
+
   let(:object) { instance_double(Dor::Item, collections: [collection]) }
   let(:collection_id) { 'druid:999123' }
   let(:collection) do
     Dor::Collection.new(pid: collection_id, label: 'collection #1')
   end
 
-  before do
-    allow(Dor).to receive(:find).and_return(object)
+  let(:expected) do
+    {
+      collections: [
+        {
+          externalIdentifier: 'druid:999123',
+          type: 'collection',
+          label: 'collection #1',
+          version: 1,
+          access: {},
+          administrative: {
+            releaseTags: []
+          },
+          identification: {},
+          structural: {}
+        }
+      ]
+    }
   end
 
   describe 'as used by WAS crawl seed registration' do
-    it 'returns (at a minimum) the identifiers of the collections ' do
+    it 'returns (at a minimum) the identifiers of the collections' do
       get '/v1/objects/druid:mk420bs7601/query/collections',
           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
-      expect(response.body).to eq '{"collections":[{"externalIdentifier":"druid:999123","type":"collection","label":"collection #1"}]}'
+      expect(response.body).to eq expected.to_json
     end
   end
 end

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -15,11 +15,26 @@ RSpec.describe 'Get the object' do
       object.label = 'foo'
     end
 
+    let(:expected) do
+      {
+        externalIdentifier: 'druid:1234',
+        type: 'object',
+        label: 'foo',
+        version: 1,
+        access: {},
+        administrative: {
+          releaseTags: []
+        },
+        identification: {},
+        structural: {}
+      }
+    end
+
     it 'returns the object' do
       get '/v1/objects/druid:mk420bs7601',
           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to have_http_status(:ok)
-      expect(response.body).to eq '{"externalIdentifier":"druid:1234","type":"object","label":"foo"}'
+      expect(response.body).to eq expected.to_json
     end
   end
 
@@ -28,14 +43,43 @@ RSpec.describe 'Get the object' do
       object.descMetadata.title_info.main_title = 'Hello'
       object.label = 'foo'
       object.embargoMetadata.release_date = DateTime.parse '2019-09-26T07:00:00Z'
+      ReleaseTags.create(object, release: true,
+                                 what: 'self',
+                                 to: 'Searchworks',
+                                 who: 'petucket',
+                                 when: '2014-08-30T01:06:28Z')
+    end
+
+    let(:expected) do
+      {
+        externalIdentifier: 'druid:1234',
+        type: 'object',
+        label: 'foo',
+        version: 1,
+        access: {
+          embargoReleaseDate: '2019-09-26T07:00:00.000+00:00'
+        },
+        administrative: {
+          releaseTags: [
+            {
+              to: 'Searchworks',
+              what: 'self',
+              date: '2014-08-30T01:06:28.000+00:00',
+              who: 'petucket',
+              release: true
+            }
+          ]
+        },
+        identification: {},
+        structural: {}
+      }
     end
 
     it 'returns the object' do
       get '/v1/objects/druid:mk420bs7601',
           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to have_http_status(:ok)
-      expect(response.body).to eq '{"externalIdentifier":"druid:1234","type":"object","label":"foo",' \
-        '"access":{"embargoReleaseDate":"2019-09-26T07:00:00.000+00:00"}}'
+      expect(response.body).to eq expected.to_json
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

So that Argo doesn't have to be aware of the Fedora 3 data model to display the tags.


## Was the API documentation (openapi.json) updated?
Yes