### PR TITLE
Return a helpful message if a directory doesn't exist

### DIFF
--- a/app/services/cleanup_reset_service.rb
+++ b/app/services/cleanup_reset_service.rb
@@ -6,6 +6,7 @@ require 'pathname'
 class CleanupResetService
   # @param [String] druid The identifier for the object whose reset data is to be removed
   # @return [void] remove copy of the reset data that was exported to preservation core
+  # @raises [Errno::ENOENT] if the directory does not exist
   def self.cleanup_by_reset_druid(druid)
     last_version = get_druid_last_version(druid)
     cleanup_reset_workspace_content(druid, last_version, Settings.cleanup.local_workspace_root)
@@ -26,6 +27,7 @@ class CleanupResetService
   # @param [String] base The base directory to delete from
   # @param [Integer] last_version The last version that the data should be removed until version 1
   # @return [void] remove all the object's reset data files from the workspace area equal to less than the last_version
+  # @raises [Errno::ENOENT] if the directory does not exist
   def self.cleanup_reset_workspace_content(druid, last_version, base)
     base_druid = DruidTools::Druid.new(druid, base)
     base_druid_tree = base_druid.pathname.to_s

--- a/app/services/prune_service.rb
+++ b/app/services/prune_service.rb
@@ -16,6 +16,7 @@ class PruneService
 
   # @param [Pathname] outermost_branch The branch at which pruning begins
   # @return [void] Ascend the druid tree and prune empty branches
+  # @raises [Errno::ENOENT] if the directory does not exist
   def prune_ancestors(outermost_branch)
     while outermost_branch.exist? && outermost_branch.children.empty?
       outermost_branch.rmdir

--- a/openapi.json
+++ b/openapi.json
@@ -585,6 +585,16 @@
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "422": {
+            "description": "There was a problem removing the workspace.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         },
         "parameters": [

--- a/spec/controllers/workspaces_controller_spec.rb
+++ b/spec/controllers/workspaces_controller_spec.rb
@@ -62,21 +62,6 @@ RSpec.describe WorkspacesController do
     end
   end
 
-  describe '#destroy' do
-    before do
-      login
-      allow(CleanupService).to receive(:cleanup_by_druid)
-    end
-
-    let(:druid) { 'druid:aa222cc3333' }
-
-    it 'is successful' do
-      delete :destroy, params: { object_id: druid }
-      expect(CleanupService).to have_received(:cleanup_by_druid).with(druid)
-      expect(response).to be_no_content
-    end
-  end
-
   describe '#reset' do
     before do
       login

--- a/spec/requests/cleanup_workspace_spec.rb
+++ b/spec/requests/cleanup_workspace_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Cleanup workspace' do
+  let(:object_id) { 'druid:aa222cc3333' }
+
+  context 'when successful' do
+    before do
+      allow(CleanupService).to receive(:cleanup_by_druid)
+    end
+
+    it 'returns 200' do
+      delete "/v1/objects/#{object_id}/workspace",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(CleanupService).to have_received(:cleanup_by_druid).with(object_id)
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+
+  context 'when an error is raised' do
+    before do
+      allow(CleanupService).to receive(:cleanup_by_druid)
+        .and_raise(Errno::ENOENT, 'dir_s_rmdir - /dor/workspace/aa/222')
+    end
+
+    it 'returns JSON-API error' do
+      delete "/v1/objects/#{object_id}/workspace",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to eq(
+        '{"errors":[{"status":"422","title":"Unable to remove directory",' \
+        '"detail":"No such file or directory - dir_s_rmdir - /dor/workspace/aa/222"}]}'
+      )
+    end
+  end
+end


### PR DESCRIPTION
Previously it was just returning 500 with no message

## Why was this change made?
So that common-accessioning has a clue about what went wrong: https://app.honeybadger.io/projects/52894/faults/53522097


## Was the API documentation (openapi.json) updated?

yes.