### PR TITLE
Update link to generated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This Ruby application provides a REST API for DOR Services.
 There is a [OAS 3.0 spec](http://spec.openapis.org/oas/v3.0.2) that documents the
-API in [openapi.json](openapi.json).  If you clone this repo, you can view this by opening [docs/index.html](docs/index.html).
+API in [openapi.json](openapi.json).  You can browse the generated documentation at [http://sul-dlss.github.io/dor-services-app/](http://sul-dlss.github.io/dor-services-app/)
 
 ## Authentication
 


### PR DESCRIPTION
## Why was this change made?
 Viewing on the web is more convenient


## Was the API documentation (openapi.json) updated?
n/a