### PR TITLE
Don't log action and controller in the register event

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -101,7 +101,7 @@ class ObjectsController < ApplicationController
   end
 
   def create_params
-    params.to_unsafe_h.merge(body_params)
+    params.except(:action, :controller).to_unsafe_h.merge(body_params)
   end
 
   def body_params

--- a/spec/requests/register_object_spec.rb
+++ b/spec/requests/register_object_spec.rb
@@ -87,6 +87,8 @@ RSpec.describe 'Register object' do
            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
       expect(response.body).to eq 'druid:xyz'
       expect(RegistrationService).to have_received(:create_from_request)
+        .with({ 'admin_policy' => 'druid:mk420bs7601', 'source_id' => 'ns:ident' },
+              event_factory: EventFactory)
       expect(response.status).to eq(201)
       expect(response.location).to end_with '/fedora/objects/druid:xyz'
     end


### PR DESCRIPTION
## Why was this change made?
These are parameters added by rails and they just clutter the event data. This filters them out.


## Was the API documentation (openapi.yml) updated?
n/a