### PR TITLE
Pass a version when starting a workflow

### DIFF
--- a/app/jobs/preserve_job.rb
+++ b/app/jobs/preserve_job.rb
@@ -20,6 +20,8 @@ class PreserveJob < ApplicationJob
                                          output: { errors: [{ title: 'Preservation error', detail: e.message }] })
     end
 
-    StartPreservationWorkflowJob.perform_later(druid: druid, background_job_result: background_job_result)
+    StartPreservationWorkflowJob.perform_later(druid: druid,
+                                               version: item.current_version,
+                                               background_job_result: background_job_result)
   end
 end

--- a/app/jobs/start_preservation_workflow_job.rb
+++ b/app/jobs/start_preservation_workflow_job.rb
@@ -7,10 +7,11 @@ class StartPreservationWorkflowJob < ApplicationJob
   queue_as :default
 
   # @param [String] druid the identifier of the item to be published
+  # @param [String] version the current version of the item to be published
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
-  def perform(druid:, background_job_result:)
+  def perform(druid:, version:, background_job_result:)
     # start SDR preservation workflow
-    Dor::Config.workflow.client.create_workflow_by_name(druid, 'preservationIngestWF')
+    Dor::Config.workflow.client.create_workflow_by_name(druid, 'preservationIngestWF', version: version)
 
     LogSuccessJob.perform_later(druid: druid,
                                 workflow: 'accessionWF',

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -36,7 +36,7 @@ class VersionService
     vmd_ds.sync_then_increment_version sdr_version
     vmd_ds.save unless work.new_record?
 
-    Dor::Config.workflow.client.create_workflow_by_name(work.pid, 'versioningWF')
+    Dor::Config.workflow.client.create_workflow_by_name(work.pid, 'versioningWF', version: work.current_version)
 
     return if (opts.keys & open_options_requiring_work_save).empty?
 

--- a/spec/jobs/preserve_job_spec.rb
+++ b/spec/jobs/preserve_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PreserveJob, type: :job do
 
   let(:druid) { 'druid:mk420bs7601' }
   let(:result) { create(:background_job_result) }
-  let(:item) { instance_double(Dor::Item) }
+  let(:item) { instance_double(Dor::Item, current_version: '7') }
 
   before do
     allow(Dor).to receive(:find).with(druid).and_return(item)

--- a/spec/jobs/start_preservation_workflow_job_spec.rb
+++ b/spec/jobs/start_preservation_workflow_job_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe StartPreservationWorkflowJob, type: :job do
   subject(:perform) do
     described_class.perform_now(druid: druid,
+                                version: '7',
                                 background_job_result: result)
   end
 
@@ -19,7 +20,7 @@ RSpec.describe StartPreservationWorkflowJob, type: :job do
   it 'marks the job as success' do
     perform
     expect(Dor::Config.workflow.client).to have_received(:create_workflow_by_name)
-      .with(druid, 'preservationIngestWF')
+      .with(druid, 'preservationIngestWF', version: '7')
     expect(LogSuccessJob).to have_received(:perform_later)
       .with(
         druid: druid,

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe VersionService do
         expect(workflow_client).to have_received(:lifecycle).with('dor', druid, 'accessioned')
         expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'opened', version: '1')
         expect(workflow_client).to have_received(:active_lifecycle).with('dor', druid, 'submitted', version: '1')
-        expect(workflow_client).to have_received(:create_workflow_by_name).with(obj.pid, 'versioningWF')
+        expect(workflow_client).to have_received(:create_workflow_by_name).with(obj.pid, 'versioningWF', version: '2')
       end
 
       it 'includes options' do


### PR DESCRIPTION
## Why was this change made?

Not passing a version is deprecated as the workflow server would have to call back to dor-services-app to get the current version.

## Was the API documentation (openapi.json) updated?
n/a