### PR TITLE
Disable ParamsWrapper

### DIFF
--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -7,5 +7,5 @@
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
 ActiveSupport.on_load(:action_controller) do
-  wrap_parameters format: [:json]
+  wrap_parameters format: []
 end


### PR DESCRIPTION
## Why was this change made?

This was causing parameters passed to services to be wrapped in an extra hash with "object" as the keys:

```
Parameters: {"object_type"=>"item", "source_id"=>"googlebooks:stanford_20500066514", "admin_policy"=>"druid:sc012gz0974", "tag"=>["Process : Content Type : Book (ltr)", "Registered By : jcoyne85@stanford.edu"], "label"=>":auto", "collection"=>"druid:hv320hk4091", "rights"=>"default", "metadata_source"=>"symphony", "other_id"=>"symphony:10048349", "object"=>{"object_type"=>"item", "source_id"=>"googlebooks:stanford_20500066514", "admin_policy"=>"druid:sc012gz0974", "tag"=>["Process : Content Type : Book (ltr)", "Registered By : jcoyne85@stanford.edu"], "label"=>":auto", "collection"=>"druid:hv320hk4091", "rights"=>"default", "metadata_source"=>"symphony", "other_id"=>"symphony:10048349"}}
```

This shows up in the logs and in the events.





## Was the API documentation (openapi.yml) updated?
n/a