### PR TITLE
Log errors in PreserveJob in Honeybadger

### DIFF
--- a/app/jobs/preserve_job.rb
+++ b/app/jobs/preserve_job.rb
@@ -13,6 +13,8 @@ class PreserveJob < ApplicationJob
       item = Dor.find(druid)
       SdrIngestService.transfer(item)
     rescue StandardError => e
+      Honeybadger.context(background_job_result_id: background_job_result.id)
+      Honeybadger.notify(e)
       return LogFailureJob.perform_later(druid: druid,
                                          background_job_result: background_job_result,
                                          workflow: 'accessionWF',

--- a/spec/jobs/preserve_job_spec.rb
+++ b/spec/jobs/preserve_job_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe PreserveJob, type: :job do
   before do
     allow(Dor).to receive(:find).with(druid).and_return(item)
     allow(result).to receive(:processing!)
+    allow(Honeybadger).to receive(:notify)
+    allow(Honeybadger).to receive(:context)
   end
 
   context 'with no errors' do
@@ -52,6 +54,8 @@ RSpec.describe PreserveJob, type: :job do
               workflow: 'accessionWF',
               workflow_process: 'sdr-ingest-transfer',
               output: { errors: [{ detail: error_message, title: 'Preservation error' }] })
+      expect(Honeybadger).to have_received(:context).with(background_job_result_id: result.id)
+      expect(Honeybadger).to have_received(:notify).with(StandardError)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Honeybadger is not notifying on these errors, so we only see them by the BackgroundJobId that is in the error message of the workflow process.

## Was the API documentation (openapi.json) updated?
n/a