### PR TITLE
Run database migrations on deploys

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -24,9 +24,8 @@ install_plugin Capistrano::SCM::Git
 require 'capistrano/bundler'
 require 'capistrano/honeybadger'
 require 'capistrano/passenger'
+require 'capistrano/rails/migrations'
 require 'capistrano/sidekiq'
-# require 'capistrano/rails/assets'
-# require 'capistrano/rails/migrations'
 require 'dlss/capistrano'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.

--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :deployment do
   gem 'capistrano', '~> 3.6'
   gem 'capistrano-bundler'
   gem 'capistrano-passenger'
+  gem 'capistrano-rails'
   gem 'capistrano-shared_configs'
   gem 'capistrano-sidekiq'
   gem 'dlss-capistrano'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,9 @@ GEM
       capistrano (~> 3.0)
     capistrano-passenger (0.2.0)
       capistrano (~> 3.0)
+    capistrano-rails (1.4.0)
+      capistrano (~> 3.1)
+      capistrano-bundler (~> 1.1)
     capistrano-shared_configs (0.2.2)
     capistrano-sidekiq (1.0.3)
       capistrano (>= 3.9.0)
@@ -480,6 +483,7 @@ DEPENDENCIES
   capistrano (~> 3.6)
   capistrano-bundler
   capistrano-passenger
+  capistrano-rails
   capistrano-shared_configs
   capistrano-sidekiq
   cocina-models (~> 0.4.0)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -44,6 +44,9 @@ set :sidekiq_processes, 1
 # stage rather than the Rails environment).
 set :sidekiq_env, 'production'
 
+# Run db migrations on app servers, not db server
+set :migration_role, :app
+
 # honeybadger_env otherwise defaults to rails_env
 set :honeybadger_env, fetch(:stage)
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -43,6 +43,7 @@ set :sidekiq_processes, 1
 # capistrano will run sidekiq in the `stage` or `prod` env (from the capistrano
 # stage rather than the Rails environment).
 set :sidekiq_env, 'production'
+set :rails_env, 'production'
 
 # Run db migrations on app servers, not db server
 set :migration_role, :app


### PR DESCRIPTION
This was not needed until now that dor-services-app uses a database and is connected to one in deployed environments.

