### PR TITLE
update openapi_parser to a released version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'jbuilder'
 gem 'jwt'
 gem 'net-http-persistent', '~> 2.9' # Pin to avoid problem exhausting file handles under load
 gem 'okcomputer'
-gem 'openapi_parser', github: 'ota42y/openapi_parser' # fixes https://github.com/ota42y/openapi_parser/issues/61
+gem 'openapi_parser'
 gem 'pg'
 gem 'progressbar' # for the cleaner rake task
 gem 'ruby-cache', '~> 0.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: https://github.com/ota42y/openapi_parser.git
-  revision: 8bdfcf24c7d62cb6de8488c613a51080a8122a80
-  specs:
-    openapi_parser (0.6.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -292,6 +286,7 @@ GEM
       activesupport
       nokogiri (>= 1.4.2)
       solrizer (~> 3.3)
+    openapi_parser (0.7.0)
     parallel (1.19.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)
@@ -511,7 +506,7 @@ DEPENDENCIES
   moab-versioning (~> 4.0)
   net-http-persistent (~> 2.9)
   okcomputer
-  openapi_parser!
+  openapi_parser
   pg
   preservation-client (~> 2.0)
   progressbar


### PR DESCRIPTION
## Why was this change made?

So we don't have to depend on git to retrieve the code we need.


## Was the API documentation (openapi.json) updated?

n/a
