### PR TITLE
Support old digest algorithm codes

### DIFF
--- a/app/services/cocina/dro_structural_builder.rb
+++ b/app/services/cocina/dro_structural_builder.rb
@@ -45,8 +45,9 @@ module Cocina
 
     def build_files(file_nodes, version:, parent_id:)
       file_nodes.map do |node|
-        md5 = node.xpath('checksum[@type="MD5"]').text
-        sha1 = node.xpath('checksum[@type="SHA-1"]').text
+        # The old google books use these upcased versions. See https://argo.stanford.edu/view/druid:dd116zh0343
+        md5 = node.xpath('checksum[@type="md5"]').text.presence || node.xpath('checksum[@type="MD5"]').text
+        sha1 = node.xpath('checksum[@type="sha1"]').text.presence || node.xpath('checksum[@type="SHA-1"]').text
         Cocina::Models::File.new(
           {
             externalIdentifier: "#{parent_id}/#{node['id']}",

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -27,38 +27,38 @@ RSpec.describe Cocina::Mapper do
             <resource sequence="1" type="folder" id="folder1PuSu">
               <label>Folder 1</label>
               <file shelve="yes" publish="yes" size="7888" preserve="yes" datetime="2012-06-15T22:57:43Z" id="folder1PuSu/story1u.txt">
-                <checksum type="MD5">e2837b9f02e0b0b76f526eeb81c7aa7b</checksum>
-                <checksum type="SHA-1">61dfac472b7904e1413e0cbf4de432bda2a97627</checksum>
+                <checksum type="md5">e2837b9f02e0b0b76f526eeb81c7aa7b</checksum>
+                <checksum type="sha1">61dfac472b7904e1413e0cbf4de432bda2a97627</checksum>
               </file>
               <file shelve="yes" publish="yes" size="5983" preserve="yes" datetime="2012-06-15T22:58:56Z" id="folder1PuSu/story2r.txt">
-                <checksum type="MD5">dc2be64ae43f1c1db4a068603465955d</checksum>
-                <checksum type="SHA-1">b8a672c1848fc3d13b5f380e15835690e24600e0</checksum>
+                <checksum type="md5">dc2be64ae43f1c1db4a068603465955d</checksum>
+                <checksum type="sha1">b8a672c1848fc3d13b5f380e15835690e24600e0</checksum>
               </file>
               <file shelve="yes" publish="yes" size="5951" preserve="yes" datetime="2012-06-15T23:00:43Z" id="folder1PuSu/story3m.txt">
-                <checksum type="MD5">3d67f52e032e36b641d0cad40816f048</checksum>
-                <checksum type="SHA-1">548f349c79928b6d0996b7ff45990bdce5ee9753</checksum>
+                <checksum type="md5">3d67f52e032e36b641d0cad40816f048</checksum>
+                <checksum type="sha1">548f349c79928b6d0996b7ff45990bdce5ee9753</checksum>
               </file>
               <file shelve="yes" publish="yes" size="6307" preserve="yes" datetime="2012-06-15T23:02:22Z" id="folder1PuSu/story4d.txt">
-                <checksum type="MD5">34f3f646523b0a8504f216483a57bce4</checksum>
-                <checksum type="SHA-1">d498b513add5bb138ed4f6205453a063a2434dc4</checksum>
+                <checksum type="md5">34f3f646523b0a8504f216483a57bce4</checksum>
+                <checksum type="sha1">d498b513add5bb138ed4f6205453a063a2434dc4</checksum>
               </file>
             </resource>
             <resource sequence="2" type="folder" id="folder2PdSa">
               <file shelve="no" publish="yes" size="2534" preserve="yes" datetime="2012-06-15T23:05:03Z" id="folder2PdSa/story6u.txt">
-                <checksum type="MD5">1f15cc786bfe832b2fa1e6f047c500ba</checksum>
-                <checksum type="SHA-1">bf3af01de2afa15719d8c42a4141e3b43d06fef6</checksum>
+                <checksum type="md5">1f15cc786bfe832b2fa1e6f047c500ba</checksum>
+                <checksum type="sha1">bf3af01de2afa15719d8c42a4141e3b43d06fef6</checksum>
               </file>
               <file shelve="no" publish="yes" size="17074" preserve="yes" datetime="2012-06-15T23:08:35Z" id="folder2PdSa/story7r.txt">
-                <checksum type="MD5">205271287477c2309512eb664eff9130</checksum>
-                <checksum type="SHA-1">b23aa592ab673030ace6178e29fad3cf6a45bd32</checksum>
+                <checksum type="md5">205271287477c2309512eb664eff9130</checksum>
+                <checksum type="sha1">b23aa592ab673030ace6178e29fad3cf6a45bd32</checksum>
               </file>
               <file shelve="no" publish="yes" size="5643" preserve="yes" datetime="2012-06-15T23:09:26Z" id="folder2PdSa/story8m.txt">
-                <checksum type="MD5">ce474f4c512953f20a8c4c5b92405cf7</checksum>
-                <checksum type="SHA-1">af9cbf5ab4f020a8bb17b180fbd5c41598d89b37</checksum>
+                <checksum type="md5">ce474f4c512953f20a8c4c5b92405cf7</checksum>
+                <checksum type="sha1">af9cbf5ab4f020a8bb17b180fbd5c41598d89b37</checksum>
               </file>
               <file shelve="no" publish="yes" size="19599" preserve="yes" datetime="2012-06-15T23:14:32Z" id="folder2PdSa/story9d.txt">
-                <checksum type="MD5">135cb2db6a35afac590687f452053baf</checksum>
-                <checksum type="SHA-1">e74274d7bc06ef44a408a008f5160b3756cb2ab0</checksum>
+                <checksum type="md5">135cb2db6a35afac590687f452053baf</checksum>
+                <checksum type="sha1">e74274d7bc06ef44a408a008f5160b3756cb2ab0</checksum>
               </file>
             </resource>
           </contentMetadata>


### PR DESCRIPTION


## Why was this change made?
Some old objects (circa 2011) use these upcased algorithms.  Modern objects use the downcased version


## Was the API documentation (openapi.yml) updated?
n/a