### PR TITLE
Pull MIME type from contentMD and map to Cocina model

### DIFF
--- a/app/services/cocina/dro_structural_builder.rb
+++ b/app/services/cocina/dro_structural_builder.rb
@@ -54,6 +54,7 @@ module Cocina
             type: Cocina::Models::Vocab.file,
             label: node['id'],
             size: node['size'],
+            hasMimeType: node['mimetype'],
             version: version,
             hasMessageDigests: []
           }.tap do |attrs|

--- a/openapi.yml
+++ b/openapi.yml
@@ -937,6 +937,8 @@ components:
           type: integer
         version:
           type: integer
+        hasMimeType:
+          type: string
         hasMessageDigests:
           type: array
           items:

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -26,37 +26,37 @@ RSpec.describe Cocina::Mapper do
           <contentMetadata type="sample" objectId="druid:dd116zh0343">
             <resource sequence="1" type="folder" id="folder1PuSu">
               <label>Folder 1</label>
-              <file shelve="yes" publish="yes" size="7888" preserve="yes" datetime="2012-06-15T22:57:43Z" id="folder1PuSu/story1u.txt">
+              <file mimetype="text/plain" shelve="yes" publish="yes" size="7888" preserve="yes" datetime="2012-06-15T22:57:43Z" id="folder1PuSu/story1u.txt">
                 <checksum type="md5">e2837b9f02e0b0b76f526eeb81c7aa7b</checksum>
                 <checksum type="sha1">61dfac472b7904e1413e0cbf4de432bda2a97627</checksum>
               </file>
-              <file shelve="yes" publish="yes" size="5983" preserve="yes" datetime="2012-06-15T22:58:56Z" id="folder1PuSu/story2r.txt">
+              <file mimetype="text/plain" shelve="yes" publish="yes" size="5983" preserve="yes" datetime="2012-06-15T22:58:56Z" id="folder1PuSu/story2r.txt">
                 <checksum type="md5">dc2be64ae43f1c1db4a068603465955d</checksum>
                 <checksum type="sha1">b8a672c1848fc3d13b5f380e15835690e24600e0</checksum>
               </file>
-              <file shelve="yes" publish="yes" size="5951" preserve="yes" datetime="2012-06-15T23:00:43Z" id="folder1PuSu/story3m.txt">
+              <file mimetype="text/plain" shelve="yes" publish="yes" size="5951" preserve="yes" datetime="2012-06-15T23:00:43Z" id="folder1PuSu/story3m.txt">
                 <checksum type="md5">3d67f52e032e36b641d0cad40816f048</checksum>
                 <checksum type="sha1">548f349c79928b6d0996b7ff45990bdce5ee9753</checksum>
               </file>
-              <file shelve="yes" publish="yes" size="6307" preserve="yes" datetime="2012-06-15T23:02:22Z" id="folder1PuSu/story4d.txt">
+              <file mimetype="text/plain" shelve="yes" publish="yes" size="6307" preserve="yes" datetime="2012-06-15T23:02:22Z" id="folder1PuSu/story4d.txt">
                 <checksum type="md5">34f3f646523b0a8504f216483a57bce4</checksum>
                 <checksum type="sha1">d498b513add5bb138ed4f6205453a063a2434dc4</checksum>
               </file>
             </resource>
             <resource sequence="2" type="folder" id="folder2PdSa">
-              <file shelve="no" publish="yes" size="2534" preserve="yes" datetime="2012-06-15T23:05:03Z" id="folder2PdSa/story6u.txt">
+              <file mimetype="text/plain" shelve="no" publish="yes" size="2534" preserve="yes" datetime="2012-06-15T23:05:03Z" id="folder2PdSa/story6u.txt">
                 <checksum type="md5">1f15cc786bfe832b2fa1e6f047c500ba</checksum>
                 <checksum type="sha1">bf3af01de2afa15719d8c42a4141e3b43d06fef6</checksum>
               </file>
-              <file shelve="no" publish="yes" size="17074" preserve="yes" datetime="2012-06-15T23:08:35Z" id="folder2PdSa/story7r.txt">
+              <file mimetype="text/plain" shelve="no" publish="yes" size="17074" preserve="yes" datetime="2012-06-15T23:08:35Z" id="folder2PdSa/story7r.txt">
                 <checksum type="md5">205271287477c2309512eb664eff9130</checksum>
                 <checksum type="sha1">b23aa592ab673030ace6178e29fad3cf6a45bd32</checksum>
               </file>
-              <file shelve="no" publish="yes" size="5643" preserve="yes" datetime="2012-06-15T23:09:26Z" id="folder2PdSa/story8m.txt">
+              <file mimetype="text/plain" shelve="no" publish="yes" size="5643" preserve="yes" datetime="2012-06-15T23:09:26Z" id="folder2PdSa/story8m.txt">
                 <checksum type="md5">ce474f4c512953f20a8c4c5b92405cf7</checksum>
                 <checksum type="sha1">af9cbf5ab4f020a8bb17b180fbd5c41598d89b37</checksum>
               </file>
-              <file shelve="no" publish="yes" size="19599" preserve="yes" datetime="2012-06-15T23:14:32Z" id="folder2PdSa/story9d.txt">
+              <file mimetype="text/plain" shelve="no" publish="yes" size="19599" preserve="yes" datetime="2012-06-15T23:14:32Z" id="folder2PdSa/story9d.txt">
                 <checksum type="md5">135cb2db6a35afac590687f452053baf</checksum>
                 <checksum type="sha1">e74274d7bc06ef44a408a008f5160b3756cb2ab0</checksum>
               </file>
@@ -83,6 +83,7 @@ RSpec.describe Cocina::Mapper do
         file1 = folder1.structural.contains.first
         expect(file1.label).to eq 'folder1PuSu/story1u.txt'
         expect(file1.size).to eq 7888
+        expect(file1.hasMimeType).to eq 'text/plain'
         expect(file1.hasMessageDigests.first.digest).to eq '61dfac472b7904e1413e0cbf4de432bda2a97627'
         expect(file1.hasMessageDigests.first.type).to eq 'sha1'
         true


### PR DESCRIPTION
Fixes #686

## Why was this change made?

To show the MIME type on the Cocina side of the world.

## Was the API documentation (openapi.yml) updated?

yes