### PR TITLE
ShelvingService provides more details to client when missing content dir

### DIFF
--- a/app/controllers/shelves_controller.rb
+++ b/app/controllers/shelves_controller.rb
@@ -4,6 +4,11 @@
 class ShelvesController < ApplicationController
   before_action :load_item, only: :create
 
+  # exception defined in application.rb;  see https://pdabrowski.com/blog/ruby-rescue-from-errors-with-grace
+  rescue_from(DorServices::ContentDirNotFoundError) do |e|
+    render status: :internal_server_error, plain: e.message
+  end
+
   def create
     if @item.is_a?(Dor::Item)
       ShelvingService.shelve(@item)

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,4 +31,11 @@ module DorServices
     # This makes sure our Postgres enums function are persisted to the schema
     config.active_record.schema_format = :sql
   end
+
+  # see https://pdabrowski.com/blog/ruby-rescue-from-errors-with-grace
+  class ContentDirNotFoundError < RuntimeError
+    def self.===(exception)
+      exception.class == RuntimeError && exception.message.match(/content dir not found for /)
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

So argo will show something more useful than this when a content dir is missing in the shelve step for common-accessioning.

![image](https://user-images.githubusercontent.com/96775/66791063-68fef800-eea7-11e9-8472-f7e191f32700.png)

"shelve : Internal Server Error: 500 (Response from dor-services-app did not contain a body. Check honeybadger for dor-services-app for backtraces, and look into adding a `rescue_from` in dor-services-app to provide more details to the client in the future)"

## Was the API documentation (openapi.json) updated?

n/a