### PR TITLE
Bump cocina-models to 0.25.0 and add hasAgreement to cocina mapper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.24.0'
+gem 'cocina-models', '~> 0.25.0'
 gem 'dor-services', '~> 9.0'
 gem 'dor-workflow-client', '~> 3.17'
 gem 'marc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/lostisland/faraday_middleware.git
-  revision: 5d97b780fc32ba4c6e055606d51771ca5cae127c
+  revision: 13e29232f0fb083173e12f8a26b278c5e7869e10
   specs:
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
@@ -98,7 +98,7 @@ GEM
       capistrano (>= 3.9.0)
       sidekiq (>= 3.4, < 6.0)
     chronic (0.10.2)
-    cocina-models (0.24.0)
+    cocina-models (0.25.0)
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
@@ -489,7 +489,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-shared_configs
   capistrano-sidekiq
-  cocina-models (~> 0.24.0)
+  cocina-models (~> 0.25.0)
   committee
   config
   deprecation

--- a/app/services/cocina/dro_structural_builder.rb
+++ b/app/services/cocina/dro_structural_builder.rb
@@ -21,6 +21,7 @@ module Cocina
         end
 
         structural[:contains] = build_filesets(item.contentMetadata, version: item.current_version, id: item.pid) unless item.is_a?(Dor::Etd) || item.contentMetadata.new?
+        structural[:hasAgreement] = item.identityMetadata.agreementId.first unless item.identityMetadata.agreementId.empty?
       end
     end
 

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -9,13 +9,16 @@ RSpec.describe Cocina::Mapper do
     let(:item) do
       Dor::Item.new(pid: 'druid:mx000xm0000',
                     source_id: 'whaever:8888',
-                    label: 'test object', admin_policy_object_id: 'druid:sc012gz0974')
+                    label: 'test object',
+                    admin_policy_object_id: 'druid:sc012gz0974')
     end
 
     let(:type) { 'Process : Content Type : 3D' }
+    let(:agreement) { 'druid:666' }
 
     before do
       item.identityMetadata.tag = [type]
+      item.identityMetadata.agreementId = [agreement]
       item.descMetadata.title_info.main_title = 'Hello'
     end
 
@@ -74,6 +77,8 @@ RSpec.describe Cocina::Mapper do
         expect(cocina_model.type).to eq Cocina::Models::Vocab.three_dimensional
 
         expect(cocina_model.administrative.hasAdminPolicy).to eq 'druid:sc012gz0974'
+
+        expect(cocina_model.structural.hasAgreement).to eq 'druid:666'
 
         expect(cocina_model.structural.contains.size).to eq 2
         folder1 = cocina_model.structural.contains.first


### PR DESCRIPTION
## Why was this change made?

Fixes #683 - adds `hasAgreement` to cocina Mapper now that `hasAgreement` is in the structural metadata

## Was the API documentation (openapi.yml) updated?

N/A

## Does this change affect how this application integrates with other services?

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
