### PR TITLE
Don't send invoked_by when there is no context

### DIFF
--- a/app/services/event_factory.rb
+++ b/app/services/event_factory.rb
@@ -3,7 +3,7 @@
 # Creates Event records and adds the host name and invoking system identifier
 class EventFactory
   def self.create(druid:, event_type:, data:)
-    invoked_by = Honeybadger.get_context[:invoked_by]
+    invoked_by = Honeybadger.get_context && Honeybadger.get_context[:invoked_by]
     event_data = data.merge(host: Socket.gethostname, invoked_by: invoked_by)
     Event.create!(druid: druid, event_type: event_type, data: event_data)
   end


### PR DESCRIPTION
## Why was this change made?
Honeybadger was showing null pointer errors

## Was the API documentation (openapi.yml) updated?
no.