### PR TITLE
remove unused dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem 'faraday'
 gem 'honeybadger'
 gem 'jbuilder'
 gem 'jwt'
-gem 'net-http-persistent', '~> 2.9' # Pin to avoid problem exhausting file handles under load
 gem 'okcomputer'
 gem 'openapi_parser'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,7 +262,6 @@ GEM
       nokogiri (>= 1.6.6)
       nom-xml (~> 1.0)
     multipart-post (2.1.1)
-    net-http-persistent (2.9.4)
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
     net-ssh (5.2.0)
@@ -500,7 +499,6 @@ DEPENDENCIES
   listen (~> 3.0.5)
   marc
   moab-versioning (~> 4.0)
-  net-http-persistent (~> 2.9)
   okcomputer
   openapi_parser
   pg


### PR DESCRIPTION

## Why was this change made?

This was pinned back when we used  dor-workflow-service 2.2.1 which depended on net-http-persistent, but that dependency has bee removed from dor-workflow-service, so we can remove this entirely


## Was the API documentation (openapi.yml) updated?
n/a