### PR TITLE
Allow registration requests to specify an optional value for abstract

### DIFF
--- a/app/models/registration_request.rb
+++ b/app/models/registration_request.rb
@@ -11,6 +11,7 @@ class RegistrationRequest
   # @option params [String] :metadata_source
   # @option params [String] :rights
   # @option params [String] :collection
+  # @option params [String] :abstract
   # @option params [Hash{String => String}] :source_id Primary ID from another system, max one key/value pair!
   # @option params [Hash] :other_ids including :uuid if known
   # @option params [String] :pid Fully qualified PID if you don't want one generated for you
@@ -67,6 +68,10 @@ class RegistrationRequest
 
   def label
     params[:label].length > 254 ? params[:label][0, 254] : params[:label]
+  end
+
+  def abstract
+    params[:abstract]
   end
 
   def source_id

--- a/openapi.yml
+++ b/openapi.yml
@@ -691,8 +691,8 @@ paths:
 
         If 'collection' is provided, the object will be a member of the provided
         collection.
-        
-        Note that the 'source_id' property is required for items but not for 
+
+        Note that the 'source_id' property is required for items but not for
         collections.
       operationId: 'objects#create'
       requestBody:
@@ -714,6 +714,9 @@ paths:
                 label:
                   type: string
                   example: 15th century manuscript
+                abstract:
+                  type: string
+                  example: I am a description of a 15th century manuscript
                 other_id:
                   type: string
                   example: 'symphony:1164561'

--- a/spec/services/registration_service_spec.rb
+++ b/spec/services/registration_service_spec.rb
@@ -150,10 +150,12 @@ RSpec.describe RegistrationService do
         expect(Dor::SearchService).to receive(:query_by_id).with('druid:ab123cd4567').and_return([pid])
         expect { register }.to raise_error(Dor::DuplicateIdError)
       end
+
       it 'registering a duplicate source ID' do
         expect(Dor::SearchService).to receive(:query_by_id).with('barcode:9191919191').and_return([pid])
         expect { register }.to raise_error(Dor::DuplicateIdError)
       end
+
       it 'missing a required parameter' do
         params.delete(:object_type)
         expect { register }.to raise_error(Dor::ParameterError)
@@ -312,13 +314,15 @@ RSpec.describe RegistrationService do
         end
       end
 
-      describe 'when passed metadata_source=label' do
+      context 'when passed metadata_source=label' do
         before do
           params[:metadata_source] = 'label'
+          params[:abstract] = 'A very fine description indeed.'
           @obj = register
         end
 
         it_behaves_like 'common registration'
+
         it 'sets the descriptive metadata to basic mods using the label as title' do
           expect(@obj.datastreams['descMetadata'].ng_xml).to be_equivalent_to <<-XML
             <?xml version="1.0"?>
@@ -326,6 +330,7 @@ RSpec.describe RegistrationService do
                <titleInfo>
                   <title>Google : Scanned Book 12345</title>
                </titleInfo>
+               <abstract>A very fine description indeed.</abstract>
             </mods>
           XML
         end


### PR DESCRIPTION
Fixes #632

## Why was this change made?

To allow for upstream apps to pass abstracts to dor-services-app instead of doing this directly in DOR (in support of decoupling from Fedora).

## Was the API documentation (openapi.yml) updated?

no