### PR TITLE
Use the build_request method from cocina-models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
@@ -42,7 +43,7 @@ gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.20.0'
+gem 'cocina-models', '~> 0.21.0'
 gem 'dor-services', '~> 8.6'
 gem 'dor-workflow-client', '~> 3.17'
 gem 'marc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
       capistrano (>= 3.9.0)
       sidekiq (>= 3.4, < 6.0)
     chronic (0.10.2)
-    cocina-models (0.20.0)
+    cocina-models (0.21.0)
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
@@ -485,7 +485,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-shared_configs
   capistrano-sidekiq
-  cocina-models (~> 0.20.0)
+  cocina-models (~> 0.21.0)
   committee
   config
   deprecation

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -8,16 +8,8 @@ module Cocina
     end
 
     def create(params)
-      obj = case params[:type]
-            when *Cocina::Models::DRO::TYPES
-              build_dro(params)
-            when *Cocina::Models::Collection::TYPES
-              build_collection(params)
-            when *Cocina::Models::AdminPolicy::TYPES
-              build_apo(params)
-            else
-              raise "Unknown type #{params[:type]}"
-            end
+      obj = Cocina::Models.build_request(params)
+
       if validate(obj)
         af_model = create_from_model(obj)
 
@@ -29,18 +21,6 @@ module Cocina
     end
 
     private
-
-    def build_dro(params)
-      Cocina::Models::RequestDRO.new(params)
-    end
-
-    def build_collection(params)
-      Cocina::Models::RequestCollection.new(params)
-    end
-
-    def build_apo(params)
-      Cocina::Models::RequestAdminPolicy.new(params)
-    end
 
     def validate(obj)
       if obj.is_a?(Cocina::Models::RequestDRO) && Dor::SearchService.query_by_id(obj.identification.sourceId).first


### PR DESCRIPTION
## Why was this change made?

So that we use the libraries functions, rather than rebuilding.

## Was the API documentation (openapi.yml) updated?
n/a