### PR TITLE
Handle the case where argo triggers publish

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -40,10 +40,13 @@ class ObjectsController < ApplicationController
     render json: Cocina::Mapper.build(@item)
   end
 
+  # called from Argo, the accessionWF and from the releaseWF.
+  # Takes an optional 'workflow' argument, which will call back to
+  # the 'publish-complete' step of that workflow if provided
   def publish
     result = BackgroundJobResult.create
-    workflow = params[:workflow] || 'accessionWF'
-    raise "invalid workflow #{workflow}" unless %w[accessionWF releaseWF].include?(workflow)
+    workflow = params[:workflow]
+    raise "invalid workflow #{workflow}" if workflow && !%w[accessionWF releaseWF].include?(workflow)
 
     PublishJob.perform_later(druid: params[:id], background_job_result: result, workflow: workflow)
     head :created, location: result

--- a/app/jobs/log_failure_job.rb
+++ b/app/jobs/log_failure_job.rb
@@ -8,14 +8,16 @@ class LogFailureJob < ApplicationJob
 
   # @param [String] druid the identifier of the item to be published
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
+  # @param [String,NilClass] workflow if present, which workflow to report to
   # @param [String] workflow_process
   # @param [Hash] output
-  def perform(druid:, background_job_result:, workflow_process:, output:)
+  def perform(druid:, background_job_result:, workflow:, workflow_process:, output:)
     background_job_result.output = output
     background_job_result.complete!
+    return unless workflow
 
     Dor::Config.workflow.client.update_error_status(druid: druid,
-                                                    workflow: 'accessionWF',
+                                                    workflow: workflow,
                                                     process: workflow_process,
                                                     error_msg: "problem with #{workflow_process} (BackgroundJob: #{background_job_result.id})",
                                                     error_text: output.inspect)

--- a/app/jobs/log_success_job.rb
+++ b/app/jobs/log_success_job.rb
@@ -8,9 +8,9 @@ class LogSuccessJob < ApplicationJob
 
   # @param [String] druid the identifier of the item to be published
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
-  # @param [String] workflow ('accessionWF') Which workflow should this be reported to
+  # @param [String,NilClass] workflow If provided, which workflow should this be reported to
   # @param [String] workflow_process
-  def perform(druid:, background_job_result:, workflow: 'accessionWF', workflow_process:)
+  def perform(druid:, background_job_result:, workflow:, workflow_process:)
     background_job_result.complete!
 
     Dor::Config.workflow.client.update_status(druid: druid,

--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -7,8 +7,8 @@ class PublishJob < ApplicationJob
 
   # @param [String] druid the identifier of the item to be published
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
-  # @param [String] workflow ('accessionWF') Which workflow should this be reported to?
-  def perform(druid:, background_job_result:, workflow: 'accessionWF')
+  # @param [String] workflow Which workflow should this be reported to?
+  def perform(druid:, background_job_result:, workflow:)
     background_job_result.processing!
 
     begin
@@ -17,7 +17,8 @@ class PublishJob < ApplicationJob
     rescue Dor::DataError => e
       return LogFailureJob.perform_later(druid: druid,
                                          background_job_result: background_job_result,
-                                         workflow_process: 'publish',
+                                         workflow: workflow,
+                                         workflow_process: workflow == 'accessionWF' ? 'publish' : 'release-publish',
                                          output: { errors: [{ title: 'Data error', detail: e.message }] })
     end
 

--- a/app/jobs/shelve_job.rb
+++ b/app/jobs/shelve_job.rb
@@ -15,6 +15,7 @@ class ShelveJob < ApplicationJob
     rescue ShelvingService::ContentDirNotFoundError => e
       return LogFailureJob.perform_later(druid: druid,
                                          background_job_result: background_job_result,
+                                         workflow: 'accessionWF',
                                          workflow_process: 'shelve',
                                          output: { errors: [{ title: 'Content directory not found', detail: e.message }] })
     end

--- a/spec/jobs/log_failure_job_spec.rb
+++ b/spec/jobs/log_failure_job_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe LogFailureJob, type: :job do
   subject(:perform) do
     described_class.perform_now(druid: druid,
                                 background_job_result: result,
+                                workflow: workflow,
                                 workflow_process: workflow_process,
                                 output: output)
   end
@@ -21,10 +22,25 @@ RSpec.describe LogFailureJob, type: :job do
     allow(Dor::Config.workflow.client).to receive(:update_error_status)
   end
 
-  it 'marks the job as errored' do
-    perform
-    expect(result).to have_received(:complete!).once
-    expect(result.output).to eq output
-    expect(Dor::Config.workflow.client).to have_received(:update_error_status)
+  context 'when workflow is provided' do
+    let(:workflow) { 'accessionWF' }
+
+    it 'marks the job as errored' do
+      perform
+      expect(result).to have_received(:complete!).once
+      expect(result.output).to eq output
+      expect(Dor::Config.workflow.client).to have_received(:update_error_status)
+    end
+  end
+
+  context 'when workflow is not provided' do
+    let(:workflow) { nil }
+
+    it 'marks the job as errored' do
+      perform
+      expect(result).to have_received(:complete!).once
+      expect(result.output).to eq output
+      expect(Dor::Config.workflow.client).not_to have_received(:update_error_status)
+    end
   end
 end

--- a/spec/jobs/log_success_job_spec.rb
+++ b/spec/jobs/log_success_job_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe LogSuccessJob, type: :job do
   subject(:perform) do
     described_class.perform_now(druid: druid,
                                 background_job_result: result,
+                                workflow: workflow,
                                 workflow_process: workflow_process)
   end
 
@@ -19,9 +20,23 @@ RSpec.describe LogSuccessJob, type: :job do
     allow(Dor::Config.workflow.client).to receive(:update_status)
   end
 
-  it 'marks the job as errored' do
-    perform
-    expect(result).to have_received(:complete!).once
-    expect(Dor::Config.workflow.client).to have_received(:update_status)
+  context 'when workflow is provided' do
+    let(:workflow) { 'accessionWF' }
+
+    it 'marks the job as complete' do
+      perform
+      expect(result).to have_received(:complete!).once
+      expect(Dor::Config.workflow.client).to have_received(:update_status)
+    end
+  end
+
+  context 'when workflow is not provided' do
+    let(:workflow) { nil }
+
+    it 'marks the job as complete' do
+      perform
+      expect(result).to have_received(:complete!).once
+      expect(Dor::Config.workflow.client).to have_received(:update_status)
+    end
   end
 end

--- a/spec/jobs/publish_job_spec.rb
+++ b/spec/jobs/publish_job_spec.rb
@@ -3,11 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe PublishJob, type: :job do
-  subject(:perform) { described_class.perform_now(druid: druid, background_job_result: result) }
+  subject(:perform) do
+    described_class.perform_now(druid: druid, background_job_result: result, workflow: workflow)
+  end
 
   let(:druid) { 'druid:mk420bs7601' }
   let(:result) { create(:background_job_result) }
   let(:item) { instance_double(Dor::Item) }
+  let(:workflow) { 'accessionWF' }
 
   before do
     allow(Dor).to receive(:find).with(druid).and_return(item)
@@ -56,6 +59,7 @@ RSpec.describe PublishJob, type: :job do
       expect(LogFailureJob).to have_received(:perform_later)
         .with(druid: druid,
               background_job_result: result,
+              workflow: 'accessionWF',
               workflow_process: 'publish',
               output: { errors: [{ detail: error_message, title: 'Data error' }] })
     end

--- a/spec/jobs/shelve_job_spec.rb
+++ b/spec/jobs/shelve_job_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe ShelveJob, type: :job do
       expect(LogFailureJob).to have_received(:perform_later)
         .with(druid: druid,
               background_job_result: result,
+              workflow: 'accessionWF',
               workflow_process: 'shelve',
               output: { errors: [{ detail: error_message, title: 'Content directory not found' }] })
     end

--- a/spec/requests/publish_object_spec.rb
+++ b/spec/requests/publish_object_spec.rb
@@ -10,11 +10,32 @@ RSpec.describe 'Publish object' do
     allow(PublishJob).to receive(:perform_later)
   end
 
-  it 'calls PublishMetadataService and returns 201' do
-    post '/v1/objects/druid:1234/publish?workflow=releaseWF', headers: { 'Authorization' => "Bearer #{jwt}" }
+  context 'with a workflow provided' do
+    it 'calls PublishMetadataService and returns 201' do
+      post '/v1/objects/druid:1234/publish?workflow=releaseWF', headers: { 'Authorization' => "Bearer #{jwt}" }
 
-    expect(PublishJob).to have_received(:perform_later)
-      .with(druid: 'druid:1234', background_job_result: BackgroundJobResult, workflow: 'releaseWF')
-    expect(response.status).to eq(201)
+      expect(PublishJob).to have_received(:perform_later)
+        .with(druid: 'druid:1234', background_job_result: BackgroundJobResult, workflow: 'releaseWF')
+      expect(response.status).to eq(201)
+    end
+  end
+
+  context 'with an invalid workflow provided' do
+    it 'calls PublishMetadataService and returns 201' do
+      expect do
+        post '/v1/objects/druid:1234/publish?workflow=badWF', headers: { 'Authorization' => "Bearer #{jwt}" }
+      end.to raise_error('invalid workflow badWF')
+    end
+  end
+
+  context 'without a workflow provided' do
+    # This happens when Argo invokes the API
+    it 'calls PublishMetadataService and returns 201' do
+      post '/v1/objects/druid:1234/publish', headers: { 'Authorization' => "Bearer #{jwt}" }
+
+      expect(PublishJob).to have_received(:perform_later)
+        .with(druid: 'druid:1234', background_job_result: BackgroundJobResult, workflow: nil)
+      expect(response.status).to eq(201)
+    end
   end
 end


### PR DESCRIPTION
Where there is no workflow to call back to

## Why was this change made?

We hadn't considered the case where Argo can do a publish outside of a workflow.


## Was the API documentation (openapi.json) updated?
n/a
