### PR TITLE
implement endpoint for starting accessioning

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -52,14 +52,16 @@ class ObjectsController < ApplicationController
 
   # Initialize specified workflow (assemblyWF by default), and also version if needed
   # called by pre-assembly, goobi and lybservices-scripts to kick off accessioning for a new or existing object
-  # params can optionally include the information needed to open a new version as well as the workflow to start (which defaults to assemblyWF)
-  # @option opts [Boolean] :assume_accessioned If true, does not check whether object has been accessioned.
+  #
+  # You can specify params when POSTing to this method to include when opening a version (if that is required to accession).
+  # The optional versioning params are included below for reference.  You can also optionally include a workflow to initialize
+  #   (which defaults to assemblyWF)
   # @option opts [String] :significance set significance (major/minor/patch) of version change
   # @option opts [String] :description set description of version change
   # @option opts [String] :opening_user_name add opening username to the events datastream
   # @option opts [String] :workflow the workflow to start (defaults to 'assemblyWF')
-  def start_accession
-    params[:workflow] ||= default_start_accession_workflow # default if not specified
+  def accession
+    workflow = params[:workflow] || default_start_accession_workflow
 
     # if this is an existing versionable object, open and close it without starting accessioning
     if VersionService.can_open?(@item, params)
@@ -68,7 +70,7 @@ class ObjectsController < ApplicationController
     end
 
     # initialize workflow
-    workflow_client.create_workflow_by_name(@item.pid, params[:workflow], version: @item.current_version)
+    workflow_client.create_workflow_by_name(@item.pid, workflow, version: @item.current_version)
     head :created
   end
 

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -61,7 +61,7 @@ class VersionsController < ApplicationController
     params.permit(
       :description,
       :significance,
-      :start_accession,
+      :accession,
       :user_name,
       :version_num
     ).to_h.symbolize_keys

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -69,7 +69,7 @@ class VersionService
   #  :major, :minor, :admin (see Dor::VersionTag#increment)
   # @option opts [String] :version_num version number to archive rows with. Otherwise, current version is used
   # @option opts [String] :user_name add username to the events datastream
-  # @option opts [Boolean] :start_accesion set to true if you want accessioning to start (default), false otherwise
+  # @option opts [Boolean] :start_accession set to true if you want accessioning to start (default), false otherwise
   # @raise [Dor::Exception] if the object hasn't been opened for versioning, or if accessionWF has
   #   already been instantiated or the current version is missing a tag or description
   def close(opts = {})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
         post 'preserve'
         post 'update_marc_record'
         post 'notify_goobi'
-        post 'start_accession'
+        post 'accession'
         post 'refresh_metadata', to: 'metadata_refresh#refresh'
 
         get 'contents', to: 'content#list'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
         post 'preserve'
         post 'update_marc_record'
         post 'notify_goobi'
+        post 'start_accession'
         post 'refresh_metadata', to: 'metadata_refresh#refresh'
 
         get 'contents', to: 'content#list'

--- a/openapi.yml
+++ b/openapi.yml
@@ -147,7 +147,7 @@ paths:
     post:
       tags:
         - objects
-      summary: Publish object to Searchworks
+      summary: Publish object to PURL
       description: ''
       operationId: 'objects#publish'
       responses:
@@ -175,6 +175,32 @@ paths:
               - accessionWF
               - releaseWF
             example: releaseWF
+  '/v1/objects/{id}/start_accession':
+    post:
+      tags:
+        - objects
+      summary: Start accessioning or re-accession an object to DOR
+      description: ''
+      operationId: 'objects#start_accession'
+      responses:
+        '201':
+          description: Accessiong/re-accessioning started
+      parameters:
+        - name: id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: workflow
+          in: query
+          description: which workflow should be started
+          schema:
+            type: string
+            enum:
+              - accessionWF
+              - assemblyWF
+            example: assemblyWF
   '/v1/objects/{id}/preserve':
     post:
       tags:

--- a/openapi.yml
+++ b/openapi.yml
@@ -175,13 +175,13 @@ paths:
               - accessionWF
               - releaseWF
             example: releaseWF
-  '/v1/objects/{id}/start_accession':
+  '/v1/objects/{id}/accession':
     post:
       tags:
         - objects
       summary: Start accessioning or re-accession an object to DOR
       description: ''
-      operationId: 'objects#start_accession'
+      operationId: 'objects#accession'
       responses:
         '201':
           description: Accessiong/re-accessioning started
@@ -195,12 +195,38 @@ paths:
         - name: workflow
           in: query
           description: which workflow should be started
+          required: false
           schema:
             type: string
+            default: assemblyWF
             enum:
               - accessionWF
               - assemblyWF
             example: assemblyWF
+        - name: significance
+          in: query
+          description: the significance of the version change (if versioning is needed)
+          required: false
+          schema:
+            type: string
+            enum:
+              - Minor
+              - Major
+              - Admin
+            example: Admin
+        - name: description
+          in: query
+          description: the description of the version change (if versioning is needed)
+          required: false
+          schema:
+            type: string
+            example: 'Re-accessioning this object'
+        - name: opening_user_name
+          in: query
+          description: the username of the person creating the version (if versioning is needed)
+          schema:
+            type: string
+            example: 'some_sunetid'
   '/v1/objects/{id}/preserve':
     post:
       tags:

--- a/spec/requests/start_accession_spec.rb
+++ b/spec/requests/start_accession_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
+  let(:druid) { 'druid:mx123qw2323' }
+  let(:object) { Dor::Item.new(pid: druid) }
+  let(:workflow_client) { instance_double(Dor::Workflow::Client, create_workflow_by_name: true) }
+  let(:default_start_accession_workflow) { ObjectsController.new.send(:default_start_accession_workflow) }
+
+  before do
+    allow(Dor).to receive(:find).and_return(object)
+    allow(VersionService).to receive(:close)
+    allow(VersionService).to receive(:open)
+    allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+  end
+
+  context 'when new object' do
+    before do
+      allow(VersionService).to receive(:can_open?).and_return(false)
+    end
+
+    it 'does not open or close a version and starts default workflow' do
+      post "/v1/objects/#{druid}/start_accession",
+           headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to be_successful
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(object.pid, default_start_accession_workflow, version: '1')
+      expect(VersionService).not_to have_received(:open)
+      expect(VersionService).not_to have_received(:close)
+    end
+
+    it 'can override the default workflow' do
+      params = { workflow: 'accessionWF', opening_user_name: 'some_person' }
+      post "/v1/objects/#{druid}/start_accession",
+           params: params,
+           headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to be_successful
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(object.pid, 'accessionWF', version: '1')
+      expect(VersionService).not_to have_received(:open)
+      expect(VersionService).not_to have_received(:close)
+    end
+  end
+
+  context 'when existing object' do
+    let(:base_params) { { 'controller' => 'objects', 'action' => 'start_accession', 'id' => druid } }
+
+    before do
+      allow(VersionService).to receive(:can_open?).and_return(true)
+    end
+
+    it 'opens and closes a version and starts default workflow' do
+      post "/v1/objects/#{druid}/start_accession",
+           headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(object.pid, default_start_accession_workflow, version: '1')
+      expect(VersionService).to have_received(:open).with(base_params.merge('workflow' => default_start_accession_workflow))
+      expect(VersionService).to have_received(:close).with(base_params.merge('workflow' => default_start_accession_workflow, 'start_accession' => false))
+    end
+
+    it 'can override the default workflow' do
+      params = { 'workflow' => 'accessionWF', 'opening_user_name' => 'some_person' }
+      post "/v1/objects/#{druid}/start_accession",
+           params: params,
+           headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(object.pid, 'accessionWF', version: '1')
+      expect(VersionService).to have_received(:open).with(base_params.merge(params))
+      expect(VersionService).to have_received(:close).with(base_params.merge(params).merge('start_accession' => false))
+    end
+  end
+end

--- a/spec/requests/start_accession_spec.rb
+++ b/spec/requests/start_accession_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
     end
 
     it 'does not open or close a version and starts default workflow' do
-      post "/v1/objects/#{druid}/start_accession",
+      post "/v1/objects/#{druid}/accession",
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
       expect(workflow_client).to have_received(:create_workflow_by_name).with(object.pid, default_start_accession_workflow, version: '1')
@@ -31,7 +31,7 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
 
     it 'can override the default workflow' do
       params = { workflow: 'accessionWF', opening_user_name: 'some_person' }
-      post "/v1/objects/#{druid}/start_accession",
+      post "/v1/objects/#{druid}/accession",
            params: params,
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
@@ -42,23 +42,23 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
   end
 
   context 'when existing object' do
-    let(:base_params) { { 'controller' => 'objects', 'action' => 'start_accession', 'id' => druid } }
+    let(:base_params) { { 'controller' => 'objects', 'action' => 'accession', 'id' => druid } }
 
     before do
       allow(VersionService).to receive(:can_open?).and_return(true)
     end
 
     it 'opens and closes a version and starts default workflow' do
-      post "/v1/objects/#{druid}/start_accession",
+      post "/v1/objects/#{druid}/accession",
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(workflow_client).to have_received(:create_workflow_by_name).with(object.pid, default_start_accession_workflow, version: '1')
-      expect(VersionService).to have_received(:open).with(base_params.merge('workflow' => default_start_accession_workflow))
-      expect(VersionService).to have_received(:close).with(base_params.merge('workflow' => default_start_accession_workflow, 'start_accession' => false))
+      expect(VersionService).to have_received(:open).with(base_params)
+      expect(VersionService).to have_received(:close).with(base_params.merge('start_accession' => false))
     end
 
     it 'can override the default workflow' do
       params = { 'workflow' => 'accessionWF', 'opening_user_name' => 'some_person' }
-      post "/v1/objects/#{druid}/start_accession",
+      post "/v1/objects/#{druid}/accession",
            params: params,
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(workflow_client).to have_received(:create_workflow_by_name).with(object.pid, 'accessionWF', version: '1')


### PR DESCRIPTION
## Why was this change made?

part of #702 to allow for reaccessioning via Goobi
when done, return to the checklist in #702 

## Was the API documentation (openapi.yml) updated?

yes


## Does this change affect how this application integrates with other services?

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
