### PR TITLE
Add provenance metadata to the legacy update endpoint

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -19,7 +19,8 @@ class MetadataController < ApplicationController
     datastream_names = { descriptive: 'descMetadata',
                          technical: 'technicalMetadata',
                          content: 'contentMetadata',
-                         rights: 'rightsMetadata' }
+                         rights: 'rightsMetadata',
+                         provenance: 'provenanceMetadata' }
 
     datastream_names.each do |section, datastream_name|
       values = params[section]

--- a/openapi.yml
+++ b/openapi.yml
@@ -924,6 +924,8 @@ components:
           $ref: '#/components/schemas/LegacyDatastream'
         technical:
           $ref: '#/components/schemas/LegacyDatastream'
+        provenance:
+          $ref: '#/components/schemas/LegacyDatastream'
     LegacyDatastream:
       type: object
       properties:

--- a/spec/requests/legacy_metadata_update_spec.rb
+++ b/spec/requests/legacy_metadata_update_spec.rb
@@ -9,13 +9,15 @@ RSpec.describe 'Update the legacy (datastream) metadata' do
   let(:rightsMetadata) { instance_double(Dor::RightsMetadataDS, createDate: create_date) }
   let(:technicalMetadata) { instance_double(Dor::TechnicalMetadataDS, createDate: create_date) }
   let(:contentMetadata) { instance_double(Dor::ContentMetadataDS, createDate: create_date) }
+  let(:provenanceMetadata) { instance_double(Dor::ProvenanceMetadataDS, createDate: create_date) }
 
   let(:datastreams) do
     {
       'descMetadata' => descMetadata,
       'rightsMetadata' => rightsMetadata,
       'technicalMetadata' => technicalMetadata,
-      'contentMetadata' => contentMetadata
+      'contentMetadata' => contentMetadata,
+      'provenanceMetadata' => provenanceMetadata
     }
   end
 
@@ -35,6 +37,10 @@ RSpec.describe 'Update the legacy (datastream) metadata' do
           "rights": {
             "updated": "2019-11-08T15:15:43Z",
             "content": "<rightsMetadata></rightsMetadata>"
+          },
+          "provenance": {
+            "updated": "2019-11-08T15:15:43Z",
+            "content": "<provMetadata></provMetadata>"
           }
         }
       JSON
@@ -56,6 +62,12 @@ RSpec.describe 'Update the legacy (datastream) metadata' do
         .with(datastream: rightsMetadata,
               updated: Time.zone.parse('2019-11-08T15:15:43Z'),
               content: '<rightsMetadata></rightsMetadata>',
+              event_factory: EventFactory)
+
+      expect(LegacyMetadataService).to have_received(:update_datastream_if_newer)
+        .with(datastream: provenanceMetadata,
+              updated: Time.zone.parse('2019-11-08T15:15:43Z'),
+              content: '<provMetadata></provMetadata>',
               event_factory: EventFactory)
 
       expect(work).to have_received(:save!)


### PR DESCRIPTION
## Why was this change made?
This will allow us to refactor the provenance robot so that it doesn't need to hit Fedora directly


## Was the API documentation (openapi.yml) updated?
yes.