### PR TITLE
Update to bundler 2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -531,4 +531,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.3
+   2.1.1


### PR DESCRIPTION
## Why was this change made?

So that all of our projects are consistently on bundler 2.


## Was the API documentation (openapi.json) updated?
n/a