### PR TITLE
Add an endpoint that can replace all extant uses of dor-fetcher

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Responds to queries about the members of a collection
+class MembersController < ApplicationController
+  # Return the published members of this collection
+  def index
+    solr_params = {
+      q: "is_member_of_collection_ssim:\"#{params[:id]}\" published_dttsim:[* TO *]",
+      wt: :json,
+      fl: 'id,objectType_ssim',
+      rows: 100_000_000
+    }
+    response = ActiveFedora::SolrService.instance.conn.get 'select', params: solr_params
+    @members = response['response']['docs']
+  end
+end

--- a/app/views/members/index.json.jbuilder
+++ b/app/views/members/index.json.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.members @members do |member|
+  json.externalIdentifier member['id']
+  json.type member['objectType_ssim']
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
         get 'contents', to: 'content#list'
         get 'contents/*path', to: 'content#read', format: false, as: :read_content
       end
+      resources :members, only: [:index], defaults: { format: :json }
 
       resource :query, only: [], defaults: { format: :json } do
         collection do

--- a/openapi.yml
+++ b/openapi.yml
@@ -427,6 +427,41 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
+  '/v1/objects/{object_id}/members':
+    get:
+      tags:
+        - objects
+      summary: List the members of this collection
+      description: ''
+      operationId: 'members#index'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  members:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        externalIdentifier:
+                          $ref: '#/components/schemas/Druid'
+                        type:
+
+                          type: string
+                          enum:
+                            - 'item'
+                            - 'collection'
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
   '/v1/objects/{object_id}/workspace':
     delete:
       tags:

--- a/spec/requests/members_for_collection_spec.rb
+++ b/spec/requests/members_for_collection_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Get the members' do
+  before do
+    allow(ActiveFedora::SolrService.instance.conn).to receive(:get).and_return(solr_response)
+  end
+
+  let(:solr_response) do
+    {
+      'response' => {
+        'docs' => [
+          { 'id' => 'druid:xx222xx3282', 'objectType_ssim' => 'collection' },
+          { 'id' => 'druid:xx828xx3282', 'objectType_ssim' => 'item' }
+        ]
+      }
+    }
+  end
+
+  let(:expected) do
+    {
+      members: [
+        {
+          externalIdentifier: 'druid:xx222xx3282',
+          type: 'collection'
+        },
+        {
+          externalIdentifier: 'druid:xx828xx3282',
+          type: 'item'
+        }
+      ]
+    }
+  end
+
+  let(:response_model) { JSON.parse(response.body).deep_symbolize_keys }
+
+  it 'returns the druid & type of the members' do
+    get '/v1/objects/druid:mk420bs7601/members',
+        headers: { 'Authorization' => "Bearer #{jwt}" }
+    expect(response).to be_successful
+    expect(response_model).to eq expected
+  end
+end


### PR DESCRIPTION
## Why was this change made?

This allows consumers to determine the members of a collection. Adding this will allow us to close down the dor-fetcher-service and retire the dor-fetcher client.

## Was the API documentation (openapi.yml) updated?
yes