### PR TITLE
Generate the db structure under postgres 10

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,20 +10,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
---
 -- Name: background_job_result_status; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -131,3 +117,5 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20190917215521');
+
+


### PR DESCRIPTION


## Why was this change made?

Previously was generated for postgres 9

## Was the API documentation (openapi.json) updated?
N/A