### PR TITLE
Fix forbidden errors when browsing sidekiq routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   require 'sidekiq/web'
-  Sidekiq::Web.set :session_secret, Rails.application.credentials[:secret_key_base]
+  Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
   mount Sidekiq::Web => '/queues'
 
   scope '/v1' do


### PR DESCRIPTION
## Why was this change made?

This, and the replaced code, are both incantations listed in the Sidekiq wiki: https://github.com/mperham/sidekiq/wiki/Monitoring#forbidden

I confirmed this was the right incantation by SSHing to a deployed instance and running:

```
2.5.0 :001 > Rails.configuration.secret_token
 => nil
2.5.0 :002 >  Rails.application.credentials[:secret_key_base]
 => nil
2.5.0 :003 > Rails.application.secrets[:secret_key_base]
 => "a non-nil value which is hidden here to protect the instance"
```

I did this because I noticed when troubleshooting sul-dlss/argo#1800 that I could not use the Sidekiq UI to delete or kill individual jobs. I briefly entertained the idea that this was related to committee/OpenAPI but this is not related to OpenAPI.


## Was the API documentation (openapi.yml) updated?

no