### PR TITLE
The new registration method logs an event

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -3,15 +3,17 @@
 module Cocina
   # Given a Cocina model, create an ActiveFedora model.
   class ObjectCreator
-    def self.create(params)
-      new.create(params)
+    def self.create(params, event_factory: EventFactory)
+      new.create(params, event_factory: event_factory)
     end
 
-    def create(params)
+    def create(params, event_factory:)
       obj = Cocina::Models.build_request(params)
 
       if validate(obj)
         af_model = create_from_model(obj)
+
+        event_factory.create(druid: af_model.pid, event_type: 'registration', data: params)
 
         # This will rebuild the cocina model from fedora, which shows we are only returning persisted data
         return Mapper.build(af_model)

--- a/app/services/registration_service.rb
+++ b/app/services/registration_service.rb
@@ -13,7 +13,7 @@ class RegistrationService
       request = RegistrationRequest.new(dor_params)
       dor_obj = register_object(request)
       pid = dor_obj.pid
-      event_factory.create(druid: pid, event_type: 'registration', data: params)
+      event_factory.create(druid: pid, event_type: 'legacy-registration', data: params)
       location = URI.parse(Dor::Config.fedora.safeurl.sub(%r{/*$}, '/')).merge("objects/#{pid}").to_s
 
       Dor::RegistrationResponse.new(dor_params.merge(location: location, pid: pid))

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -74,10 +74,11 @@ RSpec.describe 'Create object' do
         end
 
         it 'registers the object with the registration service' do
-          post '/v1/objects',
-               params: data,
-               headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-
+          expect do
+            post '/v1/objects',
+                 params: data,
+                 headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+          end.to change(Event, :count).by(1)
           expect(response.body).to eq expected.to_json
           expect(response.status).to eq(201)
           expect(response.location).to eq '/v1/objects/druid:gg777gg7777'


### PR DESCRIPTION
## Why was this change made?
So we can track when this method was used for registration.


## Was the API documentation (openapi.yml) updated?
n/a