### PR TITLE
Add endpoint for displaying release tags

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -76,25 +76,6 @@ class ObjectsController < ApplicationController
     proxy_faraday_response(response)
   end
 
-  # You can post a release tag as JSON in the body to add a release tag to an item.
-  # If successful it will return a 201 code, otherwise the error that occurred will bubble to the top
-  #
-  # 201
-  def release_tags
-    request.body.rewind
-    body = request.body.read
-    raw_params = JSON.parse body # This should produce a hash in valid release tag form=
-    raw_params.symbolize_keys!
-
-    if raw_params.key?(:release) && (raw_params[:release] == true || raw_params[:release] == false)
-      ReleaseTags.create(@item, raw_params.slice(:release, :what, :to, :who, :when))
-      @item.save
-      head :created
-    else
-      render status: :bad_request, plain: "A release attribute is required in the JSON, and its value must be either 'true' or 'false'. You sent '#{raw_params[:release]}'"
-    end
-  end
-
   private
 
   def proxy_faraday_response(response)

--- a/app/controllers/release_tags_controller.rb
+++ b/app/controllers/release_tags_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Release tags controller (nested resource under objects)
+class ReleaseTagsController < ApplicationController
+  before_action :load_item
+
+  rescue_from(ActiveFedora::ObjectNotFoundError) do |e|
+    render status: :not_found, plain: e.message
+  end
+
+  def show
+    render json: ReleaseTags.for(item: @item)
+  end
+
+  # You can post a release tag as JSON in the body to add a release tag to an item.
+  # If successful it will return a 201 code, otherwise the error that occurred will bubble to the top
+  #
+  # 201
+  def create
+    ReleaseTags.create(@item, create_parameters)
+    @item.save
+    head :created
+  end
+
+  private
+
+  def create_parameters
+    params.permit(:release, :what, :to, :who, :when).to_h
+  end
+end

--- a/app/models/dor/update_marc_record_service.rb
+++ b/app/models/dor/update_marc_record_service.rb
@@ -176,7 +176,7 @@ module Dor
     private
 
     def released_for
-      Dor::ReleaseTags::IdentityMetadata.for(@druid_obj).released_for({})
+      ::ReleaseTags.for(item: @druid_obj)
     end
 
     def dor_items_for_constituents

--- a/app/services/publish_metadata_service.rb
+++ b/app/services/publish_metadata_service.rb
@@ -17,7 +17,7 @@ class PublishMetadataService
     return unpublish unless world_discoverable?
 
     # Retrieve release tags from identityMetadata and all collections this item is a member of
-    release_tags = Dor::ReleaseTags::IdentityMetadata.for(item).released_for({})
+    release_tags = ReleaseTags.for(item: item)
 
     transfer_metadata(release_tags)
     publish_notify_on_success

--- a/app/services/release_tags.rb
+++ b/app/services/release_tags.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
-# Creates workspaces.  This replaces https://github.com/sul-dlss/dor-services/blob/master/lib/dor/models/concerns/assembleable.rb
+# Shows and creates release tags. This replaces parts of https://github.com/sul-dlss/dor-services/blob/master/lib/dor/models/concerns/releaseable.rb
 class ReleaseTags
+  # Display release tags for an item
+  #
+  # @param item [Dor::Item] the item to list release tags for
+  # @return [Hash] (see Dor::ReleaseTags::IdentityMetadata.released_for)
+  def self.for(item:)
+    Dor::ReleaseTags::IdentityMetadata.for(item).released_for({})
+  end
+
   # Add a release node for the item
   # Will use the current time if timestamp not supplied. You can supply a timestap for correcting history, etc if desired
   # Timestamp will be calculated by the function

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,12 +20,13 @@ Rails.application.routes.draw do
     resources :background_job_results, only: [:show], defaults: { format: :json }
 
     resources :objects, only: [:create, :show] do
+      resource :release_tags, only: [:create, :show]
+
       member do
         post 'publish'
         post 'preserve'
         post 'update_marc_record'
         post 'notify_goobi'
-        post 'release_tags'
         post 'refresh_metadata', to: 'metadata_refresh#refresh'
 
         get 'contents', to: 'content#list'

--- a/openapi.yml
+++ b/openapi.yml
@@ -306,23 +306,49 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
-  '/v1/objects/{id}/release_tags':
-    post:
+  '/v1/objects/{object_id}/release_tags':
+    get:
       tags:
         - objects
-      summary: Assign the release tags
+      summary: Show release tags for an object
       description: ''
-      operationId: 'objects#release_tags'
+      operationId: 'release_tags#show'
       responses:
         '200':
           description: OK
+        '404':
+          description: Object not found
       parameters:
-        - name: id
+        - name: object_id
           in: path
           description: ID of object
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
+    post:
+      tags:
+        - objects
+      summary: Assign the release tags
+      description: ''
+      operationId: 'release_tags#create'
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad request
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
+      requestBody:
+        description: a release tag for an object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReleaseTag'
   '/v1/objects/{id}/refresh_metadata':
     post:
       tags:
@@ -691,8 +717,8 @@ paths:
 
         If 'collection' is provided, the object will be a member of the provided
         collection.
-        
-        Note that the 'source_id' property is required for items but not for 
+
+        Note that the 'source_id' property is required for items but not for
         collections.
       operationId: 'objects#create'
       requestBody:
@@ -1028,6 +1054,8 @@ components:
       properties: {}
     ReleaseTag:
       type: object
+      required:
+        - release
       properties:
         who:
           type: string

--- a/spec/requests/add_release_tags_spec.rb
+++ b/spec/requests/add_release_tags_spec.rb
@@ -2,58 +2,112 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Add release tags' do
+RSpec.describe 'Release tags' do
   let(:druid) { 'druid:mx123qw2323' }
   let(:object) { Dor::Item.new(pid: druid) }
 
-  before do
-    allow(Dor).to receive(:find).and_return(object)
-    allow(ReleaseTags).to receive(:create)
-    allow(object).to receive(:save)
-  end
+  describe 'display' do
+    context 'when item is not found' do
+      before do
+        allow(ReleaseTags).to receive(:for)
+        allow(Dor).to receive(:find)
+          .and_raise(ActiveFedora::ObjectNotFoundError, "Unable to find '#{druid}' in fedora. See logger for details.")
+      end
 
-  context 'when release is false' do
-    it 'adds a release tag' do
-      post "/v1/objects/#{druid}/release_tags",
-           params: %( {"to":"searchworks","who":"carrickr","what":"self","release":false} ),
-           headers: { 'Authorization' => "Bearer #{jwt}" }
+      it 'returns a 404' do
+        get "/v1/objects/#{druid}/release_tags",
+            headers: { 'Authorization' => "Bearer #{jwt}" }
 
-      expect(ReleaseTags).to have_received(:create)
-        .with(Dor::Item, release: false, to: 'searchworks', who: 'carrickr', what: 'self')
-      expect(object).to have_received(:save)
+        expect(ReleaseTags).not_to have_received(:for)
+        expect(response.status).to eq(404)
+        expect(response.body).to eq('Unable to find \'druid:mx123qw2323\' in fedora. See logger for details.')
+      end
+    end
 
-      expect(response.status).to eq(201)
+    context 'when item is found' do
+      before do
+        allow(Dor).to receive(:find).and_return(object)
+        allow(ReleaseTags).to receive(:for).and_return(
+          'SearchWorks' => { 'release' => true },
+          'elsewhere' => { 'release' => false }
+        )
+      end
+
+      it 'returns a 200' do
+        get "/v1/objects/#{druid}/release_tags",
+            headers: { 'Authorization' => "Bearer #{jwt}" }
+
+        expect(ReleaseTags).to have_received(:for).with(item: object).once
+        expect(response.status).to eq(200)
+        expect(response.body).to eq('{"SearchWorks":{"release":true},"elsewhere":{"release":false}}')
+      end
     end
   end
 
-  context 'when release is true' do
-    it 'adds a release tag' do
-      post "/v1/objects/#{druid}/release_tags",
-           params: %( {"to":"searchworks","who":"carrickr","what":"self","release":true} ),
-           headers: { 'Authorization' => "Bearer #{jwt}" }
-
-      expect(ReleaseTags).to have_received(:create)
-        .with(Dor::Item, release: true, to: 'searchworks', who: 'carrickr', what: 'self')
-      expect(object).to have_received(:save)
-      expect(response.status).to eq(201)
+  describe 'creation' do
+    before do
+      allow(Dor).to receive(:find).and_return(object)
+      allow(ReleaseTags).to receive(:create)
+      allow(object).to receive(:save)
     end
-  end
 
-  context 'with an invalid release attribute' do
-    it 'returns an error' do
-      post "/v1/objects/#{druid}/release_tags",
-           params: %( {"to":"searchworks","who":"carrickr","what":"self","release":"seven"} ),
-           headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response.status).to eq(400)
+    context 'when release is false' do
+      it 'adds a release tag' do
+        post "/v1/objects/#{druid}/release_tags",
+             params: %( {"to":"searchworks","who":"carrickr","what":"self","release":false} ),
+             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+
+        expect(ReleaseTags).to have_received(:create)
+          .with(Dor::Item, release: false, to: 'searchworks', who: 'carrickr', what: 'self')
+        expect(object).to have_received(:save)
+        expect(response.status).to eq(201)
+      end
     end
-  end
 
-  context 'with a missing release attribute' do
-    it 'returns an error' do
-      post '/v1/objects/druid:1234/release_tags',
-           params: %( {"to":"searchworks","who":"carrickr","what":"self"} ),
-           headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response.status).to eq(400)
+    context 'when release is true' do
+      it 'adds a release tag' do
+        post "/v1/objects/#{druid}/release_tags",
+             params: %( {"to":"searchworks","who":"carrickr","what":"self","release":true} ),
+             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+
+        expect(ReleaseTags).to have_received(:create)
+          .with(Dor::Item, release: true, to: 'searchworks', who: 'carrickr', what: 'self')
+        expect(object).to have_received(:save)
+        expect(response.status).to eq(201)
+      end
+    end
+
+    context 'without JSON content-type' do
+      it 'returns an error' do
+        post "/v1/objects/#{druid}/release_tags",
+             params: %( {"to":"searchworks","who":"carrickr","what":"self","release":"seven"} ),
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response.status).to eq(400)
+        expect(response.body).to eq('{"errors":[{"status":"bad_request","detail":"\"Content-Type\" request header must be set to \"application/json\"."}]}')
+      end
+    end
+
+    context 'with an invalid release attribute' do
+      it 'returns an error' do
+        post "/v1/objects/#{druid}/release_tags",
+             params: %( {"to":"searchworks","who":"carrickr","what":"self","release":"seven"} ),
+             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+        expect(response.status).to eq(400)
+        expect(response.body).to eq('{"errors":[{"status":"bad_request","detail":"#/components/schemas/ReleaseTag/properties/release expected boolean, but received String: seven"}]}')
+      end
+    end
+
+    context 'with a missing release attribute' do
+      it 'returns an error' do
+        post '/v1/objects/druid:1234/release_tags',
+             params: %( {"to":"searchworks","who":"carrickr","what":"self"} ),
+             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+        expect(response.status).to eq(400)
+        expect(response.body).to eq(
+          '{"errors":[{"status":"bad_request",'\
+          '"detail":"#/components/schemas/Druid pattern ^druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$ does not match value: druid:1234, example: druid:bc123df4567"}]}'
+        )
+      end
     end
   end
 end

--- a/spec/services/release_tags_spec.rb
+++ b/spec/services/release_tags_spec.rb
@@ -3,18 +3,28 @@
 require 'rails_helper'
 
 RSpec.describe ReleaseTags do
-  describe '.create' do
-    before do
-      allow(Dor::SuriService).to receive(:mint_id).and_return('druid:aa123bb7890')
+  before do
+    # allow(Dor::SuriService).to receive(:mint_id).and_return('druid:aa123bb7890')
+    described_class.create(work, release: true, what: 'self', when: '2018-11-30T22:41:35Z', to: 'SearchWorks')
+  end
+
+  let(:work) { Dor::Item.new(pid: 'druid:aa123bb7890') }
+
+  describe '.for' do
+    it 'returns the hash of release tags' do
+      expect(described_class.for(item: work)).to eq(
+        'SearchWorks' => {
+          'release' => true
+        }
+      )
     end
+  end
 
-    let(:work) { Dor::Item.new }
-
+  describe '.create' do
     it 'creates a plain directory in the workspace when passed no source directory' do
-      described_class.create(work, release: true, what: 'self', when: '2018-11-30T22:41:35Z')
       expect(work.identityMetadata.to_xml).to be_equivalent_to <<-XML
         <identityMetadata>
-          <release what="self" when="2018-11-30T22:41:35Z">true</release>
+          <release what="self" when="2018-11-30T22:41:35Z" to="SearchWorks">true</release>
         </identityMetadata>
       XML
     end


### PR DESCRIPTION
Connects to sul-dlss/google-books#283
Connects to sul-dlss/dor_indexing_app#336

## Why was this change made?

Includes:

* Extract release tags action from objects controller into its own controller
* Add new `#show` action to `ReleaseTagsController`
* Use Committee for validating the `ReleaseTagsController#create` action
* Favor Rails built-in params handling to custom (outdated) handling
* Consolidate release tags-related functionality into `ReleaseTags` service
* Update OpenAPI specification

## Was the API documentation (openapi.yml) updated?

Yes.