### PR TITLE
Add an endpoint for creating events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# A RESTful controller for Event records
+class EventsController < ApplicationController
+  def create
+    params.require(:event_type)
+    Event.create!(druid: params[:object_id], event_type: params[:event_type], data: params[:data])
+    head :created
+  end
+
+  def index
+    @events = Event.where(druid: params[:object_id])
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Event < ApplicationRecord
+end

--- a/app/views/events/index.json.jbuilder
+++ b/app/views/events/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @events, :event_type, :druid, :data, :created_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,8 @@ Rails.application.routes.draw do
         end
       end
 
+      resources :events, only: [:create, :index], defaults: { format: :json }
+
       resources :versions, only: [:create] do
         collection do
           get 'openable'

--- a/db/migrate/20191209192646_create_events.rb
+++ b/db/migrate/20191209192646_create_events.rb
@@ -1,0 +1,13 @@
+class CreateEvents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :events do |t|
+      t.string :event_type, null: false
+      t.string :druid, null: false
+      t.jsonb :data
+      t.datetime :created_at
+    end
+    add_index :events, :event_type
+    add_index :events, :druid
+    add_index :events, :created_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -69,6 +69,38 @@ ALTER SEQUENCE public.background_job_results_id_seq OWNED BY public.background_j
 
 
 --
+-- Name: events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.events (
+    id bigint NOT NULL,
+    event_type character varying NOT NULL,
+    druid character varying NOT NULL,
+    data jsonb,
+    created_at timestamp without time zone
+);
+
+
+--
+-- Name: events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.events_id_seq OWNED BY public.events.id;
+
+
+--
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -82,6 +114,13 @@ CREATE TABLE public.schema_migrations (
 --
 
 ALTER TABLE ONLY public.background_job_results ALTER COLUMN id SET DEFAULT nextval('public.background_job_results_id_seq'::regclass);
+
+
+--
+-- Name: events id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events ALTER COLUMN id SET DEFAULT nextval('public.events_id_seq'::regclass);
 
 
 --
@@ -101,11 +140,40 @@ ALTER TABLE ONLY public.background_job_results
 
 
 --
+-- Name: events events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events
+    ADD CONSTRAINT events_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: index_events_on_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_on_created_at ON public.events USING btree (created_at);
+
+
+--
+-- Name: index_events_on_druid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_on_druid ON public.events USING btree (druid);
+
+
+--
+-- Name: index_events_on_event_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_on_event_type ON public.events USING btree (event_type);
 
 
 --
@@ -116,6 +184,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20190917215521'),
-('20191015193638');
+('20191015193638'),
+('20191209192646');
 
 

--- a/openapi.json
+++ b/openapi.json
@@ -47,6 +47,10 @@
       "description": "Operations about object versions"
     },
     {
+      "name": "events",
+      "description": "Operations about events"
+    },
+    {
       "name": "files",
       "description": "Operations about files"
     },
@@ -843,6 +847,76 @@
         ]
       }
     },
+    "/v1/objects/{object_id}/events": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Return a list of events about this object",
+        "description": "",
+        "operationId": "events#index",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Event"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "object_id",
+            "in": "path",
+            "description": "ID of object",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Druid"
+            }
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Create an event about this object",
+        "description": "",
+        "operationId": "events#create",
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        },
+        "parameters": [
+          {
+            "name": "object_id",
+            "in": "path",
+            "description": "ID of object",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Druid"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "event to add to the system",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Event"
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/objects/{object_id}/versions/openable": {
       "get": {
         "tags": [
@@ -1198,6 +1272,20 @@
                 "example": "/data/attributes/title"
               }
             }
+          }
+        }
+      },
+      "Event" : {
+        "type": "object",
+        "required": ["event_type", "data"],
+        "properties": {
+          "event_type": {
+            "description": "the type of event",
+            "type": "string"
+          },
+          "data": {
+            "description": "details about the event",
+            "type": "object"
           }
         }
       },

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Add and retrieve events' do
+  let(:druid) { 'druid:bc123df4567' }
+
+  context 'when update is successful' do
+    let(:data) do
+      <<~JSON
+        {
+          "event_type": "publish",
+          "data": {
+            "size": 1900,
+            "description": "stuff"
+          }
+        }
+      JSON
+    end
+
+    it 'creates events' do
+      post "/v1/objects/#{druid}/events",
+           params: data,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'CONTENT_TYPE' => 'application/json' }
+      expect(response).to have_http_status(:created)
+
+      get "/v1/objects/#{druid}/events",
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json[0]['event_type']).to eq 'publish'
+      expect(json[0]['data']).to eq('description' => 'stuff', 'size' => 1900)
+      expect(json[0]).to have_key 'created_at'
+    end
+  end
+end


### PR DESCRIPTION
~DO NOT MERGE:  per F2F team discussions on Jan 7, 2020, we want to wait on this.~
Per team discussion on Jan 14, 2020, okay to proceed.

## Why was this change made?

This is a solution to preservation_catalog#1249 and can also be used as our "provenance service" as well as for adding events showing the objects progress through workflows.

## Was the API documentation (openapi.json) updated?
yes.