### PR TITLE
Correct agreement type URI in OpenAPI specification

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -835,7 +835,7 @@ components:
           enum:
             - 'http://cocina.sul.stanford.edu/models/object.jsonld'
             - 'http://cocina.sul.stanford.edu/models/3d.jsonld'
-            - 'http://cocina.sul.stanford.edu/models/agreement.jsonl'
+            - 'http://cocina.sul.stanford.edu/models/agreement.jsonld'
             - 'http://cocina.sul.stanford.edu/models/book.jsonld'
             - 'http://cocina.sul.stanford.edu/models/document.jsonld'
             - 'http://cocina.sul.stanford.edu/models/geo.jsonld'
@@ -1117,7 +1117,7 @@ components:
           enum:
             - 'http://cocina.sul.stanford.edu/models/object.jsonld'
             - 'http://cocina.sul.stanford.edu/models/3d.jsonld'
-            - 'http://cocina.sul.stanford.edu/models/agreement.jsonl'
+            - 'http://cocina.sul.stanford.edu/models/agreement.jsonld'
             - 'http://cocina.sul.stanford.edu/models/book.jsonld'
             - 'http://cocina.sul.stanford.edu/models/document.jsonld'
             - 'http://cocina.sul.stanford.edu/models/geo.jsonld'


### PR DESCRIPTION
## Why was this change made?

To correct typos.

## Was the API documentation (openapi.yml) updated?

Yes.