### PR TITLE
pass auth token to pres-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,9 @@ gem 'dor-services', '~> 8.0'
 gem 'dor-workflow-client', '~> 3.14'
 gem 'marc'
 gem 'moab-versioning', '~> 4.0', require: 'moab/stanford'
-gem 'preservation-client', '~> 2.0'
+# switch back to official release once available
+# gem 'preservation-client', '~> 2.0'
+gem 'preservation-client', git: 'https://github.com/sul-dlss/preservation-client.git', branch: 'pass-jwt-token'
 
 group :test, :development do
   gem 'equivalent-xml'

--- a/Gemfile
+++ b/Gemfile
@@ -46,9 +46,7 @@ gem 'dor-services', '~> 8.0'
 gem 'dor-workflow-client', '~> 3.14'
 gem 'marc'
 gem 'moab-versioning', '~> 4.0', require: 'moab/stanford'
-# switch back to official release once available
-# gem 'preservation-client', '~> 2.0'
-gem 'preservation-client', git: 'https://github.com/sul-dlss/preservation-client.git', branch: 'pass-jwt-token'
+gem 'preservation-client', '>= 3.0' # 3.x or greater is needed for token auth
 
 group :test, :development do
   gem 'equivalent-xml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/sul-dlss/preservation-client.git
-  revision: 39de52282fa0b0e562d78fd4f8602ad841da1cc1
-  branch: pass-jwt-token
-  specs:
-    preservation-client (2.1.0)
-      activesupport (>= 4.2, < 7)
-      faraday (~> 0.15)
-      moab-versioning (~> 4.3)
-      zeitwerk (~> 2.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -302,6 +291,11 @@ GEM
     parser (2.7.0.2)
       ast (~> 2.4.0)
     pg (1.2.2)
+    preservation-client (3.0.0)
+      activesupport (>= 4.2, < 7)
+      faraday (>= 0.15, < 2.0)
+      moab-versioning (~> 4.3)
+      zeitwerk (~> 2.1)
     progressbar (1.10.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -514,7 +508,7 @@ DEPENDENCIES
   okcomputer
   openapi_parser
   pg
-  preservation-client!
+  preservation-client (>= 3.0)
   progressbar
   pry-byebug
   puma (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/sul-dlss/preservation-client.git
+  revision: 39de52282fa0b0e562d78fd4f8602ad841da1cc1
+  branch: pass-jwt-token
+  specs:
+    preservation-client (2.1.0)
+      activesupport (>= 4.2, < 7)
+      faraday (~> 0.15)
+      moab-versioning (~> 4.3)
+      zeitwerk (~> 2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -291,11 +302,6 @@ GEM
     parser (2.7.0.2)
       ast (~> 2.4.0)
     pg (1.2.2)
-    preservation-client (2.1.0)
-      activesupport (>= 4.2, < 7)
-      faraday (~> 0.15)
-      moab-versioning (~> 4.3)
-      zeitwerk (~> 2.1)
     progressbar (1.10.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -508,7 +514,7 @@ DEPENDENCIES
   okcomputer
   openapi_parser
   pg
-  preservation-client (~> 2.0)
+  preservation-client!
   progressbar
   pry-byebug
   puma (~> 3.0)

--- a/config/initializers/preservation_client.rb
+++ b/config/initializers/preservation_client.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 # Configure preservation-client to use preservation catalog URL
-Preservation::Client.configure(url: Settings.preservation_catalog.url)
+Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.token)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,6 +34,7 @@ sdr:
 
 preservation_catalog:
   url: 'https://example.org/prescat'
+  token: 'mint-token-with-target-preservation-catalog-rake-generate-token'
 purl_services_url: ~
 
 cleanup:


### PR DESCRIPTION
HOLD until: 

- [x] shared_configs PRs are merged (sul-dlss/shared_configs/pull/1172, sul-dlss/shared_configs/pull/1174)
- [x] test this branch on stage!
- [x] sul-dlss/preservation-client/pull/29 is merged  
- [x] a new version of pres-client gem is released
- [x] Fix this branch to use released gem
- [x] Take this PR out of draft

## Why was this change made?

pres cat will start requiring that all API clients supply an auth token, or their requests will be rejected as Unauthorized.

Fixes #573
connects to sul-dlss/preservation_catalog#1298
blocks sul-dlss/preservation_catalog#1306

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a
