### PR TITLE
Test without using node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 jobs:
   test:
     docker:
-    - image: circleci/ruby:2.5.3-stretch-node
+    - image: circleci/ruby:2.5.3-stretch
       environment:
         BUNDLE_JOBS: 3
         BUNDLE_RETRY: 3


### PR DESCRIPTION
## Why was this change made?

* Don't install software we don't need.
* Make the builds faster


## Was the API documentation (openapi.json) updated?
n/a