### PR TITLE
Increase pool size so sidekiq doesn't exhaust it

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,3 +17,4 @@ test:
 
 production:
   <<: *default
+  pool: 10 # same as sidekiq concurrency


### PR DESCRIPTION
## Why was this change made?

The pool size was previously 5, but we have 10 workers, so the pool gets exhausted.


## Was the API documentation (openapi.json) updated?
n/a