### PR TITLE
Add an etd class so that they can be instantiated via Dor.find

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This is necessary, so that Dor.find will cast etds to this type.
+# Otherwise it'll say: Etd is not a real class
+# and return a Dor::Item.
+# This is necessary for the Cocina::Mapper because Etds do not use descMetadata
+# like ever other object.
+class Etd < Dor::Etd; end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Etd do
+  it 'exists as a constant', skip: true
+end


### PR DESCRIPTION
## Why was this change made?
This is necessary, so that Dor.find will cast etds to this type. Otherwise it'll say: `Etd is not a real class` and return a `Dor::Item`. This is necessary for the `Cocina::Mapper` because Etds do not use descMetadata like ever other object.


## Was the API documentation (openapi.yml) updated?
