### PR TITLE
return metadata identifiers in preferred order

### DIFF
--- a/app/services/metadata_service.rb
+++ b/app/services/metadata_service.rb
@@ -9,9 +9,14 @@ class MetadataService
   class << self
     @@cache = Cache.new(nil, nil, 250, 300)
 
-    # TODO: Return a prioritized list
+    def known_prefixes
+      handlers.keys
+    end
+
+    # return the identifiers found in the same order of the known prefixes we specified
     def resolvable(identifiers)
-      identifiers.select { |identifier| can_resolve?(identifier) }
+      res_ids = identifiers.select { |identifier| can_resolve?(identifier) }
+      MetadataService.known_prefixes.map { |prefix| res_ids.find { |res_id| res_id.start_with?(prefix.to_s) } }.compact
     end
 
     def fetch(identifier)

--- a/app/services/metadata_service.rb
+++ b/app/services/metadata_service.rb
@@ -13,6 +13,8 @@ class MetadataService
     def resolvable(identifiers)
       res_ids = identifiers.select { |identifier| can_resolve?(identifier) }
       VALID_PREFIXES.map { |prefix| res_ids.find { |res_id| res_id.start_with?(prefix.to_s) } }.compact
+      # NOTE: the purpose of .map here is to ensure we return any resolvable identifiers in the
+      #       preferred order specified above in KNOWN_PREFIXES, so that the .first is the preferred one
     end
 
     def fetch(identifier)

--- a/app/services/metadata_service.rb
+++ b/app/services/metadata_service.rb
@@ -9,14 +9,10 @@ class MetadataService
   class << self
     @@cache = Cache.new(nil, nil, 250, 300)
 
-    def known_prefixes
-      handlers.keys
-    end
-
     # return the identifiers found in the same order of the known prefixes we specified
     def resolvable(identifiers)
       res_ids = identifiers.select { |identifier| can_resolve?(identifier) }
-      MetadataService.known_prefixes.map { |prefix| res_ids.find { |res_id| res_id.start_with?(prefix.to_s) } }.compact
+      VALID_PREFIXES.map { |prefix| res_ids.find { |res_id| res_id.start_with?(prefix.to_s) } }.compact
     end
 
     def fetch(identifier)

--- a/app/services/refresh_metadata_action.rb
+++ b/app/services/refresh_metadata_action.rb
@@ -27,6 +27,6 @@ class RefreshMetadataAction
   def fetch_datastream
     candidates = @object.identityMetadata.otherId.collect(&:to_s)
     metadata_id = MetadataService.resolvable(candidates).first
-    metadata_id.blank? ? nil : MetadataService.fetch(metadata_id.to_s)
+    metadata_id.nil? ? nil : MetadataService.fetch(metadata_id.to_s)
   end
 end

--- a/app/services/refresh_metadata_action.rb
+++ b/app/services/refresh_metadata_action.rb
@@ -27,6 +27,6 @@ class RefreshMetadataAction
   def fetch_datastream
     candidates = @object.identityMetadata.otherId.collect(&:to_s)
     metadata_id = MetadataService.resolvable(candidates).first
-    metadata_id.nil? ? nil : MetadataService.fetch(metadata_id.to_s)
+    metadata_id.blank? ? nil : MetadataService.fetch(metadata_id.to_s)
   end
 end

--- a/spec/services/metadata_service_spec.rb
+++ b/spec/services/metadata_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe MetadataService do
   let(:mods) { File.read(File.join(fixture_dir, 'mods_record.xml')) }
 
-  describe 'resolvable' do
+  describe '#resolvable' do
     it 'returns only resolvable identifiers' do
       expect(described_class.resolvable(['bogus:1234', 'catkey:5678'])).to eq(['catkey:5678'])
     end
@@ -16,6 +16,20 @@ RSpec.describe MetadataService do
 
     it 'returns an empty array when no resolvable identifiers are found' do
       expect(described_class.resolvable(['bogus:1234', 'nada:5678'])).to eq([])
+    end
+  end
+
+  describe '#can_resolve?' do
+    it 'returns false for an unknown prefix' do
+      expect(described_class.send(:'can_resolve?', 'bogus:1234')).to be_falsey
+    end
+
+    it 'returns true for barcodes' do
+      expect(described_class.send(:'can_resolve?', 'barcode:1234')).to be_truthy
+    end
+
+    it 'returns true for catkeys' do
+      expect(described_class.send(:'can_resolve?', 'catkey:1234')).to be_truthy
     end
   end
 

--- a/spec/services/metadata_service_spec.rb
+++ b/spec/services/metadata_service_spec.rb
@@ -5,6 +5,20 @@ require 'rails_helper'
 RSpec.describe MetadataService do
   let(:mods) { File.read(File.join(fixture_dir, 'mods_record.xml')) }
 
+  describe 'resolvable' do
+    it 'returns only resolvable identifiers' do
+      expect(described_class.resolvable(['bogus:1234', 'catkey:5678'])).to eq(['catkey:5678'])
+    end
+
+    it 'returns only resolvable identifiers in preferred order when more one is resolvable' do
+      expect(described_class.resolvable(['barcode:1234', 'catkey:5678'])).to eq(['catkey:5678', 'barcode:1234'])
+    end
+
+    it 'returns an empty array when no resolvable identifiers are found' do
+      expect(described_class.resolvable(['bogus:1234', 'nada:5678'])).to eq([])
+    end
+  end
+
   describe '#fetch' do
     let(:resource) { instance_double(MarcxmlResource, mods: mods) }
 


### PR DESCRIPTION
## Why was this change made?

Based on a discussion in `#dlss-aaas` about metadata refreshes for objects with both a catkey and a barcode, it may be necessary to prefer they catkey when both are present.  This returns the identifiers in a preferred order based on the known prefixes configured so that when the first is selected it will work as desired.

## Was the API documentation (openapi.json) updated?
