### PR TITLE
Use committee middleware to verify requests using OpenAPI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'rails', '~> 5.2.0'
 
@@ -21,16 +22,16 @@ group :development do
 end
 
 # Ruby general dependencies
+gem 'committee' # validates Open API spec (OAS)
 gem 'config'
 gem 'deprecation'
-gem 'dry-struct'
-gem 'dry-types'
 gem 'faraday'
 gem 'honeybadger'
 gem 'jbuilder'
 gem 'jwt'
 gem 'net-http-persistent', '~> 2.9' # Pin to avoid problem exhausting file handles under load
 gem 'okcomputer'
+gem 'openapi_parser', github: 'ota42y/openapi_parser' # fixes https://github.com/ota42y/openapi_parser/issues/61
 gem 'pg'
 gem 'progressbar' # for the cleaner rake task
 gem 'ruby-cache', '~> 0.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/ota42y/openapi_parser.git
+  revision: 8bdfcf24c7d62cb6de8488c613a51080a8122a80
+  specs:
+    openapi_parser (0.6.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -95,6 +101,10 @@ GEM
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
     coderay (1.1.2)
+    committee (3.3.0)
+      json_schema (~> 0.14, >= 0.14.3)
+      openapi_parser (>= 0.6.1)
+      rack (>= 1.5)
     concurrent-ruby (1.1.5)
     config (2.0.0)
       activesupport (>= 4.2)
@@ -226,6 +236,7 @@ GEM
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     json (2.3.0)
+    json_schema (0.20.8)
     jwt (2.2.1)
     link_header (0.0.8)
     listen (3.0.8)
@@ -489,14 +500,13 @@ DEPENDENCIES
   capistrano-shared_configs
   capistrano-sidekiq
   cocina-models (~> 0.6.0)
+  committee
   config
   coveralls (~> 0.8)
   deprecation
   dlss-capistrano
   dor-services (~> 8.0)
   dor-workflow-client (~> 3.9)
-  dry-struct
-  dry-types
   equivalent-xml
   factory_bot_rails
   faraday
@@ -508,6 +518,7 @@ DEPENDENCIES
   moab-versioning (~> 4.0)
   net-http-persistent (~> 2.9)
   okcomputer
+  openapi_parser!
   pg
   preservation-client (~> 2.0)
   progressbar

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -49,10 +49,7 @@ class ObjectsController < ApplicationController
   # the 'publish-complete' step of that workflow if provided
   def publish
     result = BackgroundJobResult.create
-    workflow = params[:workflow]
-    raise "invalid workflow #{workflow}" if workflow && !%w[accessionWF releaseWF].include?(workflow)
-
-    PublishJob.perform_later(druid: params[:id], background_job_result: result, workflow: workflow)
+    PublishJob.perform_later(druid: params[:id], background_job_result: result, workflow: params[:workflow])
     head :created, location: result
   end
 

--- a/app/controllers/virtual_objects_controller.rb
+++ b/app/controllers/virtual_objects_controller.rb
@@ -2,8 +2,6 @@
 
 # Create virtual objects
 class VirtualObjectsController < ApplicationController
-  before_action :validate_params!, only: :create
-
   # Create one or more virtual objects represented by JSON (see `#schema` below):
   def create
     result = BackgroundJobResult.create
@@ -16,35 +14,5 @@ class VirtualObjectsController < ApplicationController
 
   def create_params
     params.to_unsafe_h
-  end
-
-  # Use dry-validation to validate params instead of Rails strong parameters.
-  # This gives us finer-grained validation.
-  def validate_params!
-    errors = schema.call(create_params).errors(full: true)
-    return render json: { errors: errors }, status: :bad_request if errors.any?
-  end
-
-  # {
-  #   virtual_objects: [
-  #     {
-  #       parent_id: 'a-non-empty-string',
-  #       child_ids: [
-  #         'another-non-empty-string',
-  #         ...
-  #       ]
-  #     },
-  #     ...
-  #   ]
-  # }
-  def schema
-    Dry::Schema.JSON do
-      required(:virtual_objects).value(:array, min_size?: 1).each do
-        hash do
-          required(:parent_id).filled(:string)
-          required(:child_ids).value(:array, min_size?: 1).each(:filled?)
-        end
-      end
-    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,8 +12,30 @@ require 'active_record/railtie'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+class JSONAPIError < Committee::ValidationError
+  def error_body
+    {
+      errors: [
+        { status: id, detail: message }
+      ]
+    }
+  end
+
+  def render
+    [
+      status,
+      { "Content-Type" => "application/vnd.api+json" },
+      [JSON.generate(error_body)]
+    ]
+  end
+end
+
 module DorServices
   class Application < Rails::Application
+    config.middleware.use Committee::Middleware::RequestValidation, schema_path: 'openapi.json', strict: true, error_class: JSONAPIError
+    # TODO: we can uncomment this at a later date to ensure we are passing back valid responses
+    # config.middleware.use Committee::Middleware::ResponseValidation, schema: schema
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/openapi.json
+++ b/openapi.json
@@ -11,26 +11,20 @@
   },
   "servers": [
     {
-      "url": "https://dor-services-{env}.stanford.edu/{version}",
+      "url": "https://dor-services-{env}.stanford.edu",
       "description": "Production service",
       "variables": {
         "env": {
           "default": "prod"
-        },
-        "version": {
-          "default": "v1"
         }
       }
     },
     {
-      "url": "https://dor-services-{env}.stanford.edu/{version}",
+      "url": "https://dor-services-{env}.stanford.edu",
       "description": "Staging service",
       "variables": {
         "env": {
           "default": "stage"
-        },
-        "version": {
-          "default": "v1"
         }
       }
     }
@@ -70,7 +64,17 @@
     }
   ],
   "paths": {
-    "/sdr/objects/{id}/cm-inv-diff": {
+    "/v1/about": {
+      "get": {
+        "summary": "A healthcheck endpoint",
+        "responses": {
+          "200": {
+            "description": "The status of the service"
+          }
+        }
+      }
+    },
+    "/v1/sdr/objects/{id}/cm-inv-diff": {
       "post": {
         "tags": [
           "preservation"
@@ -97,7 +101,7 @@
         ]
       }
     },
-    "/sdr/objects/{id}/current_version": {
+    "/v1/sdr/objects/{id}/current_version": {
       "get": {
         "tags": [
           "preservation"
@@ -124,7 +128,7 @@
         ]
       }
     },
-    "/sdr/objects/{id}/manifest/{datastream}": {
+    "/v1/sdr/objects/{id}/manifest/{datastream}": {
       "get": {
         "tags": [
           "preservation"
@@ -160,7 +164,7 @@
         ]
       }
     },
-    "/sdr/objects/{id}/metadata/{datastream}": {
+    "/v1/sdr/objects/{id}/metadata/{datastream}": {
       "get": {
         "tags": [
           "preservation"
@@ -196,7 +200,7 @@
         ]
       }
     },
-    "/sdr/objects/{id}/content/{filename}": {
+    "/v1/sdr/objects/{id}/content/{filename}": {
       "get": {
         "tags": [
           "preservation"
@@ -232,7 +236,7 @@
         ]
       }
     },
-    "/catalog/catkey": {
+    "/v1/catalog/catkey": {
       "get": {
         "tags": [
           "integrations"
@@ -258,7 +262,7 @@
         ]
       }
     },
-    "/background_job_results/{id}": {
+    "/v1/background_job_results/{id}": {
       "get": {
         "tags": [
           "jobs"
@@ -311,7 +315,7 @@
         ]
       }
     },
-    "/virtual_objects": {
+    "/v1/virtual_objects": {
       "post": {
         "tags": [
           "objects"
@@ -338,9 +342,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "required": ["virtual_objects"],
                 "properties": {
                   "virtual_objects": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                       "$ref": "#/components/schemas/VirtualObjectRequest"
                     }
@@ -352,7 +358,7 @@
         }
       }
     },
-    "/objects/{id}/publish": {
+    "/v1/objects/{id}/publish": {
       "post": {
         "tags": [
           "objects"
@@ -397,7 +403,7 @@
         ]
       }
     },
-    "/objects/{id}/preserve": {
+    "/v1/objects/{id}/preserve": {
       "post": {
         "tags": [
           "objects"
@@ -432,7 +438,7 @@
         ]
       }
     },
-    "/objects/{id}/update_marc_record": {
+    "/v1/objects/{id}/update_marc_record": {
       "post": {
         "tags": [
           "integrations"
@@ -458,7 +464,7 @@
         ]
       }
     },
-    "/objects/{id}/notify_goobi": {
+    "/v1/objects/{id}/notify_goobi": {
       "post": {
         "tags": [
           "integrations"
@@ -484,7 +490,7 @@
         ]
       }
     },
-    "/objects/{id}/release_tags": {
+    "/v1/objects/{id}/release_tags": {
       "post": {
         "tags": [
           "objects"
@@ -510,7 +516,7 @@
         ]
       }
     },
-    "/objects/{id}/refresh_metadata": {
+    "/v1/objects/{id}/refresh_metadata": {
       "post": {
         "tags": [
           "integrations"
@@ -536,7 +542,7 @@
         ]
       }
     },
-    "/objects/{id}/contents": {
+    "/v1/objects/{id}/contents": {
       "get": {
         "tags": [
           "files"
@@ -562,7 +568,7 @@
         ]
       }
     },
-    "/objects/{id}/contents/{path}": {
+    "/v1/objects/{id}/contents/{path}": {
       "get": {
         "tags": [
           "files"
@@ -597,7 +603,7 @@
         ]
       }
     },
-    "/objects/{object_id}/query/collections": {
+    "/v1/objects/{object_id}/query/collections": {
       "get": {
         "tags": [
           "objects"
@@ -623,7 +629,7 @@
         ]
       }
     },
-    "/objects/{object_id}/workspace": {
+    "/v1/objects/{object_id}/workspace": {
       "delete": {
         "tags": [
           "workspaces"
@@ -683,7 +689,7 @@
         ]
       }
     },
-    "/objects/{object_id}/workspace/reset": {
+    "/v1/objects/{object_id}/workspace/reset": {
       "post": {
         "tags": [
           "workspaces"
@@ -719,7 +725,7 @@
         ]
       }
     },
-    "/objects/{object_id}/embargo": {
+    "/v1/objects/{object_id}/embargo": {
       "patch": {
         "tags": [
           "embargoes"
@@ -745,7 +751,7 @@
         ]
       }
     },
-    "/objects/{object_id}/shelve": {
+    "/v1/objects/{object_id}/shelve": {
       "post": {
         "tags": [
           "objects"
@@ -790,8 +796,8 @@
         ]
       }
     },
-    "/objects/{object_id}/metadata/legacy": {
-      "post": {
+    "/v1/objects/{object_id}/metadata/legacy": {
+      "patch": {
         "tags": [
           "objects"
         ],
@@ -825,7 +831,7 @@
         }
       }
     },
-    "/objects/{object_id}/metadata/dublin_core": {
+    "/v1/objects/{object_id}/metadata/dublin_core": {
       "get": {
         "tags": [
           "objects"
@@ -851,7 +857,7 @@
         ]
       }
     },
-    "/objects/{object_id}/metadata/descriptive": {
+    "/v1/objects/{object_id}/metadata/descriptive": {
       "get": {
         "tags": [
           "objects"
@@ -877,7 +883,7 @@
         ]
       }
     },
-    "/objects/{object_id}/versions/openable": {
+    "/v1/objects/{object_id}/versions/openable": {
       "get": {
         "tags": [
           "versions"
@@ -903,7 +909,7 @@
         ]
       }
     },
-    "/objects/{object_id}/versions/current": {
+    "/v1/objects/{object_id}/versions/current": {
       "get": {
         "tags": [
           "versions"
@@ -929,7 +935,7 @@
         ]
       }
     },
-    "/objects/{object_id}/versions/current/close": {
+    "/v1/objects/{object_id}/versions/current/close": {
       "post": {
         "tags": [
           "versions"
@@ -955,7 +961,7 @@
         ]
       }
     },
-    "/objects/{object_id}/versions": {
+    "/v1/objects/{object_id}/versions": {
       "post": {
         "tags": [
           "versions"
@@ -981,7 +987,7 @@
         ]
       }
     },
-    "/objects": {
+    "/v1/objects": {
       "post": {
         "tags": [
           "objects"
@@ -997,7 +1003,7 @@
         "parameters": []
       }
     },
-    "/objects/{id}": {
+    "/v1/objects/{id}": {
       "get": {
         "tags": [
           "objects"
@@ -1271,12 +1277,14 @@
       },
       "VirtualObjectRequest": {
         "type": "object",
+        "required": ["parent_id", "child_ids"],
         "properties": {
           "parent_id": {
             "$ref": "#/components/schemas/Druid"
           },
           "child_ids": {
             "type": "array",
+            "minItems": 1,
             "items": {
               "$ref": "#/components/schemas/Druid"
             }

--- a/spec/requests/add_release_tags_spec.rb
+++ b/spec/requests/add_release_tags_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Add release tags' do
-  let(:object) { Dor::Item.new(pid: 'druid:1234') }
+  let(:druid) { 'druid:mx123qw2323' }
+  let(:object) { Dor::Item.new(pid: druid) }
 
   before do
     allow(Dor).to receive(:find).and_return(object)
@@ -13,7 +14,7 @@ RSpec.describe 'Add release tags' do
 
   context 'when release is false' do
     it 'adds a release tag' do
-      post '/v1/objects/druid:1234/release_tags',
+      post "/v1/objects/#{druid}/release_tags",
            params: %( {"to":"searchworks","who":"carrickr","what":"self","release":false} ),
            headers: { 'Authorization' => "Bearer #{jwt}" }
 
@@ -27,7 +28,7 @@ RSpec.describe 'Add release tags' do
 
   context 'when release is true' do
     it 'adds a release tag' do
-      post '/v1/objects/druid:1234/release_tags',
+      post "/v1/objects/#{druid}/release_tags",
            params: %( {"to":"searchworks","who":"carrickr","what":"self","release":true} ),
            headers: { 'Authorization' => "Bearer #{jwt}" }
 
@@ -40,7 +41,7 @@ RSpec.describe 'Add release tags' do
 
   context 'with an invalid release attribute' do
     it 'returns an error' do
-      post '/v1/objects/druid:1234/release_tags',
+      post "/v1/objects/#{druid}/release_tags",
            params: %( {"to":"searchworks","who":"carrickr","what":"self","release":"seven"} ),
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.status).to eq(400)

--- a/spec/requests/batch_create_virtual_objects_spec.rb
+++ b/spec/requests/batch_create_virtual_objects_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Batch creation of virtual objects' do
-  let(:child1_id) { 'druid:child1' }
-  let(:child2_id) { 'druid:child2' }
+  let(:child1_id) { 'druid:kx420bs7601' }
+  let(:child2_id) { 'druid:sb340kx7205' }
   # We use `#with_indifferent_access` here to mimic how Rails parses JSON parameters
   let(:body) { JSON.parse(response.body).with_indifferent_access }
   let(:parent_id) { 'druid:mk420bs7601' }
@@ -18,8 +18,8 @@ RSpec.describe 'Batch creation of virtual objects' do
   context 'when virtual_objects param is provided' do
     it 'queues a background job to create a virtual object' do
       post '/v1/virtual_objects',
-           params: { virtual_objects: virtual_objects },
-           headers: { 'Authorization' => "Bearer #{jwt}" }
+           params: { virtual_objects: virtual_objects }.to_json,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'CONTENT_TYPE' => 'application/json' }
       expect(CreateVirtualObjectsJob).to have_received(:perform_later)
         .with(virtual_objects: virtual_objects, background_job_result: instance_of(BackgroundJobResult)).once
       expect(response).to have_http_status(:created)
@@ -30,99 +30,100 @@ RSpec.describe 'Batch creation of virtual objects' do
   context 'when virtual_objects param is not provided' do
     it 'renders an error' do
       post '/v1/virtual_objects',
-           params: { title: 'New name' },
-           headers: { 'Authorization' => "Bearer #{jwt}" }
+           params: { title: 'New name' }.to_json,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'CONTENT_TYPE' => 'application/json' }
       expect(CreateVirtualObjectsJob).not_to have_received(:perform_later)
       expect(response).to have_http_status(:bad_request)
-      expect(body['errors'][0]['text']).to eq('virtual_objects is missing')
+      expect(body['errors'][0]['detail']).to eq('#/paths/~1v1~1virtual_objects/post/requestBody/content/application~1json/schema missing required parameters: virtual_objects')
     end
   end
 
   context 'when virtual_objects is not an array' do
     it 'renders an error' do
       post '/v1/virtual_objects',
-           params: { virtual_objects: child1_id },
-           headers: { 'Authorization' => "Bearer #{jwt}" }
+           params: { virtual_objects: child1_id }.to_json,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'CONTENT_TYPE' => 'application/json' }
       expect(CreateVirtualObjectsJob).not_to have_received(:perform_later)
       expect(response).to have_http_status(:bad_request)
-      expect(body['errors'][0]['text']).to eq('virtual_objects must be an array')
+      expect(body['errors'][0]['detail']).to eq('#/paths/~1v1~1virtual_objects/post/requestBody/content/application~1json/schema/properties/virtual_objects ' \
+        "expected array, but received String: #{child1_id}")
     end
   end
 
   context 'when virtual_objects is empty array' do
     it 'renders an error' do
       post '/v1/virtual_objects',
-           params: { virtual_objects: [] },
-           headers: { 'Authorization' => "Bearer #{jwt}" }
+           params: { virtual_objects: [] }.to_json,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'CONTENT_TYPE' => 'application/json' }
       expect(CreateVirtualObjectsJob).not_to have_received(:perform_later)
       expect(response).to have_http_status(:bad_request)
-      expect(body['errors'][0]['text']).to eq('parent_id is missing')
+      expect(body['errors'][0]['detail']).to eq('#/paths/~1v1~1virtual_objects/post/requestBody/content/application~1json/schema/properties/virtual_objects [] contains fewer than min items')
     end
   end
 
   context 'when virtual_objects array lacks hashes defining parent_id' do
     it 'renders an error' do
       post '/v1/virtual_objects',
-           params: { virtual_objects: [{ child_ids: ['foo'] }] },
-           headers: { 'Authorization' => "Bearer #{jwt}" }
+           params: { virtual_objects: [{ child_ids: ['druid:bb111cc3333'] }] }.to_json,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'CONTENT_TYPE' => 'application/json' }
       expect(CreateVirtualObjectsJob).not_to have_received(:perform_later)
       expect(response).to have_http_status(:bad_request)
-      expect(body['errors'][0]['text']).to eq('parent_id is missing')
+      expect(body['errors'][0]['detail']).to eq('#/components/schemas/VirtualObjectRequest missing required parameters: parent_id')
     end
   end
 
   context 'when virtual_objects array has a hash w/ an empty parent_id' do
     it 'renders an error' do
       post '/v1/virtual_objects',
-           params: { virtual_objects: [{ parent_id: '' }] },
-           headers: { 'Authorization' => "Bearer #{jwt}" }
+           params: { virtual_objects: [{ parent_id: '' }] }.to_json,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'CONTENT_TYPE' => 'application/json' }
       expect(CreateVirtualObjectsJob).not_to have_received(:perform_later)
       expect(response).to have_http_status(:bad_request)
-      expect(body['errors'][0]['text']).to eq('parent_id must be filled')
+      expect(body['errors'][0]['detail']).to eq('#/components/schemas/Druid pattern ^druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$ does not match value: ')
     end
   end
 
   context 'when virtual_objects array lacks hashes defining child_ids' do
     it 'renders an error' do
       post '/v1/virtual_objects',
-           params: { virtual_objects: [{ parent_id: 'foo' }] },
-           headers: { 'Authorization' => "Bearer #{jwt}" }
+           params: { virtual_objects: [{ parent_id: 'druid:bb111cc3333' }] }.to_json,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'CONTENT_TYPE' => 'application/json' }
       expect(CreateVirtualObjectsJob).not_to have_received(:perform_later)
       expect(response).to have_http_status(:bad_request)
-      expect(body['errors'][0]['text']).to eq('child_ids is missing')
+      expect(body['errors'][0]['detail']).to eq('#/components/schemas/VirtualObjectRequest missing required parameters: child_ids')
     end
   end
 
   context 'when virtual_objects array has a hash w/ child_ids not an array' do
     it 'renders an error' do
       post '/v1/virtual_objects',
-           params: { virtual_objects: [{ parent_id: 'foo', child_ids: '' }] },
-           headers: { 'Authorization' => "Bearer #{jwt}" }
+           params: { virtual_objects: [{ parent_id: 'druid:bb111cc3333', child_ids: '' }] }.to_json,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'CONTENT_TYPE' => 'application/json' }
       expect(CreateVirtualObjectsJob).not_to have_received(:perform_later)
       expect(response).to have_http_status(:bad_request)
-      expect(body['errors'][0]['text']).to eq('child_ids must be an array')
+      expect(body['errors'][0]['detail']).to eq('#/components/schemas/VirtualObjectRequest/properties/child_ids expected array, but received String: ')
     end
   end
 
   context 'when virtual_objects array has a hash w/ child_ids empty' do
     it 'renders an error' do
       post '/v1/virtual_objects',
-           params: { virtual_objects: [{ parent_id: 'foo', child_ids: [] }] },
-           headers: { 'Authorization' => "Bearer #{jwt}" }
+           params: { virtual_objects: [{ parent_id: 'druid:bb111cc3333', child_ids: [] }] }.to_json,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'CONTENT_TYPE' => 'application/json' }
       expect(CreateVirtualObjectsJob).not_to have_received(:perform_later)
       expect(response).to have_http_status(:bad_request)
-      expect(body['errors'][0]['text']).to eq('0 must be filled')
+      expect(body['errors'][0]['detail']).to eq('#/components/schemas/VirtualObjectRequest/properties/child_ids [] contains fewer than min items')
     end
   end
 
   context 'when virtual_objects array has a hash w/ child_ids containing empties' do
     it 'renders an error' do
       post '/v1/virtual_objects',
-           params: { virtual_objects: [{ parent_id: 'foo', child_ids: ['foo', 'bar', ''] }] },
-           headers: { 'Authorization' => "Bearer #{jwt}" }
+           params: { virtual_objects: [{ parent_id: 'druid:bb111cc3333', child_ids: ['druid:ff111cc3333', 'druid:cc111dd3333', ''] }] }.to_json,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'CONTENT_TYPE' => 'application/json' }
       expect(CreateVirtualObjectsJob).not_to have_received(:perform_later)
       expect(response).to have_http_status(:bad_request)
-      expect(body['errors'][0]['text']).to eq('2 must be filled')
+      expect(body['errors'][0]['detail']).to eq('#/components/schemas/Druid pattern ^druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$ does not match value: ')
     end
   end
 end

--- a/spec/requests/cleanup_workspace_spec.rb
+++ b/spec/requests/cleanup_workspace_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Cleanup workspace' do
-  let(:object_id) { 'druid:aa222cc3333' }
+  let(:object_id) { 'druid:bb222cc3333' }
 
   context 'when successful' do
     before do

--- a/spec/requests/notify_goobi_spec.rb
+++ b/spec/requests/notify_goobi_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Notify Goobi' do
-  let(:object) { Dor::Item.new(pid: 'druid:1234') }
+  let(:druid) { 'druid:mx123qw2323' }
+  let(:object) { Dor::Item.new(pid: druid) }
   let(:fake_request) { "<stanfordCreationRequest><objectId>#{object.pid}</objectId></stanfordCreationRequest>" }
 
   before do
@@ -20,7 +21,7 @@ RSpec.describe 'Notify Goobi' do
     end
 
     it 'notifies goobi of a new registration by making a web service call' do
-      post '/v1/objects/druid:1234/notify_goobi', headers: { 'Authorization' => "Bearer #{jwt}" }
+      post "/v1/objects/#{druid}/notify_goobi", headers: { 'Authorization' => "Bearer #{jwt}" }
 
       expect(response.status).to eq(201)
     end
@@ -34,7 +35,7 @@ RSpec.describe 'Notify Goobi' do
     end
 
     it 'returns the conflict code' do
-      post '/v1/objects/druid:1234/notify_goobi', headers: { 'Authorization' => "Bearer #{jwt}" }
+      post "/v1/objects/#{druid}/notify_goobi", headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.status).to eq(409)
       expect(response.body).to eq('conflict')
     end

--- a/spec/requests/preserve_spec.rb
+++ b/spec/requests/preserve_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Preserve object' do
-  let(:object) { Dor::Item.new(pid: 'druid:1234') }
+  let(:druid) { 'druid:mx123qw2323' }
+  let(:object) { Dor::Item.new(pid: druid) }
 
   before do
     allow(Dor).to receive(:find).and_return(object)
@@ -11,9 +12,9 @@ RSpec.describe 'Preserve object' do
   end
 
   it 'initiates PreserveJob and returns 201' do
-    post '/v1/objects/druid:1234/preserve', headers: { 'Authorization' => "Bearer #{jwt}" }
+    post "/v1/objects/#{druid}/preserve", headers: { 'Authorization' => "Bearer #{jwt}" }
 
-    expect(PreserveJob).to have_received(:perform_later).with(druid: 'druid:1234', background_job_result: BackgroundJobResult)
+    expect(PreserveJob).to have_received(:perform_later).with(druid: druid, background_job_result: BackgroundJobResult)
     expect(response.status).to eq(201)
   end
 end

--- a/spec/requests/reset_workspace_spec.rb
+++ b/spec/requests/reset_workspace_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Reset workspace' do
   let(:item) { instance_double(Dor::Item, current_version: 2) }
-  let(:druid) { 'druid:aa222cc3333' }
+  let(:druid) { 'druid:bb222cc3333' }
 
   before do
     allow(Dor).to receive(:find).and_return(item)
@@ -17,7 +17,6 @@ RSpec.describe 'Reset workspace' do
 
     it 'is successful' do
       post "/v1/objects/#{druid}/workspace/reset", headers: { 'Authorization' => "Bearer #{jwt}" }
-
       expect(ResetWorkspaceService).to have_received(:reset).with(druid: druid, version: 2)
       expect(response).to be_no_content
     end

--- a/spec/requests/shelving_spec.rb
+++ b/spec/requests/shelving_spec.rb
@@ -8,13 +8,14 @@ RSpec.describe 'Shelve object' do
     allow(ShelveJob).to receive(:perform_later)
   end
 
-  let(:object) { Dor::Item.new(pid: 'druid:1234') }
+  let(:druid) { 'druid:mx123qw2323' }
+  let(:object) { Dor::Item.new(pid: druid) }
 
   context 'with a collection' do
-    let(:object) { Dor::Collection.new(pid: 'druid:1234') }
+    let(:object) { Dor::Collection.new(pid: druid) }
 
     it 'returns a 422 error' do
-      post '/v1/objects/druid:1234/shelve', headers: { 'Authorization' => "Bearer #{jwt}" }
+      post "/v1/objects/#{druid}/shelve", headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to have_http_status(:unprocessable_entity)
       json = JSON.parse(response.body)
       expect(json['errors'].first['detail']).to eq("A Dor::Item is required but you provided 'Dor::Collection'")
@@ -24,11 +25,11 @@ RSpec.describe 'Shelve object' do
 
   context 'when the request is successful' do
     it 'calls ShelvingService and returns201' do
-      post '/v1/objects/druid:1234/shelve', headers: { 'Authorization' => "Bearer #{jwt}" }
+      post "/v1/objects/#{druid}/shelve", headers: { 'Authorization' => "Bearer #{jwt}" }
 
       expect(response).to have_http_status(:created)
       expect(ShelveJob).to have_received(:perform_later)
-        .with(druid: 'druid:1234', background_job_result: BackgroundJobResult)
+        .with(druid: druid, background_job_result: BackgroundJobResult)
     end
   end
 end

--- a/spec/requests/update_marc_record_spec.rb
+++ b/spec/requests/update_marc_record_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Update MARC record' do
-  let(:object) { Dor::Item.new(pid: 'druid:1234') }
+  let(:druid) { 'druid:mx123qw2323' }
+  let(:object) { Dor::Item.new(pid: druid) }
 
   before do
     allow(Dor).to receive(:find).and_return(object)
@@ -11,8 +12,7 @@ RSpec.describe 'Update MARC record' do
 
   context 'when the request is successful' do
     it 'returns a 201 response' do
-      post '/v1/objects/druid:1234/update_marc_record', headers: { 'Authorization' => "Bearer #{jwt}" }
-
+      post "/v1/objects/#{druid}/update_marc_record", headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.status).to eq(201)
     end
   end


### PR DESCRIPTION

## Why was this change made?

This uses the spec for validating requests instead of it just being for documentation. This ensures our documentation is up to date and accurate


## Was the API documentation (openapi.json) updated?

Yes