### PR TITLE
Check an item's workflow for any errors with the current version

### DIFF
--- a/app/services/item_query_service.rb
+++ b/app/services/item_query_service.rb
@@ -30,6 +30,8 @@ class ItemQueryService
   def self.find_combinable_item(druid)
     query_service = ItemQueryService.new(id: druid)
     query_service.item do |item|
+      workflow_errors = WorkflowErrorCheckingService.check(item: item, version: item.current_version)
+      raise UncombinableItemError, "Item #{item.pid} has workflow errors: #{workflow_errors.join('; ')}" if workflow_errors.any?
       raise UncombinableItemError, "Item #{item.pid} is not open or openable" unless VersionService.open?(item) || VersionService.can_open?(item)
       raise UncombinableItemError, "Item #{item.pid} is dark" if item.rightsMetadata.dra_object.dark?
       raise UncombinableItemError, "Item #{item.pid} is citation_only" if item.rightsMetadata.dra_object.citation_only?

--- a/app/services/workflow_error_checking_service.rb
+++ b/app/services/workflow_error_checking_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Checks the workflow status for a given item and version and returns error information
+class WorkflowErrorCheckingService
+  # @param [Dor::Item] item - the Dor::Item to check
+  # @param [String] version - the version of the item to check
+  # @return [Array<String>] an array of error strings, or an empty array if no errors
+  def self.check(item:, version:)
+    new(item: item, version: version).check
+  end
+
+  attr_reader :item, :version
+
+  # @param [Dor::Item] item - the Dor::Item to check
+  # @param [String] version - the version of the item to check
+  def initialize(item:, version:)
+    @item = item
+    @version = version
+  end
+
+  # @return [Array<String>] an array of error strings, or an empty array if no errors
+  def check
+    Nokogiri::XML(all_workflows_xml)
+            .xpath("//workflow/process[@version='#{version}' and @status='error']/@errorMessage")
+            .map(&:text)
+  end
+
+  private
+
+  def all_workflows_xml
+    Dor::Config.workflow.client.all_workflows_xml(item.id)
+  end
+end

--- a/spec/services/workflow_error_checking_service_spec.rb
+++ b/spec/services/workflow_error_checking_service_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WorkflowErrorCheckingService do
+  subject(:service) { described_class.new(item: item, version: item.current_version) }
+
+  let(:item) { instance_double(Dor::Item, id: 'druid:child1', current_version: '1') }
+
+  describe '.check' do
+    let(:instance) { instance_double(described_class, check: []) }
+
+    before do
+      allow(described_class).to receive(:new).and_return(instance)
+    end
+
+    it 'creates an instance of the class and calls #check' do
+      described_class.check(item: item, version: item.current_version)
+      expect(instance).to have_received(:check).once
+    end
+  end
+
+  describe '.new' do
+    it 'has an item attr' do
+      expect(service.item).to eq(item)
+    end
+
+    it 'has a version attr' do
+      expect(service.version).to eq(item.current_version)
+    end
+  end
+
+  describe '#check' do
+    let(:workflow_client) { instance_double(Dor::Workflow::Client, all_workflows_xml: xml) }
+
+    before do
+      allow(Dor::Config.workflow).to receive(:client).and_return(workflow_client)
+    end
+
+    context 'when one or more workflows contain errors' do
+      let(:xml) do
+        <<~XML
+          <workflows objectId="#{item.id}">
+            <workflow id="accessionWF" objectId="#{item.id}" repository="dor">
+              <process name="foo1" version="2" status="completed"/>
+              <process name="foo2" version="2" status="completed"/>
+              <process name="foo3" version="2" status="completed"/>
+              <process name="foo4" version="2" status="completed"/>
+              <process name="foo5" version="2" status="completed"/>
+              <process name="foo1" version="1" status="error" errorMessage="the first error"/>
+              <process name="foo2" version="1" status="waiting"/>
+              <process name="foo3" version="1" status="waiting"/>
+              <process name="foo4" version="1" status="waiting"/>
+              <process name="foo5" version="1" status="waiting"/>
+            </workflow>
+            <workflow id="foobarWF" objectId="#{item.id}" repository="dor">
+              <process name="bar1" version="2" status="completed"/>
+              <process name="bar2" version="2" status="completed"/>
+              <process name="bar3" version="2" status="completed"/>
+              <process name="bar4" version="2" status="completed"/>
+              <process name="bar5" version="2" status="completed"/>
+              <process name="bar1" version="1" status="completed"/>
+              <process name="bar2" version="1" status="completed"/>
+              <process name="bar3" version="1" status="error" errorMessage="the second error"/>
+              <process name="bar4" version="1" status="waiting"/>
+              <process name="bar5" version="1" status="waiting"/>
+            </workflow>
+          </workflows>
+        XML
+      end
+
+      it 'returns an array of error strings' do
+        expect(service.check).to eq(['the first error', 'the second error'])
+      end
+    end
+
+    context 'when no workflows contain errors' do
+      let(:xml) do
+        <<~XML
+          <workflows objectId="#{item.id}">
+            <workflow id="accessionWF" objectId="#{item.id}" repository="dor">
+              <process name="foo1" version="2" status="completed"/>
+              <process name="foo2" version="2" status="completed"/>
+              <process name="foo3" version="2" status="completed"/>
+              <process name="foo4" version="2" status="completed"/>
+              <process name="foo5" version="2" status="completed"/>
+              <process name="foo1" version="1" status="waiting"/>
+              <process name="foo2" version="1" status="waiting"/>
+              <process name="foo3" version="1" status="waiting"/>
+              <process name="foo4" version="1" status="waiting"/>
+              <process name="foo5" version="1" status="waiting"/>
+            </workflow>
+            <workflow id="foobarWF" objectId="#{item.id}" repository="dor">
+              <process name="bar1" version="2" status="completed"/>
+              <process name="bar2" version="2" status="completed"/>
+              <process name="bar3" version="2" status="completed"/>
+              <process name="bar4" version="2" status="completed"/>
+              <process name="bar5" version="2" status="completed"/>
+              <process name="bar1" version="1" status="completed"/>
+              <process name="bar2" version="1" status="completed"/>
+              <process name="bar3" version="1" status="completed"/>
+              <process name="bar4" version="1" status="waiting"/>
+              <process name="bar5" version="1" status="waiting"/>
+            </workflow>
+          </workflows>
+        XML
+      end
+
+      it 'returns an empty array' do
+        expect(service.check).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

To prevent items in an error state from being combined in a virtual merge operation. Requested by @andrewjbtw to restore behavior prior to [this change](https://github.com/sul-dlss/dor-services-app/commit/6d2c990b768556d12a7660a6db984d93dc6dfb6d#diff-d94618b2b5aef0b32a18a4a63b556d4e).

## Was the API documentation (openapi.json) updated?

Not necessary.
