### PR TITLE
Install openapi-enforcer-cli globally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,8 @@ jobs:
     - run:
         name: Validate API specification
         command: |
-          npm install openapi-enforcer-cli
-          result=$(node_modules/.bin/openapi-enforcer validate openapi.json)
+          sudo npm install -g openapi-enforcer-cli
+          result=$(openapi-enforcer validate openapi.json)
           [[ $result == $'\nDocument is valid' ]] && {
           exit 0
           } || {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
         command: |
           sudo npm install -g openapi-enforcer-cli
           result=$(openapi-enforcer validate openapi.json)
-          [[ $result == $'\nDocument is valid' ]] && {
+          [[ $result =~ "Document is valid" ]] && {
           exit 0
           } || {
           echo $result


### PR DESCRIPTION
## Why was this change made?

Avoids a warning:
```
npm WARN saveError ENOENT: no such file or directory, open '/home/circleci/project/package.json'
npm notice created a lockfile as package-lock.json. You should commit this file.
```

## Was the API documentation (openapi.json) updated?
N/A