### PR TITLE
Add coveralls token to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
     - run:
         name: Run rspec in parallel
         command: |
-          bundle exec rspec --profile 10 \
+          COVERALLS_REPO_TOKEN=z4N0NPG6SFstUz6frJqnGeQZpYUExeHRX bundle exec rspec --profile 10 \
                             --format RspecJunitFormatter \
                             --out test_results/rspec.xml \
                             --format progress \


### PR DESCRIPTION
Including as ENV var in CircleCI project does not appear to work, and Coveralls suggests this is how to handle CircleCI integration.
