### PR TITLE
Correctly reference rails when starting docker container.

### DIFF
--- a/docker/invoke.sh
+++ b/docker/invoke.sh
@@ -15,12 +15,12 @@ echo "Postgres is up - Setting up database"
 set +e
 echo "Creating DB. OK to ignore errors about test db."
 # https://github.com/rails/rails/issues/27299
-rails db:create
+bin/rails db:create
 
 # Don't allow any following commands to fail
 set -e
 echo "Migrating db"
-rails db:migrate
+bin/rails db:migrate
 
 echo "Running server"
 exec puma -C config/puma.rb config.ru


### PR DESCRIPTION
## Why was this change made?
The docker container is not correctly starting.
```
$ docker logs -f hydrus_dor-services-app_1
HOST IS: db
Postgres is up - Setting up database
Creating DB. OK to ignore errors about test db.
./docker/invoke.sh: line 18: rails: not found
Migrating db
./docker/invoke.sh: line 23: rails: not found
```
## Was the API documentation (openapi.json) updated?
No.