### PR TITLE
Shelve w pres client

### DIFF
--- a/app/controllers/sdr_controller.rb
+++ b/app/controllers/sdr_controller.rb
@@ -6,8 +6,10 @@ class SdrController < ApplicationController
 
   MANIFEST_DEPRECATION_MESSAGE = 'Use preservation-client manifest or signature_catalog in caller instead.'
   CURRENT_VERSION_DEPRECATION_MESSAGE = 'Use preservation-client current_version in caller instead.'
+  CM_INV_DIFF_DEPRECATION_MESSAGE = 'Use preservation-client content_inventory_diff or shelve_content_diff in caller instead.'
 
   def cm_inv_diff
+    Honeybadger.notify("dor-services-app deprecated API endpoint `sdr#cm_inv_diff` called. #{CM_INV_DIFF_DEPRECATION_MESSAGE}")
     unless %w(all shelve preserve publish).include?(params[:subset])
       render status: :bad_request, plain: "Invalid subset value: #{params[:subset]}"
       return
@@ -19,6 +21,7 @@ class SdrController < ApplicationController
     sdr_response = sdr_client.content_diff(current_content: current_content, subset: params[:subset], version: params[:version])
     proxy_faraday_response(sdr_response)
   end
+  deprecation_deprecate cm_inv_diff: CM_INV_DIFF_DEPRECATION_MESSAGE
 
   # Deprecated
   def ds_manifest

--- a/app/services/digital_stacks_service.rb
+++ b/app/services/digital_stacks_service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# NOTE:  this class makes use of data structures from moab-versioning gem,
+#  but it does NOT access any preservation storage roots
 class DigitalStacksService
   # Delete files from stacks that have change type 'deleted', 'copydeleted', or 'modified'
   # @param [Pathname] stacks_object_pathname the stacks location of the digital object

--- a/app/services/sdr_client.rb
+++ b/app/services/sdr_client.rb
@@ -17,6 +17,7 @@ class SdrClient
 
   # @return [Faraday::Response] with body of cm-inv-diff as xml
   def content_diff(current_content:, subset:, version: nil)
+    Honeybadger.notify('dor-services-app deprecated method `SdrClient.content_diff` called. Use preservation-client content_diff instead.')
     query_params = { subset: subset }
     query_params[:version] = version unless version.nil?
     query_string = URI.encode_www_form(query_params)
@@ -24,6 +25,7 @@ class SdrClient
     uri = sdr_uri(path)
     sdr_conn(uri).post("#{uri.path}?#{query_string}", current_content, 'Content-Type' => 'application/xml')
   end
+  deprecation_deprecate content_diff: 'Use preservation-client content_inventory_diff or shelve_content_diff in caller instead.'
 
   def manifest(ds_name:)
     sdr_get("/objects/#{druid}/manifest/#{ds_name}")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     get '/about' => 'ok_computer/ok_computer#show', defaults: { check: 'version' }
 
     scope '/sdr/objects/:druid' do
-      post 'cm-inv-diff', to: 'sdr#cm_inv_diff'
+      post 'cm-inv-diff', to: 'sdr#cm_inv_diff' # deprecated; caller should use preservation-client
       get 'current_version', to: 'sdr#current_version' # deprecated; caller should use preservation-client
       get 'manifest/:dsname', to: 'sdr#ds_manifest', format: false, constraints: { dsname: /.+/ } # deprecated
       get 'metadata/:dsname', to: 'sdr#ds_metadata', format: false, constraints: { dsname: /.+/ }

--- a/openapi.json
+++ b/openapi.json
@@ -75,8 +75,9 @@
         "tags": [
           "preservation"
         ],
-        "summary": "Get the diff between content metadata provided and version in preservation",
-        "description": "Use preservation-client gem instead.",
+        "summary": "DEPRECATED. Get the diff between content metadata provided and version in preservation",
+        "description": "DEPRECATED. Use preservation-client gem instead.",
+        "deprecated": true,
         "operationId": "sdr#cm_inv_diff",
         "responses": {
           "200": {

--- a/spec/controllers/sdr_controller_spec.rb
+++ b/spec/controllers/sdr_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe SdrController do
 
   before do
     allow(Dor).to receive(:find).and_return(item)
+    allow(Deprecation).to receive(:warn)
   end
 
   before do

--- a/spec/services/sdr_client_spec.rb
+++ b/spec/services/sdr_client_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe SdrClient do
     let(:url) { 'http://sdr-services.example.com/sdr/objects/druid:ab123cd4567/current_version' }
     let(:url_with_basic_auth) { url.sub('http://', 'http://user:password@') }
 
+    before do
+      allow(Deprecation).to receive(:warn)
+    end
+
     it 'returns the current of the object from SDR' do
       stub_request(:get, url)
         .with(headers: { 'Authorization' => 'Basic dXNlcjpwYXNzd29yZA==' })

--- a/spec/services/shelving_service_spec.rb
+++ b/spec/services/shelving_service_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ShelvingService do
     before do
       allow(described_class).to receive(:new).and_return(service)
       # stub the shelve_diff method which is unit tested below
-      expect(service).to receive(:shelve_diff).and_return(mock_diff)
+      expect(service).to receive(:shelve_diff).and_return(mock_diff).at_least(:once)
       # stub the workspace_content_dir method which is unit tested below
       expect(service).to receive(:workspace_content_dir).with(mock_diff, an_instance_of(DruidTools::Druid)).and_return(mock_workspace_path)
     end
@@ -53,56 +53,12 @@ RSpec.describe ShelvingService do
 
     context 'when contentMetadata exists' do
       before do
-        allow(SdrClient).to receive(:new).with(druid).and_return(sdr_client)
+        allow(Preservation::Client.objects).to receive(:shelve_content_diff)
       end
 
-      let(:sdr_resp) { instance_double(Faraday::Response, body: file_inventory_diff) }
-      let(:sdr_client) { instance_double(SdrClient, content_diff: sdr_resp) }
-      let(:xml_pathname) { Pathname('spec').join('fixtures', 'content_diff_reports', 'jq937jp0017-v1-v2.xml') }
-      let(:content_inventory_diff) { xml_pathname.read }
-      let(:file_inventory_diff) do
-        <<-XML
-          <fileInventoryDifference objectId="druid:jq937jp0017" differenceCount="3" basis="v1-contentMetadata-shelve" other="new-contentMetadata-shelve" reportDatetime="2019-10-14T21:53:38Z">
-            #{content_inventory_diff.sub('<?xml version="1.0" encoding="UTF-8"?>', '')}
-          </fileInventoryDifference>
-        XML
-      end
-
-      it 'retrieves the differences between the current contentMetadata and the previously ingested version' do
-        expect(result.to_xml).to be_equivalent_to(<<-XML
-          <fileGroupDifference groupId="content" differenceCount="3" identical="3" copyadded="0" copydeleted="0" renamed="0" modified="1" added="0" deleted="2">
-            <subset change="identical" count="3">
-              <file change="identical" basisPath="page-2.jpg" otherPath="same">
-                <fileSignature size="39450" md5="82fc107c88446a3119a51a8663d1e955" sha1="d0857baa307a2e9efff42467b5abd4e1cf40fcd5" sha256="235de16df4804858aefb7690baf593fb572d64bb6875ec522a4eea1f4189b5f0"/>
-              </file>
-              <file change="identical" basisPath="page-3.jpg" otherPath="same">
-                <fileSignature size="19125" md5="a5099878de7e2e064432d6df44ca8827" sha1="c0ccac433cf02a6cee89c14f9ba6072a184447a2" sha256="7bd120459eff0ecd21df94271e5c14771bfca5137d1dd74117b6a37123dfe271"/>
-              </file>
-              <file change="identical" basisPath="title.jpg" otherPath="same">
-                <fileSignature size="40873" md5="1a726cd7963bd6d3ceb10a8c353ec166" sha1="583220e0572640abcd3ddd97393d224e8053a6ad" sha256="8b0cee693a3cf93cf85220dd67c5dc017a7edcdb59cde8fa7b7f697be162b0c5"/>
-              </file>
-            </subset>
-            <subset change="renamed" count="0"/>
-            <subset change="modified" count="1">
-              <file change="modified" basisPath="page-1.jpg" otherPath="same">
-                <fileSignature size="25153" md5="3dee12fb4f1c28351c7482b76ff76ae4" sha1="906c1314f3ab344563acbbbe2c7930f08429e35b" sha256="41aaf8598c9d8e3ee5d55efb9be11c542099d9f994b5935995d0abea231b8bad"/>
-                <fileSignature size="32915" md5="c1c34634e2f18a354cd3e3e1574c3194" sha1="0616a0bd7927328c364b2ea0b4a79c507ce915ed" sha256="b78cc53b7b8d9ed86d5e3bab3b699c7ed0db958d4a111e56b6936c8397137de0"/>
-              </file>
-            </subset>
-            <subset change="deleted" count="2">
-              <file change="deleted" basisPath="intro-1.jpg" otherPath="">
-                <fileSignature size="41981" md5="915c0305bf50c55143f1506295dc122c" sha1="60448956fbe069979fce6a6e55dba4ce1f915178" sha256="4943c6ffdea7e33b74fd7918de900de60e9073148302b0ad1bf5df0e6cec032a"/>
-              </file>
-              <file change="deleted" basisPath="intro-2.jpg" otherPath="">
-                <fileSignature size="39850" md5="77f1a4efdcea6a476505df9b9fba82a7" sha1="a49ae3f3771d99ceea13ec825c9c2b73fc1a9915" sha256="3a28718a8867e4329cd0363a84aee1c614d0f11229a82e87c6c5072a6e1b15e7"/>
-              </file>
-            </subset>
-            <subset change="added" count="0"/>
-            <subset change="copyadded" count="0"/>
-            <subset change="copydeleted" count="0"/>
-          </fileGroupDifference>
-        XML
-                                                 )
+      it 'retrieves the differences between the current contentMetadata and preservation via preservation-client gem' do
+        service.send(:shelve_diff)
+        expect(Preservation::Client.objects).to have_received(:shelve_content_diff).with(druid: druid, content_metadata: work.contentMetadata.content)
       end
     end
 


### PR DESCRIPTION
DRAFT:  
- ~~must not be deployed until sul-dlss/preservation_catalog/pull/1250 is deployed.~~
- ~~should not be deployed until sul-dlss/common-accessioning/pull/465 is deployed~~

## Why was this change made?

To get rid of  `cm-inv-diff` API endpoint in sdr-services-app.  We use preservation-client `shelve_content_diff` method instead.

## Was the API documentation (openapi.json) updated?

yes - marked DEPRECATED there and also in the code.