### PR TITLE
Allow APOs to be retrieved by the show handler

### DIFF
--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -36,15 +36,19 @@ module Cocina
 
     def build_administrative
       {}.tap do |admin|
-        admin[:releaseTags] = item.identityMetadata.ng_xml.xpath('//release').map do |node|
-          {
-            to: node.attributes['to'].value,
-            what: node.attributes['what'].value,
-            date: node.attributes['when'].value,
-            who: node.attributes['who'].value,
-            release: node.text
-          }
-        end
+        admin[:releaseTags] = build_release_tags unless type == 'admin_policy'
+      end
+    end
+
+    def build_release_tags
+      item.identityMetadata.ng_xml.xpath('//release').map do |node|
+        {
+          to: node.attributes['to'].value,
+          what: node.attributes['what'].value,
+          date: node.attributes['when'].value,
+          who: node.attributes['who'].value,
+          release: node.text
+        }
       end
     end
 
@@ -55,6 +59,8 @@ module Cocina
         'object'
       when Dor::Collection
         'collection'
+      when Dor::AdminPolicyObject
+        'admin_policy'
       else
         raise "Unknown type for #{item.class}"
       end

--- a/openapi.json
+++ b/openapi.json
@@ -857,7 +857,7 @@
           "objects"
         ],
         "summary": "Retrieve the object COCINA metadata",
-        "description": "",
+        "description": "Returns a JSON representation (not yet complete) of an object, collection or admin policy.",
         "operationId": "objects#show",
         "responses": {
           "200": {
@@ -916,6 +916,7 @@
         "properties": {
           "type": {
             "type": "string",
+            "enum": ["item", "collection", "admin_policy"],
             "example": "item"
           },
           "externalIdentifier": {

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -3,83 +3,116 @@
 require 'rails_helper'
 
 RSpec.describe 'Get the object' do
-  let(:object) { Dor::Item.new(pid: 'druid:1234') }
-
   before do
     allow(Dor).to receive(:find).and_return(object)
   end
 
-  context 'when the object exists with minimal metadata' do
-    before do
-      object.descMetadata.title_info.main_title = 'Hello'
-      object.label = 'foo'
+  context 'when the requested object is an item' do
+    let(:object) { Dor::Item.new(pid: 'druid:1234') }
+
+    context 'when the object exists with minimal metadata' do
+      before do
+        object.descMetadata.title_info.main_title = 'Hello'
+        object.label = 'foo'
+      end
+
+      let(:expected) do
+        {
+          externalIdentifier: 'druid:1234',
+          type: 'object',
+          label: 'foo',
+          version: 1,
+          access: {},
+          administrative: {
+            releaseTags: []
+          },
+          identification: {},
+          structural: {}
+        }
+      end
+
+      it 'returns the object' do
+        get '/v1/objects/druid:mk420bs7601',
+            headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq expected.to_json
+      end
     end
 
-    let(:expected) do
-      {
-        externalIdentifier: 'druid:1234',
-        type: 'object',
-        label: 'foo',
-        version: 1,
-        access: {},
-        administrative: {
-          releaseTags: []
-        },
-        identification: {},
-        structural: {}
-      }
-    end
+    context 'when the object exists with full metadata' do
+      before do
+        object.descMetadata.title_info.main_title = 'Hello'
+        object.label = 'foo'
+        object.embargoMetadata.release_date = DateTime.parse '2019-09-26T07:00:00Z'
+        ReleaseTags.create(object, release: true,
+                                   what: 'self',
+                                   to: 'Searchworks',
+                                   who: 'petucket',
+                                   when: '2014-08-30T01:06:28Z')
+      end
 
-    it 'returns the object' do
-      get '/v1/objects/druid:mk420bs7601',
-          headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to eq expected.to_json
+      let(:expected) do
+        {
+          externalIdentifier: 'druid:1234',
+          type: 'object',
+          label: 'foo',
+          version: 1,
+          access: {
+            embargoReleaseDate: '2019-09-26T07:00:00.000+00:00'
+          },
+          administrative: {
+            releaseTags: [
+              {
+                to: 'Searchworks',
+                what: 'self',
+                date: '2014-08-30T01:06:28.000+00:00',
+                who: 'petucket',
+                release: true
+              }
+            ]
+          },
+          identification: {},
+          structural: {}
+        }
+      end
+
+      it 'returns the object' do
+        get '/v1/objects/druid:mk420bs7601',
+            headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq expected.to_json
+      end
     end
   end
 
-  context 'when the object exists with full metadata' do
-    before do
-      object.descMetadata.title_info.main_title = 'Hello'
-      object.label = 'foo'
-      object.embargoMetadata.release_date = DateTime.parse '2019-09-26T07:00:00Z'
-      ReleaseTags.create(object, release: true,
-                                 what: 'self',
-                                 to: 'Searchworks',
-                                 who: 'petucket',
-                                 when: '2014-08-30T01:06:28Z')
-    end
+  context 'when the requested object is an APO' do
+    let(:object) { Dor::AdminPolicyObject.new(pid: 'druid:1234') }
 
-    let(:expected) do
-      {
-        externalIdentifier: 'druid:1234',
-        type: 'object',
-        label: 'foo',
-        version: 1,
-        access: {
-          embargoReleaseDate: '2019-09-26T07:00:00.000+00:00'
-        },
-        administrative: {
-          releaseTags: [
-            {
-              to: 'Searchworks',
-              what: 'self',
-              date: '2014-08-30T01:06:28.000+00:00',
-              who: 'petucket',
-              release: true
-            }
-          ]
-        },
-        identification: {},
-        structural: {}
-      }
-    end
+    context 'when the object exists with minimal metadata' do
+      before do
+        object.descMetadata.title_info.main_title = 'Hello'
+        object.label = 'foo'
+      end
 
-    it 'returns the object' do
-      get '/v1/objects/druid:mk420bs7601',
-          headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to eq expected.to_json
+      let(:expected) do
+        {
+          externalIdentifier: 'druid:1234',
+          type: 'admin_policy',
+          label: 'foo',
+          version: 1,
+          access: {},
+          administrative: {},
+          identification: {},
+          structural: {}
+        }
+      end
+
+      it 'returns the object' do
+        get '/v1/objects/druid:mk420bs7601',
+            headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq expected.to_json
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Previously an error was raised if an APO object was requested

## Was the API documentation (openapi.json) updated?
Yes