### PR TITLE
Remove HB alert for deprecated endpoint

### DIFF
--- a/app/controllers/sdr_controller.rb
+++ b/app/controllers/sdr_controller.rb
@@ -19,7 +19,6 @@ class SdrController < ApplicationController
 
   # Deprecated
   def ds_manifest
-    Honeybadger.notify('dor-services-app deprecated API endpoint `sdr#ds_manifest` called.')
     sdr_response = sdr_client.manifest(ds_name: params[:dsname])
     proxy_faraday_response(sdr_response)
   end


### PR DESCRIPTION


## Why was this change made?

Because it is too noisy and we already have an issue to track this. Also, do not want our HB account to be throttled again.

## Was the API documentation (openapi.json) updated?

no