### PR TITLE
PreserveJob must be called with a workflow

### DIFF
--- a/app/jobs/preserve_job.rb
+++ b/app/jobs/preserve_job.rb
@@ -15,6 +15,7 @@ class PreserveJob < ApplicationJob
     rescue StandardError => e
       return LogFailureJob.perform_later(druid: druid,
                                          background_job_result: background_job_result,
+                                         workflow: 'accessionWF',
                                          workflow_process: 'sdr-ingest-transfer',
                                          output: { errors: [{ title: 'Preservation error', detail: e.message }] })
     end

--- a/spec/jobs/preserve_job_spec.rb
+++ b/spec/jobs/preserve_job_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe PreserveJob, type: :job do
       expect(LogFailureJob).to have_received(:perform_later)
         .with(druid: druid,
               background_job_result: result,
+              workflow: 'accessionWF',
               workflow_process: 'sdr-ingest-transfer',
               output: { errors: [{ detail: error_message, title: 'Preservation error' }] })
     end


### PR DESCRIPTION
## Why was this change made?

Currently there are a lot of jobs that were created when a different branch of code was deployed. Now their failure can't be logged because the wrong arguments are not passed.  Extracted from #506

Fixes #523

## Was the API documentation (openapi.json) updated?
n/a