### PR TITLE
Refactor events to supply additional attributes

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,7 +4,7 @@
 class EventsController < ApplicationController
   def create
     params.require(:event_type)
-    EventFactory.create(druid: params[:object_id], event_type: params[:event_type], data: params[:data])
+    Event.create!(druid: params[:object_id], event_type: params[:event_type], data: params[:data])
     head :created
   end
 

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -47,7 +47,7 @@ class ObjectsController < ApplicationController
   # the 'publish-complete' step of that workflow if provided
   def publish
     result = BackgroundJobResult.create
-    EventFactory.create(druid: params[:id], event_type: 'publish_request_received', data: { host: Socket.gethostname })
+    EventFactory.create(druid: params[:id], event_type: 'publish_request_received', data: { background_job_result_id: result.id })
 
     PublishJob.perform_later(druid: params[:id], background_job_result: result, workflow: params[:workflow])
     head :created, location: result
@@ -55,7 +55,7 @@ class ObjectsController < ApplicationController
 
   def preserve
     result = BackgroundJobResult.create
-    EventFactory.create(druid: params[:id], event_type: 'preserve_request_received', data: { host: Socket.gethostname })
+    EventFactory.create(druid: params[:id], event_type: 'preserve_request_received', data: { background_job_result_id: result.id })
 
     PreserveJob.perform_later(druid: params[:id], background_job_result: result)
     head :created, location: result

--- a/app/controllers/shelves_controller.rb
+++ b/app/controllers/shelves_controller.rb
@@ -7,7 +7,7 @@ class ShelvesController < ApplicationController
   def create
     if @item.is_a?(Dor::Item)
       result = BackgroundJobResult.create
-      EventFactory.create(druid: @item.pid, event_type: 'shelve_request_received', data: { host: Socket.gethostname })
+      EventFactory.create(druid: @item.pid, event_type: 'shelve_request_received', data: { background_job_result_id: result.id })
 
       ShelveJob.perform_later(druid: @item.pid, background_job_result: result)
       head :created, location: result

--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -13,7 +13,8 @@ class PublishJob < ApplicationJob
 
     begin
       item = Dor.find(druid)
-      PublishMetadataService.publish(item, event_factory: EventFactory)
+      PublishMetadataService.publish(item)
+      EventFactory.create(druid: druid, event_type: 'publishing_complete', data: { background_job_result_id: background_job_result.id })
     rescue Dor::DataError => e
       return LogFailureJob.perform_later(druid: druid,
                                          background_job_result: background_job_result,

--- a/app/jobs/shelve_job.rb
+++ b/app/jobs/shelve_job.rb
@@ -11,7 +11,8 @@ class ShelveJob < ApplicationJob
 
     begin
       item = Dor.find(druid)
-      ShelvingService.shelve(item, event_factory: EventFactory)
+      ShelvingService.shelve(item)
+      EventFactory.create(druid: druid, event_type: 'shelving_complete', data: { background_job_result_id: background_job_result.id })
     rescue ShelvingService::ContentDirNotFoundError => e
       return LogFailureJob.perform_later(druid: druid,
                                          background_job_result: background_job_result,

--- a/app/services/event_factory.rb
+++ b/app/services/event_factory.rb
@@ -3,6 +3,6 @@
 # Creates Event records
 class EventFactory
   def self.create(druid:, event_type:, data:)
-    Event.create!(druid: druid, event_type: event_type, data: data)
+    Event.create!(druid: druid, event_type: event_type, data: data.merge(host: Socket.gethostname))
   end
 end

--- a/app/services/event_factory.rb
+++ b/app/services/event_factory.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-# Creates Event records
+# Creates Event records and adds the host name and invoking system identifier
 class EventFactory
   def self.create(druid:, event_type:, data:)
-    Event.create!(druid: druid, event_type: event_type, data: data.merge(host: Socket.gethostname))
+    invoked_by = Honeybadger.get_context[:invoked_by]
+    event_data = data.merge(host: Socket.gethostname, invoked_by: invoked_by)
+    Event.create!(druid: druid, event_type: event_type, data: event_data)
   end
 end

--- a/app/services/legacy_metadata_service.rb
+++ b/app/services/legacy_metadata_service.rb
@@ -7,7 +7,7 @@ class LegacyMetadataService
   def self.update_datastream_if_newer(datastream:, updated:, content:, event_factory:)
     if !datastream.createDate || updated > datastream.createDate
       datastream.content = content
-      event_factory.create(druid: datastream.pid, event_type: 'legacy_metadata_update', data: { datastream: datastream.dsid, host: Socket.gethostname })
+      event_factory.create(druid: datastream.pid, event_type: 'legacy_metadata_update', data: { datastream: datastream.dsid })
     end
 
     validate_desc_metadata(datastream) if datastream.dsid == 'descMetadata'

--- a/app/services/publish_metadata_service.rb
+++ b/app/services/publish_metadata_service.rb
@@ -3,13 +3,12 @@
 # Merges contentMetadata from several objects into one and sends it to PURL
 class PublishMetadataService
   # @param [Dor::Item] item the object to be publshed
-  def self.publish(item, event_factory:)
-    new(item, event_factory: event_factory).publish
+  def self.publish(item)
+    new(item).publish
   end
 
-  def initialize(item, event_factory:)
+  def initialize(item)
     @item = item
-    @event_factory = event_factory
   end
 
   # Appends contentMetadata file resources from the source objects to this object
@@ -22,12 +21,11 @@ class PublishMetadataService
 
     transfer_metadata(release_tags)
     publish_notify_on_success
-    event_factory.create(druid: item.pid, event_type: 'publishing_complete', data: { host: Socket.gethostname })
   end
 
   private
 
-  attr_reader :item, :event_factory
+  attr_reader :item
 
   # @raises [Dor::DataError]
   def transfer_metadata(release_tags)

--- a/app/services/registration_service.rb
+++ b/app/services/registration_service.rb
@@ -12,7 +12,7 @@ class RegistrationService
       request = RegistrationRequest.new(dor_params)
       dor_obj = register_object(request)
       pid = dor_obj.pid
-      event_factory.create(druid: pid, event_type: 'registration', data: dor_params.merge(host: Socket.gethostname))
+      event_factory.create(druid: pid, event_type: 'registration', data: dor_params)
       location = URI.parse(Dor::Config.fedora.safeurl.sub(%r{/*$}, '/')).merge("objects/#{pid}").to_s
       dor_params.dup.merge(location: location, pid: pid)
     end

--- a/app/services/shelving_service.rb
+++ b/app/services/shelving_service.rb
@@ -4,13 +4,12 @@
 class ShelvingService
   class ContentDirNotFoundError < RuntimeError; end
 
-  def self.shelve(work, event_factory:)
-    new(work, event_factory: event_factory).shelve
+  def self.shelve(work)
+    new(work).shelve
   end
 
-  def initialize(work, event_factory:)
+  def initialize(work)
     @work = work
-    @event_factory = event_factory
   end
 
   def shelve
@@ -24,12 +23,11 @@ class ShelvingService
     DigitalStacksService.remove_from_stacks(stacks_object_pathname, shelve_diff)
     DigitalStacksService.rename_in_stacks(stacks_object_pathname, shelve_diff)
     DigitalStacksService.shelve_to_stacks(workspace_content_pathname, stacks_object_pathname, shelve_diff)
-    event_factory.create(druid: work.id, event_type: 'shelving_complete', data: { host: Socket.gethostname })
   end
 
   private
 
-  attr_reader :work, :event_factory
+  attr_reader :work
 
   # retrieve the differences between the current contentMetadata and the previously ingested version
   # (filtering to select only the files that should be shelved to stacks)

--- a/spec/jobs/publish_job_spec.rb
+++ b/spec/jobs/publish_job_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe PublishJob, type: :job do
   before do
     allow(Dor).to receive(:find).with(druid).and_return(item)
     allow(result).to receive(:processing!)
+    allow(EventFactory).to receive(:create)
   end
 
   context 'with no errors' do
@@ -29,10 +30,12 @@ RSpec.describe PublishJob, type: :job do
     end
 
     it 'invokes the PublishMetadataService' do
-      expect(PublishMetadataService).to have_received(:publish).with(item, event_factory: EventFactory).once
+      expect(PublishMetadataService).to have_received(:publish).with(item).once
     end
 
     it 'marks the job as complete' do
+      expect(EventFactory).to have_received(:create)
+
       expect(LogSuccessJob).to have_received(:perform_later)
         .with(druid: druid, background_job_result: result, workflow: 'accessionWF', workflow_process: 'publish-complete')
     end
@@ -52,7 +55,7 @@ RSpec.describe PublishJob, type: :job do
     end
 
     it 'invokes the PublishMetadataService' do
-      expect(PublishMetadataService).to have_received(:publish).with(item, event_factory: EventFactory).once
+      expect(PublishMetadataService).to have_received(:publish).with(item).once
     end
 
     it 'marks the job as complete' do

--- a/spec/jobs/shelve_job_spec.rb
+++ b/spec/jobs/shelve_job_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ShelveJob, type: :job do
   before do
     allow(Dor).to receive(:find).with(druid).and_return(item)
     allow(result).to receive(:processing!)
+    allow(EventFactory).to receive(:create)
   end
 
   context 'with no errors' do
@@ -26,10 +27,11 @@ RSpec.describe ShelveJob, type: :job do
     end
 
     it 'invokes the ShelvingService' do
-      expect(ShelvingService).to have_received(:shelve).with(item, event_factory: EventFactory).once
+      expect(ShelvingService).to have_received(:shelve).with(item).once
     end
 
     it 'marks the job as complete' do
+      expect(EventFactory).to have_received(:create)
       expect(LogSuccessJob).to have_received(:perform_later)
         .with(druid: druid,
               background_job_result: result,
@@ -49,7 +51,7 @@ RSpec.describe ShelveJob, type: :job do
     it 'marks the job as errored' do
       perform
       expect(result).to have_received(:processing!).once
-      expect(ShelvingService).to have_received(:shelve).with(item, event_factory: EventFactory).once
+      expect(ShelvingService).to have_received(:shelve).with(item).once
       expect(LogFailureJob).to have_received(:perform_later)
         .with(druid: druid,
               background_job_result: result,

--- a/spec/services/publish_metadata_service_spec.rb
+++ b/spec/services/publish_metadata_service_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe PublishMetadataService do
       i.rels_ext.content = rels
     end
   end
-  let(:service) { described_class.new(item, event_factory: event_factory) }
-  let(:event_factory) { class_double(EventFactory, create: true) }
+  let(:service) { described_class.new(item) }
 
   let(:rels) do
     <<-EOXML

--- a/spec/services/shelving_service_spec.rb
+++ b/spec/services/shelving_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ShelvingService do
-  let(:service) { described_class.new(work, event_factory: event_factory) }
+  let(:service) { described_class.new(work) }
 
   let(:shelvable_item) do
     Dor::Item
@@ -11,7 +11,6 @@ RSpec.describe ShelvingService do
 
   let!(:stacks_root) { Dir.mktmpdir }
   let!(:workspace_root) { Dir.mktmpdir }
-  let(:event_factory) { class_double(EventFactory, create: true) }
 
   before do
     allow(Dor::Config.stacks).to receive_messages(local_stacks_root: stacks_root, local_workspace_root: workspace_root)
@@ -44,8 +43,7 @@ RSpec.describe ShelvingService do
       expect(DigitalStacksService).to receive(:remove_from_stacks).with(stacks_object_pathname, mock_diff)
       expect(DigitalStacksService).to receive(:rename_in_stacks).with(stacks_object_pathname, mock_diff)
       expect(DigitalStacksService).to receive(:shelve_to_stacks).with(mock_workspace_path, stacks_object_pathname, mock_diff)
-      described_class.shelve(work, event_factory: EventFactory)
-      expect(event_factory).to have_received(:create)
+      described_class.shelve(work)
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Version events were not supplying host.  All jobs now specify which system invoked them.



## Was the API documentation (openapi.yml) updated?
n/a
