### PR TITLE
Pass lane_id when creating workflow in start_preservation_workflow_job.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'uuidtools', '~> 2.1.4'
 # DLSS/domain-specific dependencies
 gem 'cocina-models', '~> 0.6.0'
 gem 'dor-services', '~> 8.0'
-gem 'dor-workflow-client', '~> 3.14'
+gem 'dor-workflow-client', '~> 3.17'
 gem 'marc'
 gem 'moab-versioning', '~> 4.0', require: 'moab/stanford'
 gem 'preservation-client', '>= 3.0' # 3.x or greater is needed for token auth

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-workflow-client (3.16.0)
+    dor-workflow-client (3.17.1)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (>= 0.9.2, < 2.0)
@@ -493,7 +493,7 @@ DEPENDENCIES
   deprecation
   dlss-capistrano
   dor-services (~> 8.0)
-  dor-workflow-client (~> 3.14)
+  dor-workflow-client (~> 3.17)
   dry-schema (~> 1.4)
   equivalent-xml
   factory_bot_rails

--- a/app/jobs/start_preservation_workflow_job.rb
+++ b/app/jobs/start_preservation_workflow_job.rb
@@ -10,12 +10,19 @@ class StartPreservationWorkflowJob < ApplicationJob
   # @param [String] version the current version of the item to be published
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
   def perform(druid:, version:, background_job_result:)
+    lane_id = client.process(pid: druid, workflow_name: 'accessionWF', process: 'sdr-ingest-transfer').lane_id
     # start SDR preservation workflow
-    Dor::Config.workflow.client.create_workflow_by_name(druid, 'preservationIngestWF', version: version)
+    client.create_workflow_by_name(druid, 'preservationIngestWF', version: version, lane_id: lane_id)
 
     LogSuccessJob.perform_later(druid: druid,
                                 workflow: 'accessionWF',
                                 background_job_result: background_job_result,
                                 workflow_process: 'preservation-ingest-initiated')
+  end
+
+  private
+
+  def client
+    Dor::Config.workflow.client
   end
 end

--- a/spec/jobs/start_preservation_workflow_job_spec.rb
+++ b/spec/jobs/start_preservation_workflow_job_spec.rb
@@ -11,16 +11,18 @@ RSpec.describe StartPreservationWorkflowJob, type: :job do
 
   let(:druid) { 'druid:mk420bs7601' }
   let(:result) { create(:background_job_result) }
+  let(:process) { instance_double(Dor::Workflow::Response::Process, lane_id: 'default') }
 
   before do
     allow(LogSuccessJob).to receive(:perform_later)
     allow(Dor::Config.workflow.client).to receive(:create_workflow_by_name)
+    allow(Dor::Config.workflow.client).to receive(:process).and_return(process)
   end
 
   it 'marks the job as success' do
     perform
     expect(Dor::Config.workflow.client).to have_received(:create_workflow_by_name)
-      .with(druid, 'preservationIngestWF', version: '7')
+      .with(druid, 'preservationIngestWF', version: '7', lane_id: 'default')
     expect(LogSuccessJob).to have_received(:perform_later)
       .with(
         druid: druid,


### PR DESCRIPTION
closes #583

## Why was this change made?
So that new workflows inherit the lane id from the workflow that created it.


## Was the API documentation (openapi.json) updated?
No.