### PR TITLE
Callback to the workflow service when step is complete

### DIFF
--- a/app/jobs/log_failure_job.rb
+++ b/app/jobs/log_failure_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Update the BackgroundJobResult and alert the workflow service
+# This is done as a separate job so that if the work is complete, but there is an
+# error writing to the database or workflow service, we don't have to re-do the work.
+class LogFailureJob < ApplicationJob
+  queue_as :default
+
+  # @param [String] druid the identifier of the item to be published
+  # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
+  # @param [String] workflow_process
+  # @param [Hash] output
+  def perform(druid:, background_job_result:, workflow_process:, output:)
+    background_job_result.output = output
+    background_job_result.complete!
+
+    Dor::Config.workflow.client.update_error_status(druid: druid,
+                                                    workflow: 'accessionWF',
+                                                    process: workflow_process,
+                                                    error_msg: "problem with #{workflow_process} (BackgroundJob: #{background_job_result.id})",
+                                                    error_text: output.inspect)
+  end
+end

--- a/app/jobs/log_success_job.rb
+++ b/app/jobs/log_success_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Update the BackgroundJobResult and alert the workflow service
+# This is done as a separate job so that if the work is complete, but there is an
+# error writing this data, we don't have to re-do the work.
+class LogSuccessJob < ApplicationJob
+  queue_as :default
+
+  # @param [String] druid the identifier of the item to be published
+  # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
+  # @param [String] workflow_process
+  def perform(druid:, background_job_result:, workflow_process:)
+    background_job_result.complete!
+
+    Dor::Config.workflow.client.update_status(druid: druid,
+                                              workflow: 'accessionWF',
+                                              process: workflow_process,
+                                              status: 'completed',
+                                              elapsed: 1,
+                                              note: "Completed Job #{background_job_result.id} on dor-services-app")
+  end
+end

--- a/app/jobs/preserve_job.rb
+++ b/app/jobs/preserve_job.rb
@@ -13,11 +13,12 @@ class PreserveJob < ApplicationJob
       item = Dor.find(druid)
       SdrIngestService.transfer(item)
     rescue StandardError => e
-      background_job_result.output = { errors: [{ title: 'Preservation error', detail: e.message }] }
-      background_job_result.complete!
-      raise e
+      return LogFailureJob.perform_later(druid: druid,
+                                         background_job_result: background_job_result,
+                                         workflow_process: 'sdr-ingest-transfer',
+                                         output: { errors: [{ title: 'Preservation error', detail: e.message }] })
     end
 
-    background_job_result.complete!
+    StartPreservationWorkflowJob.perform_later(druid: druid, background_job_result: background_job_result)
   end
 end

--- a/app/jobs/start_preservation_workflow_job.rb
+++ b/app/jobs/start_preservation_workflow_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Update the BackgroundJobResult and alert the workflow service
+# This is done as a separate job so that if the work is complete, but there is an
+# error writing this data, we don't have to re-do the work.
+class StartPreservationWorkflowJob < ApplicationJob
+  queue_as :default
+
+  # @param [String] druid the identifier of the item to be published
+  # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
+  def perform(druid:, background_job_result:)
+    background_job_result.complete!
+
+    # start SDR preservation workflow
+    Dor::Config.workflow.client.create_workflow_by_name(druid, 'preservationIngestWF')
+  end
+end

--- a/app/services/sdr_ingest_service.rb
+++ b/app/services/sdr_ingest_service.rb
@@ -33,11 +33,6 @@ class SdrIngestService
     bagger.deposit_group('metadata', metadata_dir)
     bagger.create_tagfiles
     verify_bag_structure(bag_dir)
-
-    # start SDR preservation workflow
-    Dor::Config.workflow.client.create_workflow_by_name(druid, 'preservationIngestWF')
-  rescue Exception => e
-    raise Dor::Exception, "Error exporting new object version to bag for #{dor_item.pid}: #{e.message}"
   end
 
   # Note: the following methods should probably all be private

--- a/spec/jobs/log_failure_job_spec.rb
+++ b/spec/jobs/log_failure_job_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LogFailureJob, type: :job do
+  subject(:perform) do
+    described_class.perform_now(druid: druid,
+                                background_job_result: result,
+                                workflow_process: workflow_process,
+                                output: output)
+  end
+
+  let(:output) { { 'errors' => [{ 'title' => 'hah!' }] } }
+  let(:druid) { 'druid:mk420bs7601' }
+  let(:result) { create(:background_job_result) }
+  let(:workflow_process) { 'shelve' }
+
+  before do
+    allow(result).to receive(:complete!)
+    allow(LogFailureJob).to receive(:perform_later)
+    allow(Dor::Config.workflow.client).to receive(:update_error_status)
+  end
+
+  it 'marks the job as errored' do
+    perform
+    expect(result).to have_received(:complete!).once
+    expect(result.output).to eq output
+    expect(Dor::Config.workflow.client).to have_received(:update_error_status)
+  end
+end

--- a/spec/jobs/log_success_job_spec.rb
+++ b/spec/jobs/log_success_job_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LogSuccessJob, type: :job do
+  subject(:perform) do
+    described_class.perform_now(druid: druid,
+                                background_job_result: result,
+                                workflow_process: workflow_process)
+  end
+
+  let(:druid) { 'druid:mk420bs7601' }
+  let(:result) { create(:background_job_result) }
+  let(:workflow_process) { 'shelve' }
+
+  before do
+    allow(result).to receive(:complete!)
+    allow(LogFailureJob).to receive(:perform_later)
+    allow(Dor::Config.workflow.client).to receive(:update_status)
+  end
+
+  it 'marks the job as errored' do
+    perform
+    expect(result).to have_received(:complete!).once
+    expect(Dor::Config.workflow.client).to have_received(:update_status)
+  end
+end

--- a/spec/jobs/start_preservation_workflow_job_spec.rb
+++ b/spec/jobs/start_preservation_workflow_job_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StartPreservationWorkflowJob, type: :job do
+  subject(:perform) do
+    described_class.perform_now(druid: druid,
+                                background_job_result: result)
+  end
+
+  let(:druid) { 'druid:mk420bs7601' }
+  let(:result) { create(:background_job_result) }
+
+  before do
+    allow(result).to receive(:complete!)
+    allow(LogFailureJob).to receive(:perform_later)
+    allow(Dor::Config.workflow.client).to receive(:create_workflow_by_name)
+  end
+
+  it 'marks the job as errored' do
+    perform
+    expect(result).to have_received(:complete!).once
+    expect(Dor::Config.workflow.client).to have_received(:create_workflow_by_name)
+      .with(druid, 'preservationIngestWF')
+  end
+end

--- a/spec/services/sdr_ingest_service_spec.rb
+++ b/spec/services/sdr_ingest_service_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe SdrIngestService do
 
   describe '.transfer' do
     let(:druid) { 'druid:dd116zh0343' }
-    let(:workflow_client) { instance_double(Dor::Workflow::Client, create_workflow_by_name: true) }
     let(:dor_item) { instance_double(Dor::Item, pid: druid) }
     let(:metadata_dir) { fixtures.join('workspace/dd/116/zh/0343/dd116zh0343/metadata') }
 
@@ -73,7 +72,6 @@ RSpec.describe SdrIngestService do
           }
         )
         .to_return(status: 200, body: File.open(fixtures.join('sdr_repo/dd116zh0343/v0001/manifests/signatureCatalog.xml')).read)
-      allow(Dor::Config.workflow).to receive(:client).and_return(workflow_client)
       expect(described_class).to receive(:extract_datastreams).with(dor_item, an_instance_of(DruidTools::Druid)).and_return(metadata_dir)
     end
 
@@ -108,7 +106,6 @@ RSpec.describe SdrIngestService do
                                  'export/dd116zh0343/versionAdditions.xml',
                                  'export/dd116zh0343/versionInventory.xml'
                                ])
-      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'preservationIngestWF')
     end
 
     specify 'with no change in content' do
@@ -137,7 +134,6 @@ RSpec.describe SdrIngestService do
                                  'export/dd116zh0343/versionAdditions.xml',
                                  'export/dd116zh0343/versionInventory.xml'
                                ])
-      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'preservationIngestWF')
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

This avoids the need for common-accessioning to poll for job completion

Depends on https://github.com/sul-dlss/workflow-server-rails/pull/271

## Was the API documentation (openapi.json) updated?
