### PR TITLE
Don't configure SSL on development

### DIFF
--- a/config/initializers/dor_config.rb
+++ b/config/initializers/dor_config.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 Dor.configure do
+  # rubocop:disable Style/MultilineIfModifier
   ssl do
     cert_file Settings.ssl.cert_file
     key_file Settings.ssl.key_file
     key_pass Settings.ssl.key_pass
-  end
+  end if Settings.ssl
+  # rubocop:enable Style/MultilineIfModifier
 
   fedora do
     url Settings.fedora_url

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,9 +1,3 @@
-# SSL
-ssl:
-  cert_file: "/etc/pki/tls/certs/<%= (`echo $HOSTNAME`).strip.gsub('.stanford.edu', '') %>-dor-prod.crt"
-  key_file: "/etc/pki/tls/private/<%= (`echo $HOSTNAME`).strip.gsub('.stanford.edu', '') %>-dor-prod.key"
-  key_pass: 'password'
-
 content:
   base_dir: '/dor/workspace'
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,1 @@
+fedora_url: 'http://fedoraAdmin:fedoraAdmin@localhost:8983/fedora'


### PR DESCRIPTION
## Why was this change made?

This change was made for consistency as it matches how we do configuration in Argo.
Additionally this allows us to run in development mode without SSL configured.

This depends on https://github.com/sul-dlss/shared_configs/pull/1101


## Was the API documentation (openapi.json) updated?
n/a