### PR TITLE
Revert "Sets workflow step status to started when workflow-related jo…

### DIFF
--- a/app/jobs/preserve_job.rb
+++ b/app/jobs/preserve_job.rb
@@ -9,13 +9,6 @@ class PreserveJob < ApplicationJob
   def perform(druid:, background_job_result:)
     background_job_result.processing!
 
-    Dor::Config.workflow.client.update_status(druid: druid,
-                                              workflow: 'accessionWF',
-                                              process: 'preservation-ingest-initiated',
-                                              status: 'started',
-                                              elapsed: 1,
-                                              note: Socket.gethostname)
-
     begin
       item = Dor.find(druid)
       SdrIngestService.transfer(item)

--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -11,13 +11,6 @@ class PublishJob < ApplicationJob
   def perform(druid:, background_job_result:, workflow:)
     background_job_result.processing!
 
-    Dor::Config.workflow.client.update_status(druid: druid,
-                                              workflow: workflow,
-                                              process: 'publish-complete',
-                                              status: 'started',
-                                              elapsed: 1,
-                                              note: Socket.gethostname)
-
     begin
       item = Dor.find(druid)
       PublishMetadataService.publish(item, event_factory: EventFactory)

--- a/app/jobs/shelve_job.rb
+++ b/app/jobs/shelve_job.rb
@@ -9,13 +9,6 @@ class ShelveJob < ApplicationJob
   def perform(druid:, background_job_result:)
     background_job_result.processing!
 
-    Dor::Config.workflow.client.update_status(druid: druid,
-                                              workflow: 'accessionWF',
-                                              process: 'shelve-complete',
-                                              status: 'started',
-                                              elapsed: 1,
-                                              note: Socket.gethostname)
-
     begin
       item = Dor.find(druid)
       ShelvingService.shelve(item, event_factory: EventFactory)

--- a/spec/jobs/preserve_job_spec.rb
+++ b/spec/jobs/preserve_job_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe PreserveJob, type: :job do
     allow(result).to receive(:processing!)
     allow(Honeybadger).to receive(:notify)
     allow(Honeybadger).to receive(:context)
-    allow(Dor::Config.workflow.client).to receive(:update_status)
   end
 
   context 'with no errors' do
@@ -26,15 +25,6 @@ RSpec.describe PreserveJob, type: :job do
 
     it 'marks the job as processing' do
       expect(result).to have_received(:processing!).once
-    end
-
-    it 'sets the workflow step status to started' do
-      expect(Dor::Config.workflow.client).to have_received(:update_status).with(druid: druid,
-                                                                                workflow: 'accessionWF',
-                                                                                process: 'preservation-ingest-initiated',
-                                                                                status: 'started',
-                                                                                elapsed: 1,
-                                                                                note: Socket.gethostname)
     end
 
     it 'invokes the SdrIngestService' do

--- a/spec/jobs/publish_job_spec.rb
+++ b/spec/jobs/publish_job_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe PublishJob, type: :job do
   before do
     allow(Dor).to receive(:find).with(druid).and_return(item)
     allow(result).to receive(:processing!)
-    allow(Dor::Config.workflow.client).to receive(:update_status)
   end
 
   context 'with no errors' do
@@ -27,15 +26,6 @@ RSpec.describe PublishJob, type: :job do
 
     it 'marks the job as processing' do
       expect(result).to have_received(:processing!).once
-    end
-
-    it 'sets the workflow step status to started' do
-      expect(Dor::Config.workflow.client).to have_received(:update_status).with(druid: druid,
-                                                                                workflow: 'accessionWF',
-                                                                                process: 'publish-complete',
-                                                                                status: 'started',
-                                                                                elapsed: 1,
-                                                                                note: Socket.gethostname)
     end
 
     it 'invokes the PublishMetadataService' do

--- a/spec/jobs/shelve_job_spec.rb
+++ b/spec/jobs/shelve_job_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe ShelveJob, type: :job do
   before do
     allow(Dor).to receive(:find).with(druid).and_return(item)
     allow(result).to receive(:processing!)
-    allow(Dor::Config.workflow.client).to receive(:update_status)
   end
 
   context 'with no errors' do
@@ -24,15 +23,6 @@ RSpec.describe ShelveJob, type: :job do
 
     it 'marks the job as processing' do
       expect(result).to have_received(:processing!).once
-    end
-
-    it 'sets the workflow step status to started' do
-      expect(Dor::Config.workflow.client).to have_received(:update_status).with(druid: druid,
-                                                                                workflow: 'accessionWF',
-                                                                                process: 'shelve-complete',
-                                                                                status: 'started',
-                                                                                elapsed: 1,
-                                                                                note: Socket.gethostname)
     end
 
     it 'invokes the ShelvingService' do


### PR DESCRIPTION
…bs."

This reverts commit fc5ed488422ac2b0abfb02ad29e343e6274ed2fc.

## Why was this change made?

These steps are `skip-queue=true`, which means they are only "events" and can't be started.



## Was the API documentation (openapi.yml) updated?
n/a