### PR TITLE
Remove the copying relationships from APOs when registering

### DIFF
--- a/app/services/registration_service.rb
+++ b/app/services/registration_service.rb
@@ -100,15 +100,6 @@ class RegistrationService
       idmd.tag = request.tags
       request.other_ids.each_pair { |name, value| idmd.add_otherId("#{name}:#{value}") }
 
-      apo_object.administrativeMetadata.ng_xml.xpath('/administrativeMetadata/relationships/*').each do |rel|
-        short_predicate = ActiveFedora::RelsExtDatastream.short_predicate rel.namespace.href + rel.name
-        if short_predicate.nil?
-          ix = 0
-          ix += 1 while ActiveFedora::Predicates.predicate_mappings[rel.namespace.href].key?(short_predicate = :"extra_predicate_#{ix}")
-          ActiveFedora::Predicates.predicate_mappings[rel.namespace.href][short_predicate] = rel.name
-        end
-        new_item.add_relationship short_predicate, rel['rdf:resource']
-      end
       new_item.add_collection(request.collection) if request.collection
       add_rights(item: new_item, pid: pid, request: request, apo: apo_object)
 

--- a/spec/fixtures/apo_druid_fg890hi1234.xml
+++ b/spec/fixtures/apo_druid_fg890hi1234.xml
@@ -163,10 +163,6 @@
               <access override="yes"/>
             </use>
           </rights>
-          <relationships xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-              <fedora:isMemberOf rdf:resource="info:fedora/druid:zb871zd0767"></fedora:isMemberOf>
-              <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:zb871zd0767"></fedora:isMemberOfCollection>
-          </relationships>
           <registration>
             <itemTag>AdminPolicy : Topographical Map</itemTag>
             <itemTag>Keyword : topographical</itemTag>

--- a/spec/services/registration_service_spec.rb
+++ b/spec/services/registration_service_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe RegistrationService do
         end
 
         it_behaves_like 'common registration'
-        it 'produces correct rels_ext' do
+        it 'produces isGovernedBy and hasModel assertions' do
           expect(@obj.rels_ext.to_rels_ext).to be_equivalent_to <<-XML
             <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fedora="info:fedora/fedora-system:def/relations-external#"
               xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#">
@@ -230,8 +230,6 @@ RSpec.describe RegistrationService do
                 <hydra:isGovernedBy rdf:resource="info:fedora/druid:fg890hi1234"/>
                 <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_Item"/>
                 <fedora-model:hasModel rdf:resource='info:fedora/afmodel:Dor_Abstract' />
-                <fedora:isMemberOf rdf:resource="info:fedora/druid:zb871zd0767"/>
-                <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:zb871zd0767"/>
               </rdf:Description>
             </rdf:RDF>
           XML
@@ -255,9 +253,7 @@ RSpec.describe RegistrationService do
                 <fedora-model:hasModel rdf:resource="info:fedora/afmodel:Dor_Item"/>
                 <fedora-model:hasModel rdf:resource='info:fedora/afmodel:Dor_Abstract' />
                 <fedora:isMemberOf rdf:resource="info:fedora/druid:something"/>
-                <fedora:isMemberOf rdf:resource="info:fedora/druid:zb871zd0767"/>
                 <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:something"/>
-                <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:zb871zd0767"/>
               </rdf:Description>
             </rdf:RDF>
           XML


### PR DESCRIPTION

## Why was this change made?

We no longer rely on this behavior, and it would be challenging to migrate this from Fedora 3.
Fixes sul-dlss/argo#1802


## Was the API documentation (openapi.yml) updated?
n/a