### PR TITLE
Provides complete workflow error in error_msg field.

### DIFF
--- a/app/jobs/log_failure_job.rb
+++ b/app/jobs/log_failure_job.rb
@@ -16,10 +16,11 @@ class LogFailureJob < ApplicationJob
     background_job_result.complete!
     return unless workflow
 
+    # Note: Setting error_text same as in LyberCore::Robot.
     Dor::Config.workflow.client.update_error_status(druid: druid,
                                                     workflow: workflow,
                                                     process: workflow_process,
-                                                    error_msg: "problem with #{workflow_process} (BackgroundJob: #{background_job_result.id})",
-                                                    error_text: output.inspect)
+                                                    error_msg: "problem with #{workflow_process} (BackgroundJob: #{background_job_result.id}): #{output.inspect}",
+                                                    error_text: Socket.gethostname)
   end
 end


### PR DESCRIPTION
## Why was this change made?
When reporting a workflow error, the error message was split between `error_msg` and `error_txt` fields. The intended use of the `error_txt` field is unclear and is not displayed in Argo.

To address this, the complete error message was added to `error_msg` field.

See https://github.com/sul-dlss/argo/issues/1762


## Was the API documentation (openapi.json) updated?
No.