### PR TITLE
deprecate API endpoints sdr#content, sdr#metadata and SdrClient.file_content, SdrClient.metadata

### DIFF
--- a/app/controllers/sdr_controller.rb
+++ b/app/controllers/sdr_controller.rb
@@ -4,9 +4,10 @@ class SdrController < ApplicationController
   extend Deprecation
   self.deprecation_horizon = 'dor-services-app version 4.0'
 
-  MANIFEST_DEPRECATION_MESSAGE = 'Use preservation-client manifest or signature_catalog in caller instead.'
-  CURRENT_VERSION_DEPRECATION_MESSAGE = 'Use preservation-client current_version in caller instead.'
-  CM_INV_DIFF_DEPRECATION_MESSAGE = 'Use preservation-client content_inventory_diff or shelve_content_diff in caller instead.'
+  MANIFEST_DEPRECATION_MESSAGE = 'Use preservation-client .manifest or .signature_catalog in caller instead.'
+  CURRENT_VERSION_DEPRECATION_MESSAGE = 'Use preservation-client .current_version in caller instead.'
+  CM_INV_DIFF_DEPRECATION_MESSAGE = 'Use preservation-client .content_inventory_diff or .shelve_content_diff in caller instead.'
+  CONTENT_DEPRECATION_MESSAGE = 'Use preservation-client .content in caller instead.'
 
   def cm_inv_diff
     Honeybadger.notify("dor-services-app deprecated API endpoint `sdr#cm_inv_diff` called. #{CM_INV_DIFF_DEPRECATION_MESSAGE}")
@@ -43,9 +44,11 @@ class SdrController < ApplicationController
   deprecation_deprecate current_version: CURRENT_VERSION_DEPRECATION_MESSAGE
 
   def file_content
+    Honeybadger.notify("dor-services-app deprecated API endpoint `sdr#file_content` called. #{CONTENT_DEPRECATION_MESSAGE}")
     sdr_response = sdr_client.file_content(version: params[:version], filename: params[:filename])
     proxy_faraday_response(sdr_response)
   end
+  deprecation_deprecate file_content: CONTENT_DEPRECATION_MESSAGE
 
   private
 

--- a/app/controllers/sdr_controller.rb
+++ b/app/controllers/sdr_controller.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
+# Deprecated; remove in release 4.0
 class SdrController < ApplicationController
   extend Deprecation
   self.deprecation_horizon = 'dor-services-app version 4.0'
 
   MANIFEST_DEPRECATION_MESSAGE = 'Use preservation-client .manifest or .signature_catalog in caller instead.'
+  METADATA_DEPRECATION_MESSAGE = 'Use preservation-client .metadata in caller instead.'
   CURRENT_VERSION_DEPRECATION_MESSAGE = 'Use preservation-client .current_version in caller instead.'
   CM_INV_DIFF_DEPRECATION_MESSAGE = 'Use preservation-client .content_inventory_diff or .shelve_content_diff in caller instead.'
   CONTENT_DEPRECATION_MESSAGE = 'Use preservation-client .content in caller instead.'
 
+  # Deprecated
   def cm_inv_diff
     Honeybadger.notify("dor-services-app deprecated API endpoint `sdr#cm_inv_diff` called. #{CM_INV_DIFF_DEPRECATION_MESSAGE}")
     unless %w(all shelve preserve publish).include?(params[:subset])
@@ -32,17 +35,22 @@ class SdrController < ApplicationController
   end
   deprecation_deprecate ds_manifest: MANIFEST_DEPRECATION_MESSAGE
 
+  # Deprecated
   def ds_metadata
+    Honeybadger.notify("dor-services-app deprecated API endpoint `sdr#ds_metadata` called. #{METADATA_DEPRECATION_MESSAGE}")
     sdr_response = sdr_client.metadata(ds_name: params[:dsname])
     proxy_faraday_response(sdr_response)
   end
+  deprecation_deprecate ds_manifest: METADATA_DEPRECATION_MESSAGE
 
+  # Deprecated
   def current_version
     Honeybadger.notify("dor-services-app deprecated API endpoint `sdr#current_version` called. #{CURRENT_VERSION_DEPRECATION_MESSAGE}")
     proxy_faraday_response(sdr_client.current_version)
   end
   deprecation_deprecate current_version: CURRENT_VERSION_DEPRECATION_MESSAGE
 
+  # Deprecated
   def file_content
     Honeybadger.notify("dor-services-app deprecated API endpoint `sdr#file_content` called. #{CONTENT_DEPRECATION_MESSAGE}")
     sdr_response = sdr_client.file_content(version: params[:version], filename: params[:filename])

--- a/app/services/sdr_client.rb
+++ b/app/services/sdr_client.rb
@@ -17,7 +17,7 @@ class SdrClient
 
   # @return [Faraday::Response] with body of cm-inv-diff as xml
   def content_diff(current_content:, subset:, version: nil)
-    Honeybadger.notify('dor-services-app deprecated method `SdrClient.content_diff` called. Use preservation-client content_diff instead.')
+    Honeybadger.notify('dor-services-app deprecated method `SdrClient.content_diff` called. Use preservation-client .content_diff instead.')
     query_params = { subset: subset }
     query_params[:version] = version unless version.nil?
     query_string = URI.encode_www_form(query_params)
@@ -25,7 +25,7 @@ class SdrClient
     uri = sdr_uri(path)
     sdr_conn(uri).post("#{uri.path}?#{query_string}", current_content, 'Content-Type' => 'application/xml')
   end
-  deprecation_deprecate content_diff: 'Use preservation-client content_inventory_diff or shelve_content_diff in caller instead.'
+  deprecation_deprecate content_diff: 'Use preservation-client .content_inventory_diff or .shelve_content_diff in caller instead.'
 
   def manifest(ds_name:)
     sdr_get("/objects/#{druid}/manifest/#{ds_name}")
@@ -36,7 +36,7 @@ class SdrClient
   end
 
   def current_version(parsed: false)
-    Honeybadger.notify('dor-services-app deprecated method `SdrClient.current_version` called. Use preservation-client current_version instead.')
+    Honeybadger.notify('dor-services-app deprecated method `SdrClient.current_version` called. Use preservation-client .current_version instead.')
     path = "/objects/#{druid}/current_version"
     response = sdr_get(path)
     return response unless parsed
@@ -55,13 +55,15 @@ class SdrClient
       raise "Unable to parse XML from SDR current_version API call.\n\turl: #{sdr_uri(path)}\n\tstatus: #{response.status}\n\tbody: #{response.body}"
     end
   end
-  deprecation_deprecate current_version: 'Use preservation-client current_version in caller instead.'
+  deprecation_deprecate current_version: 'Use preservation-client .current_version in caller instead.'
 
   def file_content(version:, filename:)
+    Honeybadger.notify('dor-services-app deprecated method `SdrClient.file_content` called. Use preservation-client .content instead.')
     query_string = URI.encode_www_form(version: version.to_s)
     encoded_filename = CGI.escape(filename)
     sdr_get("/objects/#{druid}/content/#{encoded_filename}?#{query_string}")
   end
+  deprecation_deprecate content_diff: 'Use preservation-client .content in caller instead.'
 
   private
 

--- a/app/services/sdr_client.rb
+++ b/app/services/sdr_client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # A client for talking to sdr-services-app
+# Deprecated; remove in release 4.0
 class SdrClient
   extend Deprecation
   self.deprecation_horizon = 'dor-services-app version 4.0'
@@ -32,8 +33,10 @@ class SdrClient
   end
 
   def metadata(ds_name:)
+    Honeybadger.notify('dor-services-app deprecated method `SdrClient.metadata` called. Use preservation-client .metadata instead.')
     sdr_get("/objects/#{druid}/metadata/#{ds_name}")
   end
+  deprecation_deprecate metadata: 'Use preservation-client .metadata in caller instead.'
 
   def current_version(parsed: false)
     Honeybadger.notify('dor-services-app deprecated method `SdrClient.current_version` called. Use preservation-client .current_version instead.')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
       get 'current_version', to: 'sdr#current_version' # deprecated; caller should use preservation-client
       get 'manifest/:dsname', to: 'sdr#ds_manifest', format: false, constraints: { dsname: /.+/ } # deprecated
       get 'metadata/:dsname', to: 'sdr#ds_metadata', format: false, constraints: { dsname: /.+/ }
-      get 'content/:filename', to: 'sdr#file_content', format: false, constraints: { filename: /.+/ }
+      get 'content/:filename', to: 'sdr#file_content', format: false, constraints: { filename: /.+/ } # deprecated
     end
 
     scope :catalog do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,11 +10,12 @@ Rails.application.routes.draw do
   scope '/v1' do
     get '/about' => 'ok_computer/ok_computer#show', defaults: { check: 'version' }
 
+    # deprecated; caller should use preservation-client;  remove in release 4.0
     scope '/sdr/objects/:druid' do
       post 'cm-inv-diff', to: 'sdr#cm_inv_diff' # deprecated; caller should use preservation-client
       get 'current_version', to: 'sdr#current_version' # deprecated; caller should use preservation-client
       get 'manifest/:dsname', to: 'sdr#ds_manifest', format: false, constraints: { dsname: /.+/ } # deprecated
-      get 'metadata/:dsname', to: 'sdr#ds_metadata', format: false, constraints: { dsname: /.+/ }
+      get 'metadata/:dsname', to: 'sdr#ds_metadata', format: false, constraints: { dsname: /.+/ } # deprecated
       get 'content/:filename', to: 'sdr#file_content', format: false, constraints: { filename: /.+/ } # deprecated
     end
 

--- a/openapi.json
+++ b/openapi.json
@@ -165,8 +165,9 @@
         "tags": [
           "preservation"
         ],
-        "summary": "Get the metadata file from preservation",
-        "description": "",
+        "summary": "DEPRECATED. Get the metadata file from preservation",
+        "description": "DEPRECATED. Use preservation-client gem instead.",
+        "deprecated": true,
         "operationId": "sdr#ds_metadata",
         "responses": {
           "200": {

--- a/openapi.json
+++ b/openapi.json
@@ -200,8 +200,9 @@
         "tags": [
           "preservation"
         ],
-        "summary": "Get the file content from preservation",
-        "description": "",
+        "summary": "DEPRECATED. Get the file content from preservation",
+        "description": "DEPRECATED. Use preservation-client gem instead.",
+        "deprecated": true,
         "operationId": "sdr#file_content",
         "responses": {
           "200": {


### PR DESCRIPTION
- ~~should not be deployed before sul-dlss/argo#1741 is deployed~~

## Why was this change made?

To get rid of `content` and `metadata` API endpoints in sdr-services-app. We use preservation-client gem's `content` or `metadata` method in the caller instead, going directly to preservation-catalog API.

- only caller of `content`:
  - was here:  https://github.com/sul-dlss/argo/blob/master/app/controllers/files_controller.rb#L28
  - PR sul-dlss/argo#1741
- only caller of `metadata`
  - was here: https://github.com/sul-dlss/common-accessioning/blob/master/lib/technical_metadata_service.rb#L105
  - PR sul-dlss/common-accessioning/pull/465, deployed with Monday updates on 12/9

## Was the API documentation (openapi.json) updated?

yes - marked deprecated there and also in the code.