### PR TITLE
deprecate sdr#current_version in favor of preservation-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ end
 
 # Ruby general dependencies
 gem 'config'
+gem 'deprecation'
 gem 'dry-struct'
 gem 'dry-types'
 gem 'faraday'
@@ -43,6 +44,7 @@ gem 'dor-services', '~> 8.0'
 gem 'dor-workflow-client', '~> 3.9'
 gem 'marc'
 gem 'moab-versioning', '~> 4.0', require: 'moab/stanford'
+gem 'preservation-client'
 
 group :test, :development do
   gem 'coveralls', '~> 0.8', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,10 @@ GEM
     parser (2.6.4.1)
       ast (~> 2.4.0)
     pg (1.1.4)
+    preservation-client (0.2.0)
+      activesupport (>= 4.2, < 7)
+      faraday (~> 0.15)
+      zeitwerk (~> 2.1)
     progressbar (1.10.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -481,6 +485,7 @@ DEPENDENCIES
   cocina-models (~> 0.4.0)
   config
   coveralls (~> 0.8)
+  deprecation
   dlss-capistrano
   dor-services (~> 8.0)
   dor-workflow-client (~> 3.9)
@@ -498,6 +503,7 @@ DEPENDENCIES
   net-http-persistent (~> 2.9)
   okcomputer
   pg
+  preservation-client
   progressbar
   pry-byebug
   puma (~> 3.0)

--- a/app/controllers/sdr_controller.rb
+++ b/app/controllers/sdr_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class SdrController < ApplicationController
+  extend Deprecation
+  self.deprecation_horizon = 'dor-services-app version 4.0'
+
   def cm_inv_diff
     unless %w(all shelve preserve publish).include?(params[:subset])
       render status: :bad_request, plain: "Invalid subset value: #{params[:subset]}"
@@ -25,8 +28,10 @@ class SdrController < ApplicationController
   end
 
   def current_version
+    Honeybadger.notify('dor-services-app deprecated API endpoint `sdr#current_version` called - use preservation-client current_version instead')
     proxy_faraday_response(sdr_client.current_version)
   end
+  deprecation_deprecate current_version: 'use preservation-client current_version in caller instead'
 
   def file_content
     sdr_response = sdr_client.file_content(version: params[:version], filename: params[:filename])

--- a/app/services/sdr_client.rb
+++ b/app/services/sdr_client.rb
@@ -2,6 +2,9 @@
 
 # A client for talking to sdr-services-app
 class SdrClient
+  extend Deprecation
+  self.deprecation_horizon = 'dor-services-app version 4.0'
+
   # @raises [Dor::Exception] if SDR doesn't know about the object (i.e. 404 response code)
   # @raises [StandardError] if the response from SDR can't be parsed
   def self.current_version(druid)
@@ -30,6 +33,7 @@ class SdrClient
   end
 
   def current_version(parsed: false)
+    Honeybadger.notify('dor-services-app deprecated method `SDRClient.current_version` called - use preservation-client current_version instead')
     path = "/objects/#{druid}/current_version"
     response = sdr_get(path)
     return response unless parsed
@@ -48,6 +52,7 @@ class SdrClient
       raise "Unable to parse XML from SDR current_version API call.\n\turl: #{sdr_uri(path)}\n\tstatus: #{response.status}\n\tbody: #{response.body}"
     end
   end
+  deprecation_deprecate current_version: 'use preservation-client current_version in caller instead'
 
   def file_content(version:, filename:)
     query_string = URI.encode_www_form(version: version.to_s)

--- a/config/initializers/preservation_client.rb
+++ b/config/initializers/preservation_client.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Configure preservation-client to use preservation catalog URL
+Preservation::Client.configure(url: Settings.preservation_catalog.url)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
     scope '/sdr/objects/:druid' do
       post 'cm-inv-diff', to: 'sdr#cm_inv_diff'
-      get 'current_version', to: 'sdr#current_version'
+      get 'current_version', to: 'sdr#current_version' # deprecated; caller should use preservation-client
       get 'manifest/:dsname', to: 'sdr#ds_manifest', format: false, constraints: { dsname: /.+/ }
       get 'metadata/:dsname', to: 'sdr#ds_metadata', format: false, constraints: { dsname: /.+/ }
       get 'content/:filename', to: 'sdr#file_content', format: false, constraints: { filename: /.+/ }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,6 +34,8 @@ solr:
 
 workflow_url: 'https://workflow.example.com/workflow'
 sdr_url: 'http://user:password@sdr-services.example.com/sdr'
+preservation_catalog:
+  url: 'https://example.org/prescat'
 purl_services_url: ~
 
 cleanup:

--- a/openapi.json
+++ b/openapi.json
@@ -101,8 +101,9 @@
         "tags": [
           "preservation"
         ],
-        "summary": "Get the current version of the object from SDR",
-        "description": "",
+        "summary": "DEPRECATED. Get the current version of the object from SDR",
+        "description": "DEPRECATED.  Use preservation-client gem instead.",
+        "deprecated": true,
         "operationId": "sdr#current_version",
         "responses": {
           "200": {

--- a/spec/controllers/sdr_controller_spec.rb
+++ b/spec/controllers/sdr_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe SdrController do
     login
   end
 
+  # TODO: Remove this in 4.0.0
   describe 'current_version' do
     let(:mock_response) { '<currentVersion>1</currentVersion>' }
 

--- a/spec/services/sdr_client_spec.rb
+++ b/spec/services/sdr_client_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe SdrClient do
+  # TODO: Remove this in 4.0.0
   describe '.current_version' do
     subject(:current_version) { described_class.current_version('druid:ab123cd4567') }
 


### PR DESCRIPTION
## Why was this change made?

To use the new preservation-client gem to get current_version from a preservation-catalog ReST endpoint, rather than the Sinatra sdr-services-app.  Also deprecates methods here designed to proxy getting current version from sdr-services-app.

## Was the API documentation (openapi.json) updated?

Yes, marked the sdr#current_version endpoint deprecated.

## Reviewers, please

- does this notify Honeybadger appropriately?
- does this have appropriate deprecation warnings?