### PR TITLE
add info from Dry::Struct::Error to 500 errors in objects#show

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -15,6 +15,10 @@ class ObjectsController < ApplicationController
     render status: :conflict, plain: e.message, location: object_location(e.pid)
   end
 
+  rescue_from(Dry::Struct::Error) do |e|
+    render status: :internal_server_error, plain: e.message
+  end
+
   rescue_from(SymphonyReader::ResponseError) do |e|
     render status: :internal_server_error, plain: e.message
   end


### PR DESCRIPTION
## Why was this change made?

To surface better error info to the caller (e.g. argo) when objects fail cocina model validation

Current error messages suck:

for argo:  (https://app.honeybadger.io/projects/49894/faults/57442187)

```
Dor::Services::Client::UnexpectedResponse: Internal Server Error: 500 (Response from dor-services-app did not contain a body.                         Check honeybadger for dor-services-app for backtraces,                         and look into adding a `rescue_from` in dor-services-app                         to provide more details to the client in the future)
```

same reflected in dor-services-app: (https://app.honeybadger.io/projects/50568/faults/57389070)

```
Dry::Struct::Error: [Cocina::Models::DRO.new] nil (NilClass) has invalid type for :label violates constraints (type?(String, nil) failed)
```

## Was the API documentation (openapi.json) updated?

n/a