### PR TITLE
ShelvingService.shelve fixed 'undefined method ' error

### DIFF
--- a/app/services/sdr_client.rb
+++ b/app/services/sdr_client.rb
@@ -15,6 +15,7 @@ class SdrClient
     @druid = druid
   end
 
+  # @return [Faraday::Response] with body of cm-inv-diff as xml
   def content_diff(current_content:, subset:, version: nil)
     query_params = { subset: subset }
     query_params[:version] = version unless version.nil?

--- a/app/services/shelving_service.rb
+++ b/app/services/shelving_service.rb
@@ -38,7 +38,8 @@ class ShelvingService
 
     client = SdrClient.new(work.pid)
     current_content = work.contentMetadata.content
-    inventory_diff = client.content_diff(current_content: current_content, subset: 'shelve')
+    sdr_resp = client.content_diff(current_content: current_content, subset: 'shelve')
+    inventory_diff = Moab::FileInventoryDifference.parse(sdr_resp.body)
     inventory_diff.group_difference('content')
   end
 


### PR DESCRIPTION
## Why was this change made?

To fix `NoMethodError: undefined method `group_difference' for #<Faraday::Response:0x...>` for ShelvingService.shelve, used by common-accessioning robots.

Fixes #463 (when deployed).

The error was introduced here:  https://github.com/sul-dlss/dor-services-app/commit/309dbc7b48fd10203dc59f209dd8a77eef7ca09e

## Was the API documentation (openapi.json) updated?

n/a