### PR TITLE
Replace Coveralls with CodeClimate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,13 @@ jobs:
         name: Check styles using rubocop
         command: bundle exec rubocop
 
+    - run:
+        name: Setup Code Climate test-reporter
+        command: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
+
     # Run rspec in parallel
     - run:
         name: Run rspec in parallel
@@ -79,6 +86,10 @@ jobs:
                             --out test_results/rspec.xml \
                             --format progress \
                             $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+
+    - run:
+        name: upload test coverage report to Code Climate
+        command: ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
 
     - run:
         name: Validate API specification

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ gem 'moab-versioning', '~> 4.0', require: 'moab/stanford'
 gem 'preservation-client', '~> 2.0'
 
 group :test, :development do
-  gem 'coveralls', '~> 0.8', require: false
   gem 'equivalent-xml'
   gem 'factory_bot_rails'
   gem 'rack-console'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,12 +112,6 @@ GEM
     confstruct (1.0.2)
       hashie (~> 3.3)
     connection_pool (2.2.2)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -465,15 +459,10 @@ GEM
     stanford-mods-normalizer (0.1.0)
       nokogiri (~> 1.8)
     stomp (1.4.9)
-    sync (0.5.0)
     temple (0.8.2)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tins (1.24.0)
-      sync
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uber (0.0.15)
@@ -506,7 +495,6 @@ DEPENDENCIES
   cocina-models (~> 0.6.0)
   committee
   config
-  coveralls (~> 0.8)
   deprecation
   dlss-capistrano
   dor-services (~> 8.0)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CircleCI](https://circleci.com/gh/sul-dlss/dor-services-app.svg?style=svg)](https://circleci.com/gh/sul-dlss/dor-services-app)
-[![Coverage Status](https://coveralls.io/repos/github/sul-dlss/dor-services-app/badge.svg?branch=master)](https://coveralls.io/github/sul-dlss/dor-services-app?branch=master)
+[![Maintainability](https://api.codeclimate.com/v1/badges/955223f2386ae5f10e33/maintainability)](https://codeclimate.com/github/sul-dlss/dor-services-app/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/955223f2386ae5f10e33/test_coverage)](https://codeclimate.com/github/sul-dlss/dor-services-app/test_coverage)
 [![GitHub version](https://badge.fury.io/gh/sul-dlss%2Fdor-services-app.svg)](https://badge.fury.io/gh/sul-dlss%2Fdor-services-app)
 [![Docker image](https://images.microbadger.com/badges/image/suldlss/dor-services-app.svg)](https://microbadger.com/images/suldlss/dor-services-app "Get your own image badge on microbadger.com")
 [![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/dor-services-app/master/openapi.json)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/dor-services-app/master/openapi.json)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-require 'coveralls'
 SimpleCov.start :rails do
   add_filter '/spec/'
 end
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-                                                                 SimpleCov::Formatter::HTMLFormatter,
-                                                                 Coveralls::SimpleCov::Formatter
-                                                               ])
 
 FIXTURES_PATH = File.expand_path('fixtures', __dir__)
 


### PR DESCRIPTION
Because we use CodeClimate generally, and this adds maintainability stats. Also, coveralls wasn't integrated with PR checks...