### PR TITLE
ShelveJob should provide a workflow for logging

### DIFF
--- a/app/jobs/log_success_job.rb
+++ b/app/jobs/log_success_job.rb
@@ -10,7 +10,7 @@ class LogSuccessJob < ApplicationJob
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
   # @param [String,NilClass] workflow If provided, which workflow should this be reported to
   # @param [String] workflow_process
-  def perform(druid:, background_job_result:, workflow:, workflow_process:)
+  def perform(druid:, background_job_result:, workflow: 'accessionWF', workflow_process:)
     background_job_result.complete!
 
     Dor::Config.workflow.client.update_status(druid: druid,

--- a/app/jobs/shelve_job.rb
+++ b/app/jobs/shelve_job.rb
@@ -21,6 +21,7 @@ class ShelveJob < ApplicationJob
     end
 
     LogSuccessJob.perform_later(druid: druid,
+                                workflow: 'accessionWF',
                                 background_job_result: background_job_result,
                                 workflow_process: 'shelve-complete')
   end

--- a/spec/jobs/shelve_job_spec.rb
+++ b/spec/jobs/shelve_job_spec.rb
@@ -30,7 +30,11 @@ RSpec.describe ShelveJob, type: :job do
     end
 
     it 'marks the job as complete' do
-      expect(LogSuccessJob).to have_received(:perform_later).with(druid: druid, background_job_result: result, workflow_process: 'shelve-complete')
+      expect(LogSuccessJob).to have_received(:perform_later)
+        .with(druid: druid,
+              background_job_result: result,
+              workflow: 'accessionWF',
+              workflow_process: 'shelve-complete')
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

The LogSuccessJob should always receive a workflow argument (which can be nil)

## Was the API documentation (openapi.json) updated?
n/a