### PR TITLE
Re-adds route for getting MARCXML.

### DIFF
--- a/app/controllers/marcxml_controller.rb
+++ b/app/controllers/marcxml_controller.rb
@@ -1,10 +1,27 @@
 # frozen_string_literal: true
 
-# Given a barcode, returns a catkey by looking in searchworks
-class MarcxmlController < ApplicationController
-  def catkey
-    marcxml = MarcxmlResource.find_by(barcode: params[:barcode])
+class MarcxmlController < ApplicationController #:nodoc:
+  before_action :set_marcxml_resource
 
-    render plain: marcxml.catkey
+  rescue_from(SymphonyReader::ResponseError) do |e|
+    render status: :internal_server_error, plain: e.message
+  end
+
+  def catkey
+    render plain: @marcxml.catkey
+  end
+
+  def marcxml
+    render xml: @marcxml.marcxml
+  end
+
+  private
+
+  def set_marcxml_resource
+    @marcxml = MarcxmlResource.find_by(**marcxml_resource_params)
+  end
+
+  def marcxml_resource_params
+    params.permit(:barcode, :catkey).to_unsafe_h.symbolize_keys
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     get '/about' => 'ok_computer/ok_computer#show', defaults: { check: 'version' }
 
     scope :catalog do
+      get 'marcxml', to: 'marcxml#marcxml'
       get 'catkey', to: 'marcxml#catkey'
     end
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -132,6 +132,29 @@ paths:
           required: false
           schema:
             type: string
+  /v1/catalog/marcxml:
+    get:
+      tags:
+        - integrations
+      summary: Lookup the MARC XML from Symphony
+      description: ''
+      operationId: 'marcxml#marcxml'
+      responses:
+        '200':
+          description: OK
+      parameters:
+        - name: barcode
+          in: query
+          description: barcode of an item
+          required: false
+          schema:
+            type: string
+        - name: catkey
+          in: query
+          description: catalog identifier of an item
+          required: false
+          schema:
+            type: string
   '/v1/background_job_results/{id}':
     get:
       tags:

--- a/spec/requests/get_marcxml_spec.rb
+++ b/spec/requests/get_marcxml_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Looking up an item's marcxml" do
+  let(:body) do
+    {
+      resource: '/catalog/bib',
+      key: '111',
+      fields: {
+        bib: {
+          standard: 'MARC21',
+          type: 'BIB',
+          leader: '00956cem 2200229Ma 4500',
+          fields: [
+            { tag: '001', subfields: [{ code: '_', data: 'some data' }] },
+            { tag: '001', subfields: [{ code: '_', data: 'some other data' }] },
+            { tag: '009', subfields: [{ code: '_', data: 'whatever' }] },
+            {
+              tag: '245',
+              inds: '41',
+              subfields: [{ code: 'a', data: 'some data' }]
+            }
+          ]
+        }
+      }
+    }
+  end
+
+  it 'looks up an item by catkey' do
+    stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: '12345')).to_return(body: body.to_json, headers: { 'Content-Length': 394 })
+
+    get '/v1/catalog/marcxml?catkey=12345', headers: { 'Authorization' => "Bearer #{jwt}" }
+    expect(response.body).to start_with '<record'
+  end
+
+  describe 'errors in response from Symphony' do
+    context 'when incomplete response' do
+      before do
+        stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: '12345')).to_return(body: '{}', headers: { 'Content-Length': 0 })
+      end
+
+      it 'returns a 500 error' do
+        get '/v1/catalog/marcxml?catkey=12345', headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response.status).to eq(500)
+        expect(response.body).to eq('Incomplete response received from Symphony for 12345 - expected 0 bytes but got 2')
+      end
+    end
+
+    context 'when catkey not found' do
+      before do
+        stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: '12345')).to_return(status: 404)
+      end
+
+      it 'returns a 500 error' do
+        get '/v1/catalog/marcxml?catkey=12345', headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response.status).to eq(500)
+        expect(response.body).to eq('Record not found in Symphony: 12345')
+      end
+    end
+
+    context 'when other HTTP error' do
+      let(:err_body) do
+        {
+          messageList: [
+            {
+              code: 'oops',
+              message: 'Something somewhere went wrong.'
+            }
+          ]
+        }
+      end
+
+      before do
+        stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: '12345')).to_return(status: 403, body: err_body.to_json)
+      end
+
+      it 'returns a 500 error' do
+        get '/v1/catalog/marcxml?catkey=12345', headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response.status).to eq(500)
+        expect(response.body).to match(/^Got HTTP Status-Code 403 retrieving 12345 from Symphony:.*Something somewhere went wrong./)
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #594

## Why was this change made?
To re-add a route for getting the MARCXML for an object, so that it can be used to determine the rights of Google books.


## Was the API documentation (openapi.yml) updated?
Yes.