### PR TITLE
Upgrade to preservation-client 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'dor-services', '~> 8.0'
 gem 'dor-workflow-client', '~> 3.9'
 gem 'marc'
 gem 'moab-versioning', '~> 4.0', require: 'moab/stanford'
-gem 'preservation-client'
+gem 'preservation-client', '~> 2.0'
 
 group :test, :development do
   gem 'coveralls', '~> 0.8', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,7 @@ GEM
     parser (2.6.5.0)
       ast (~> 2.4.0)
     pg (1.1.4)
-    preservation-client (1.0.0)
+    preservation-client (2.0.0)
       activesupport (>= 4.2, < 7)
       faraday (~> 0.15)
       moab-versioning (~> 4.3)
@@ -509,7 +509,7 @@ DEPENDENCIES
   net-http-persistent (~> 2.9)
   okcomputer
   pg
-  preservation-client
+  preservation-client (~> 2.0)
   progressbar
   pry-byebug
   puma (~> 3.0)


### PR DESCRIPTION
## Why was this change made?

Need to use the correct urls for preservation service

## Was the API documentation (openapi.json) updated?
n/a