### PR TITLE
Updated dor-workflow-client to 3.15.1.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-workflow-client (3.15.0)
+    dor-workflow-client (3.15.1)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (~> 0.9, >= 0.9.2)


### PR DESCRIPTION
## Why was this change made?
To prevent https://github.com/sul-dlss/dor-workflow-client/issues/144, an error when closing versions.

## Was the API documentation (openapi.json) updated?
No.