### PR TITLE
Etds must have their own mapping to cocina

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -17,6 +17,7 @@ class ObjectsController < ApplicationController
 
   rescue_from(Dry::Struct::Error) do |e|
     render status: :internal_server_error, plain: e.message
+    raise e
   end
 
   rescue_from(SymphonyReader::ResponseError) do |e|

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -29,6 +29,7 @@ module Cocina
       klass.new(props)
     end
 
+    # This handles Dor::Item and Dor::Etd models
     def dro_props
       {
         externalIdentifier: item.pid,
@@ -43,7 +44,7 @@ module Cocina
             embargoReleaseDate: item.embargoMetadata.release_date.iso8601
           }
         end
-        unless item.contentMetadata.new?
+        unless item.is_a?(Dor::Etd) || item.contentMetadata.new?
           props[:structural] = {
             contains: build_filesets(item.contentMetadata, version: item.current_version, id: item.pid)
           }
@@ -78,7 +79,12 @@ module Cocina
     attr_reader :item
 
     def build_descriptive
-      { title: [{ primary: true, titleFull: item.full_title }] }
+      case item
+      when Dor::Etd
+        { title: [{ primary: true, titleFull: item.properties.title.first }] }
+      else
+        { title: [{ primary: true, titleFull: item.full_title }] }
+      end
     end
 
     def build_filesets(content_metadata_ds, version:, id:)
@@ -138,7 +144,7 @@ module Cocina
     # @todo This should have more speicific type such as found in identityMetadata.objectType
     def cocina_klass
       case item
-      when Dor::Item
+      when Dor::Item, Dor::Etd
         Cocina::Models::DRO
       when Dor::Collection
         Cocina::Models::Collection

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -73,6 +73,24 @@ RSpec.describe Cocina::Mapper do
     end
   end
 
+  context 'when item is a Dor::Etd' do
+    let(:item) do
+      Dor::Etd.new(pid: 'druid:mx000xm0000',
+                   admin_policy_object_id: 'druid:sc012gz0974',
+                   label: 'test object')
+    end
+
+    before do
+      item.properties.title = 'Test ETD'
+    end
+
+    it 'builds the object' do
+      expect(cocina_model).to be_kind_of Cocina::Models::DRO
+
+      expect(cocina_model.administrative.hasAdminPolicy).to eq 'druid:sc012gz0974'
+    end
+  end
+
   context 'when item is a Dor::Collection' do
     let(:item) { Dor::Collection.new(pid: 'druid:fh138mm2023', label: 'test object', admin_policy_object_id: 'druid:sc012gz0974') }
     let(:identity_metadata_ds) { instance_double(Dor::IdentityMetadataDS, new?: false, ng_xml: Nokogiri::XML(xml)) }


### PR DESCRIPTION

## Why was this change made?

ETDs don't have descMetadata, so must have special handling.

Fixes  argo/issues#1806
## Was the API documentation (openapi.yml) updated?
n/a