### PR TITLE
Validate that object is valid before saving.

### DIFF
--- a/app/controllers/metadata_refresh_controller.rb
+++ b/app/controllers/metadata_refresh_controller.rb
@@ -10,6 +10,14 @@ class MetadataRefreshController < ApplicationController
 
   def refresh
     status = RefreshMetadataAction.run(@item)
-    @item.save if status
+    return render status: :internal_server_error, plain: "#{@item.pid} descMetadata missing required fields (<title>)" if missing_required_fields?
+
+    @item.save! if status
+  end
+
+  private
+
+  def missing_required_fields?
+    @item.descMetadata.mods_title.blank?
   end
 end

--- a/app/services/legacy_metadata_service.rb
+++ b/app/services/legacy_metadata_service.rb
@@ -6,10 +6,17 @@ class LegacyMetadataService
   # If the updated value is newer than then createDate of the datastream, then update it.
   def self.update_datastream_if_newer(datastream:, updated:, content:)
     datastream.content = content if !datastream.createDate || updated > datastream.createDate
+    validate_desc_metadata(datastream) if datastream.dsid == 'descMetadata'
+
     return if !datastream.createDate || updated > datastream.createDate
 
     Honeybadger.notify("Found #{datasteam.pid}/#{datastream.dsid} that had a create " \
       "date (#{datastream.createDate}) after the file was modified (#{updated}). " \
       'Doing an experiment to see if this ever happens.')
   end
+
+  def self.validate_desc_metadata(datastream)
+    raise "#{datastream.pid} descMetadata missing required fields (<title>)" if datastream.mods_title.blank?
+  end
+  private_class_method :validate_desc_metadata
 end

--- a/app/services/refresh_metadata_action.rb
+++ b/app/services/refresh_metadata_action.rb
@@ -12,6 +12,7 @@ class RefreshMetadataAction
   end
 
   # Returns nil if it didn't retrieve anything
+  # @param [DescMetadataDS] datastream the descriptive metadata
   def run(datastream)
     content = fetch_datastream
     return nil if content.nil?

--- a/spec/requests/metadata_refresh_spec.rb
+++ b/spec/requests/metadata_refresh_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'Refresh metadata' do
 
   context 'when happy path' do
     before do
+      object.descMetadata.mods_title = ['one title']
       allow(RefreshMetadataAction).to receive(:run).and_return('<xml />')
     end
 
@@ -21,6 +22,21 @@ RSpec.describe 'Refresh metadata' do
       expect(response).to be_successful
       expect(RefreshMetadataAction).to have_received(:run).with(object)
       expect(object).to have_received(:save)
+    end
+  end
+
+  context "when the item doesn't get a title" do
+    before do
+      allow(RefreshMetadataAction).to receive(:run).and_return('<xml />')
+    end
+
+    it 'raises an error' do
+      post '/v1/objects/druid:mk420bs7601/refresh_metadata',
+           headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response.status).to eq(500)
+      expect(response.body).to eq('druid:1234 descMetadata missing required fields (<title>)')
+      expect(RefreshMetadataAction).to have_received(:run).with(object)
+      expect(object).not_to have_received(:save)
     end
   end
 

--- a/spec/services/legacy_metadata_service_spec.rb
+++ b/spec/services/legacy_metadata_service_spec.rb
@@ -8,7 +8,14 @@ RSpec.describe LegacyMetadataService do
 
     let(:updated) { Time.zone.parse('2019-08-09T19:18:15Z') }
     let(:content) { '<descMetadata><foo/></descMetadata>' }
-    let(:datastream) { instance_double(Dor::DescMetadataDS, createDate: create_date, :content= => nil) }
+    let(:title) { ['One title'] }
+    let(:datastream) do
+      instance_double(Dor::DescMetadataDS, createDate: create_date,
+                                           dsid: 'descMetadata',
+                                           pid: 'druid:123',
+                                           :content= => nil,
+                                           mods_title: title)
+    end
 
     context 'with a new datastream' do
       let(:create_date) { nil }
@@ -25,6 +32,15 @@ RSpec.describe LegacyMetadataService do
       it 'updates the content' do
         update
         expect(datastream).to have_received(:content=).with(content)
+      end
+    end
+
+    context 'with an invalid datastream' do
+      let(:create_date) { Time.zone.parse('2019-07-09T19:18:15Z') }
+      let(:title) { [] }
+
+      it 'raises an error' do
+        expect { update }.to raise_error 'druid:123 descMetadata missing required fields (<title>)'
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

This catches problems earlier than when this was done in common-accessioning



## Was the API documentation (openapi.json) updated?
n/a