### PR TITLE
Books have viewingDirection, not images

### DIFF
--- a/app/services/cocina/dro_structural_builder.rb
+++ b/app/services/cocina/dro_structural_builder.rb
@@ -14,9 +14,9 @@ module Cocina
     def build
       {}.tap do |structural|
         case item.content_type_tag
-        when 'Image (ltr)'
+        when 'Book (ltr)'
           structural[:hasMemberOrders] = [{ viewingDirection: 'left-to-right' }]
-        when 'Image (rtl)'
+        when 'Book (rtl)'
           structural[:hasMemberOrders] = [{ viewingDirection: 'right-to-left' }]
         end
 

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -87,7 +87,7 @@ module Cocina
 
     def dro_type
       case item.content_type_tag
-      when 'Image (ltr)', 'Image (rtl)'
+      when 'Image'
         Cocina::Models::Vocab.image
       when '3D'
         Cocina::Models::Vocab.three_dimensional
@@ -97,7 +97,7 @@ module Cocina
         Cocina::Models::Vocab.media
       when /^Manuscript/
         Cocina::Models::Vocab.manuscript
-      when /^Book/
+      when 'Book (ltr)', 'Book (rtl)'
         Cocina::Models::Vocab.book
       else
         Cocina::Models::Vocab.object

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -103,8 +103,7 @@ module Cocina
     def content_type_tag(type, direction)
       tag = case type
             when Cocina::Models::Vocab.image
-              short_dir = direction == 'right-to-left' ? 'rtl' : 'ltr'
-              "Image (#{short_dir})"
+              'Image'
             when Cocina::Models::Vocab.three_dimensional
               '3D'
             when Cocina::Models::Vocab.map
@@ -114,7 +113,8 @@ module Cocina
             when Cocina::Models::Vocab.manuscript
               'Manuscript'
             when Cocina::Models::Vocab.book
-              'Book'
+              short_dir = direction == 'right-to-left' ? 'rtl' : 'ltr'
+              "Book (#{short_dir})"
             else
               Cocina::Models::Vocab.object
             end


### PR DESCRIPTION
## Why was this change made?
I made a mistake earlier and applied the viewingDirection to Images rather than Books.


## Was the API documentation (openapi.yml) updated?
n/a