### PR TITLE
Adds Embargo Service and uses when doing a cocina deposit.

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -59,7 +59,7 @@ module Cocina
                                  admin_policy_object_id: obj.administrative.hasAdminPolicy,
                                  # source_id: obj.identification.sourceId,
                                  label: obj.label).tap do |item|
-        item.descMetadata.mods_title = obj.description.title.first.titleFull
+        item.descMetadata.mods_title = obj.description.title.first.titleFull if obj.description
 
         admin_node = item.administrativeMetadata.ng_xml.xpath('//administrativeMetadata').first
         admin_node.add_child "<dissemination><workflow id=\"#{obj.administrative.registration_workflow}\"></dissemination>"
@@ -75,8 +75,13 @@ module Cocina
                     source_id: obj.identification.sourceId,
                     catkey: catkey_for(obj),
                     label: obj.label).tap do |item|
-        item.descMetadata.mods_title = obj.description.title.first.titleFull
+        item.descMetadata.mods_title = obj.description.title.first.titleFull if obj.description
         item.identityMetadata.tag = content_type_tag(obj.type)
+        if obj.access.embargo
+          EmbargoService.embargo(item: item,
+                                 release_date: obj.access.embargo.releaseDate,
+                                 access: obj.access.embargo.access)
+        end
       end
     end
 
@@ -87,7 +92,7 @@ module Cocina
                           admin_policy_object_id: obj.administrative.hasAdminPolicy,
                           catkey: catkey_for(obj),
                           label: obj.label).tap do |item|
-        item.descMetadata.mods_title = obj.description.title.first.titleFull
+        item.descMetadata.mods_title = obj.description.title.first.titleFull if obj.description
       end
     end
 

--- a/app/services/embargo_service.rb
+++ b/app/services/embargo_service.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Sets an embargo for an item.
+class EmbargoService
+  def self.embargo(item:, release_date:, access:)
+    new(item: item, release_date: release_date, access: access).embargo
+  end
+
+  def initialize(item:, release_date:, access:)
+    @item = item
+    @release_date = release_date
+    @access = access
+  end
+
+  def embargo
+    return unless release_date
+
+    # Based on https://github.com/sul-dlss/hydrus/blob/master/app/models/hydrus/item.rb#L451
+    # Except Hydrus has a slightly different model than DOR, so, not setting rightsMetadata.rmd_embargo_release_date
+    # item.rightsMetadata.rmd_embargo_release_date = release_date.utc.strftime('%FT%TZ')
+    item.embargoMetadata.release_date = release_date
+    item.embargoMetadata.status = 'embargoed'
+
+    item.embargoMetadata.release_access_node = Nokogiri::XML(generic_access_xml)
+    deny_read_access
+  end
+
+  private
+
+  attr_reader :item, :release_date, :access
+
+  def deny_read_access
+    rights_xml = item.rightsMetadata.ng_xml
+    rights_xml.search('//rightsMetadata/access[@type=\'read\']').each do |node|
+      node.children.remove
+      machine_node = Nokogiri::XML::Node.new('machine', rights_xml)
+      node.add_child(machine_node)
+      machine_node.add_child Nokogiri::XML::Node.new('none', rights_xml)
+    end
+    item.rightsMetadata.ng_xml_will_change!
+  end
+
+  def generic_access_xml
+    <<-XML
+      <releaseAccess>
+        <access type="discover">
+          <machine>
+            <world/>
+          </machine>
+        </access>
+        <access type="read">
+          <machine>
+            #{read_access_xml}
+          </machine>
+        </access>
+      </embargoAccess>
+    XML
+  end
+
+  def read_access_xml
+    case access
+    when 'world'
+      '<world />'
+    when 'dark'
+      '<none />'
+    else
+      "<group>#{access}</group>"
+    end
+  end
+end

--- a/openapi.yml
+++ b/openapi.yml
@@ -777,21 +777,6 @@ components:
             - 'dark'
         embargo:
           $ref: '#/components/schemas/Embargo'
-    Embargo:
-      type: object
-      properties:
-        access:
-          type: string
-          enum:
-            - 'world'
-            - 'stanford'
-            - 'location-based'
-            - 'citation-only'
-            - 'dark'
-        releaseDate:
-          type: string
-          format: date-time
-          example: '2029-06-22T07:00:00.000+00:00'
     EmptyAdministrative:
       type: object
       properties: {}
@@ -928,6 +913,24 @@ components:
         - administrative
         - identification
         - structural
+    Embargo:
+      type: object
+      properties:
+        releaseDate:
+          type: string
+          format: date-time
+          example: '2029-06-22T07:00:00.000+00:00'
+        access:
+          type: string
+          enum:
+            - world
+            - stanford
+            - location-based
+            - citation-only
+            - dark
+      required:
+        - releaseDate
+        - access
     FileSet:
       type: object
       properties:

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Get the object' do
     context 'when the object exists with full metadata' do
       before do
         object.descMetadata.title_info.main_title = 'Hello'
-        object.embargoMetadata.release_date = DateTime.parse '2019-09-26T07:00:00Z'
+        EmbargoService.embargo(item: object, release_date: DateTime.parse('2019-09-26T07:00:00Z'), access: 'world')
         ReleaseTags.create(object, release: true,
                                    what: 'self',
                                    to: 'Searchworks',
@@ -74,10 +74,10 @@ RSpec.describe 'Get the object' do
           label: 'foo',
           version: 1,
           access: {
-            access: 'world',
+            access: 'citation-only',
             embargo: {
-              access: 'dark',
-              releaseDate: '2019-09-26T07:00:00.000+00:00'
+              releaseDate: '2019-09-26T07:00:00.000+00:00',
+              access: 'world'
             }
           },
           administrative: {

--- a/spec/services/embargo_service_spec.rb
+++ b/spec/services/embargo_service_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmbargoService do
+  let(:item) do
+    Dor::Item.new.tap do |item|
+      rights_datastream = Dor::RightsMetadataDS.new
+      rights_datastream.content = Nokogiri::XML(rights_xml) { |config| config.default_xml.noblanks }.to_s
+      item.datastreams['rightsMetadata'] = rights_datastream
+    end
+  end
+
+  let(:release_date) { Time.gm(2045) }
+
+  let(:rights_xml) do
+    <<-XML
+    <?xml version="1.0"?>
+    <rightsMetadata>
+      <access type="discover">
+        <machine>
+          <world />
+        </machine>
+      </access>
+      <access type="read">
+        <machine>
+          <group>stanford</group>
+        </machine>
+      </access>
+    </rightsMetadata>
+    XML
+  end
+
+  before do
+    described_class.embargo(item: item, release_date: release_date, access: access)
+  end
+
+  RSpec.shared_examples 'common embargo' do
+    it 'sets rightsMetadata to deny read' do
+      expect(item.datastreams['rightsMetadata'].ng_xml).to be_equivalent_to <<-XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine><none/></machine>
+              </access>
+            </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'when access is stanford' do
+    let(:access) { 'stanford' }
+
+    it_behaves_like 'common embargo'
+
+    it 'sets embargoMetadata to embargoed and release access to stanford' do
+      expect(item.datastreams['embargoMetadata'].ng_xml).to be_equivalent_to <<-XML
+            <?xml version="1.0"?>
+            <embargoMetadata>
+              <status>embargoed</status>
+              <releaseDate>2045-01-01T00:00:00Z</releaseDate>
+              <twentyPctVisibilityStatus/>
+              <twentyPctVisibilityReleaseDate/>
+              <releaseAccess>
+                <access type="discover">
+                  <machine><world/></machine>
+                </access>
+                <access type="read">
+                  <machine>
+                    <group>stanford</group>
+                    </machine>
+                </access>
+              </releaseAccess>
+            </embargoMetadata>\n"
+      XML
+    end
+  end
+
+  context 'when access is world' do
+    let(:access) { 'world' }
+
+    it_behaves_like 'common embargo'
+
+    it 'sets embargoMetadata to embargoed and release access to world' do
+      expect(item.datastreams['embargoMetadata'].ng_xml).to be_equivalent_to <<-XML
+            <?xml version="1.0"?>
+            <embargoMetadata>
+              <status>embargoed</status>
+              <releaseDate>2045-01-01T00:00:00Z</releaseDate>
+              <twentyPctVisibilityStatus/>
+              <twentyPctVisibilityReleaseDate/>
+              <releaseAccess>
+                <access type="discover">
+                  <machine><world/></machine>
+                </access>
+                <access type="read">
+                  <machine>
+                    <world />
+                    </machine>
+                </access>
+              </releaseAccess>
+            </embargoMetadata>\n"
+      XML
+    end
+  end
+
+  context 'when access is dark' do
+    let(:access) { 'dark' }
+
+    it_behaves_like 'common embargo'
+
+    it 'sets embargoMetadata to embargoed and release access to none' do
+      expect(item.datastreams['embargoMetadata'].ng_xml).to be_equivalent_to <<-XML
+            <?xml version="1.0"?>
+            <embargoMetadata>
+              <status>embargoed</status>
+              <releaseDate>2045-01-01T00:00:00Z</releaseDate>
+              <twentyPctVisibilityStatus/>
+              <twentyPctVisibilityReleaseDate/>
+              <releaseAccess>
+                <access type="discover">
+                  <machine><world/></machine>
+                </access>
+                <access type="read">
+                  <machine>
+                    <none />
+                    </machine>
+                </access>
+              </releaseAccess>
+            </embargoMetadata>\n"
+      XML
+    end
+  end
+end


### PR DESCRIPTION
closes #659

## Why was this change made?
So that embargo can be set when doing a cocina deposit.


## Was the API documentation (openapi.yml) updated?
No.