### PR TITLE
Run CI tests on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,12 +155,6 @@ jobs:
 workflows:
   version: 2
 
-  test:
-    jobs:
-    - test:
-        filters:
-          branches:
-            ignore: master
   build:
     jobs:
     - build-image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,10 @@ jobs:
 workflows:
   version: 2
 
+  test:
+    jobs:
+    - test
+
   build:
     jobs:
     - build-image:


### PR DESCRIPTION
This was disabled in the CircleCI config, likely because of copypasta.
