### PR TITLE
Upgrade to postgres 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
         PGUSER: circleci-demo-ruby
         RAILS_ENV: test
         NOKOGIRI_USE_SYSTEM_LIBRARIES: true
-    - image: circleci/postgres:10
+    - image: circleci/postgres:11
       environment:
         POSTGRES_USER: postgres
         POSTGRES_DB: dor_services_test

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,22 +5,9 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
 
 --
 -- Name: background_job_result_status; Type: TYPE; Schema: public; Owner: -

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       DATABASE_PORT: 5432
       SETTINGS__REDIS__HOSTNAME: redis
   db:
-    image: postgres:10
+    image: postgres:11
     ports:
       - 5432:5432
     environment:


### PR DESCRIPTION
You may need to remove the old volume first if you have one.

```
docker-compose down --volumes
```

## Why was this change made?

Because PG 10 is far out of date.

## Was the API documentation (openapi.json) updated?

n/a