### PR TITLE
Provide administrative properties of an APO via the Cocina API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'sidekiq-statistic'
 gem 'uuidtools', '~> 2.1.4'
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.6.0'
+gem 'cocina-models', '~> 0.10.0'
 gem 'dor-services', '~> 8.0'
 gem 'dor-workflow-client', '~> 3.17'
 gem 'marc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     capistrano-sidekiq (1.0.3)
       capistrano (>= 3.9.0)
       sidekiq (>= 3.4, < 6.0)
-    cocina-models (0.6.0)
+    cocina-models (0.10.0)
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
@@ -482,7 +482,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-shared_configs
   capistrano-sidekiq
-  cocina-models (~> 0.6.0)
+  cocina-models (~> 0.10.0)
   committee
   config
   deprecation

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -60,13 +60,21 @@ module Cocina
         type: Cocina::Models::AdminPolicy::TYPES.first,
         label: item.label,
         version: item.current_version,
-        administrative: build_administrative
+        administrative: build_apo_administrative
       }
     end
 
     private
 
     attr_reader :item
+
+    def build_apo_administrative
+      {}.tap do |admin|
+        registration_workflow = item.administrativeMetadata.ng_xml.xpath('//administrativeMetadata/dissemination/workflow/@id').text
+        admin[:default_object_rights] = item.defaultObjectRights.content
+        admin[:registration_workflow] = registration_workflow.presence
+      end
+    end
 
     def build_administrative
       {}.tap do |admin|

--- a/openapi.yml
+++ b/openapi.yml
@@ -706,6 +706,15 @@ components:
     Administrative:
       type: object
       properties: {}
+    APOAdministrative:
+      type: object
+      required:
+        - default_object_rights
+      properties:
+        default_object_rights:
+          type: string
+        registration_workflow:
+          type: string
     DROAdministrative:
       type: object
       properties:
@@ -730,7 +739,7 @@ components:
         access:
           $ref: '#/components/schemas/Access'
         administrative:
-          $ref: '#/components/schemas/Administrative'
+          $ref: '#/components/schemas/APOAdministrative'
         identification:
           $ref: '#/components/schemas/Identification'
         structural:

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -94,24 +94,52 @@ RSpec.describe 'Get the object' do
         object.label = 'foo'
       end
 
-      let(:expected) do
-        {
-          externalIdentifier: 'druid:1234',
-          type: 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld',
-          label: 'foo',
-          version: 1,
-          access: {},
-          administrative: {},
-          identification: {},
-          structural: {}
-        }
+      it 'returns the object' do
+        get '/v1/objects/druid:mk420bs7601',
+            headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+
+        expect(json['externalIdentifier']).to eq 'druid:1234'
+        expect(json['type']).to eq 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld'
+        expect(json['label']).to eq 'foo'
+        expect(json['version']).to eq 1
+        expect(json['access']).to eq({})
+        expect(json['identification']).to eq({})
+        expect(json['structural']).to eq({})
+        expect(json['administrative']['default_object_rights']).to match '<rightsMetadata>'
+        expect(json['administrative']['registration_workflow']).to be_nil
+      end
+    end
+
+    context 'when the object exists with all metadata' do
+      before do
+        object.administrativeMetadata.content = <<~XML
+          <administrativeMetadata>
+            <dissemination>
+              <workflow id="wasCrawlPreassemblyWF"/>
+            </dissemination>
+          </administrativeMetadata>
+        XML
+        object.descMetadata.title_info.main_title = 'Hello'
+        object.label = 'foo'
       end
 
       it 'returns the object' do
         get '/v1/objects/druid:mk420bs7601',
             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status(:ok)
-        expect(response.body).to eq expected.to_json
+        json = JSON.parse(response.body)
+
+        expect(json['externalIdentifier']).to eq 'druid:1234'
+        expect(json['type']).to eq 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld'
+        expect(json['label']).to eq 'foo'
+        expect(json['version']).to eq 1
+        expect(json['access']).to eq({})
+        expect(json['identification']).to eq({})
+        expect(json['structural']).to eq({})
+        expect(json['administrative']['default_object_rights']).to match '<rightsMetadata>'
+        expect(json['administrative']['registration_workflow']).to eq 'wasCrawlPreassemblyWF'
       end
     end
   end


### PR DESCRIPTION


## Why was this change made?
This will enable us to decouple common-accessioning from direct Fedora calls


## Was the API documentation (openapi.yml) updated?
Yes