### PR TITLE
Allow the release workflow to be notified that publish is comple…

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -42,7 +42,10 @@ class ObjectsController < ApplicationController
 
   def publish
     result = BackgroundJobResult.create
-    PublishJob.perform_later(druid: params[:id], background_job_result: result)
+    workflow = params[:workflow] || 'accessionWF'
+    raise "invalid workflow #{workflow}" unless %w[accessionWF releaseWF].include?(workflow)
+
+    PublishJob.perform_later(druid: params[:id], background_job_result: result, workflow: workflow)
     head :created, location: result
   end
 

--- a/app/jobs/log_success_job.rb
+++ b/app/jobs/log_success_job.rb
@@ -8,12 +8,13 @@ class LogSuccessJob < ApplicationJob
 
   # @param [String] druid the identifier of the item to be published
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
+  # @param [String] workflow ('accessionWF') Which workflow should this be reported to
   # @param [String] workflow_process
-  def perform(druid:, background_job_result:, workflow_process:)
+  def perform(druid:, background_job_result:, workflow: 'accessionWF', workflow_process:)
     background_job_result.complete!
 
     Dor::Config.workflow.client.update_status(druid: druid,
-                                              workflow: 'accessionWF',
+                                              workflow: workflow,
                                               process: workflow_process,
                                               status: 'completed',
                                               elapsed: 1,

--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-# Create virtual objects in the background
+# Create virtual objects in the background.
+# Both accessionWF and releaseWF use this step.
 class PublishJob < ApplicationJob
   queue_as :default
 
   # @param [String] druid the identifier of the item to be published
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
-  def perform(druid:, background_job_result:)
+  # @param [String] workflow ('accessionWF') Which workflow should this be reported to?
+  def perform(druid:, background_job_result:, workflow: 'accessionWF')
     background_job_result.processing!
 
     begin
@@ -21,6 +23,7 @@ class PublishJob < ApplicationJob
 
     LogSuccessJob.perform_later(druid: druid,
                                 background_job_result: background_job_result,
+                                workflow: workflow,
                                 workflow_process: 'publish-complete')
   end
 end

--- a/openapi.json
+++ b/openapi.json
@@ -380,6 +380,16 @@
             "schema": {
               "$ref": "#/components/schemas/Druid"
             }
+          },
+          {
+            "name": "workflow",
+            "in": "query",
+            "description": "which workflow should this be reported to",
+            "schema": {
+              "type": "string",
+              "enum": ["accessionWF", "releaseWF"],
+              "example": "releaseWF"
+            },
           }
         ]
       }

--- a/spec/jobs/publish_job_spec.rb
+++ b/spec/jobs/publish_job_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe PublishJob, type: :job do
     end
 
     it 'marks the job as complete' do
-      expect(LogSuccessJob).to have_received(:perform_later).with(druid: druid, background_job_result: result, workflow_process: 'publish-complete')
+      expect(LogSuccessJob).to have_received(:perform_later)
+        .with(druid: druid, background_job_result: result, workflow: 'accessionWF', workflow_process: 'publish-complete')
     end
   end
 

--- a/spec/requests/publish_object_spec.rb
+++ b/spec/requests/publish_object_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe 'Publish object' do
   end
 
   it 'calls PublishMetadataService and returns 201' do
-    post '/v1/objects/druid:1234/publish', headers: { 'Authorization' => "Bearer #{jwt}" }
+    post '/v1/objects/druid:1234/publish?workflow=releaseWF', headers: { 'Authorization' => "Bearer #{jwt}" }
 
-    expect(PublishJob).to have_received(:perform_later).with(druid: 'druid:1234', background_job_result: BackgroundJobResult)
+    expect(PublishJob).to have_received(:perform_later)
+      .with(druid: 'druid:1234', background_job_result: BackgroundJobResult, workflow: 'releaseWF')
     expect(response.status).to eq(201)
   end
 end


### PR DESCRIPTION
## Why was this change made?
Publish is used for both releaseWF and accessionWF, but we were always notifying the accessionWF that the job was complete.


## Was the API documentation (openapi.json) updated?
Yes