### PR TITLE
Add status checks to the OAS

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -64,6 +64,26 @@
     }
   ],
   "paths": {
+    "/status": {
+      "get": {
+        "summary": "A healthcheck endpoint for the application",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/status/external-symphony": {
+      "get": {
+        "summary": "A healthcheck endpoint for the symphony connection",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/v1/about": {
       "get": {
         "summary": "A healthcheck endpoint",

--- a/spec/requests/status_spec.rb
+++ b/spec/requests/status_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Status (okcomputer)' do
+  describe 'for application health' do
+    it 'is successful' do
+      get '/status'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'for Symphony connection' do
+    let(:symphony_client) { instance_double(Faraday::Connection, get: true) }
+
+    before do
+      allow(SymphonyReader).to receive(:client).and_return(symphony_client)
+    end
+
+    it 'is successful' do
+      get '/status/external-symphony'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Health checks from Nagios were now getting 404

## Was the API documentation (openapi.json) updated?
yes