### PR TITLE
Add sidekiq support to openapi

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -61,6 +61,10 @@
     {
       "name": "embargoes",
       "description": "Operations about embargoes"
+    },
+    {
+      "name": "sidekiq",
+      "description": "Queue monitoring"
     }
   ],
   "paths": {
@@ -77,6 +81,65 @@
     "/status/external-symphony": {
       "get": {
         "summary": "A healthcheck endpoint for the symphony connection",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/queues": {
+      "get": {
+        "summary": "Endpoint for sidekiq web monitoring",
+        "tags": [
+          "sidekiq"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/queues/{path}/{file}": {
+      "get": {
+        "summary": "Assets for sidekiq web monitoring",
+        "tags": [
+          "sidekiq"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "parameters": [
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "example": "javascripts",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "file",
+            "in": "path",
+            "required": true,
+            "example": "application.js",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/queues/stats": {
+      "get": {
+        "summary": "Stats for sidekiq web monitoring",
+        "tags": [
+          "sidekiq"
+        ],
         "responses": {
           "200": {
             "description": "OK"


### PR DESCRIPTION

## Why was this change made?

Presently the middleware prevents us from monitoring sidekiq.
Ideally this would probably be on a different machine (similar to robot-console)


## Was the API documentation (openapi.json) updated?
yes