### PR TITLE
be more consistent with deprecation messages

### DIFF
--- a/app/controllers/sdr_controller.rb
+++ b/app/controllers/sdr_controller.rb
@@ -19,10 +19,12 @@ class SdrController < ApplicationController
 
   # Deprecated
   def ds_manifest
-    Honeybadger.notify('dor-services-app deprecated API endpoint `sdr#ds_manifest` called.')
+    dep_msg = 'Use preservation-client manifest or signature_catalog in caller instead.'
+    Honeybadger.notify("dor-services-app deprecated API endpoint `sdr#ds_manifest` called. #{dep_msg}")
     sdr_response = sdr_client.manifest(ds_name: params[:dsname])
     proxy_faraday_response(sdr_response)
   end
+  deprecation_deprecate ds_manifest: 'Use preservation-client manifest or signature_catalog in caller instead.'
 
   def ds_metadata
     sdr_response = sdr_client.metadata(ds_name: params[:dsname])
@@ -30,10 +32,11 @@ class SdrController < ApplicationController
   end
 
   def current_version
-    Honeybadger.notify('dor-services-app deprecated API endpoint `sdr#current_version` called - use preservation-client current_version instead')
+    dep_msg = 'Use preservation-client current_version in caller instead.'
+    Honeybadger.notify("dor-services-app deprecated API endpoint `sdr#current_version` called. #{dep_msg}")
     proxy_faraday_response(sdr_client.current_version)
   end
-  deprecation_deprecate current_version: 'use preservation-client current_version in caller instead'
+  deprecation_deprecate current_version: 'Use preservation-client current_version in caller instead.'
 
   def file_content
     sdr_response = sdr_client.file_content(version: params[:version], filename: params[:filename])

--- a/app/services/sdr_client.rb
+++ b/app/services/sdr_client.rb
@@ -34,7 +34,7 @@ class SdrClient
   end
 
   def current_version(parsed: false)
-    Honeybadger.notify('dor-services-app deprecated method `SDRClient.current_version` called - use preservation-client current_version instead')
+    Honeybadger.notify('dor-services-app deprecated method `SdrClient.current_version` called. Use preservation-client current_version instead.')
     path = "/objects/#{druid}/current_version"
     response = sdr_get(path)
     return response unless parsed
@@ -53,7 +53,7 @@ class SdrClient
       raise "Unable to parse XML from SDR current_version API call.\n\turl: #{sdr_uri(path)}\n\tstatus: #{response.status}\n\tbody: #{response.body}"
     end
   end
-  deprecation_deprecate current_version: 'use preservation-client current_version in caller instead'
+  deprecation_deprecate current_version: 'Use preservation-client current_version in caller instead.'
 
   def file_content(version:, filename:)
     query_string = URI.encode_www_form(version: version.to_s)

--- a/openapi.json
+++ b/openapi.json
@@ -75,8 +75,8 @@
         "tags": [
           "preservation"
         ],
-        "summary": "Get the diff of the content metadata from DOR and SDR",
-        "description": "",
+        "summary": "DEPRECATED. Get the diff between content metadata provided and version in preservation",
+        "description": "DEPRECATED. Use preservation-client gem instead.",
         "operationId": "sdr#cm_inv_diff",
         "responses": {
           "200": {
@@ -101,8 +101,8 @@
         "tags": [
           "preservation"
         ],
-        "summary": "DEPRECATED. Get the current version of the object from SDR",
-        "description": "DEPRECATED.  Use preservation-client gem instead.",
+        "summary": "DEPRECATED. Get the current version of the object from preservation",
+        "description": "DEPRECATED. Use preservation-client gem instead.",
         "deprecated": true,
         "operationId": "sdr#current_version",
         "responses": {
@@ -128,8 +128,8 @@
         "tags": [
           "preservation"
         ],
-        "summary": "Get the manifest of the datastream from SDR",
-        "description": "",
+        "summary": "DEPRECATED. Get the manifest file from preservation",
+        "description": "DEPRECATED. Use preservation-client gem instead.",
         "deprecated": true,
         "operationId": "sdr#ds_manifest",
         "responses": {
@@ -164,7 +164,7 @@
         "tags": [
           "preservation"
         ],
-        "summary": "Get the metadata from the datastream from SDR",
+        "summary": "Get the metadata file from preservation",
         "description": "",
         "operationId": "sdr#ds_metadata",
         "responses": {
@@ -199,7 +199,7 @@
         "tags": [
           "preservation"
         ],
-        "summary": "Get the file content from SDR",
+        "summary": "Get the file content from preservation",
         "description": "",
         "operationId": "sdr#file_content",
         "responses": {


### PR DESCRIPTION
## Why was this change made?

To make deprecation more consistent;  as I will be deprecating the rest of the SDR related code soon, I was paying attention.

## Was the API documentation (openapi.json) updated?

Yup.