### PR TITLE
Refactor: Have the RegistrationService return the RegistrationResponse

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -12,7 +12,7 @@ class ObjectsController < ApplicationController
   end
 
   rescue_from(Dor::DuplicateIdError) do |e|
-    render status: :conflict, plain: e.message, location: object_location(e.pid)
+    render status: :conflict, plain: e.message
   end
 
   rescue_from(Dry::Struct::Error) do |e|
@@ -30,11 +30,10 @@ class ObjectsController < ApplicationController
     rescue ArgumentError => e
       return render status: :unprocessable_entity, plain: e.message
     end
-    pid = reg_response[:pid]
 
     respond_to do |format|
-      format.all { render status: :created, location: object_location(pid), plain: Dor::RegistrationResponse.new(reg_response).to_txt }
-      format.json { render status: :created, location: object_location(pid), json: Dor::RegistrationResponse.new(reg_response) }
+      format.all { render status: :created, location: reg_response.location, plain: reg_response.to_txt }
+      format.json { render status: :created, location: reg_response.location, json: reg_response }
     end
   end
 
@@ -99,14 +98,6 @@ class ObjectsController < ApplicationController
 
   def proxy_faraday_response(response)
     render status: response.status, content_type: response.headers['Content-Type'], body: response.body
-  end
-
-  def fedora_base
-    URI.parse(Dor::Config.fedora.safeurl.sub(%r{/*$}, '/'))
-  end
-
-  def object_location(pid)
-    fedora_base.merge("objects/#{pid}").to_s
   end
 
   def create_params

--- a/app/models/dor/registration_response.rb
+++ b/app/models/dor/registration_response.rb
@@ -12,5 +12,9 @@ module Dor
     def to_txt
       @params[:pid]
     end
+
+    def location
+      @params[:location]
+    end
   end
 end

--- a/app/services/registration_service.rb
+++ b/app/services/registration_service.rb
@@ -6,6 +6,7 @@ class RegistrationService
     # @param [Hash] params
     # @param [EventFactory] event_factory
     # @see register_object similar but different
+    # @return [Dor::RegistrationResponse]
     def create_from_request(params, event_factory: EventFactory)
       dor_params = registration_request_params(params)
 
@@ -14,7 +15,8 @@ class RegistrationService
       pid = dor_obj.pid
       event_factory.create(druid: pid, event_type: 'registration', data: params)
       location = URI.parse(Dor::Config.fedora.safeurl.sub(%r{/*$}, '/')).merge("objects/#{pid}").to_s
-      dor_params.dup.merge(location: location, pid: pid)
+
+      Dor::RegistrationResponse.new(dor_params.merge(location: location, pid: pid))
     end
 
     private
@@ -123,6 +125,7 @@ class RegistrationService
       new_item
     end
 
+    # NOTE: This could fail if Symphony has problems
     def refresh_metadata(item:, request:)
       # This will give us our namespaced identifiers like "catkey:00012032"
       identifiers = request.other_ids.map { |k, v| "#{k}:#{v}" }

--- a/spec/requests/register_object_spec.rb
+++ b/spec/requests/register_object_spec.rb
@@ -15,12 +15,11 @@ RSpec.describe 'Register object' do
       allow(RegistrationService).to receive(:register_object).and_raise(Dor::DuplicateIdError.new('druid:existing123obj'))
     end
 
-    it 'returns a 409 error with location header' do
+    it 'returns a 409 error' do
       post '/v1/objects',
            params: data,
            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
       expect(response.status).to eq(409)
-      expect(response.headers['Location']).to match(%r{/fedora/objects/druid:existing123obj})
     end
   end
 

--- a/spec/requests/register_object_spec.rb
+++ b/spec/requests/register_object_spec.rb
@@ -74,7 +74,12 @@ RSpec.describe 'Register object' do
 
   context 'when the request is successful' do
     before do
-      allow(RegistrationService).to receive(:create_from_request).and_return(pid: 'druid:xyz')
+      allow(RegistrationService).to receive(:create_from_request).and_return(reg_response)
+    end
+
+    let(:reg_response) do
+      instance_double(Dor::RegistrationResponse, to_txt: 'druid:xyz',
+                                                 location: 'https://fedora.example.com:3333/fedora/objects/druid:xyz')
     end
 
     it 'registers the object with the registration service' do

--- a/spec/services/registration_service_spec.rb
+++ b/spec/services/registration_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RegistrationService do
     allow(EventFactory).to receive(:create)
   end
 
-  context '#register_object' do
+  describe '#register_object' do
     subject(:register) { described_class.send(:register_object, request) }
 
     before do
@@ -345,7 +345,9 @@ RSpec.describe RegistrationService do
     end # context common cases
   end
 
-  context '#create_from_request' do
+  describe '#create_from_request' do
+    subject(:create) { described_class.create_from_request(params) }
+
     before do
       allow(Dor::SuriService).to receive(:mint_id).and_return(pid)
       allow(Dor::SearchService).to receive(:query_by_id).and_return([])
@@ -359,35 +361,75 @@ RSpec.describe RegistrationService do
         object_type: 'item',
         admin_policy: 'druid:fg890hi1234',
         label: 'web-archived-crawl for http://www.example.org',
-        source_id: 'sul:SOMETHING-www.example.org'
+        source_id: source_id
       }
     end
 
+    let(:source_id) { 'sul:SOMETHING-www.example.org' }
+
     it 'creates an event' do
-      described_class.create_from_request(params)
+      create
       expect(EventFactory).to have_received(:create)
     end
 
-    it 'source_id may have one or more colons' do
-      expect { described_class.create_from_request(params) }.not_to raise_error
-      params[:source_id] = 'sul:SOMETHING-http://www.example.org'
-      expect { described_class.create_from_request(params) }.not_to raise_error
+    context 'when source_id has one colon' do
+      it 'is successful' do
+        expect { create }.not_to raise_error
+      end
     end
 
-    it 'source_id must have at least one colon' do
-      # Execution gets into IdentityMetadataDS code for specific error
-      params[:source_id] = 'no-colon'
-      exp_regex = /Source ID must follow the format 'namespace:value'/
-      expect { described_class.create_from_request(params) }.to raise_error(ArgumentError, exp_regex)
+    context 'when source_id has more than one colon' do
+      let(:source_id) { 'sul:SOMETHING-http://www.example.org' }
+
+      it 'is successful' do
+        expect { create }.not_to raise_error
+      end
     end
 
-    it 'other_id may have any number of colons' do
-      params[:other_id] = 'no-colon'
-      expect { described_class.create_from_request(params) }.not_to raise_error
-      params[:other_id] = 'catkey:000'
-      expect { described_class.create_from_request(params) }.not_to raise_error
-      params[:other_id] = 'catkey:oop:sie'
-      expect { described_class.create_from_request(params) }.not_to raise_error
+    context 'when source_id has no colon' do
+      let(:source_id) { 'no-colon' }
+
+      it 'is raises an exception' do
+        # Execution gets into IdentityMetadataDS code for specific error
+        exp_regex = /Source ID must follow the format 'namespace:value'/
+        expect { create }.to raise_error(ArgumentError, exp_regex)
+      end
     end
-  end # create_from_request
+
+    context 'when other_id is provided' do
+      let(:params) do
+        {
+          object_type: 'item',
+          admin_policy: 'druid:fg890hi1234',
+          label: 'web-archived-crawl for http://www.example.org',
+          source_id: source_id,
+          other_id: other_id
+        }
+      end
+
+      context 'when other_id has no colon' do
+        let(:other_id) { 'no-colon' }
+
+        it 'is successful' do
+          expect { create }.not_to raise_error
+        end
+      end
+
+      context 'when other_id has one colon' do
+        let(:other_id) { 'catkey:000' }
+
+        it 'is successful' do
+          expect { create }.not_to raise_error
+        end
+      end
+
+      context 'when other_id has many colons' do
+        let(:other_id) { 'catkey:oop:sie' }
+
+        it 'is successful' do
+          expect { create }.not_to raise_error
+        end
+      end
+    end
+  end
 end

--- a/spec/services/registration_service_spec.rb
+++ b/spec/services/registration_service_spec.rb
@@ -367,8 +367,8 @@ RSpec.describe RegistrationService do
 
     let(:source_id) { 'sul:SOMETHING-www.example.org' }
 
-    it 'creates an event' do
-      create
+    it 'is successful' do
+      expect(create).to be_kind_of Dor::RegistrationResponse
       expect(EventFactory).to have_received(:create)
     end
 


### PR DESCRIPTION
Also refactored tests and removed a Location header from a 4xx response.

## Why was this change made?

* This avoids duplication in computing the location header.
* The old tests grouped multiple scenarios into one test.
* Location headers only make sense on 3xx or 201 responses: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location


## Was the API documentation (openapi.yml) updated?
n/a