### PR TITLE
Returns 502 from symphony error. Stop logging to HB.

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -21,7 +21,7 @@ class ObjectsController < ApplicationController
   end
 
   rescue_from(SymphonyReader::ResponseError) do |e|
-    render status: :internal_server_error, plain: e.message
+    render status: :bad_gateway, plain: e.message
   end
 
   def create

--- a/app/models/symphony_reader.rb
+++ b/app/models/symphony_reader.rb
@@ -52,7 +52,6 @@ class SymphonyReader
       errmsg = "Record not found in Symphony: #{@catkey}"
     else
       errmsg = "Got HTTP Status-Code #{resp.status} retrieving #{@catkey} from Symphony: #{resp.body}"
-      Honeybadger.notify(errmsg)
     end
 
     raise ResponseError, errmsg

--- a/openapi.yml
+++ b/openapi.yml
@@ -695,6 +695,16 @@ paths:
       responses:
         '200':
           description: OK
+        '400':
+          description: Invalid DOR parameter
+        '404':
+          description: Object not found in DOR
+        '409':
+          description: Object with that sourceId already exists
+        '500':
+          description: Server error
+        '502':
+          description: Error connecting to Symphony
   '/v1/objects/{id}':
     get:
       tags:

--- a/spec/models/symphony_reader_spec.rb
+++ b/spec/models/symphony_reader_spec.rb
@@ -110,11 +110,9 @@ RSpec.describe SymphonyReader do
           stub_request(:get, format(Settings.catalog.symphony.json_url, catkey: catkey)).to_return(status: 403, body: err_body.to_json)
         end
 
-        it 'raises ResponseError and notifies Honeybadger' do
+        it 'raises ResponseError' do
           msg_regex = /^Got HTTP Status-Code 403 retrieving catkey from Symphony:.*Something somewhere went wrong./
-          allow(Honeybadger).to receive(:notify)
           expect { reader.to_marc }.to raise_error(SymphonyReader::ResponseError, msg_regex)
-          expect(Honeybadger).to have_received(:notify).with(msg_regex)
         end
       end
 

--- a/spec/requests/legacy_register_object_spec.rb
+++ b/spec/requests/legacy_register_object_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe 'Register object' do
       allow(RegistrationService).to receive(:register_object).and_raise(SymphonyReader::ResponseError.new(errmsg))
     end
 
-    it 'returns a 500 error' do
+    it 'returns a 502 error' do
       post '/v1/objects',
            params: data,
            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-      expect(response.status).to eq(500)
+      expect(response.status).to eq(502)
       expect(response.body).to eq(errmsg)
     end
   end


### PR DESCRIPTION
closes #694

## Why was this change made?
So that a correct error was returned when Symphony failed. And stop spamming HB.


## Was the API documentation (openapi.yml) updated?
Yes