### PR TITLE
Allow Cocina::Mapper to build APOs with parent APOs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.14.0'
+gem 'cocina-models', '~> 0.15.0'
 gem 'dor-services', '~> 8.0'
 gem 'dor-workflow-client', '~> 3.17'
 gem 'marc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
       capistrano (>= 3.9.0)
       sidekiq (>= 3.4, < 6.0)
     chronic (0.10.2)
-    cocina-models (0.14.0)
+    cocina-models (0.15.0)
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
@@ -485,7 +485,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-shared_configs
   capistrano-sidekiq
-  cocina-models (~> 0.14.0)
+  cocina-models (~> 0.15.0)
   committee
   config
   deprecation

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -103,6 +103,7 @@ module Cocina
         registration_workflow = item.administrativeMetadata.ng_xml.xpath('//administrativeMetadata/dissemination/workflow/@id').text
         admin[:default_object_rights] = item.defaultObjectRights.content
         admin[:registration_workflow] = registration_workflow.presence
+        admin[:hasAdminPolicy] = item.admin_policy_object_id
       end
     end
 

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe 'Get the object' do
       before do
         object.descMetadata.title_info.main_title = 'Hello'
         object.label = 'foo'
+        allow(object).to receive(:admin_policy_object_id).and_return('druid:ab123cd4567')
       end
 
       it 'returns the object' do
@@ -111,6 +112,7 @@ RSpec.describe 'Get the object' do
         expect(json['structural']).to eq({})
         expect(json['administrative']['default_object_rights']).to match '<rightsMetadata>'
         expect(json['administrative']['registration_workflow']).to be_nil
+        expect(json['administrative']['hasAdminPolicy']).to eq 'druid:ab123cd4567'
       end
     end
 


### PR DESCRIPTION
Connects to sul-dlss/common-accessioning#556

## Why was this change made?

To fix a production bug with APOs asserting parent APOs.

## Was the API documentation (openapi.yml) updated?

no