### PR TITLE
Adds support to setting embargo when registering.

### DIFF
--- a/app/models/registration_request.rb
+++ b/app/models/registration_request.rb
@@ -17,6 +17,7 @@ class RegistrationRequest
   # @option params [String] :pid Fully qualified PID if you don't want one generated for you
   # @option params [Array<String>] :seed_datastream datastream_names (only 'descMetadata' is a permitted value)
   # @option params [Array] :tags
+  # @option params [Hash] :embargo release_date and access for item
   def initialize(params)
     @params = params
   end
@@ -92,7 +93,25 @@ class RegistrationRequest
     params[:collection]
   end
 
+  def embargo_access
+    embargo.fetch(:access, 'world')
+  end
+
+  # rubocop:disable Rails/Date
+  # This rubocop is a false positive given the string being parsed.
+  def embargo_release_date
+    release_date = embargo[:release_date]
+    return nil if release_date.nil?
+
+    release_date.to_time
+  end
+  # rubocop:enable Rails/Date
+
   private
 
   attr_reader :params
+
+  def embargo
+    params.fetch(:embargo, {})
+  end
 end

--- a/spec/services/registration_service_spec.rb
+++ b/spec/services/registration_service_spec.rb
@@ -336,6 +336,60 @@ RSpec.describe RegistrationService do
         end
       end
 
+      context 'when embargoing' do
+        before do
+          params[:embargo] = { release_date: '2045-01-01T00:00:00+00:00', access: 'stanford' }
+          @obj = register
+        end
+
+        it_behaves_like 'common registration'
+
+        it 'sets rightsMetadata to deny read' do
+          expect(@obj.datastreams['rightsMetadata'].ng_xml).to be_equivalent_to <<-XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <copyright>
+                <human type=\"copyright\">This work is in the Public Domain.</human>
+              </copyright>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine><none/></machine>
+              </access>
+              <use>
+                <human type="creativecommons">Attribution Share Alike license</human>
+                <machine type="creativecommons">by-sa</machine>
+              </use>
+            </rightsMetadata>
+          XML
+        end
+
+        it 'sets embargoMetadata to embargoed' do
+          expect(@obj.datastreams['embargoMetadata'].ng_xml).to be_equivalent_to <<-XML
+            <?xml version="1.0"?>
+            <embargoMetadata>
+              <status>embargoed</status>
+              <releaseDate>2045-01-01T00:00:00Z</releaseDate>
+              <twentyPctVisibilityStatus/>
+              <twentyPctVisibilityReleaseDate/>
+              <releaseAccess>
+                <access type="discover">
+                  <machine><world/></machine>
+                </access>
+                <access type="read">
+                  <machine>
+                    <group>stanford</group>
+                    </machine>
+                </access>
+              </releaseAccess>
+            </embargoMetadata>\n"
+          XML
+        end
+      end
+
       it 'truncates label if >= 255 chars' do
         # expect(Dor.logger).to receive(:warn).at_least(:once)
         params[:label] = 'a' * 256


### PR DESCRIPTION
refs https://github.com/sul-dlss/sdr-api/issues/122

## Why was this change made?
Allow an embargo to be set when creating an object.


## Was the API documentation (openapi.yml) updated?
Yes.