### PR TITLE
Return Cocina Collections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'sidekiq-statistic'
 gem 'uuidtools', '~> 2.1.4'
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.4.0'
+gem 'cocina-models', '~> 0.6.0'
 gem 'dor-services', '~> 8.0'
 gem 'dor-workflow-client', '~> 3.9'
 gem 'marc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     capistrano-sidekiq (1.0.3)
       capistrano (>= 3.9.0)
       sidekiq (>= 3.4, < 6.0)
-    cocina-models (0.4.1)
+    cocina-models (0.6.0)
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
@@ -487,7 +487,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-shared_configs
   capistrano-sidekiq
-  cocina-models (~> 0.4.0)
+  cocina-models (~> 0.6.0)
   config
   coveralls (~> 0.8)
   deprecation

--- a/openapi.json
+++ b/openapi.json
@@ -893,7 +893,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DRO"
+                  "oneOf": [
+                    "$ref": "#/components/schemas/DRO",
+                    "$ref": "#/components/schemas/Collection",
+                    "$ref": "#/components/schemas/AdminPolicy"
+                  ]
                 }
               }
             }
@@ -932,6 +936,10 @@
       },
       "Administrative": {
         "type": "object",
+        "properties": { }
+      },
+      "DROAdministrative": {
+        "type": "object",
         "properties": {
           "releaseTags": {
             "type": "array",
@@ -941,12 +949,12 @@
           }
         }
       },
-      "DRO": {
+      "AdminPolicy": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["item", "collection", "admin_policy"],
+            "enum": ["http://cocina.sul.stanford.edu/models/admin_policy.jsonld"],
             "example": "item"
           },
           "externalIdentifier": {
@@ -963,6 +971,92 @@
           },
           "administrative": {
             "$ref": "#/components/schemas/Administrative"
+          },
+          "identification": {
+            "$ref": "#/components/schemas/Identification"
+          },
+          "structural": {
+            "$ref": "#/components/schemas/Structural"
+          }
+        },
+        "required": ["externalIdentifier", "label", "type", "version", "access", "administrative", "identification", "structural"]
+      },
+      "Collection": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "http://cocina.sul.stanford.edu/models/collection.jsonld",
+              "http://cocina.sul.stanford.edu/models/curated-collection.jsonld",
+              "http://cocina.sul.stanford.edu/models/user-collection.jsonld",
+              "http://cocina.sul.stanford.edu/models/exhibit.jsonld",
+              "http://cocina.sul.stanford.edu/models/series.jsonld"
+            ],
+            "example": "item"
+          },
+          "externalIdentifier": {
+            "$ref": "#/components/schemas/Druid"
+          },
+          "label": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer"
+          },
+          "access": {
+            "$ref": "#/components/schemas/Access"
+          },
+          "administrative": {
+            "$ref": "#/components/schemas/Administrative"
+          },
+          "identification": {
+            "$ref": "#/components/schemas/Identification"
+          },
+          "structural": {
+            "$ref": "#/components/schemas/Structural"
+          }
+        },
+        "required": ["externalIdentifier", "label", "type", "version", "access", "administrative", "identification", "structural"]
+      },
+      "DRO": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "http://cocina.sul.stanford.edu/models/object.jsonld",
+              "http://cocina.sul.stanford.edu/models/3d.jsonld",
+              "http://cocina.sul.stanford.edu/models/agreement.jsonl",
+              "http://cocina.sul.stanford.edu/models/book.jsonld",
+              "http://cocina.sul.stanford.edu/models/document.jsonld",
+              "http://cocina.sul.stanford.edu/models/geo.jsonld",
+              "http://cocina.sul.stanford.edu/models/image.jsonld",
+              "http://cocina.sul.stanford.edu/models/page.jsonld",
+              "http://cocina.sul.stanford.edu/models/photograph.jsonld",
+              "http://cocina.sul.stanford.edu/models/manuscript.jsonld",
+              "http://cocina.sul.stanford.edu/models/map.jsonld",
+              "http://cocina.sul.stanford.edu/models/media.jsonld",
+              "http://cocina.sul.stanford.edu/models/track.jsonld",
+              "http://cocina.sul.stanford.edu/models/webarchive-binary.jsonld",
+              "http://cocina.sul.stanford.edu/models/webarchive-seed.jsonld"
+            ],
+            "example": "item"
+          },
+          "externalIdentifier": {
+            "$ref": "#/components/schemas/Druid"
+          },
+          "label": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer"
+          },
+          "access": {
+            "$ref": "#/components/schemas/Access"
+          },
+          "administrative": {
+            "$ref": "#/components/schemas/DROAdministrative"
           },
           "identification": {
             "$ref": "#/components/schemas/Identification"

--- a/spec/requests/collections_for_object_spec.rb
+++ b/spec/requests/collections_for_object_spec.rb
@@ -18,13 +18,11 @@ RSpec.describe 'Get the object' do
       collections: [
         {
           externalIdentifier: 'druid:999123',
-          type: 'collection',
+          type: 'http://cocina.sul.stanford.edu/models/collection.jsonld',
           label: 'collection #1',
           version: 1,
           access: {},
-          administrative: {
-            releaseTags: []
-          },
+          administrative: {},
           identification: {},
           structural: {}
         }

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Get the object' do
       let(:expected) do
         {
           externalIdentifier: 'druid:1234',
-          type: 'object',
+          type: 'http://cocina.sul.stanford.edu/models/object.jsonld',
           label: 'foo',
           version: 1,
           access: {},
@@ -54,7 +54,7 @@ RSpec.describe 'Get the object' do
       let(:expected) do
         {
           externalIdentifier: 'druid:1234',
-          type: 'object',
+          type: 'http://cocina.sul.stanford.edu/models/object.jsonld',
           label: 'foo',
           version: 1,
           access: {
@@ -97,7 +97,7 @@ RSpec.describe 'Get the object' do
       let(:expected) do
         {
           externalIdentifier: 'druid:1234',
-          type: 'admin_policy',
+          type: 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld',
           label: 'foo',
           version: 1,
           access: {},


### PR DESCRIPTION
## Why was this change made?
So that we can differentiate object types in common-accessioning.

## Was the API documentation (openapi.json) updated?
Yes