### PR TITLE
Instrument the code with events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,7 +4,7 @@
 class EventsController < ApplicationController
   def create
     params.require(:event_type)
-    Event.create!(druid: params[:object_id], event_type: params[:event_type], data: params[:data])
+    EventFactory.create(druid: params[:object_id], event_type: params[:event_type], data: params[:data])
     head :created
   end
 

--- a/app/controllers/shelves_controller.rb
+++ b/app/controllers/shelves_controller.rb
@@ -7,6 +7,8 @@ class ShelvesController < ApplicationController
   def create
     if @item.is_a?(Dor::Item)
       result = BackgroundJobResult.create
+      EventFactory.create(druid: @item.pid, event_type: 'shelve_request_received', data: { host: Socket.gethostname })
+
       ShelveJob.perform_later(druid: @item.pid, background_job_result: result)
       head :created, location: result
     else

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -4,7 +4,7 @@ class VersionsController < ApplicationController
   before_action :load_item
 
   def create
-    VersionService.open(@item, open_params)
+    VersionService.open(@item, open_params, event_factory: EventFactory)
     render plain: @item.current_version
   rescue Dor::Exception => e
     render build_error('Unable to open version', e)
@@ -17,7 +17,7 @@ class VersionsController < ApplicationController
   end
 
   def close_current
-    VersionService.close(@item, close_params)
+    VersionService.close(@item, close_params, event_factory: EventFactory)
     render plain: "version #{@item.current_version} closed"
   rescue Dor::Exception => e
     render build_error('Unable to close version', e)

--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -13,7 +13,7 @@ class PublishJob < ApplicationJob
 
     begin
       item = Dor.find(druid)
-      PublishMetadataService.publish(item)
+      PublishMetadataService.publish(item, event_factory: EventFactory)
     rescue Dor::DataError => e
       return LogFailureJob.perform_later(druid: druid,
                                          background_job_result: background_job_result,

--- a/app/jobs/shelve_job.rb
+++ b/app/jobs/shelve_job.rb
@@ -11,7 +11,7 @@ class ShelveJob < ApplicationJob
 
     begin
       item = Dor.find(druid)
-      ShelvingService.shelve(item)
+      ShelvingService.shelve(item, event_factory: EventFactory)
     rescue ShelvingService::ContentDirNotFoundError => e
       return LogFailureJob.perform_later(druid: druid,
                                          background_job_result: background_job_result,

--- a/app/services/event_factory.rb
+++ b/app/services/event_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Creates Event records
+class EventFactory
+  def self.create(druid:, event_type:, data:)
+    Event.create!(druid: druid, event_type: event_type, data: data)
+  end
+end

--- a/app/services/legacy_metadata_service.rb
+++ b/app/services/legacy_metadata_service.rb
@@ -4,8 +4,12 @@
 # This is used by the accessionWF
 class LegacyMetadataService
   # If the updated value is newer than then createDate of the datastream, then update it.
-  def self.update_datastream_if_newer(datastream:, updated:, content:)
-    datastream.content = content if !datastream.createDate || updated > datastream.createDate
+  def self.update_datastream_if_newer(datastream:, updated:, content:, event_factory:)
+    if !datastream.createDate || updated > datastream.createDate
+      datastream.content = content
+      event_factory.create(druid: datastream.pid, event_type: 'legacy_metadata_update', data: { datastream: datastream, host: Socket.gethostname })
+    end
+
     validate_desc_metadata(datastream) if datastream.dsid == 'descMetadata'
 
     return if !datastream.createDate || updated > datastream.createDate

--- a/app/services/publish_metadata_service.rb
+++ b/app/services/publish_metadata_service.rb
@@ -3,12 +3,13 @@
 # Merges contentMetadata from several objects into one and sends it to PURL
 class PublishMetadataService
   # @param [Dor::Item] item the object to be publshed
-  def self.publish(item)
-    new(item).publish
+  def self.publish(item, event_factory:)
+    new(item, event_factory: event_factory).publish
   end
 
-  def initialize(item)
+  def initialize(item, event_factory:)
     @item = item
+    @event_factory = event_factory
   end
 
   # Appends contentMetadata file resources from the source objects to this object
@@ -21,11 +22,12 @@ class PublishMetadataService
 
     transfer_metadata(release_tags)
     publish_notify_on_success
+    event_factory.create(druid: item.pid, event_type: 'publishing_complete', data: { host: Socket.gethostname })
   end
 
   private
 
-  attr_reader :item
+  attr_reader :item, :event_factory
 
   # @raises [Dor::DataError]
   def transfer_metadata(release_tags)

--- a/app/services/registration_service.rb
+++ b/app/services/registration_service.rb
@@ -4,13 +4,15 @@
 class RegistrationService
   class << self
     # @param [Hash] params
+    # @param [EventFactory] event_factory
     # @see register_object similar but different
-    def create_from_request(params)
+    def create_from_request(params, event_factory: EventFactory)
       dor_params = registration_request_params(params)
 
       request = RegistrationRequest.new(dor_params)
       dor_obj = register_object(request)
       pid = dor_obj.pid
+      event_factory.create(druid: pid, event_type: 'registration', data: dor_params.merge(host: Socket.gethostname))
       location = URI.parse(Dor::Config.fedora.safeurl.sub(%r{/*$}, '/')).merge("objects/#{pid}").to_s
       dor_params.dup.merge(location: location, pid: pid)
     end

--- a/app/services/shelving_service.rb
+++ b/app/services/shelving_service.rb
@@ -8,8 +8,9 @@ class ShelvingService
     new(work).shelve
   end
 
-  def initialize(work)
+  def initialize(work, event_factory:)
     @work = work
+    @event_factory = event_factory
   end
 
   def shelve
@@ -23,11 +24,12 @@ class ShelvingService
     DigitalStacksService.remove_from_stacks(stacks_object_pathname, shelve_diff)
     DigitalStacksService.rename_in_stacks(stacks_object_pathname, shelve_diff)
     DigitalStacksService.shelve_to_stacks(workspace_content_pathname, stacks_object_pathname, shelve_diff)
+    event_factory.create(druid: work.id, event_type: 'shelving_complete', data: { host: Socket.gethostname })
   end
 
   private
 
-  attr_reader :work
+  attr_reader :work, :event_factory
 
   # retrieve the differences between the current contentMetadata and the previously ingested version
   # (filtering to select only the files that should be shelved to stacks)

--- a/spec/jobs/publish_job_spec.rb
+++ b/spec/jobs/publish_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe PublishJob, type: :job do
     end
 
     it 'invokes the PublishMetadataService' do
-      expect(PublishMetadataService).to have_received(:publish).with(item).once
+      expect(PublishMetadataService).to have_received(:publish).with(item, event_factory: EventFactory).once
     end
 
     it 'marks the job as complete' do
@@ -52,7 +52,7 @@ RSpec.describe PublishJob, type: :job do
     end
 
     it 'invokes the PublishMetadataService' do
-      expect(PublishMetadataService).to have_received(:publish).with(item).once
+      expect(PublishMetadataService).to have_received(:publish).with(item, event_factory: EventFactory).once
     end
 
     it 'marks the job as complete' do

--- a/spec/jobs/shelve_job_spec.rb
+++ b/spec/jobs/shelve_job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ShelveJob, type: :job do
     end
 
     it 'invokes the ShelvingService' do
-      expect(ShelvingService).to have_received(:shelve).with(item).once
+      expect(ShelvingService).to have_received(:shelve).with(item, event_factory: EventFactory).once
     end
 
     it 'marks the job as complete' do
@@ -49,7 +49,7 @@ RSpec.describe ShelveJob, type: :job do
     it 'marks the job as errored' do
       perform
       expect(result).to have_received(:processing!).once
-      expect(ShelvingService).to have_received(:shelve).with(item).once
+      expect(ShelvingService).to have_received(:shelve).with(item, event_factory: EventFactory).once
       expect(LogFailureJob).to have_received(:perform_later)
         .with(druid: druid,
               background_job_result: result,

--- a/spec/requests/versions_spec.rb
+++ b/spec/requests/versions_spec.rb
@@ -36,7 +36,10 @@ RSpec.describe 'Operations regarding object versions' do
              params: %( {"description": "some text", "significance": "major"} ),
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
         expect(response.body).to match(/version 1 closed/)
-        expect(VersionService).to have_received(:close).with(item, description: 'some text', significance: 'major')
+        expect(VersionService).to have_received(:close)
+          .with(item,
+                { description: 'some text', significance: 'major' },
+                event_factory: EventFactory)
       end
     end
 
@@ -93,7 +96,7 @@ RSpec.describe 'Operations regarding object versions' do
         post '/v1/objects/druid:mx123qw2323/versions',
              params: open_params.to_json,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(VersionService).to have_received(:open).with(item, open_params)
+        expect(VersionService).to have_received(:open).with(item, open_params, event_factory: EventFactory)
         expect(response.body).to eq('2')
         expect(response).to be_successful
       end

--- a/spec/services/legacy_metadata_service_spec.rb
+++ b/spec/services/legacy_metadata_service_spec.rb
@@ -4,8 +4,14 @@ require 'rails_helper'
 
 RSpec.describe LegacyMetadataService do
   describe '.update_datastream_if_newer' do
-    subject(:update) { described_class.update_datastream_if_newer(datastream: datastream, updated: updated, content: content) }
+    subject(:update) do
+      described_class.update_datastream_if_newer(datastream: datastream,
+                                                 updated: updated,
+                                                 content: content,
+                                                 event_factory: event_factory)
+    end
 
+    let(:event_factory) { class_double(EventFactory, create: true) }
     let(:updated) { Time.zone.parse('2019-08-09T19:18:15Z') }
     let(:content) { '<descMetadata><foo/></descMetadata>' }
     let(:title) { ['One title'] }
@@ -23,6 +29,7 @@ RSpec.describe LegacyMetadataService do
       it 'updates the content' do
         update
         expect(datastream).to have_received(:content=).with(content)
+        expect(event_factory).to have_received(:create)
       end
     end
 
@@ -32,6 +39,7 @@ RSpec.describe LegacyMetadataService do
       it 'updates the content' do
         update
         expect(datastream).to have_received(:content=).with(content)
+        expect(event_factory).to have_received(:create)
       end
     end
 

--- a/spec/services/publish_metadata_service_spec.rb
+++ b/spec/services/publish_metadata_service_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe PublishMetadataService do
       i.rels_ext.content = rels
     end
   end
-  let(:service) { described_class.new(item) }
+  let(:service) { described_class.new(item, event_factory: event_factory) }
+  let(:event_factory) { class_double(EventFactory, create: true) }
 
   let(:rels) do
     <<-EOXML

--- a/spec/services/registration_service_spec.rb
+++ b/spec/services/registration_service_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe RegistrationService do
     @apo = instantiate_fixture('druid:fg890hi1234', Dor::AdminPolicyObject)
     allow(@apo).to receive(:new_record?).and_return false
     allow(Dor).to receive(:find).with('druid:fg890hi1234').and_return(@apo)
+    allow(EventFactory).to receive(:create)
   end
 
   context '#register_object' do
@@ -358,6 +359,11 @@ RSpec.describe RegistrationService do
         label: 'web-archived-crawl for http://www.example.org',
         source_id: 'sul:SOMETHING-www.example.org'
       }
+    end
+
+    it 'creates an event' do
+      described_class.create_from_request(params)
+      expect(EventFactory).to have_received(:create)
     end
 
     it 'source_id may have one or more colons' do

--- a/spec/services/shelving_service_spec.rb
+++ b/spec/services/shelving_service_spec.rb
@@ -3,12 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe ShelvingService do
+  let(:service) { described_class.new(work, event_factory: event_factory) }
+
   let(:shelvable_item) do
     Dor::Item
   end
 
   let!(:stacks_root) { Dir.mktmpdir }
   let!(:workspace_root) { Dir.mktmpdir }
+  let(:event_factory) { class_double(EventFactory, create: true) }
 
   before do
     allow(Dor::Config.stacks).to receive_messages(local_stacks_root: stacks_root, local_workspace_root: workspace_root)
@@ -20,7 +23,6 @@ RSpec.describe ShelvingService do
   end
 
   let(:work) { shelvable_item.new(pid: druid) }
-  let(:service) { described_class.new work }
 
   describe '.shelve' do
     let(:druid) { 'druid:ng782rw8378' }
@@ -43,6 +45,7 @@ RSpec.describe ShelvingService do
       expect(DigitalStacksService).to receive(:rename_in_stacks).with(stacks_object_pathname, mock_diff)
       expect(DigitalStacksService).to receive(:shelve_to_stacks).with(mock_workspace_path, stacks_object_pathname, mock_diff)
       described_class.shelve(work)
+      expect(event_factory).to have_received(:create)
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

So that we log important events for an object.

## Was the API documentation (openapi.json) updated?
n/a