### PR TITLE
Add endpoints for retrying jobs

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -101,6 +101,32 @@
         }
       }
     },
+    "/queues/retries": {
+      "post": {
+        "summary": "Endpoint for sidekiq web monitoring to retry a job",
+        "tags": [
+          "sidekiq"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/queues/retries/all/retry": {
+      "post": {
+        "summary": "Endpoint for sidekiq web monitoring to retry all jobs",
+        "tags": [
+          "sidekiq"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/queues/{path}/{file}": {
       "get": {
         "summary": "Assets for sidekiq web monitoring",


### PR DESCRIPTION
## Why was this change made?

Currently we can't retry jobs from the UI


## Was the API documentation (openapi.json) updated?
yes