### PR TITLE
DRY up deprecation warning strings and mark endpoint as deprecated

### DIFF
--- a/app/controllers/sdr_controller.rb
+++ b/app/controllers/sdr_controller.rb
@@ -4,6 +4,9 @@ class SdrController < ApplicationController
   extend Deprecation
   self.deprecation_horizon = 'dor-services-app version 4.0'
 
+  MANIFEST_DEPRECATION_MESSAGE = 'Use preservation-client manifest or signature_catalog in caller instead.'
+  CURRENT_VERSION_DEPRECATION_MESSAGE = 'Use preservation-client current_version in caller instead.'
+
   def cm_inv_diff
     unless %w(all shelve preserve publish).include?(params[:subset])
       render status: :bad_request, plain: "Invalid subset value: #{params[:subset]}"
@@ -19,12 +22,11 @@ class SdrController < ApplicationController
 
   # Deprecated
   def ds_manifest
-    dep_msg = 'Use preservation-client manifest or signature_catalog in caller instead.'
-    Honeybadger.notify("dor-services-app deprecated API endpoint `sdr#ds_manifest` called. #{dep_msg}")
+    Honeybadger.notify("dor-services-app deprecated API endpoint `sdr#ds_manifest` called. #{MANIFEST_DEPRECATION_MESSAGE}")
     sdr_response = sdr_client.manifest(ds_name: params[:dsname])
     proxy_faraday_response(sdr_response)
   end
-  deprecation_deprecate ds_manifest: 'Use preservation-client manifest or signature_catalog in caller instead.'
+  deprecation_deprecate ds_manifest: MANIFEST_DEPRECATION_MESSAGE
 
   def ds_metadata
     sdr_response = sdr_client.metadata(ds_name: params[:dsname])
@@ -32,11 +34,10 @@ class SdrController < ApplicationController
   end
 
   def current_version
-    dep_msg = 'Use preservation-client current_version in caller instead.'
-    Honeybadger.notify("dor-services-app deprecated API endpoint `sdr#current_version` called. #{dep_msg}")
+    Honeybadger.notify("dor-services-app deprecated API endpoint `sdr#current_version` called. #{CURRENT_VERSION_DEPRECATION_MESSAGE}")
     proxy_faraday_response(sdr_client.current_version)
   end
-  deprecation_deprecate current_version: 'Use preservation-client current_version in caller instead.'
+  deprecation_deprecate current_version: CURRENT_VERSION_DEPRECATION_MESSAGE
 
   def file_content
     sdr_response = sdr_client.file_content(version: params[:version], filename: params[:filename])

--- a/openapi.json
+++ b/openapi.json
@@ -75,8 +75,8 @@
         "tags": [
           "preservation"
         ],
-        "summary": "DEPRECATED. Get the diff between content metadata provided and version in preservation",
-        "description": "DEPRECATED. Use preservation-client gem instead.",
+        "summary": "Get the diff between content metadata provided and version in preservation",
+        "description": "Use preservation-client gem instead.",
         "operationId": "sdr#cm_inv_diff",
         "responses": {
           "200": {


### PR DESCRIPTION
## Why was this change made?

To DRY up deprecation warning strings and mark endpoint as deprecated in the API doc

## Was the API documentation (openapi.json) updated?

yes