### PR TITLE
Allow identityMetadata to be updated using the legacy metadata API

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -20,6 +20,7 @@ class MetadataController < ApplicationController
                          technical: 'technicalMetadata',
                          content: 'contentMetadata',
                          rights: 'rightsMetadata',
+                         identity: 'identityMetadata',
                          provenance: 'provenanceMetadata' }
 
     datastream_names.each do |section, datastream_name|

--- a/app/services/legacy_metadata_service.rb
+++ b/app/services/legacy_metadata_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Operations on the legacy Fedora 3 metadata.
-# This is used by the accessionWF
+# This is used by the accessionWF and the etdSubmitWF
 class LegacyMetadataService
   # If the updated value is newer than then createDate of the datastream, then update it.
   def self.update_datastream_if_newer(datastream:, updated:, content:, event_factory:)

--- a/openapi.yml
+++ b/openapi.yml
@@ -1209,6 +1209,8 @@ components:
           $ref: '#/components/schemas/LegacyDatastream'
         technical:
           $ref: '#/components/schemas/LegacyDatastream'
+        identity:
+          $ref: '#/components/schemas/LegacyDatastream'
         provenance:
           $ref: '#/components/schemas/LegacyDatastream'
     LegacyDatastream:

--- a/spec/requests/legacy_metadata_update_spec.rb
+++ b/spec/requests/legacy_metadata_update_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Update the legacy (datastream) metadata' do
   let(:technicalMetadata) { instance_double(Dor::TechnicalMetadataDS, createDate: create_date) }
   let(:contentMetadata) { instance_double(Dor::ContentMetadataDS, createDate: create_date) }
   let(:provenanceMetadata) { instance_double(Dor::ProvenanceMetadataDS, createDate: create_date) }
+  let(:identityMetadata) { instance_double(Dor::IdentityMetadataDS, createDate: create_date) }
 
   let(:datastreams) do
     {
@@ -17,7 +18,8 @@ RSpec.describe 'Update the legacy (datastream) metadata' do
       'rightsMetadata' => rightsMetadata,
       'technicalMetadata' => technicalMetadata,
       'contentMetadata' => contentMetadata,
-      'provenanceMetadata' => provenanceMetadata
+      'provenanceMetadata' => provenanceMetadata,
+      'identityMetadata' => identityMetadata
     }
   end
 
@@ -31,6 +33,10 @@ RSpec.describe 'Update the legacy (datastream) metadata' do
         "rights": {
           "updated": "2019-11-08T15:15:43Z",
           "content": "<rightsMetadata></rightsMetadata>"
+        },
+        "identity": {
+          "updated": "2019-11-08T15:15:43Z",
+          "content": "<identityMetadata></identityMetadata>"
         },
         "provenance": {
           "updated": "2019-11-08T15:15:43Z",
@@ -62,6 +68,12 @@ RSpec.describe 'Update the legacy (datastream) metadata' do
         .with(datastream: rightsMetadata,
               updated: Time.zone.parse('2019-11-08T15:15:43Z'),
               content: '<rightsMetadata></rightsMetadata>',
+              event_factory: EventFactory)
+
+      expect(LegacyMetadataService).to have_received(:update_datastream_if_newer)
+        .with(datastream: identityMetadata,
+              updated: Time.zone.parse('2019-11-08T15:15:43Z'),
+              content: '<identityMetadata></identityMetadata>',
               event_factory: EventFactory)
 
       expect(LegacyMetadataService).to have_received(:update_datastream_if_newer)


### PR DESCRIPTION


## Why was this change made?

This will be used by the etd robots so they can be decoupled from Fedora 3
Ref sul-dlss/common-accessioning#582
## Was the API documentation (openapi.yml) updated?

yes