### PR TITLE
use pry for irb

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,5 +3,9 @@
 
 ENV['RACK_ENV'] = ARGV.first unless ARGV.first.nil?
 require File.expand_path(File.dirname(__FILE__) + '/../config/boot')
-require 'irb'
-IRB.start
+
+# require 'irb'
+# IRB.start
+
+require 'pry'
+Pry.start


### PR DESCRIPTION
## Why was this change made?

So rails console will be pry, rather than irb.  I find it really useful to be able to "ls xxx", where xxx is an object, to see the available methods and where they come from.  I also really appreciate the color output.

## Was the API documentation (openapi.json) updated?

n/a