### PR TITLE
Inject ReleaseTags as a dependency

### DIFF
--- a/app/services/public_xml_service.rb
+++ b/app/services/public_xml_service.rb
@@ -4,8 +4,11 @@
 class PublicXmlService
   attr_reader :object
 
-  def initialize(object)
+  # @param [Dor::Item] object
+  # @param [Hash{String => Boolean}] released_for keys are Project name strings, values are boolean
+  def initialize(object, released_for:)
     @object = object
+    @released_for = released_for
   end
 
   # @raises [Dor::DataError]
@@ -35,6 +38,8 @@ class PublicXmlService
 
   private
 
+  attr_reader :released_for
+
   # Generate XML structure for inclusion to Purl
   # @return [String] The XML release node as a string, with ReleaseDigest as the root document
   def release_xml
@@ -48,10 +53,6 @@ class PublicXmlService
       end
       Nokogiri::XML(builder.to_xml)
     end
-  end
-
-  def released_for
-    Dor::ReleaseTagService.for(object).released_for(skip_live_purl: false)
   end
 
   def public_relationships

--- a/app/services/publish_metadata_service.rb
+++ b/app/services/publish_metadata_service.rb
@@ -30,7 +30,9 @@ class PublishMetadataService
     %w[identityMetadata contentMetadata rightsMetadata].each do |stream|
       transfer_to_document_store(item.datastreams[stream].content.to_s, stream) if item.datastreams[stream]
     end
-    transfer_to_document_store(PublicXmlService.new(item).to_xml, 'public')
+    # Retrieve release tags from metadata and PURL
+    released_for = Dor::ReleaseTagService.for(item).released_for(skip_live_purl: false)
+    transfer_to_document_store(PublicXmlService.new(item, released_for: released_for).to_xml, 'public')
     transfer_to_document_store(PublicDescMetadataService.new(item).to_xml, 'mods')
   end
 

--- a/spec/services/publish_metadata_service_spec.rb
+++ b/spec/services/publish_metadata_service_spec.rb
@@ -105,11 +105,15 @@ RSpec.describe PublishMetadataService do
           expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(no_args)
         end
 
+        let(:release_tags) do
+          { 'Searchworks' => { 'release' => true }, 'Some_special_place' => { 'release' => true } }
+        end
+
         it 'identityMetadta, contentMetadata, rightsMetadata, generated dublin core, and public xml' do
           item.rightsMetadata.content = "<rightsMetadata><access type='discover'><machine><world/></machine></access></rightsMetadata>"
           service.publish
           expect(DublinCoreService).to have_received(:new).with(item)
-          expect(PublicXmlService).to have_received(:new).with(item)
+          expect(PublicXmlService).to have_received(:new).with(item, released_for: release_tags)
           expect(PublicDescMetadataService).to have_received(:new).with(item)
         end
 


### PR DESCRIPTION

## Why was this change made?

So it's easier to see where the dependencies are. This is especially important as ReleaseTags makes a remote HTTP call


## Was the API documentation (openapi.json) updated?

N/A