### PR TITLE
Try releasing and reconnecting to the db

### DIFF
--- a/app/jobs/shelve_job.rb
+++ b/app/jobs/shelve_job.rb
@@ -17,6 +17,12 @@ class ShelveJob < ApplicationJob
       background_job_result.complete!
     end
 
-    background_job_result.complete!
+    # These two lines should be unnecessary, but we are getting:
+    #   "PG::ConnectionBad: PQconsumeInput() could not receive data from server: Connection timed out"
+    # and "PG::UnableToSend: server closed the connection unexpectedly This probably means the server terminated abnormally before or while processing the request"
+    ActiveRecord::Base.connection_pool.release_connection
+    ActiveRecord::Base.connection_pool.with_connection do
+      background_job_result.complete!
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?

The database connection seems to go bad in very long (> 3 hour long jobs)

## Was the API documentation (openapi.json) updated?
n/a