### PR TITLE
Revert "Avoid calling active_lifecycle"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-workflow-client (3.8.0)
+    dor-workflow-client (3.7.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (~> 0.9, >= 0.9.2)

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -109,7 +109,7 @@ class VersionService
   # Checks if current version has any incomplete wf steps and there is a versionWF
   # @return [Boolean] true if object is open for versioning
   def open_for_versioning?
-    return true if Dor::Config.workflow.client.lifecycle('dor', work.pid, 'opened', version: work.current_version)
+    return true if Dor::Config.workflow.client.active_lifecycle('dor', work.pid, 'opened')
 
     false
   end
@@ -117,7 +117,7 @@ class VersionService
   # Checks if the current version has any incomplete wf steps and there is an accessionWF.
   # @return [Boolean] true if object is currently being accessioned
   def accessioning?
-    return true if Dor::Config.workflow.client.lifecycle('dor', work.pid, 'submitted', version: work.current_version)
+    return true if Dor::Config.workflow.client.active_lifecycle('dor', work.pid, 'submitted')
 
     false
   end

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -40,12 +40,13 @@ RSpec.describe VersionService do
         allow(Dor::Config.workflow).to receive(:client).and_return(workflow_client)
         allow(obj).to receive(:new_record?).and_return(false)
         allow(vmd_ds).to receive(:save)
-        allow(workflow_client).to receive(:lifecycle).and_return(true, nil)
       end
 
       let(:workflow_client) do
         instance_double(Dor::Workflow::Client,
-                        create_workflow_by_name: true)
+                        create_workflow_by_name: true,
+                        lifecycle: true,
+                        active_lifecycle: nil)
       end
 
       it 'creates the versionMetadata datastream and starts a workflow' do
@@ -55,8 +56,8 @@ RSpec.describe VersionService do
         expect(vmd_ds.ng_xml.to_xml).to match(/Initial Version/)
         open
         expect(workflow_client).to have_received(:lifecycle).with('dor', druid, 'accessioned')
-        expect(workflow_client).to have_received(:lifecycle).with('dor', druid, 'opened', version: '1')
-        expect(workflow_client).to have_received(:lifecycle).with('dor', druid, 'submitted', version: '1')
+        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'opened')
+        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'submitted')
         expect(workflow_client).to have_received(:create_workflow_by_name).with(obj.pid, 'versioningWF')
       end
 
@@ -98,8 +99,8 @@ RSpec.describe VersionService do
     context "when SDR's current version is greater than the current version" do
       it 'raises an exception' do
         expect(Dor::Config.workflow.client).to receive(:lifecycle).with('dor', druid, 'accessioned').and_return(true)
-        expect(Dor::Config.workflow.client).to receive(:lifecycle).with('dor', druid, 'opened', version: '1').and_return(nil)
-        expect(Dor::Config.workflow.client).to receive(:lifecycle).with('dor', druid, 'submitted', version: '1').and_return(nil)
+        expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'opened').and_return(nil)
+        expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'submitted').and_return(nil)
         expect(SdrClient).to receive(:current_version).and_return(3)
         expect { open }.to raise_error(Dor::Exception, 'Cannot sync to a version greater than current: 1, requested 3')
       end
@@ -109,10 +110,13 @@ RSpec.describe VersionService do
       before do
         allow(Dor::Config.workflow).to receive(:client).and_return(workflow_client)
         allow(SdrClient).to receive(:current_version).and_raise(Dor::Exception, 'SDR is not yet answering queries about this object')
-        allow(workflow_client).to receive(:lifecycle).and_return(true, nil)
       end
 
-      let(:workflow_client) { instance_double(Dor::Workflow::Client) }
+      let(:workflow_client) do
+        instance_double(Dor::Workflow::Client,
+                        lifecycle: true,
+                        active_lifecycle: nil)
+      end
 
       it 'raises an exception' do
         expect { open }.to raise_error(Dor::Exception, /SDR is not yet answering queries about this object/)
@@ -125,11 +129,12 @@ RSpec.describe VersionService do
 
     before do
       allow(Dor::Config.workflow).to receive(:client).and_return(workflow_client)
-      allow(workflow_client).to receive(:lifecycle).and_return(true, nil)
     end
 
     let(:workflow_client) do
-      instance_double(Dor::Workflow::Client)
+      instance_double(Dor::Workflow::Client,
+                      lifecycle: true,
+                      active_lifecycle: nil)
     end
 
     context 'when a new version can be opened' do
@@ -140,8 +145,8 @@ RSpec.describe VersionService do
       it 'returns true' do
         expect(can_open?).to be true
         expect(workflow_client).to have_received(:lifecycle).with('dor', druid, 'accessioned')
-        expect(workflow_client).to have_received(:lifecycle).with('dor', druid, 'opened', version: '1')
-        expect(workflow_client).to have_received(:lifecycle).with('dor', druid, 'submitted', version: '1')
+        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'opened')
+        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'submitted')
       end
     end
 
@@ -158,23 +163,23 @@ RSpec.describe VersionService do
 
     context 'when the object has already been opened' do
       before do
-        allow(workflow_client).to receive(:lifecycle).with('dor', druid, 'opened', version: '1').and_return(Time.new)
+        allow(workflow_client).to receive(:active_lifecycle).with('dor', druid, 'opened').and_return(Time.new)
       end
 
       it 'returns false' do
         expect(can_open?).to be false
-        expect(workflow_client).to have_received(:lifecycle).with('dor', druid, 'opened', version: '1')
+        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'opened')
       end
     end
 
     context 'when the object is still being accessioned' do
       before do
-        allow(workflow_client).to receive(:lifecycle).with('dor', druid, 'submitted', version: '1').and_return(Time.new)
+        allow(workflow_client).to receive(:active_lifecycle).with('dor', druid, 'submitted').and_return(Time.new)
       end
 
       it 'returns false' do
         expect(can_open?).to be false
-        expect(workflow_client).to have_received(:lifecycle).with('dor', druid, 'submitted', version: '1')
+        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'submitted')
       end
     end
 
@@ -198,7 +203,7 @@ RSpec.describe VersionService do
 
       it 'sets tag, description and an event' do
         allow(vmd_ds).to receive(:pid).and_return('druid:ab123cd4567')
-        allow(Dor::Config.workflow.client).to receive(:lifecycle).and_return(true, false)
+        allow(Dor::Config.workflow.client).to receive(:active_lifecycle).and_return(true, false)
 
         # Stub out calls to update and archive workflow
         allow(Dor::Config.workflow.client).to receive(:update_workflow_status)
@@ -229,15 +234,15 @@ RSpec.describe VersionService do
 
     context 'when the object has not been opened for versioning' do
       it 'raises an exception' do
-        expect(Dor::Config.workflow.client).to receive(:lifecycle).with('dor', druid, 'opened', version: '1').and_return(nil)
+        expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'opened').and_return(nil)
         expect { close }.to raise_error(Dor::Exception, 'Trying to close version on druid:ab12cd3456 which is not opened for versioning')
       end
     end
 
     context 'when the object already has an active instance of accesssionWF' do
       it 'raises an exception' do
-        expect(Dor::Config.workflow.client).to receive(:lifecycle).with('dor', druid, 'opened', version: '1').and_return(Time.new)
-        expect(Dor::Config.workflow.client).to receive(:lifecycle).with('dor', druid, 'submitted', version: '1').and_return(true)
+        expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'opened').and_return(Time.new)
+        expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'submitted').and_return(true)
         expect { close }.to raise_error(Dor::Exception, 'accessionWF already created for versioned object druid:ab12cd3456')
       end
     end


### PR DESCRIPTION
This reverts commit 70a720c26f243688ddde7dcaa05e0b11a1c799af.

## Why was this change made?

Bug https://github.com/sul-dlss/argo/issues/1654


## Was the API documentation (openapi.json) updated?
N/a
