### PR TITLE
Create virtual objects using database-backed approach

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ jobs:
         BUNDLE_JOBS: 3
         BUNDLE_RETRY: 3
         BUNDLE_PATH: vendor/bundle
+        PGHOST: 127.0.0.1
+        PGUSER: circleci-demo-ruby
         RAILS_ENV: test
         NOKOGIRI_USE_SYSTEM_LIBRARIES: true
     - image: circleci/postgres:10
@@ -55,6 +57,14 @@ jobs:
         command: |
           sudo apt update -y
           sudo apt install -y postgresql-client || true
+
+    - run:
+        name: Wait for DB
+        command: dockerize -wait tcp://localhost:5432 -timeout 1m
+
+    - run:
+        name: Test prepare
+        command: bin/rails db:test:prepare
 
     - run:
         name: Check styles using rubocop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,10 @@ jobs:
         BUNDLE_PATH: vendor/bundle
         RAILS_ENV: test
         NOKOGIRI_USE_SYSTEM_LIBRARIES: true
-    - image: circleci/postgres:9.6-alpine
+    - image: circleci/postgres:10
       environment:
         POSTGRES_USER: postgres
-        POSTGRES_DB: dor_services
+        POSTGRES_DB: dor_services_test
         POSTGRES_PASSWORD: ""
     steps:
     - checkout
@@ -49,15 +49,12 @@ jobs:
         paths:
         - vendor/bundle
 
-    - run: sudo apt update && sudo apt install -y postgresql-client || true
-
+    # Need `psql` command when you store the app schema as SQL instead of as Ruby
     - run:
-        name: Wait for DB
-        command: dockerize -wait tcp://localhost:5432 -timeout 1m
-
-    - run:
-        name: Test prepare
-        command: bin/rails db:test:prepare
+        name: Install postgresql client
+        command: |
+          sudo apt update -y
+          sudo apt install -y postgresql-client || true
 
     - run:
         name: Check styles using rubocop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,11 @@ jobs:
         BUNDLE_PATH: vendor/bundle
         RAILS_ENV: test
         NOKOGIRI_USE_SYSTEM_LIBRARIES: true
+    - image: circleci/postgres:9.6-alpine
+      environment:
+        POSTGRES_USER: postgres
+        POSTGRES_DB: dor_services
+        POSTGRES_PASSWORD: ""
     steps:
     - checkout
 
@@ -43,6 +48,16 @@ jobs:
         key: dor-services-app-bundle-v2-{{ checksum "Gemfile.lock" }}
         paths:
         - vendor/bundle
+
+    - run: sudo apt update && sudo apt install -y postgresql-client || true
+
+    - run:
+        name: Wait for DB
+        command: dockerize -wait tcp://localhost:5432 -timeout 1m
+
+    - run:
+        name: Test prepare
+        command: bin/rails db:test:prepare
 
     - run:
         name: Check styles using rubocop

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5-stretch
+FROM ruby:2.5.3-alpine
 
 # Provide SSL defaults that work in dev/test environments where we do not require connections to secured services
 # These values are overrideable at both buildtime and runtime (hence the ARG/ENV combo).
@@ -9,15 +9,22 @@ ENV SETTINGS__SSL__CERT_FILE="${SETTINGS__SSL__CERT_FILE}"
 ENV SETTINGS__SSL__KEY_FILE="${SETTINGS__SSL__KEY_FILE}"
 ENV SETTINGS__SSL__KEY_PASS="${SETTINGS__SSL__KEY_PASS}"
 
-RUN apt-get update -qq && \
-    apt-get install -y nano build-essential libsqlite3-dev nodejs
+# postgresql-client is required for invoke.sh
+RUN apk --no-cache add \
+  postgresql-dev \
+  postgresql-client \
+  tzdata
 
 RUN mkdir /app
 WORKDIR /app
 
 COPY Gemfile Gemfile.lock ./
-RUN bundle install --without production
+
+RUN apk --no-cache add --virtual build-dependencies \
+  build-base \
+  && bundle install --without production \
+  && apk del build-dependencies
 
 COPY . .
 
-CMD puma -C config/puma.rb
+CMD ["./docker/invoke.sh"]

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'jbuilder'
 gem 'jwt'
 gem 'net-http-persistent', '~> 2.9' # Pin to avoid problem exhausting file handles under load
 gem 'okcomputer'
+gem 'pg'
 gem 'progressbar' # for the cleaner rake task
 gem 'ruby-cache', '~> 0.3.0'
 gem 'sidekiq'
@@ -48,6 +49,7 @@ gem 'preservation-client'
 group :test, :development do
   gem 'coveralls', '~> 0.8', require: false
   gem 'equivalent-xml'
+  gem 'factory_bot_rails'
   gem 'rack-console'
   gem 'rails-controller-testing'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,11 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubi (1.9.0)
+    factory_bot (5.0.2)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.0.2)
+      factory_bot (~> 5.0.2)
+      railties (>= 4.2.0)
     faraday (0.16.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.13.1)
@@ -276,6 +281,7 @@ GEM
     parallel (1.17.0)
     parser (2.6.4.1)
       ast (~> 2.4.0)
+    pg (1.1.4)
     preservation-client (0.2.2)
       activesupport (>= 4.2, < 7)
       faraday (~> 0.15)
@@ -486,6 +492,7 @@ DEPENDENCIES
   dry-struct
   dry-types
   equivalent-xml
+  factory_bot_rails
   faraday
   honeybadger
   jbuilder
@@ -495,6 +502,7 @@ DEPENDENCIES
   moab-versioning (~> 4.0)
   net-http-persistent (~> 2.9)
   okcomputer
+  pg
   preservation-client
   progressbar
   pry-byebug

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ Note that the application has a web UI for monitoring Sidekiq activity at `/queu
 
 ## Running Tests
 
+First, ensure the database container is spun up:
+
+```shell
+docker-compose up db # use -d to daemonize/run in background
+```
+
+And if you haven't yet prepared the test database, run:
+
+```shell
+RAILS_ENV=test rails db:test:prepare
+```
+
 To run the tests:
 
   `bundle exec rake`

--- a/app/controllers/background_job_results_controller.rb
+++ b/app/controllers/background_job_results_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Controller for background job results
+class BackgroundJobResultsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound do |exception|
+    render json: {
+      errors: [
+        { title: 'not found', detail: exception.message }
+      ]
+    }, status: :not_found
+  end
+
+  def show
+    result = BackgroundJobResult.find(params[:id])
+    @output = result.output
+    @status = result.status
+
+    render status: result.code
+  end
+end

--- a/app/controllers/virtual_objects_controller.rb
+++ b/app/controllers/virtual_objects_controller.rb
@@ -6,19 +6,10 @@ class VirtualObjectsController < ApplicationController
 
   # Create one or more virtual objects represented by JSON (see `#schema` below):
   def create
-    errors = []
-
-    create_params[:virtual_objects].each do |virtual_object|
-      parent_id, child_ids = virtual_object.values_at(:parent_id, :child_ids)
-      # Update the constituent relationship between the parent and child druids
-      errors << ConstituentService.new(parent_druid: parent_id).add(child_druids: child_ids)
-    rescue ActiveFedora::ObjectNotFoundError, Rubydora::FedoraInvalidRequest, Dor::Exception => e
-      errors << { parent_id => [e.message] }
-    end
-
-    return render_error(errors: errors, status: :unprocessable_entity) if errors.any?
-
-    head :no_content
+    result = BackgroundJobResult.create
+    CreateVirtualObjectsJob.perform_later(virtual_objects: create_params[:virtual_objects],
+                                          background_job_result: result)
+    head :created, location: result
   end
 
   private
@@ -31,11 +22,7 @@ class VirtualObjectsController < ApplicationController
   # This gives us finer-grained validation.
   def validate_params!
     errors = schema.call(create_params).errors(full: true)
-    return render_error(errors: errors, status: :bad_request) if errors.any?
-  end
-
-  def render_error(errors:, status:)
-    render json: { errors: errors }, status: status
+    return render json: { errors: errors }, status: :bad_request if errors.any?
   end
 
   # {

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Common superclass for all jobs
+class ApplicationJob < ActiveJob::Base
+  # Automatically retry jobs that encountered a deadlock
+  # retry_on ActiveRecord::Deadlocked
+
+  # Most jobs are safe to ignore if the underlying records are no longer available
+  # discard_on ActiveJob::DeserializationError
+end

--- a/app/jobs/create_virtual_objects_job.rb
+++ b/app/jobs/create_virtual_objects_job.rb
@@ -19,12 +19,8 @@ class CreateVirtualObjectsJob < ApplicationJob
       errors << { parent_id => [e.message] }
     end
 
-    if errors.any?
-      background_job_result.output = { errors: errors }
-      background_job_result.code = 422
-    else
-      background_job_result.code = 200
-    end
+    background_job_result.output = { errors: errors } if errors.any?
+    background_job_result.code = 200
 
     background_job_result.complete!
   end

--- a/app/jobs/create_virtual_objects_job.rb
+++ b/app/jobs/create_virtual_objects_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Create virtual objects in the background
+class CreateVirtualObjectsJob < ApplicationJob
+  queue_as :default
+
+  # @param [Array] virtual_objects an array of hashes representing a batch of virtual objects
+  # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
+  def perform(virtual_objects:, background_job_result:)
+    background_job_result.processing!
+
+    errors = []
+
+    virtual_objects.each do |virtual_object|
+      parent_id, child_ids = virtual_object.values_at(:parent_id, :child_ids)
+      # Update the constituent relationship between the parent and child druids
+      errors << ConstituentService.new(parent_druid: parent_id).add(child_druids: child_ids)
+    rescue ActiveFedora::ObjectNotFoundError, Rubydora::FedoraInvalidRequest, Dor::Exception => e
+      errors << { parent_id => [e.message] }
+    end
+
+    if errors.any?
+      background_job_result.output = { errors: errors }
+      background_job_result.code = 422
+    else
+      background_job_result.code = 200
+    end
+
+    background_job_result.complete!
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Common superclass for ActiveRecord-based models
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/background_job_result.rb
+++ b/app/models/background_job_result.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Database-backed model to hold results of long-running jobs
+class BackgroundJobResult < ApplicationRecord
+  enum status: {
+    pending: 'pending',
+    processing: 'processing',
+    complete: 'complete'
+  }
+
+  # Deserialize JSON output field as a Hash with indifferent access
+  def output
+    @output ||= super.with_indifferent_access
+  end
+end

--- a/app/views/background_job_results/show.json.jbuilder
+++ b/app/views/background_job_results/show.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.output @output
+json.status @status

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,7 @@ require "rails"
 # Pick the frameworks you want:
 require "action_controller/railtie"
 require 'active_job/railtie'
+require 'active_record/railtie'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,8 @@ module DorServices
     config.action_dispatch.rescue_responses.merge!(
       "ActiveFedora::ObjectNotFoundError" => :not_found
     )
+
+    # This makes sure our Postgres enums function are persisted to the schema
+    config.active_record.schema_format = :sql
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,19 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  database: "<%= ENV.fetch('DATABASE_NAME', 'dor_services') %>"
+  username: "<%= ENV.fetch('DATABASE_USERNAME', 'postgres') %>"
+  password: "<%= ENV.fetch('DATABASE_PASSWORD', 'sekret') %>"
+  host: "<%= ENV.fetch('DATABASE_HOSTNAME', 'localhost') %>"
+  port: "<%= ENV.fetch('DATABASE_PORT', 5432) %>"
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,9 @@ Rails.application.routes.draw do
       get 'catkey', to: 'marcxml#catkey'
     end
 
-    resources :virtual_objects, only: [:create]
+    resources :virtual_objects, only: [:create], defaults: { format: :json }
+
+    resources :background_job_results, only: [:show], defaults: { format: :json }
 
     resources :objects, only: [:create, :show] do
       member do

--- a/db/migrate/20190917215521_create_background_job_results.rb
+++ b/db/migrate/20190917215521_create_background_job_results.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateBackgroundJobResults < ActiveRecord::Migration[5.2]
+  def up
+    execute <<-SQL
+      CREATE TYPE background_job_result_status AS ENUM (
+        'pending', 'processing', 'complete'
+      );
+    SQL
+
+    create_table :background_job_results do |t|
+      t.json :output, default: {}
+      t.integer :code, default: 202
+      t.column :status, :background_job_result_status, default: 'pending'
+
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :background_job_results
+    execute 'DROP TYPE background_job_result_status;'
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -131,5 +131,3 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20190917215521');
-
-

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,0 +1,135 @@
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+--
+-- Name: background_job_result_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.background_job_result_status AS ENUM (
+    'pending',
+    'processing',
+    'complete'
+);
+
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ar_internal_metadata (
+    key character varying NOT NULL,
+    value character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: background_job_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.background_job_results (
+    id bigint NOT NULL,
+    output json DEFAULT '{}'::json,
+    code integer DEFAULT 202,
+    status public.background_job_result_status DEFAULT 'pending'::public.background_job_result_status,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: background_job_results_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.background_job_results_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: background_job_results_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.background_job_results_id_seq OWNED BY public.background_job_results.id;
+
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schema_migrations (
+    version character varying NOT NULL
+);
+
+
+--
+-- Name: background_job_results id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.background_job_results ALTER COLUMN id SET DEFAULT nextval('public.background_job_results_id_seq'::regclass);
+
+
+--
+-- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ar_internal_metadata
+    ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: background_job_results background_job_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.background_job_results
+    ADD CONSTRAINT background_job_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+SET search_path TO "$user", public;
+
+INSERT INTO "schema_migrations" (version) VALUES
+('20190917215521');
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,16 @@ services:
       - workflow
       - redis
       - workers
+      - db
     ports:
       - 3000:3000
     environment:
+      DATABASE_NAME: dor_services
+      DATABASE_USERNAME: postgres
+      DATABASE_PASSWORD: sekret
+      DATABASE_HOSTNAME: db
+      DATABASE_PORT: 5432
+      RAILS_LOG_TO_STDOUT: 'true'
       REDIS_URL: redis://redis:6379/
       SOLR_URL: http://solr:8983/solr/dorservices
       SETTINGS__SSL__CERT_FILE: /app/spec/support/certs/spec.crt
@@ -69,14 +76,14 @@ services:
     ports:
       - 3001:3000
     environment:
-      - DATABASE_NAME=workflow-server
-      - DATABASE_USERNAME=postgres
-      - DATABASE_PASSWORD=sekret
-      - DATABASE_HOSTNAME=db
-      - DATABASE_PORT=5432
-      - SETTINGS__REDIS__HOSTNAME=redis
+      DATABASE_NAME: workflow-server
+      DATABASE_USERNAME: postgres
+      DATABASE_PASSWORD: sekret
+      DATABASE_HOSTNAME: db
+      DATABASE_PORT: 5432
+      SETTINGS__REDIS__HOSTNAME: redis
   db:
-    image: postgres
+    image: postgres:9.5-alpine
     ports:
       - 5432:5432
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       DATABASE_PORT: 5432
       SETTINGS__REDIS__HOSTNAME: redis
   db:
-    image: postgres:9.5-alpine
+    image: postgres:10
     ports:
       - 5432:5432
     environment:

--- a/docker/invoke.sh
+++ b/docker/invoke.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Don't allow this command to fail
+set -e
+
+echo "HOST IS: $DATABASE_HOSTNAME"
+until PGPASSWORD=$DATABASE_PASSWORD psql -h "$DATABASE_HOSTNAME" -U $DATABASE_USERNAME -c '\q'; do
+    echo "Postgres is unavailable - sleeping"
+    sleep 1
+done
+
+echo "Postgres is up - Setting up database"
+
+# Allow this command to fail
+set +e
+echo "Creating DB. OK to ignore errors about test db."
+# https://github.com/rails/rails/issues/27299
+rails db:create
+
+# Don't allow any following commands to fail
+set -e
+echo "Migrating db"
+rails db:migrate
+
+echo "Running server"
+exec puma -C config/puma.rb config.ru

--- a/openapi.json
+++ b/openapi.json
@@ -250,6 +250,59 @@
         ]
       }
     },
+    "/background_job_results/{id}": {
+      "get": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "View results of a background job",
+        "description": "Used to allow the application run long-running processes out of the request/response cycle",
+        "operationId": "background_job_results#show",
+        "responses": {
+          "200": {
+            "description": "The background job has completed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackgroundJobResultResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "The background job is pending or processing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackgroundJobResultResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "One or more errors occurred running the background job",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackgroundJobResultResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of background job result",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ]
+      }
+    },
     "/virtual_objects": {
       "post": {
         "tags": [
@@ -264,7 +317,7 @@
           },
           "422": {
             "description": "unable to process request"
-          },
+          }
         },
         "requestBody": {
           "content": {
@@ -905,6 +958,21 @@
           },
         },
         "required": ["externalIdentifier", "label", "type", "version", "access", "administrative", "identification", "structural"]
+      },
+      "BackgroundJobResultResponse": {
+        "type": "object",
+        "properties": {
+          "output": {
+            "type": "object",
+            "description": "output from the job",
+            "$ref": "#/components/schemas/ErrorResponse"
+          },
+          "status": {
+            "type": "string",
+            "description": "the status of the background job",
+            "enum": ["pending", "processing", "complete"]
+          }
+        }
       },
       "ErrorResponse": {
         "type": "object",

--- a/openapi.json
+++ b/openapi.json
@@ -45,6 +45,10 @@
       "description": "Integrations with other Systems"
     },
     {
+      "name": "jobs",
+      "description": "Operations involving background jobs"
+    },
+    {
       "name": "versions",
       "description": "Operations about object versions"
     },
@@ -914,7 +918,7 @@
             "format": "date-time",
             "example": "2029-06-22T07:00:00.000+00:00"
           }
-        },
+        }
       },
       "Administrative": {
         "type": "object",
@@ -925,7 +929,7 @@
               "$ref": "#/components/schemas/ReleaseTag"
             }
           }
-        },
+        }
       },
       "DRO": {
         "type": "object",
@@ -955,7 +959,7 @@
           },
           "structural": {
             "$ref": "#/components/schemas/Structural"
-          },
+          }
         },
         "required": ["externalIdentifier", "label", "type", "version", "access", "administrative", "identification", "structural"]
       },
@@ -1011,7 +1015,7 @@
       },
       "Identification": {
         "type": "object",
-        "properties": { },
+        "properties": { }
       },
       "ReleaseTag": {
         "type": "object",
@@ -1037,19 +1041,19 @@
             "type": "boolean"
           }
 
-        },
+        }
       },
       "Structural": {
         "type": "object",
-        "properties": { },
+        "properties": { }
       },
       "VirtualObjectRequest": {
         "type": "object",
         "properties": {
-          "parent_druid": {
+          "parent_id": {
             "$ref": "#/components/schemas/Druid"
           },
-          "child_druids": {
+          "child_ids": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Druid"

--- a/openapi.json
+++ b/openapi.json
@@ -260,7 +260,7 @@
         "operationId": "background_job_results#show",
         "responses": {
           "200": {
-            "description": "The background job has completed successfully",
+            "description": "The background job has completed",
             "content": {
               "application/json": {
                 "schema": {
@@ -279,12 +279,12 @@
               }
             }
           },
-          "422": {
-            "description": "One or more errors occurred running the background job",
+          "404": {
+            "description": "The background job with the given id was not found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BackgroundJobResultResponse"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/spec/factories/background_job_results.rb
+++ b/spec/factories/background_job_results.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :background_job_result do
+    output { {} }
+    status { 'pending' }
+    code { 202 }
+  end
+end

--- a/spec/jobs/create_virtual_objects_job_spec.rb
+++ b/spec/jobs/create_virtual_objects_job_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe CreateVirtualObjectsJob, type: :job do
       expect(result).to be_complete
     end
 
-    it 'sets the HTTP status code to 422' do
-      expect(result.code).to eq(422)
+    it 'sets the HTTP status code to 200' do
+      expect(result.code).to eq(200)
     end
 
     it 'has output with errors' do

--- a/spec/jobs/create_virtual_objects_job_spec.rb
+++ b/spec/jobs/create_virtual_objects_job_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreateVirtualObjectsJob, type: :job do
+  let(:child1_id) { 'druid:child1' }
+  let(:child2_id) { 'druid:child2' }
+  let(:parent_id) { 'druid:mk420bs7601' }
+  let(:result) { create(:background_job_result) }
+  let(:service) { instance_double(ConstituentService, add: nil) }
+  let(:virtual_objects) { [{ parent_id: parent_id, child_ids: [child1_id, child2_id] }] }
+
+  before do
+    allow(ConstituentService).to receive(:new).with(parent_druid: parent_id).and_return(service)
+    allow(BackgroundJobResult).to receive(:find).and_return(result)
+    allow(result).to receive(:processing!)
+  end
+
+  context 'with no errors' do
+    before do
+      described_class.perform_now(virtual_objects: virtual_objects,
+                                  background_job_result: result)
+    end
+
+    it 'marks the job as processing' do
+      expect(result).to have_received(:processing!).once
+    end
+
+    it 'invokes the constituent service to do the virtual object creation' do
+      expect(service).to have_received(:add).with(child_druids: [child1_id, child2_id]).once
+    end
+
+    it 'marks the job as complete' do
+      expect(result).to be_complete
+    end
+
+    it 'sets the HTTP status code to 200' do
+      expect(result.code).to eq(200)
+    end
+
+    it 'has no output' do
+      expect(result.output).to be_blank
+    end
+  end
+
+  context 'with errors returned by constituent service' do
+    before do
+      allow(service).to receive(:add).and_return(parent_id => ['One thing was not combinable', 'And another'])
+      described_class.perform_now(virtual_objects: virtual_objects,
+                                  background_job_result: result)
+    end
+
+    it 'marks the job as processing' do
+      expect(result).to have_received(:processing!).once
+    end
+
+    it 'invokes the constituent service to do the virtual object creation' do
+      expect(service).to have_received(:add).with(child_druids: [child1_id, child2_id]).once
+    end
+
+    it 'marks the job as complete' do
+      expect(result).to be_complete
+    end
+
+    it 'sets the HTTP status code to 422' do
+      expect(result.code).to eq(422)
+    end
+
+    it 'has output with errors' do
+      expect(result.output[:errors].first[parent_id]).to match_array(['One thing was not combinable', 'And another'])
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ require 'rspec/matchers'
 require 'equivalent-xml/rspec_matchers'
 require 'rspec/rails'
 require 'support/foxml_helper'
+require 'support/factory_bot'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/requests/background_job_results_spec.rb
+++ b/spec/requests/background_job_results_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'background job result' do
+  let(:background_job_result) { create(:background_job_result) }
+  let(:body) { JSON.parse(response.body).with_indifferent_access }
+
+  context 'when it does not exist' do
+    it 'renders 404' do
+      get '/v1/background_job_results/0',
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to have_http_status(:not_found)
+      expect(body[:errors].first[:title]).to eq('not found')
+      expect(body[:errors].first[:detail]).to eq('Couldn\'t find BackgroundJobResult with \'id\'=0')
+    end
+  end
+
+  context 'when it is pending' do
+    before do
+      get "/v1/background_job_results/#{background_job_result.id}",
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+    end
+
+    it 'renders an HTTP 202 status code' do
+      expect(response).to have_http_status(:accepted)
+    end
+
+    it 'states the job is pending' do
+      expect(body[:status]).to eq('pending')
+    end
+
+    it 'has no output' do
+      expect(body[:output]).to be_empty
+    end
+  end
+
+  context 'when it is processing' do
+    before do
+      background_job_result.processing!
+      get "/v1/background_job_results/#{background_job_result.id}",
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+    end
+
+    it 'renders an HTTP 202 status code' do
+      expect(response).to have_http_status(:accepted)
+    end
+
+    it 'states the job is processing' do
+      expect(body[:status]).to eq('processing')
+    end
+
+    it 'has no output' do
+      expect(body[:output]).to be_empty
+    end
+  end
+
+  context 'when it is complete' do
+    let(:background_job_result) { create(:background_job_result, code: code, output: output) }
+
+    before do
+      background_job_result.complete!
+      get "/v1/background_job_results/#{background_job_result.id}",
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+    end
+
+    context 'without errors' do
+      let(:code) { 200 }
+      let(:output) { { result: 'succeeded!' } }
+
+      it 'renders an HTTP 200 status code' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'states the job is complete' do
+        expect(body[:status]).to eq('complete')
+      end
+
+      it 'has output from the job' do
+        expect(body[:output][:result]).to eq('succeeded!')
+      end
+    end
+
+    context 'with errors' do
+      let(:code) { 422 }
+      let(:output) { { errors: [{ detail: 'failed!' }] } }
+
+      it 'renders an HTTP 422 status code' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'states the job is complete' do
+        expect(body[:status]).to eq('complete')
+      end
+
+      it 'has output from the job' do
+        expect(body[:output][:errors].first[:detail]).to eq('failed!')
+      end
+    end
+  end
+end

--- a/spec/requests/background_job_results_spec.rb
+++ b/spec/requests/background_job_results_spec.rb
@@ -82,11 +82,11 @@ RSpec.describe 'background job result' do
     end
 
     context 'with errors' do
-      let(:code) { 422 }
+      let(:code) { 200 }
       let(:output) { { errors: [{ detail: 'failed!' }] } }
 
-      it 'renders an HTTP 422 status code' do
-        expect(response).to have_http_status(:unprocessable_entity)
+      it 'renders an HTTP 200 status code' do
+        expect(response).to have_http_status(:ok)
       end
 
       it 'states the job is complete' do

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
Fixes #447 

Includes:
* Align docker configuration with workflow-service
* Document background job result bodies: I started down this road when discovering in dor-services-client that dor-services-app was not reliably returning JSON as output. Part of this work includes ensuring the output field of background job results is serialized as JSON (and deserialized as a hash with indifferent access because we are used to dealing with hashes with indifferent access in the Rails context).
* Add ActiveRecord and Postgres as dependencies. This makes it possible to reliably stash information about background jobs in a persistent store, which will be used to run virtual object creation in the background.
* Include `factory_bot_rails` as a dependency which will make it easier to spin
up fixture-like factories when testing with database entities later.
* Create a model and a table for background job results. The model holds any output from the job, an HTTP status code, and a processing status.
* Add factory_bot_rails to the test suite. This allows us to more efficiently test database-backed entities, specifically `BackgroundJobResults`.
* Add new controller and view for background job results.
* Use a background job to create virtual objects. Use the new job from the `CreateVirtualObjectsController`. In the job, record progress and results in the application database

## Why was this change made?

1. Prior to this, the application in containerland was not connecting to its database, and the docker-compose image lacked psql.
1. To add missing detail to the API specification.
1. To be able to process large batches of virtual objects outside of the request/response cycle.

## Was the API documentation (openapi.json) updated?

Yes.