### PR TITLE
Disable writing to solr

### DIFF
--- a/app/services/embargo_release_service.rb
+++ b/app/services/embargo_release_service.rb
@@ -5,9 +5,6 @@
 #
 # Should run once a day from cron
 class EmbargoReleaseService
-  # Turn off active_fedora updates of solr
-  ENABLE_SOLR_UPDATES = false
-
   # Finds druids from solr based on the passed in query
   # It will then load each item from Dor, and call the block with the item
   # @param [String] query used to locate druids of items to release from solr

--- a/config/initializers/activefedora_solr_updates.rb
+++ b/config/initializers/activefedora_solr_updates.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Cannot just do:
+#   ::ENABLE_SOLR_UPDATES = false
+# Because "warning: already initialized constant ENABLE_SOLR_UPDATES".
+# ActiveFedora assigns a default (if unassigned) and we cannot pre-empt it from here.
+
+self.class.send(:remove_const, 'ENABLE_SOLR_UPDATES') if self.class.const_defined?('ENABLE_SOLR_UPDATES')
+self.class.const_set('ENABLE_SOLR_UPDATES', false)


### PR DESCRIPTION
This mimics what Argo is doing and allows dor_indexing_app to handle all indexing. This is an important step as the indexing code is no longer shared in dor-services gem, so they could potentially be indexing different things.  This also helps reduce load on solr, as every write to fedora already triggers an indexing action via a message from Fedora 3 to activemq, which is read by dor_indexing_app. Furthermore, this increases the reliability of dor-services-app as we no longer have a dependency on writing to solr regularly (see https://app.honeybadger.io/projects/50568/faults/60653735).

Fixes #30

## Why was this change made?



## Was the API documentation (openapi.yml) updated?
n/a
