### PR TITLE
Add who wrote a version to the version event

### DIFF
--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -47,7 +47,7 @@ class VersionService
     vmd_ds.update_current_version(description: opts[:description], significance: opts[:significance].to_sym) if opts[:description] && opts[:significance]
 
     work.save!
-    event_factory.create(druid: work.pid, event_type: 'version_open', data: { version: work.current_version })
+    event_factory.create(druid: work.pid, event_type: 'version_open', data: { who: opts[:opening_user_name], version: work.current_version })
   end
 
   # Determines whether a new version can be opened for an object.
@@ -91,7 +91,7 @@ class VersionService
                                               create_accession_wf: create_accession_wf)
     work.events.add_event('close', opts[:user_name], "Version #{work.current_version} closed") if opts[:user_name]
     work.save!
-    event_factory.create(druid: work.pid, event_type: 'version_close', data: { version: work.current_version })
+    event_factory.create(druid: work.pid, event_type: 'version_close', data: { who: opts[:user_name], version: work.current_version })
   end
 
   # Performs checks on whether a new version can be opened for an object

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -73,6 +73,10 @@ RSpec.describe VersionService do
         expect(obj).to receive(:save!)
 
         described_class.open(obj, options, event_factory: event_factory)
+
+        expect(event_factory).to have_received(:create).with(data: { version: '2', who: 'sunetid' },
+                                                             druid: 'druid:ab12cd3456',
+                                                             event_type: 'version_open')
       end
 
       it "doesn't include options" do
@@ -226,7 +230,9 @@ RSpec.describe VersionService do
       it 'sets tag, description and an event' do
         close
         expect(vmd_ds).to have_received(:save)
-        expect(event_factory).to have_received(:create)
+        expect(event_factory).to have_received(:create).with(data: { version: '2', who: 'jcoyne' },
+                                                             druid: 'druid:ab12cd3456',
+                                                             event_type: 'version_close')
 
         expect(Dor::Config.workflow.client).to have_received(:close_version)
           .with(repo: 'dor', druid: druid, version: '2', create_accession_wf: true)


### PR DESCRIPTION
## Why was this change made?

This will enable us to record all the information currently in the events datastream.
Fixes #612

## Was the API documentation (openapi.yml) updated?
n/a
