### PR TITLE
Specify docker volume correctly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,4 +89,6 @@ services:
     environment:
       - POSTGRES_PASSWORD=sekret
     volumes:
-      - ./postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/data
+volumes:
+  postgres-data:


### PR DESCRIPTION
See https://docs.docker.com/compose/compose-file/#volume-configuration-reference

without this I get:

```
10:37 $ docker-compose up db
Starting dor-services-app_db_1 ... done
Attaching to dor-services-app_db_1
db_1        | FATAL:  "/var/lib/postgresql/data" is not a valid data directory
db_1        | DETAIL:  File "/var/lib/postgresql/data/PG_VERSION" does not contain valid data.
db_1        | HINT:  You might need to initdb.
dor-services-app_db_1 exited with code 1
```

## Why was this change made?



## Was the API documentation (openapi.json) updated?
