### PR TITLE
Move shelving to a background job

### DIFF
--- a/app/jobs/shelve_job.rb
+++ b/app/jobs/shelve_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Move files to Stacks in the background
+class ShelveJob < ApplicationJob
+  queue_as :default
+
+  # @param [String] druid the identifier of the item to be published
+  # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
+  def perform(druid:, background_job_result:)
+    background_job_result.processing!
+
+    begin
+      item = Dor.find(druid)
+      ShelvingService.shelve(item)
+    rescue ShelvingService::ContentDirNotFoundError => e
+      background_job_result.output = { errors: [{ title: 'Content directory not found', detail: e.message }] }
+      background_job_result.complete!
+    end
+
+    background_job_result.complete!
+  end
+end

--- a/openapi.json
+++ b/openapi.json
@@ -130,6 +130,7 @@
         ],
         "summary": "Get the manifest of the datastream from SDR",
         "description": "",
+        "deprecated": true,
         "operationId": "sdr#ds_manifest",
         "responses": {
           "200": {
@@ -730,8 +731,17 @@
         "description": "",
         "operationId": "shelves#create",
         "responses": {
-          "204": {
-            "description": "The object was shelved"
+          "201": {
+            "description": "Shelving action started",
+            "headers": {
+              "Location": {
+                "description": "the status of the action is found at this URI",
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
           },
           "422": {
             "description": "The object you provided was not a Dor::Item and could not be shelved",

--- a/spec/jobs/shelve_job_spec.rb
+++ b/spec/jobs/shelve_job_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ShelveJob, type: :job do
+  subject(:perform) { described_class.perform_now(druid: druid, background_job_result: result) }
+
+  let(:druid) { 'druid:mk420bs7601' }
+  let(:result) { create(:background_job_result) }
+  let(:item) { instance_double(Dor::Item) }
+
+  before do
+    allow(Dor).to receive(:find).with(druid).and_return(item)
+    allow(result).to receive(:processing!)
+  end
+
+  context 'with no errors' do
+    before do
+      allow(ShelvingService).to receive(:shelve)
+      perform
+    end
+
+    it 'marks the job as processing' do
+      expect(result).to have_received(:processing!).once
+    end
+
+    it 'invokes the ShelvingService' do
+      expect(ShelvingService).to have_received(:shelve).with(item).once
+    end
+
+    it 'marks the job as complete' do
+      expect(result).to be_complete
+    end
+
+    it 'has no output' do
+      expect(result.output).to be_blank
+    end
+  end
+
+  context 'with errors returned by ShelvingService' do
+    let(:error_message) { "file isn't where we looked" }
+
+    before do
+      allow(ShelvingService).to receive(:shelve).and_raise(ShelvingService::ContentDirNotFoundError, error_message)
+    end
+
+    it 'marks the job as errored' do
+      perform
+      expect(result).to have_received(:processing!).once
+      expect(ShelvingService).to have_received(:shelve).with(item).once
+      expect(result).to be_complete
+      expect(result.output[:errors]).to eq [{ 'detail' => error_message, 'title' => 'Content directory not found' }]
+    end
+  end
+end

--- a/spec/requests/shelving_spec.rb
+++ b/spec/requests/shelving_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Shelve object' do
   before do
     allow(Dor).to receive(:find).and_return(object)
-    allow(ShelvingService).to receive(:shelve)
+    allow(ShelveJob).to receive(:perform_later)
   end
 
   let(:object) { Dor::Item.new(pid: 'druid:1234') }
@@ -18,29 +18,17 @@ RSpec.describe 'Shelve object' do
       expect(response).to have_http_status(:unprocessable_entity)
       json = JSON.parse(response.body)
       expect(json['errors'].first['detail']).to eq("A Dor::Item is required but you provided 'Dor::Collection'")
-      expect(ShelvingService).not_to have_received(:shelve)
+      expect(ShelveJob).not_to have_received(:perform_later)
     end
   end
 
   context 'when the request is successful' do
-    it 'calls ShelvingService and returns 204' do
+    it 'calls ShelvingService and returns201' do
       post '/v1/objects/druid:1234/shelve', headers: { 'Authorization' => "Bearer #{jwt}" }
 
-      expect(response).to have_http_status(:no_content)
-      expect(ShelvingService).to have_received(:shelve)
-    end
-  end
-
-  context "when the file can't be found" do
-    before do
-      allow(ShelvingService).to receive(:shelve).and_raise(ShelvingService::ContentDirNotFoundError, "file isn't where we looked")
-    end
-
-    it 'returns a 422 error' do
-      post '/v1/objects/druid:1234/shelve', headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response).to have_http_status(:unprocessable_entity)
-      json = JSON.parse(response.body)
-      expect(json['errors'].first['detail']).to eq("file isn't where we looked")
+      expect(response).to have_http_status(:created)
+      expect(ShelveJob).to have_received(:perform_later)
+        .with(druid: 'druid:1234', background_job_result: BackgroundJobResult)
     end
   end
 end


### PR DESCRIPTION
So that web archiving shelving jobs don't time out.

## Why was this change made?

Some web archiving jobs were timing out when processing.
Fixes #485

## Was the API documentation (openapi.json) updated?

Yes
