### PR TITLE
Increase the number of sidekiq processes to 3

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -36,9 +36,9 @@ set :log_level, :info
 set :linked_dirs, %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle config/certs config/settings)
 set :linked_files, %w(bin/write_marc_record config/secrets.yml config/honeybadger.yml config/newrelic.yml config/database.yml)
 
-# Sidekiq configuration (run one process)
+# Sidekiq configuration (run three processes)
 # see sidekiq.yml for concurrency and queue settings
-set :sidekiq_processes, 1
+set :sidekiq_processes, 3
 # All of our deployed environments use RAILS_ENV=production. Without this line,
 # capistrano will run sidekiq in the `stage` or `prod` env (from the capistrano
 # stage rather than the Rails environment).

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,3 @@
-:concurrency: 10
+:concurrency: 6
 :queues:
   - default


### PR DESCRIPTION

## Why was this change made?

Currently running one process and we've pegged out the CPU, but only on one core.
This reduces concurrency on each process but increases the number of processes


## Was the API documentation (openapi.json) updated?
n/a