### PR TITLE
Pass the version to the active_version workflow call

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'uuidtools', '~> 2.1.4'
 # DLSS/domain-specific dependencies
 gem 'cocina-models', '~> 0.4.0'
 gem 'dor-services', '~> 8.0'
+gem 'dor-workflow-client', '~> 3.9'
 gem 'marc'
 gem 'moab-versioning', '~> 4.0', require: 'moab/stanford'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-workflow-client (3.7.0)
+    dor-workflow-client (3.9.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (~> 0.9, >= 0.9.2)
@@ -483,6 +483,7 @@ DEPENDENCIES
   coveralls (~> 0.8)
   dlss-capistrano
   dor-services (~> 8.0)
+  dor-workflow-client (~> 3.9)
   dry-struct
   dry-types
   equivalent-xml

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -109,7 +109,7 @@ class VersionService
   # Checks if current version has any incomplete wf steps and there is a versionWF
   # @return [Boolean] true if object is open for versioning
   def open_for_versioning?
-    return true if Dor::Config.workflow.client.active_lifecycle('dor', work.pid, 'opened')
+    return true if Dor::Config.workflow.client.active_lifecycle('dor', work.pid, 'opened', version: work.current_version)
 
     false
   end
@@ -117,7 +117,7 @@ class VersionService
   # Checks if the current version has any incomplete wf steps and there is an accessionWF.
   # @return [Boolean] true if object is currently being accessioned
   def accessioning?
-    return true if Dor::Config.workflow.client.active_lifecycle('dor', work.pid, 'submitted')
+    return true if Dor::Config.workflow.client.active_lifecycle('dor', work.pid, 'submitted', version: work.current_version)
 
     false
   end

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -56,8 +56,8 @@ RSpec.describe VersionService do
         expect(vmd_ds.ng_xml.to_xml).to match(/Initial Version/)
         open
         expect(workflow_client).to have_received(:lifecycle).with('dor', druid, 'accessioned')
-        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'opened')
-        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'submitted')
+        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'opened', version: '1')
+        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'submitted', version: '1')
         expect(workflow_client).to have_received(:create_workflow_by_name).with(obj.pid, 'versioningWF')
       end
 
@@ -99,8 +99,8 @@ RSpec.describe VersionService do
     context "when SDR's current version is greater than the current version" do
       it 'raises an exception' do
         expect(Dor::Config.workflow.client).to receive(:lifecycle).with('dor', druid, 'accessioned').and_return(true)
-        expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'opened').and_return(nil)
-        expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'submitted').and_return(nil)
+        expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'opened', version: '1').and_return(nil)
+        expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'submitted', version: '1').and_return(nil)
         expect(SdrClient).to receive(:current_version).and_return(3)
         expect { open }.to raise_error(Dor::Exception, 'Cannot sync to a version greater than current: 1, requested 3')
       end
@@ -145,8 +145,8 @@ RSpec.describe VersionService do
       it 'returns true' do
         expect(can_open?).to be true
         expect(workflow_client).to have_received(:lifecycle).with('dor', druid, 'accessioned')
-        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'opened')
-        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'submitted')
+        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'opened', version: '1')
+        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'submitted', version: '1')
       end
     end
 
@@ -163,23 +163,23 @@ RSpec.describe VersionService do
 
     context 'when the object has already been opened' do
       before do
-        allow(workflow_client).to receive(:active_lifecycle).with('dor', druid, 'opened').and_return(Time.new)
+        allow(workflow_client).to receive(:active_lifecycle).with('dor', druid, 'opened', version: '1').and_return(Time.new)
       end
 
       it 'returns false' do
         expect(can_open?).to be false
-        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'opened')
+        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'opened', version: '1')
       end
     end
 
     context 'when the object is still being accessioned' do
       before do
-        allow(workflow_client).to receive(:active_lifecycle).with('dor', druid, 'submitted').and_return(Time.new)
+        allow(workflow_client).to receive(:active_lifecycle).with('dor', druid, 'submitted', version: '1').and_return(Time.new)
       end
 
       it 'returns false' do
         expect(can_open?).to be false
-        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'submitted')
+        expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'submitted', version: '1')
       end
     end
 
@@ -234,15 +234,15 @@ RSpec.describe VersionService do
 
     context 'when the object has not been opened for versioning' do
       it 'raises an exception' do
-        expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'opened').and_return(nil)
+        expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'opened', version: '1').and_return(nil)
         expect { close }.to raise_error(Dor::Exception, 'Trying to close version on druid:ab12cd3456 which is not opened for versioning')
       end
     end
 
     context 'when the object already has an active instance of accesssionWF' do
       it 'raises an exception' do
-        expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'opened').and_return(Time.new)
-        expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'submitted').and_return(true)
+        expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'opened', version: '1').and_return(Time.new)
+        expect(Dor::Config.workflow.client).to receive(:active_lifecycle).with('dor', druid, 'submitted', version: '1').and_return(true)
         expect { close }.to raise_error(Dor::Exception, 'accessionWF already created for versioned object druid:ab12cd3456')
       end
     end


### PR DESCRIPTION
## Why was this change made?

If you don't pass a version the workflow service will make another call back to dor-services-app to get the version. This makes it very slow to open/close versions.


## Was the API documentation (openapi.json) updated?

Not an api level change.