### PR TITLE
Add admin policy to cocina models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'sidekiq-statistic'
 gem 'uuidtools', '~> 2.1.4'
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.12.0'
+gem 'cocina-models', '~> 0.14.0'
 gem 'dor-services', '~> 8.0'
 gem 'dor-workflow-client', '~> 3.17'
 gem 'marc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     capistrano-sidekiq (1.0.3)
       capistrano (>= 3.9.0)
       sidekiq (>= 3.4, < 6.0)
-    cocina-models (0.12.0)
+    cocina-models (0.14.0)
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
@@ -482,7 +482,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-shared_configs
   capistrano-sidekiq
-  cocina-models (~> 0.12.0)
+  cocina-models (~> 0.14.0)
   committee
   config
   deprecation

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -109,6 +109,7 @@ module Cocina
     def build_administrative
       {}.tap do |admin|
         admin[:releaseTags] = build_release_tags
+        admin[:hasAdminPolicy] = item.admin_policy_object_id
       end
     end
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -703,7 +703,7 @@ components:
           type: string
           format: date-time
           example: '2029-06-22T07:00:00.000+00:00'
-    Administrative:
+    EmptyAdministrative:
       type: object
       properties: {}
     APOAdministrative:
@@ -715,9 +715,11 @@ components:
           type: string
         registration_workflow:
           type: string
-    DROAdministrative:
+    Administrative:
       type: object
       properties:
+        hasAdminPolicy:
+          $ref: '#/components/schemas/Druid'
         releaseTags:
           type: array
           items:
@@ -819,7 +821,7 @@ components:
         access:
           $ref: '#/components/schemas/Access'
         administrative:
-          $ref: '#/components/schemas/DROAdministrative'
+          $ref: '#/components/schemas/Administrative'
         identification:
           $ref: '#/components/schemas/Identification'
         structural:
@@ -849,7 +851,7 @@ components:
         access:
           $ref: '#/components/schemas/Access'
         administrative:
-          $ref: '#/components/schemas/Administrative'
+          $ref: '#/components/schemas/EmptyAdministrative'
         identification:
           $ref: '#/components/schemas/Identification'
         structural:
@@ -879,7 +881,7 @@ components:
         access:
           $ref: '#/components/schemas/Access'
         administrative:
-          $ref: '#/components/schemas/Administrative'
+          $ref: '#/components/schemas/EmptyAdministrative'
         identification:
           $ref: '#/components/schemas/Identification'
         structural:

--- a/spec/requests/collections_for_object_spec.rb
+++ b/spec/requests/collections_for_object_spec.rb
@@ -22,7 +22,10 @@ RSpec.describe 'Get the object' do
           label: 'collection #1',
           version: 1,
           access: {},
-          administrative: {},
+          administrative: {
+            releaseTags: [],
+            hasAdminPolicy: nil
+          },
           identification: {},
           structural: {}
         }

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Cocina::Mapper do
   subject(:cocina_model) { described_class.build(item) }
 
   context 'when item is a Dor::Item' do
-    let(:item) { Dor::Item.new(pid: 'druid:mx000xm0000', label: 'test object') }
+    let(:item) { Dor::Item.new(pid: 'druid:mx000xm0000', label: 'test object', admin_policy_object_id: 'druid:sc012gz0974') }
     let(:content_metadata_ds) { instance_double(Dor::ContentMetadataDS, new?: false, ng_xml: Nokogiri::XML(xml)) }
     let(:xml) do
       <<~XML
@@ -58,10 +58,22 @@ RSpec.describe Cocina::Mapper do
 
     it 'builds the object with filesets' do
       expect(cocina_model).to be_kind_of Cocina::Models::DRO
+
+      expect(cocina_model.administrative.hasAdminPolicy).to eq 'druid:sc012gz0974'
+
       expect(cocina_model.structural.contains.size).to eq 2
       folder1 = cocina_model.structural.contains.first
       expect(folder1.label).to eq 'Folder 1'
       expect(folder1.structural.contains.first.label).to eq 'folder1PuSu/story1u.txt'
+    end
+  end
+
+  context 'when item is a Dor::Collection' do
+    let(:item) { Dor::Collection.new(pid: 'druid:fh138mm2023', label: 'test object', admin_policy_object_id: 'druid:sc012gz0974') }
+
+    it 'builds the collection' do
+      expect(cocina_model).to be_kind_of Cocina::Models::Collection
+      expect(cocina_model.administrative.hasAdminPolicy).to eq 'druid:sc012gz0974'
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

It's expected here: https://github.com/sul-dlss/common-accessioning/blob/76304371a7fec9c87ea0007325c3e1e34d65e63c/lib/robots/dor_repo/accession/rights_metadata.rb#L27


## Was the API documentation (openapi.yml) updated?

yes