### PR TITLE
Handles Rubydora error when updating legacy metadata.

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -33,5 +33,8 @@ class MetadataController < ApplicationController
     end
 
     @item.save!
+  rescue Rubydora::FedoraInvalidRequest
+    render json: { error: 'Invalid Fedora request possibly due to concurrent requests' },
+           status: :service_unavailable
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -519,6 +519,8 @@ paths:
       responses:
         '200':
           description: OK
+        '503':
+          description: Service unavailable when an error occurs saving to Fedora
       parameters:
         - name: object_id
           in: path


### PR DESCRIPTION
closes #645

## Why was this change made?
To handle a Rubydora error that is thrown when two requests are made concurrently to the same resource.


## Was the API documentation (openapi.yml) updated?
Yes.