### PR TITLE
Improve the documentation for release tags service

### DIFF
--- a/app/controllers/release_tags_controller.rb
+++ b/app/controllers/release_tags_controller.rb
@@ -8,6 +8,7 @@ class ReleaseTagsController < ApplicationController
     render status: :not_found, plain: e.message
   end
 
+  # Show release tags for an object and for all the collections that it belongs to
   def show
     render json: ReleaseTags.for(item: @item)
   end

--- a/app/services/release_tags.rb
+++ b/app/services/release_tags.rb
@@ -2,7 +2,7 @@
 
 # Shows and creates release tags. This replaces parts of https://github.com/sul-dlss/dor-services/blob/master/lib/dor/models/concerns/releaseable.rb
 class ReleaseTags
-  # Display release tags for an item
+  # Retrieve the release tags for an item and all the collections that it is a part of
   #
   # @param item [Dor::Item] the item to list release tags for
   # @return [Hash] (see Dor::ReleaseTags::IdentityMetadata.released_for)

--- a/openapi.yml
+++ b/openapi.yml
@@ -310,7 +310,7 @@ paths:
     get:
       tags:
         - objects
-      summary: Show release tags for an object
+      summary: Show release tags for an object and for all the collections that it belongs to.
       description: ''
       operationId: 'release_tags#show'
       responses:


### PR DESCRIPTION
## Why was this change made?

The documentation did not reflect the totality of what it was doing and one may have wondered why they shouldn't just rely on the tags that are in the object metadata.

## Was the API documentation (openapi.yml) updated?

yes.
