### PR TITLE
SdrIngestServices uses pres-client to get signature_catalog (manifest)

### DIFF
--- a/app/jobs/preserve_job.rb
+++ b/app/jobs/preserve_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Move an object to SDR in the background
+# Move an object to Preservation (SDR) in the background
 class PreserveJob < ApplicationJob
   queue_as :default
 

--- a/app/services/sdr_client.rb
+++ b/app/services/sdr_client.rb
@@ -29,8 +29,10 @@ class SdrClient
   deprecation_deprecate content_diff: 'Use preservation-client .content_inventory_diff or .shelve_content_diff in caller instead.'
 
   def manifest(ds_name:)
+    Honeybadger.notify('dor-services-app deprecated method `SdrClient.manifest` called. Use preservation-client .manifest or .signature_catalog instead.')
     sdr_get("/objects/#{druid}/manifest/#{ds_name}")
   end
+  deprecation_deprecate manifest: 'Use preservation-client .manifest or .signature_catalog in caller instead.'
 
   def metadata(ds_name:)
     Honeybadger.notify('dor-services-app deprecated method `SdrClient.metadata` called. Use preservation-client .metadata instead.')

--- a/app/services/sdr_client.rb
+++ b/app/services/sdr_client.rb
@@ -9,6 +9,7 @@ class SdrClient
   # @raises [Dor::Exception] if SDR doesn't know about the object (i.e. 404 response code)
   # @raises [StandardError] if the response from SDR can't be parsed
   def self.current_version(druid)
+    Honeybadger.notify('dor-services-app deprecated class method `SdrClient.current_version` called. Use preservation-client .current_version instead.')
     new(druid).current_version(parsed: true)
   end
 


### PR DESCRIPTION
- ~~PR #529 to use preservation-client v1.0.0 must be merged first, and then this will need a rebase.~~

## Why was this change made?

To get rid of `manifest` API endpoint in sdr-services-app. We use preservation-client `signature_catalog` method instead.

## Was the API documentation (openapi.json) updated?

no need as the `manifest` method here was already deprecated.