### PR TITLE
Provide error handling for when the directory can't be deleted

### DIFF
--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -21,7 +21,7 @@ class WorkspacesController < ApplicationController
       CleanupService.cleanup_by_druid druid
     end
     head :no_content
-  rescue Errno::ENOENT => e
+  rescue Errno::ENOENT, Errno::ENOTEMPTY => e
     render build_error('Unable to remove directory', e)
   end
 

--- a/app/services/cleanup_service.rb
+++ b/app/services/cleanup_service.rb
@@ -13,6 +13,7 @@ class CleanupService
   # @param [String] druid The identifier for the object whose data is to be removed
   # @param [String] base The base directory to delete from
   # @return [void] remove the object's data files from the workspace area
+  # @raises [Errno::ENOTEMPTY] if the directory is not empty
   def self.cleanup_workspace_content(druid, base)
     PruneService.new(druid: DruidTools::Druid.new(druid, base)).prune!
   end

--- a/app/services/prune_service.rb
+++ b/app/services/prune_service.rb
@@ -7,6 +7,7 @@ class PruneService
     @druid = druid
   end
 
+  # @raises [Errno::ENOTEMPTY] if the directory is not empty
   def prune!
     this_path = druid.pathname
     parent = this_path.parent

--- a/spec/requests/cleanup_workspace_spec.rb
+++ b/spec/requests/cleanup_workspace_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Cleanup workspace' do
     end
   end
 
-  context 'when an error is raised' do
+  context "when the directory doesn't exist" do
     before do
       allow(CleanupService).to receive(:cleanup_by_druid)
         .and_raise(Errno::ENOENT, 'dir_s_rmdir - /dor/workspace/aa/222')
@@ -31,6 +31,23 @@ RSpec.describe 'Cleanup workspace' do
       expect(response.body).to eq(
         '{"errors":[{"status":"422","title":"Unable to remove directory",' \
         '"detail":"No such file or directory - dir_s_rmdir - /dor/workspace/aa/222"}]}'
+      )
+    end
+  end
+
+  context 'when the directory is not empty' do
+    before do
+      allow(CleanupService).to receive(:cleanup_by_druid)
+        .and_raise(Errno::ENOTEMPTY, 'dir_s_rmdir - /dor/assembly/pw/569/pw/4290')
+    end
+
+    it 'returns JSON-API error' do
+      delete "/v1/objects/#{object_id}/workspace",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to eq(
+        '{"errors":[{"status":"422","title":"Unable to remove directory",' \
+        '"detail":"Directory not empty - dir_s_rmdir - /dor/assembly/pw/569/pw/4290"}]}'
       )
     end
   end


### PR DESCRIPTION
## Why was this change made?
Better errors when a directory can't be deleted.


## Was the API documentation (openapi.json) updated?
n/a