### PR TITLE
Handles and/or documents pres client errors.

### DIFF
--- a/app/jobs/create_virtual_objects_job.rb
+++ b/app/jobs/create_virtual_objects_job.rb
@@ -17,7 +17,7 @@ class CreateVirtualObjectsJob < ApplicationJob
       # Do not add `nil`s to the errors array as they signify successful
       # creation of the virtual object
       errors << result if result.present?
-    rescue ActiveFedora::ObjectNotFoundError, Rubydora::FedoraInvalidRequest, Dor::Exception => e
+    rescue ActiveFedora::ObjectNotFoundError, Rubydora::FedoraInvalidRequest, Dor::Exception, Preservation::Client::Error => e
       errors << { parent_id => [e.message] }
     rescue StandardError => e
       errors << { parent_id => [e.message] }

--- a/app/services/constituent_service.rb
+++ b/app/services/constituent_service.rb
@@ -19,6 +19,7 @@ class ConstituentService
   # subsequent calls will erase the previous changes.
   # @param [Array<String>] child_druids the identifiers of the child objects
   # @raises ActiveFedora::RecordInvalid if AF object validations fail on #save!
+  # @raise [Preservation::Client::Error] if bad response from preservation catalog.
   # @returns [NilClass, Hash] true if successful, hash of errors otherwise (if combinable validation fails)
   def add(child_druids:)
     errors = ItemQueryService.validate_combinable_items(parent: parent_druid, children: child_druids)

--- a/app/services/sdr_ingest_service.rb
+++ b/app/services/sdr_ingest_service.rb
@@ -9,6 +9,7 @@ require 'moab/stanford'
 class SdrIngestService
   # @param [Dor::Item] dor_item The representation of the digital object
   # @return [void] Create the Moab/bag manifests for new version, export data to BagIt bag, kick off the SDR preservation workflow
+  # @raise [Preservation::Client::Error] if bad response from preservation catalog.
   def self.transfer(dor_item)
     druid = dor_item.pid
     workspace = DruidTools::Druid.new(druid, Settings.sdr.local_workspace_root)
@@ -43,6 +44,7 @@ class SdrIngestService
   # @param [String] druid The object identifier
   # @return [Moab::SignatureCatalog] the manifest of all files previously ingested,
   #   or if there is none, a SignatureCatalog object for version 0.
+  # @raise [Preservation::Client::Error] if bad response from preservation catalog.
   def self.signature_catalog_from_preservation(druid)
     Preservation::Client.objects.signature_catalog(druid)
   rescue Preservation::Client::NotFoundError

--- a/app/services/shelving_service.rb
+++ b/app/services/shelving_service.rb
@@ -31,6 +31,9 @@ class ShelvingService
 
   # retrieve the differences between the current contentMetadata and the previously ingested version
   # (filtering to select only the files that should be shelved to stacks)
+  # @raise [Preservation::Client::Error] if bad response from preservation catalog.
+  # @raise [Dor::ParameterError] if missing local workspace root.
+  # @raise [Dor::Exception] if missing contentMetadata stream or something else went wrong.
   def shelve_diff
     @shelve_diff ||= begin
       raise Dor::ParameterError, 'Missing Dor::Config.stacks.local_workspace_root' if Dor::Config.stacks.local_workspace_root.nil?
@@ -39,6 +42,8 @@ class ShelvingService
       current_content = work.contentMetadata.content
       Preservation::Client.objects.shelve_content_diff(druid: work.pid, content_metadata: current_content)
     end
+  rescue Preservation::Client::Error => e
+    raise Dor::Exception, e
   end
 
   # Find the location of the object's content files in the workspace area

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -29,6 +29,7 @@ class VersionService
   # @option opts [String] :description set description of version change
   # @option opts [String] :opening_user_name add opening username to the events datastream
   # @raise [Dor::Exception] if the object hasn't been accessioned, or if a version is already opened
+  # @raise [Preservation::Client::Error] if bad response from preservation catalog.
   def open(opts = {})
     sdr_version = try_to_get_current_version(opts[:assume_accessioned])
 
@@ -51,6 +52,7 @@ class VersionService
   # @param [Hash] opts optional params
   # @option opts [Boolean] :assume_accessioned If true, does not check whether object has been accessioned.
   # @return [Boolean] true if a new version can be opened.
+  # @raise [Preservation::Client::Error] if bad response from preservation catalog.
   def can_open?(opts = {})
     try_to_get_current_version(opts[:assume_accessioned])
     true
@@ -87,8 +89,9 @@ class VersionService
   # Performs checks on whether a new version can be opened for an object
   # @return [Integer] the version from Preservation (SDR) if a version can be opened
   # @param [Boolean] :assume_accessioned If true, does not check whether object has been accessioned.
-  # @raise [Dor::Exception, Preservation::Client::Error] if the object hasn't been accessioned,
+  # @raise [Dor::Exception, Preservation::Client::NotFoundError] if the object hasn't been accessioned,
   #    if a version is already opened, or if Preservation returns 404 when queried.
+  # @raise [Preservation::Client::Error] if bad response from preservation catalog.
   def try_to_get_current_version(assume_accessioned = false)
     # Raised when the object has never been accessioned.
     # The accessioned milestone is the last step of the accessionWF.

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -106,6 +106,18 @@ RSpec.describe VersionsController do
         expect(response.status).to eq 422
       end
     end
+
+    context 'when preservation client call fails' do
+      before do
+        allow(VersionService).to receive(:open).and_raise(Preservation::Client::UnexpectedResponseError, 'Oops, a 500')
+      end
+
+      it 'returns an error' do
+        post :create, params: { object_id: item.pid }, as: :json
+        expect(response.body).to eq('{"errors":[{"status":"500","title":"Unable to open version due to preservation client error","detail":"Oops, a 500"}]}')
+        expect(response.status).to eq 500
+      end
+    end
   end
 
   describe '/versions/openable' do
@@ -130,6 +142,18 @@ RSpec.describe VersionsController do
         get :openable, params: { object_id: item.pid }
         expect(response.body).to eq('false')
         expect(response).to be_successful
+      end
+    end
+
+    context 'when preservation client call fails' do
+      before do
+        allow(VersionService).to receive(:can_open?).and_raise(Preservation::Client::UnexpectedResponseError, 'Oops, a 500')
+      end
+
+      it 'returns an error' do
+        get :openable, params: { object_id: item.pid }
+        expect(response.body).to eq('{"errors":[{"status":"500","title":"Unable to check if openable due to preservation client error","detail":"Oops, a 500"}]}')
+        expect(response.status).to eq 500
       end
     end
   end


### PR DESCRIPTION
closes #545

## Why was this change made?
To make sure that preservation client errors are handled correctly.


## Was the API documentation (openapi.json) updated?
No.