### PR TITLE
Sets default rights for an item.

### DIFF
--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -134,12 +134,13 @@ RSpec.describe 'Create object' do
                                 hasMemberOrders: [
                                   { viewingDirection: 'right-to-left' }
                                 ]
-                              })
+                              },
+                              access: { access: 'world' })
     end
     let(:data) do
       <<~JSON
         { "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
-          "label":"#{label}","version":1,"access":{},
+          "label":"#{label}","version":1,"access":{"access":"world"},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
           "description":{"title":[{"primary":true,"titleFull":"#{title}"}]},
           "identification":{"sourceId":"googlebooks:999999"},


### PR DESCRIPTION
closes #700

## Why was this change made?
So that rights are set when creating an item.


## Was the API documentation (openapi.yml) updated?
No.


## Does this change affect how this application integrates with other services?
No.

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
