### PR TITLE
Don't update the workflow service if this job is not part of a w…

### DIFF
--- a/app/jobs/log_success_job.rb
+++ b/app/jobs/log_success_job.rb
@@ -10,8 +10,10 @@ class LogSuccessJob < ApplicationJob
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
   # @param [String,NilClass] workflow If provided, which workflow should this be reported to
   # @param [String] workflow_process
-  def perform(druid:, background_job_result:, workflow: 'accessionWF', workflow_process:)
+  def perform(druid:, background_job_result:, workflow:, workflow_process:)
     background_job_result.complete!
+
+    return unless workflow
 
     Dor::Config.workflow.client.update_status(druid: druid,
                                               workflow: workflow,

--- a/spec/jobs/log_success_job_spec.rb
+++ b/spec/jobs/log_success_job_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe LogSuccessJob, type: :job do
     it 'marks the job as complete' do
       perform
       expect(result).to have_received(:complete!).once
-      expect(Dor::Config.workflow.client).to have_received(:update_status)
+      expect(Dor::Config.workflow.client).not_to have_received(:update_status)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

So that we don't try to update workflows when work is not part of a workflow.


## Was the API documentation (openapi.json) updated?

N/A.