### PR TITLE
Use #dig as it's more readable

### DIFF
--- a/app/models/dor/update_marc_record_service.rb
+++ b/app/models/dor/update_marc_record_service.rb
@@ -170,7 +170,7 @@ module Dor
 
     def released_to_searchworks?
       rel = released_for.transform_keys { |key| key.to_s.upcase } # upcase all release tags to make the check case insensitive
-      rel.blank? || rel['SEARCHWORKS'].blank? || rel['SEARCHWORKS']['release'].blank? ? false : rel['SEARCHWORKS']['release']
+      rel.dig('SEARCHWORKS', 'release').presence || false
     end
 
     private


### PR DESCRIPTION
## Why was this change made?

 it's more readable

## Was the API documentation (openapi.yml) updated?
 n/a