### PR TITLE
Callback when preservation ingest has started

### DIFF
--- a/app/jobs/start_preservation_workflow_job.rb
+++ b/app/jobs/start_preservation_workflow_job.rb
@@ -9,9 +9,12 @@ class StartPreservationWorkflowJob < ApplicationJob
   # @param [String] druid the identifier of the item to be published
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
   def perform(druid:, background_job_result:)
-    background_job_result.complete!
-
     # start SDR preservation workflow
     Dor::Config.workflow.client.create_workflow_by_name(druid, 'preservationIngestWF')
+
+    LogSuccessJob.perform_later(druid: druid,
+                                workflow: 'accessionWF',
+                                background_job_result: background_job_result,
+                                workflow_process: 'preservation-ingest-initiated')
   end
 end

--- a/app/services/sdr_ingest_service.rb
+++ b/app/services/sdr_ingest_service.rb
@@ -118,7 +118,7 @@ class SdrIngestService
   # @return [Integer] the versionId found in the last version element, or nil if missing
   def self.vmfile_version_id(pathname)
     verify_pathname(pathname)
-    doc = Nokogiri::XML(File.open(pathname.to_s))
+    doc = Nokogiri::XML(File.read(pathname.to_s))
     nodeset = doc.xpath('/versionMetadata/version')
     version_id = nodeset.last['versionId']
     version_id.nil? ? nil : version_id.to_i

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,6 +29,7 @@ solr:
 workflow_url: 'https://workflow.example.com/workflow'
 sdr_url: 'http://user:password@sdr-services.example.com/sdr'
 sdr:
+  local_workspace_root: /dor/workspace
   local_export_home: /dor/export
 
 preservation_catalog:

--- a/spec/jobs/start_preservation_workflow_job_spec.rb
+++ b/spec/jobs/start_preservation_workflow_job_spec.rb
@@ -12,15 +12,20 @@ RSpec.describe StartPreservationWorkflowJob, type: :job do
   let(:result) { create(:background_job_result) }
 
   before do
-    allow(result).to receive(:complete!)
-    allow(LogFailureJob).to receive(:perform_later)
+    allow(LogSuccessJob).to receive(:perform_later)
     allow(Dor::Config.workflow.client).to receive(:create_workflow_by_name)
   end
 
-  it 'marks the job as errored' do
+  it 'marks the job as success' do
     perform
-    expect(result).to have_received(:complete!).once
     expect(Dor::Config.workflow.client).to have_received(:create_workflow_by_name)
       .with(druid, 'preservationIngestWF')
+    expect(LogSuccessJob).to have_received(:perform_later)
+      .with(
+        druid: druid,
+        background_job_result: result,
+        workflow: 'accessionWF',
+        workflow_process: 'preservation-ingest-initiated'
+      )
   end
 end


### PR DESCRIPTION
## Why was this change made?

So that the workflow server can log some record that this job finished successfully.

Ref https://github.com/sul-dlss/workflow-server-rails/pull/293

## Was the API documentation (openapi.json) updated?
n/a