### PR TITLE
Set correct workflow steps to report errors for jobs.

### DIFF
--- a/app/jobs/preserve_job.rb
+++ b/app/jobs/preserve_job.rb
@@ -18,7 +18,7 @@ class PreserveJob < ApplicationJob
       return LogFailureJob.perform_later(druid: druid,
                                          background_job_result: background_job_result,
                                          workflow: 'accessionWF',
-                                         workflow_process: 'sdr-ingest-transfer',
+                                         workflow_process: 'preservation-ingest-initiated',
                                          output: { errors: [{ title: 'Preservation error', detail: e.message }] })
     end
 

--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -18,7 +18,7 @@ class PublishJob < ApplicationJob
       return LogFailureJob.perform_later(druid: druid,
                                          background_job_result: background_job_result,
                                          workflow: workflow,
-                                         workflow_process: workflow == 'accessionWF' ? 'publish' : 'release-publish',
+                                         workflow_process: 'publish-complete',
                                          output: { errors: [{ title: 'Data error', detail: e.message }] })
     end
 

--- a/app/jobs/shelve_job.rb
+++ b/app/jobs/shelve_job.rb
@@ -16,7 +16,7 @@ class ShelveJob < ApplicationJob
       return LogFailureJob.perform_later(druid: druid,
                                          background_job_result: background_job_result,
                                          workflow: 'accessionWF',
-                                         workflow_process: 'shelve',
+                                         workflow_process: 'shelve-complete',
                                          output: { errors: [{ title: 'Content directory not found', detail: e.message }] })
     end
 

--- a/spec/jobs/preserve_job_spec.rb
+++ b/spec/jobs/preserve_job_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe PreserveJob, type: :job do
         .with(druid: druid,
               background_job_result: result,
               workflow: 'accessionWF',
-              workflow_process: 'sdr-ingest-transfer',
+              workflow_process: 'preservation-ingest-initiated',
               output: { errors: [{ detail: error_message, title: 'Preservation error' }] })
       expect(Honeybadger).to have_received(:context).with(background_job_result_id: result.id)
       expect(Honeybadger).to have_received(:notify).with(StandardError)

--- a/spec/jobs/publish_job_spec.rb
+++ b/spec/jobs/publish_job_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe PublishJob, type: :job do
         .with(druid: druid,
               background_job_result: result,
               workflow: 'accessionWF',
-              workflow_process: 'publish',
+              workflow_process: 'publish-complete',
               output: { errors: [{ detail: error_message, title: 'Data error' }] })
     end
   end

--- a/spec/jobs/shelve_job_spec.rb
+++ b/spec/jobs/shelve_job_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ShelveJob, type: :job do
         .with(druid: druid,
               background_job_result: result,
               workflow: 'accessionWF',
-              workflow_process: 'shelve',
+              workflow_process: 'shelve-complete',
               output: { errors: [{ detail: error_message, title: 'Content directory not found' }] })
     end
   end


### PR DESCRIPTION
closes #563

## Why was this change made?
So that jobs that update workflows report errors to the correct workflow step.

## Was the API documentation (openapi.json) updated?
No.