### PR TITLE
Install bundler 2 for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN apk add --update --no-cache  \
   postgresql-client \
   tzdata
 
+# Get bundler 2.0
+RUN gem install bundler
+
 RUN mkdir /app
 WORKDIR /app
 


### PR DESCRIPTION
## Why was this change made?
Currently it won't build the image because the Gemfile.lock requires bundler 2.


## Was the API documentation (openapi.json) updated?
n/a