### PR TITLE
preservation-client v0.2.1 fixes bug getting current_version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,7 +276,7 @@ GEM
     parallel (1.17.0)
     parser (2.6.4.1)
       ast (~> 2.4.0)
-    preservation-client (0.2.0)
+    preservation-client (0.2.1)
       activesupport (>= 4.2, < 7)
       faraday (~> 0.15)
       zeitwerk (~> 2.1)


### PR DESCRIPTION
## Why was this change made?

To fix these problems:

<img width="938" alt="image" src="https://user-images.githubusercontent.com/96775/65541520-5f92f900-dec2-11e9-9713-70e34abac3c7.png">

## Was the API documentation (openapi.json) updated?

n/a