### PR TITLE
Stop trimming the label

### DIFF
--- a/app/services/registration_service.rb
+++ b/app/services/registration_service.rb
@@ -81,7 +81,6 @@ class RegistrationService
     end
 
     # @param [RegistrationRequest] RegistrationRequest
-    # rubocop:disable Metrics/AbcSize
     def register_object(request)
       request.validate!
 
@@ -89,8 +88,9 @@ class RegistrationService
       source_id_string = check_source_id [request.source_id.keys.first, request.source_id[request.source_id.keys.first]].compact.join(':')
       pid = unduplicated_pid(request.pid)
       apo_object = Dor.find(request.admin_policy)
-      new_item = request.item_class.new(pid: pid, admin_policy_object_id: apo_object.id)
-      new_item.label = request.label.length > 254 ? request.label[0, 254] : request.label
+      new_item = request.item_class.new(pid: pid,
+                                        admin_policy_object_id: apo_object.id,
+                                        label: request.label)
       idmd = new_item.identityMetadata
       idmd.sourceId = source_id_string
       idmd.add_value(:objectId, pid)
@@ -123,7 +123,6 @@ class RegistrationService
       new_item.save!
       new_item
     end
-    # rubocop:enable Metrics/AbcSize
 
     # NOTE: This could fail if Symphony has problems
     def refresh_metadata(item:, request:)

--- a/spec/services/registration_service_spec.rb
+++ b/spec/services/registration_service_spec.rb
@@ -179,8 +179,6 @@ RSpec.describe RegistrationService do
 
     RSpec.shared_examples 'common registration' do
       it 'produces a registered object' do
-        expect(@obj.pid).to eq(pid)
-        expect(@obj.label).to eq(params[:label])
         expect(@obj.identityMetadata.sourceId).to eq('barcode:9191919191')
         expect(@obj.identityMetadata.otherId).to match_array(params[:other_ids].collect { |*e| e.join(':') })
       end
@@ -189,7 +187,7 @@ RSpec.describe RegistrationService do
     describe 'should set rightsMetadata based on the APO default (but replace read rights) even if it is a collection' do
       before do
         coll = Dor::Collection.new(pid: pid)
-        expect(Dor::Collection).to receive(:new).with(pid: pid, admin_policy_object_id: apo.id).and_return(coll)
+        allow(Dor::Collection).to receive(:new).and_return(coll)
         params[:rights] = 'stanford'
         params[:object_type] = 'collection'
         @obj = register
@@ -373,7 +371,10 @@ RSpec.describe RegistrationService do
 
       it 'is successful' do
         expect(create).to be_kind_of Dor::RegistrationResponse
-        expect(klass).to have_received(:new).with(hash_including(admin_policy_object_id: apo.id))
+        expect(klass).to have_received(:new).with(
+          hash_including(admin_policy_object_id: apo.id,
+                         label: 'web-archived-crawl for http://www.example.org')
+        )
         expect(item.rightsMetadata.content).to be_equivalent_to apo.defaultObjectRights.content
         expect(EventFactory).to have_received(:create)
       end
@@ -452,7 +453,10 @@ RSpec.describe RegistrationService do
 
       it 'is successful' do
         expect(create).to be_kind_of Dor::RegistrationResponse
-        expect(klass).to have_received(:new).with(hash_including(admin_policy_object_id: apo.id))
+        expect(klass).to have_received(:new).with(
+          hash_including(admin_policy_object_id: apo.id,
+                         label: 'Testing apo')
+        )
         expect(item.rightsMetadata.content).to be_equivalent_to apo.defaultObjectRights.content
         expect(EventFactory).to have_received(:create)
       end


### PR DESCRIPTION


## Why was this change made?

The label is already trimmed by the RegistrationRequest class

## Was the API documentation (openapi.yml) updated?
n/a