### PR TITLE
Trap for a nil pointer and give a helpful message

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -44,7 +44,11 @@ class ObjectsController < ApplicationController
     begin
       PublishMetadataService.publish(@item)
     rescue Dor::DataError => e
-      return render status: :unprocessable_entity, plain: e.message
+      return render json: {
+        errors: [
+          { title: 'Data error', detail: e.message }
+        ]
+      }, status: :unprocessable_entity
     end
     head :created
   end

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -15,10 +15,6 @@ class ObjectsController < ApplicationController
     render status: :conflict, plain: e.message, location: object_location(e.pid)
   end
 
-  rescue_from(DublinCoreService::CrosswalkError) do |e|
-    render status: :internal_server_error, plain: e.message
-  end
-
   rescue_from(SymphonyReader::ResponseError) do |e|
     render status: :internal_server_error, plain: e.message
   end
@@ -45,7 +41,11 @@ class ObjectsController < ApplicationController
   end
 
   def publish
-    PublishMetadataService.publish(@item)
+    begin
+      PublishMetadataService.publish(@item)
+    rescue Dor::DataError => e
+      return render status: :unprocessable_entity, plain: e.message
+    end
     head :created
   end
 

--- a/app/services/dublin_core_service.rb
+++ b/app/services/dublin_core_service.rb
@@ -3,7 +3,7 @@
 class DublinCoreService
   MODS_TO_DC_XSLT = Nokogiri::XSLT(File.new(File.expand_path(File.dirname(__FILE__) + '/mods2dc.xslt')))
   XMLNS_OAI_DC = 'http://www.openarchives.org/OAI/2.0/oai_dc/'
-  class CrosswalkError < RuntimeError; end
+  class CrosswalkError < Dor::DataError; end
 
   def initialize(work, include_collection_as_related_item: true)
     @work = work

--- a/app/services/public_xml_service.rb
+++ b/app/services/public_xml_service.rb
@@ -104,6 +104,13 @@ class PublicXmlService
     # locate and extract the resourceId/fileId elements
     doc = src_item.contentMetadata.ng_xml
     src_resource = doc.at_xpath("//resource[@id=\"#{src_resource_id}\"]")
+
+    unless src_resource
+      raise Dor::DataError, "The contentMetadata of #{object.pid} has an exernalFile "\
+        "reference to #{src_druid}, #{src_resource_id}, but #{src_druid} doesn't have " \
+        "a matching resource node in it's contentMetadata"
+    end
+
     src_file = src_resource.at_xpath("file[@id=\"#{src_file_id}\"]")
     raise Dor::DataError, "Unable to find a file node with id=\"#{src_file_id}\" (child of #{object.pid})" unless src_file
 

--- a/app/services/public_xml_service.rb
+++ b/app/services/public_xml_service.rb
@@ -8,6 +8,7 @@ class PublicXmlService
     @object = object
   end
 
+  # @raises [Dor::DataError]
   def to_xml
     pub = Nokogiri::XML('<publicObject/>').root
     pub['id'] = object.pid
@@ -106,9 +107,9 @@ class PublicXmlService
     src_resource = doc.at_xpath("//resource[@id=\"#{src_resource_id}\"]")
 
     unless src_resource
-      raise Dor::DataError, "The contentMetadata of #{object.pid} has an exernalFile "\
+      raise Dor::DataError, "The contentMetadata of #{object.pid} has an externalFile "\
         "reference to #{src_druid}, #{src_resource_id}, but #{src_druid} doesn't have " \
-        "a matching resource node in it's contentMetadata"
+        'a matching resource node in its contentMetadata'
     end
 
     src_file = src_resource.at_xpath("file[@id=\"#{src_file_id}\"]")

--- a/app/services/publish_metadata_service.rb
+++ b/app/services/publish_metadata_service.rb
@@ -12,6 +12,7 @@ class PublishMetadataService
   end
 
   # Appends contentMetadata file resources from the source objects to this object
+  # @raises [Dor::DataError]
   def publish
     return unpublish unless world_discoverable?
 
@@ -23,6 +24,7 @@ class PublishMetadataService
 
   attr_reader :item
 
+  # @raises [Dor::DataError]
   def transfer_metadata
     transfer_to_document_store(DublinCoreService.new(item).ng_xml.to_xml(&:no_declaration), 'dc')
     %w[identityMetadata contentMetadata rightsMetadata].each do |stream|

--- a/openapi.json
+++ b/openapi.json
@@ -353,6 +353,16 @@
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "422": {
+            "description": "There is a problem with the data that makes is impossible to publish",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         },
         "parameters": [

--- a/spec/requests/publish_object_spec.rb
+++ b/spec/requests/publish_object_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe 'Publish object' do
     let(:error_message) { "DublinCoreService#ng_xml produced incorrect xml (no children):\n<xml/>" }
 
     before do
-      allow(PublishMetadataService).to receive(:publish).and_raise(DublinCoreService::CrosswalkError, error_message)
+      allow(PublishMetadataService).to receive(:publish).and_raise(Dor::DataError, error_message)
     end
 
-    it 'returns a 409 error with location header' do
+    it 'returns a 422 error with location header' do
       post '/v1/objects/druid:1234/publish', headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response.status).to eq(500)
+      expect(response.status).to eq(422)
       expect(response.body).to eq(error_message)
     end
   end

--- a/spec/requests/publish_object_spec.rb
+++ b/spec/requests/publish_object_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe 'Publish object' do
     it 'returns a 422 error with location header' do
       post '/v1/objects/druid:1234/publish', headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.status).to eq(422)
-      expect(response.body).to eq(error_message)
+      json = JSON.parse(response.body)
+      expect(json.fetch('errors').first.fetch('detail')).to eq(error_message)
     end
   end
 

--- a/spec/services/public_xml_service_spec.rb
+++ b/spec/services/public_xml_service_spec.rb
@@ -240,9 +240,9 @@ RSpec.describe PublicXmlService do
         end
 
         it 'raises an error' do
-          expect { xml }.to raise_error(Dor::DataError, 'The contentMetadata of druid:ab123cd4567 has an exernalFile ' \
+          expect { xml }.to raise_error(Dor::DataError, 'The contentMetadata of druid:ab123cd4567 has an externalFile ' \
             "reference to druid:cg767mn6478, cg767mn6478_1, but druid:cg767mn6478 doesn't have " \
-            "a matching resource node in it's contentMetadata")
+            'a matching resource node in its contentMetadata')
         end
       end
 


### PR DESCRIPTION
## Why was this change made?

The nil pointer exceptions logged in honeybadger don't make it easy to decide what action needs to be taken.

## Was the API documentation (openapi.json) updated?
Yes