### PR TITLE
Get the label from the catalog when a catkey is provided

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -48,7 +48,10 @@ module Cocina
                   end
 
       # Synch from symphony if a catkey is present
-      RefreshMetadataAction.run(identifiers: ["catkey:#{af_object.catkey}"], datastream: af_object.descMetadata) if af_object.catkey
+      if af_object.catkey
+        RefreshMetadataAction.run(identifiers: ["catkey:#{af_object.catkey}"], datastream: af_object.descMetadata)
+        af_object.label = MetadataService.label_from_mods(af_object.descMetadata.ng_xml)
+      end
 
       af_object.save!
       af_object

--- a/app/services/metadata_service.rb
+++ b/app/services/metadata_service.rb
@@ -28,10 +28,15 @@ class MetadataService
       end
     end
 
-    def label_for(identifier)
-      mods = Nokogiri::XML(fetch(identifier))
+    def label_from_mods(mods)
       mods.root.add_namespace_definition('mods', 'http://www.loc.gov/mods/v3')
-      mods.xpath('/mods:mods/mods:titleInfo[1]').xpath('mods:title|mods:nonSort').collect(&:text).join(' ').strip
+      mods.xpath('/mods:mods/mods:titleInfo[1]')
+          .xpath('mods:title|mods:nonSort')
+          .collect(&:text).join(' ').strip
+    end
+
+    def label_for(identifier)
+      label_from_mods(Nokogiri::XML(fetch(identifier)))
     end
 
     private

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -12,12 +12,15 @@ RSpec.describe 'Create object' do
   end
 
   context 'when an image is provided' do
+    let(:label) { 'This is my label' }
+    let(:title) { 'This is my title' }
+    let(:expected_label) { label }
     let(:expected) do
       Cocina::Models::DRO.new(type: Cocina::Models::Vocab.image,
-                              label: 'This is my label',
+                              label: expected_label,
                               version: 1,
                               description: {
-                                title: [{ titleFull: 'This is my title', primary: true }]
+                                title: [{ titleFull: title, primary: true }]
                               },
                               administrative: {
                                 hasAdminPolicy: 'druid:dd999df4567'
@@ -29,9 +32,9 @@ RSpec.describe 'Create object' do
     let(:data) do
       <<~JSON
         { "type":"http://cocina.sul.stanford.edu/models/image.jsonld",
-          "label":"This is my label","version":1,"access":{},
+          "label":"#{label}","version":1,"access":{},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
-          "description":{"title":[{"primary":true,"titleFull":"This is my title"}]},
+          "description":{"title":[{"primary":true,"titleFull":"#{title}"}]},
           "identification":#{identification.to_json},"structural":{}}
       JSON
     end
@@ -56,6 +59,8 @@ RSpec.describe 'Create object' do
     end
 
     context 'when catkey is provided' do
+      let(:expected_label) { title } # label derived from catalog data
+
       let(:identification) do
         {
           sourceId: 'googlebooks:999999',
@@ -110,12 +115,15 @@ RSpec.describe 'Create object' do
   end
 
   context 'when a book is provided' do
+    let(:label) { 'This is my label' }
+    let(:title) { 'This is my title' }
+    let(:expected_label) { label }
     let(:expected) do
       Cocina::Models::DRO.new(type: Cocina::Models::Vocab.book,
-                              label: 'This is my label',
+                              label: expected_label,
                               version: 1,
                               description: {
-                                title: [{ titleFull: 'This is my title', primary: true }]
+                                title: [{ titleFull: title, primary: true }]
                               },
                               administrative: {
                                 hasAdminPolicy: 'druid:dd999df4567'
@@ -131,9 +139,9 @@ RSpec.describe 'Create object' do
     let(:data) do
       <<~JSON
         { "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
-          "label":"This is my label","version":1,"access":{},
+          "label":"#{label}","version":1,"access":{},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
-          "description":{"title":[{"primary":true,"titleFull":"This is my title"}]},
+          "description":{"title":[{"primary":true,"titleFull":"#{title}"}]},
           "identification":{"sourceId":"googlebooks:999999"},
           "structural":{"hasMemberOrders":[{"viewingDirection":"right-to-left"}]}}
       JSON
@@ -156,12 +164,15 @@ RSpec.describe 'Create object' do
   end
 
   context 'when a collection is provided' do
+    let(:label) { 'This is my label' }
+    let(:title) { 'This is my title' }
+    let(:expected_label) { label }
     let(:expected) do
       Cocina::Models::Collection.new(type: Cocina::Models::Vocab.collection,
-                                     label: 'This is my label',
+                                     label: expected_label,
                                      version: 1,
                                      description: {
-                                       title: [{ titleFull: 'This is my title', primary: true }]
+                                       title: [{ titleFull: title, primary: true }]
                                      },
                                      administrative: {
                                        hasAdminPolicy: 'druid:dd999df4567'
@@ -173,15 +184,16 @@ RSpec.describe 'Create object' do
     let(:data) do
       <<~JSON
         {"type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
-          "label":"This is my label","version":1,"access":{},
+          "label":"#{label}","version":1,"access":{},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
-          "description":{"title":[{"primary":true,"titleFull":"This is my title"}]},
+          "description":{"title":[{"primary":true,"titleFull":"#{title}"}]},
           "identification":#{identification.to_json},
           "structural":{}}
       JSON
     end
 
     context 'when the catkey is provided and save is successful' do
+      let(:expected_label) { title } # label derived from catalog data
       let(:identification) do
         {
           catalogLinks: [


### PR DESCRIPTION
## Why was this change made?
Fixes #316

So that we don't have `:auto` as the label for new google books.


## Was the API documentation (openapi.yml) updated?
n/a