### PR TITLE
Provide better error messages for reset workspace

### DIFF
--- a/app/services/reset_workspace_service.rb
+++ b/app/services/reset_workspace_service.rb
@@ -2,6 +2,11 @@
 
 # Rename the druid trees  at the end of the accessionWF in order to be cleaned/deleted later.
 class ResetWorkspaceService
+  class DirectoryAlreadyExists < StandardError; end
+  class BagAlreadyExists < StandardError; end
+
+  # @raises [DirectoryAlreadyExists] if the archived directory already exists
+  # @raises [BagAlreadyExists] if the bag for this version already exists
   def self.reset(druid:, version:)
     reset_workspace_druid_tree(druid: druid, version: version, workspace_root: Dor::Config.stacks.local_workspace_root)
     reset_export_bag(druid: druid, version: version, export_root: Settings.sdr.local_export_home)
@@ -10,7 +15,7 @@ class ResetWorkspaceService
   def self.reset_workspace_druid_tree(druid:, version:, workspace_root:)
     druid_tree_path = DruidTools::Druid.new(druid, workspace_root).pathname.to_s
 
-    raise "The archived directory #{druid_tree_path}_v#{version} already existed." if File.exist?("#{druid_tree_path}_v#{version}")
+    raise DirectoryAlreadyExists, "The archived directory #{druid_tree_path}_v#{version} already existed." if File.exist?("#{druid_tree_path}_v#{version}")
 
     # If the file doesn't exist it is a truncated tree where we shouldn't do anything
     return unless File.exist?(druid_tree_path)
@@ -22,7 +27,7 @@ class ResetWorkspaceService
     id = druid.split(':').last
     bag_dir = File.join(export_root, id)
 
-    raise "The archived bag #{bag_dir}_v#{version} already existed." if File.exist?("#{bag_dir}_v#{version}")
+    raise BagAlreadyExists, "The archived bag #{bag_dir}_v#{version} already existed." if File.exist?("#{bag_dir}_v#{version}")
 
     FileUtils.mv(bag_dir, "#{bag_dir}_v#{version}") if File.exist?(bag_dir)
 

--- a/openapi.json
+++ b/openapi.json
@@ -681,6 +681,16 @@
         "responses": {
           "204": {
             "description": "OK"
+          },
+          "422": {
+            "description": "The workspace was in a state where it could not be reset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         },
         "parameters": [

--- a/spec/controllers/workspaces_controller_spec.rb
+++ b/spec/controllers/workspaces_controller_spec.rb
@@ -61,21 +61,4 @@ RSpec.describe WorkspacesController do
       end
     end
   end
-
-  describe '#reset' do
-    before do
-      login
-      allow(ResetWorkspaceService).to receive(:reset)
-      allow(Dor).to receive(:find).and_return(item)
-    end
-
-    let(:druid) { 'druid:aa222cc3333' }
-    let(:item) { instance_double(Dor::Item, current_version: 2) }
-
-    it 'is successful' do
-      post :reset, params: { object_id: druid }
-      expect(ResetWorkspaceService).to have_received(:reset).with(druid: druid, version: 2)
-      expect(response).to be_no_content
-    end
-  end
 end

--- a/spec/requests/reset_workspace_spec.rb
+++ b/spec/requests/reset_workspace_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Reset workspace' do
+  let(:item) { instance_double(Dor::Item, current_version: 2) }
+  let(:druid) { 'druid:aa222cc3333' }
+
+  before do
+    allow(Dor).to receive(:find).and_return(item)
+  end
+
+  context 'when the request is succcessful' do
+    before do
+      allow(ResetWorkspaceService).to receive(:reset)
+    end
+
+    it 'is successful' do
+      post "/v1/objects/#{druid}/workspace/reset", headers: { 'Authorization' => "Bearer #{jwt}" }
+
+      expect(ResetWorkspaceService).to have_received(:reset).with(druid: druid, version: 2)
+      expect(response).to be_no_content
+    end
+  end
+
+  context 'when an archive directory exists' do
+    let(:errmsg) { '{"errors":[{"status":"422","title":"Archive directory already exists","detail":"dir already exists"}]}' }
+
+    before do
+      allow(ResetWorkspaceService).to receive(:reset)
+        .and_raise(ResetWorkspaceService::DirectoryAlreadyExists.new('dir already exists'))
+    end
+
+    it 'returns a 422 error' do
+      post "/v1/objects/#{druid}/workspace/reset", headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response.status).to eq(422)
+      expect(response.body).to eq(errmsg)
+    end
+  end
+
+  context 'when an archive bag exists' do
+    let(:errmsg) { '{"errors":[{"status":"422","title":"Archive bag already exists","detail":"bag already exists"}]}' }
+
+    before do
+      allow(ResetWorkspaceService).to receive(:reset)
+        .and_raise(ResetWorkspaceService::BagAlreadyExists.new('bag already exists'))
+    end
+
+    it 'returns a 422 error' do
+      post "/v1/objects/#{druid}/workspace/reset", headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response.status).to eq(422)
+      expect(response.body).to eq(errmsg)
+    end
+  end
+end

--- a/spec/services/reset_workspace_service_spec.rb
+++ b/spec/services/reset_workspace_service_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe ResetWorkspaceService do
     end
 
     it 'throws an error if the directory is already archived' do
-      expect { described_class.reset_workspace_druid_tree(druid: archived_druid, version: '2', workspace_root: workspace_root) }.to raise_error(RuntimeError)
+      expect { described_class.reset_workspace_druid_tree(druid: archived_druid, version: '2', workspace_root: workspace_root) }
+        .to raise_error(ResetWorkspaceService::DirectoryAlreadyExists)
     end
 
     it "archiveds the current directory even if there is an older archived that hasn't been cleaned up" do
@@ -85,7 +86,8 @@ RSpec.describe ResetWorkspaceService do
       create_bag_dir(existent_id)
       bag_path = "#{export_root}/#{existent_id}"
       FileUtils.mv(bag_path, "#{bag_path}_v2") unless File.exist?(bag_path + '_v2')
-      expect { described_class.reset_export_bag(druid: existent_druid, version: '2', export_root: export_root) }.to raise_error(RuntimeError)
+      expect { described_class.reset_export_bag(druid: existent_druid, version: '2', export_root: export_root) }
+        .to raise_error(ResetWorkspaceService::BagAlreadyExists)
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Previously it was just giving a 500 error without context or a helpful message.


## Was the API documentation (openapi.json) updated?

Yes.