### PR TITLE
Generate contentMetadata when RequestFileSets are provided

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -73,7 +73,8 @@ module Cocina
     # @param [Cocina::Models::RequestDRO] obj
     # @return [Dor::Item] a persisted Item model
     def create_dro(obj)
-      Dor::Item.new(pid: Dor::SuriService.mint_id,
+      pid = Dor::SuriService.mint_id
+      Dor::Item.new(pid: pid,
                     admin_policy_object_id: obj.administrative.hasAdminPolicy,
                     source_id: obj.identification.sourceId,
                     catkey: catkey_for(obj),
@@ -81,6 +82,7 @@ module Cocina
         item.descMetadata.mods_title = obj.description.title.first.titleFull if obj.description
         item.identityMetadata.tag = content_type_tag(obj.type, obj.structural.hasMemberOrders&.first&.viewingDirection)
         change_access(item, obj.access.access)
+        item.contentMetadata.content = ContentMetadataGenerator.generate(druid: pid, object: obj)
         if obj.access.embargo
           EmbargoService.embargo(item: item,
                                  release_date: obj.access.embargo.releaseDate,

--- a/app/services/content_metadata_generator.rb
+++ b/app/services/content_metadata_generator.rb
@@ -65,19 +65,6 @@ class ContentMetadataGenerator
     end
   end
 
-  def common_path
-    @common_path ||= Assembly::ContentMetadata.send(:find_common_path, object_files.values)
-  end
-
-  # @return [Array] A array of tuples of cocina fileset and assembly fileset
-  def assembly_filesets
-    filesets.map do |fs|
-      resource_files = fs.fetch('structural').fetch('contains')
-                         .map { |file| object_files.fetch(file.fetch('filename')) }
-      [fs, Assembly::ContentMetadata::FileSet.new(resource_files: resource_files, style: :simple_book)]
-    end
-  end
-
   def resource_type_counters
     @resource_type_counters ||= Hash.new(0)
   end

--- a/app/services/content_metadata_generator.rb
+++ b/app/services/content_metadata_generator.rb
@@ -76,6 +76,7 @@ class ContentMetadataGenerator
     Nokogiri::XML::Node.new('file', @xml_doc).tap do |file_node|
       file_node['id'] = id
       file_node['mimetype'] = cocina_file.hasMimeType
+      file_node['size'] = cocina_file.size
       file_node['publish'] = publish_attr(cocina_file)
       file_node['shelve'] = shelve_attr(cocina_file)
       file_node['preserve'] = preserve_attr(cocina_file)

--- a/openapi.yml
+++ b/openapi.yml
@@ -1012,9 +1012,6 @@ components:
         - label
         - type
         - version
-        - access
-        - administrative
-        - identification
         - structural
     File:
       type: object
@@ -1026,6 +1023,8 @@ components:
         externalIdentifier:
           type: string
         label:
+          type: string
+        filename:
           type: string
         size:
           type: integer
@@ -1063,6 +1062,8 @@ components:
             - 'http://cocina.sul.stanford.edu/models/file.jsonld'
         label:
           type: string
+        filename:
+          type: string
         size:
           type: integer
         version:
@@ -1085,10 +1086,9 @@ components:
         - label
         - type
         - version
+        - filename
         - access
         - administrative
-        - identification
-        - structural
     BackgroundJobResultResponse:
       type: object
       properties:

--- a/spec/services/content_metadata_generator_spec.rb
+++ b/spec/services/content_metadata_generator_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe ContentMetadataGenerator do
       'label' => '00001.html',
       'hasMimeType' => 'text/html',
       'use' => 'transcription',
+      'size' => 997,
       'administrative' => {
         'sdrPreserve' => true,
         'shelve' => false
@@ -49,6 +50,7 @@ RSpec.describe ContentMetadataGenerator do
       'filename' => '00001.jp2',
       'label' => '00001.jp2',
       'hasMimeType' => 'image/jp2',
+      'size' => 149570,
       'administrative' => {
         'sdrPreserve' => true,
         'shelve' => true
@@ -66,6 +68,7 @@ RSpec.describe ContentMetadataGenerator do
       'filename' => '00002.html',
       'label' => '00002.html',
       'hasMimeType' => 'text/html',
+      'size' => 1914,
       'administrative' => {
         'sdrPreserve' => true,
         'shelve' => false
@@ -83,6 +86,7 @@ RSpec.describe ContentMetadataGenerator do
       'filename' => '00002.jp2',
       'label' => '00002.jp2',
       'hasMimeType' => 'image/jp2',
+      'size' => 111467,
       'administrative' => {
         'sdrPreserve' => true,
         'shelve' => true
@@ -128,16 +132,16 @@ RSpec.describe ContentMetadataGenerator do
          <contentMetadata objectId="druid:bc123de5678" type="book">
            <resource id="bc123de5678_1" sequence="1" type="page">
              <label>Page 1</label>
-             <file id="00001.html" mimetype="text/html" preserve="yes" publish="no" shelve="no" role="transcription">
+             <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription">
                <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
                <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
              </file>
-             <file id="00001.jp2" mimetype="image/jp2" preserve="yes" publish="yes" shelve="yes"/>
+             <file id="00001.jp2" mimetype="image/jp2" size="149570" preserve="yes" publish="yes" shelve="yes"/>
            </resource>
            <resource id="bc123de5678_2" sequence="2" type="page">
              <label>Page 2</label>
-             <file id="00002.html" mimetype="text/html" preserve="yes" publish="yes" shelve="no"/>
-             <file id="00002.jp2" mimetype="image/jp2" preserve="yes" publish="yes" shelve="yes"/>
+             <file id="00002.html" mimetype="text/html" size="1914" preserve="yes" publish="yes" shelve="no"/>
+             <file id="00002.jp2" mimetype="image/jp2" size="111467" preserve="yes" publish="yes" shelve="yes"/>
            </resource>
          </contentMetadata>'
     end
@@ -151,16 +155,16 @@ RSpec.describe ContentMetadataGenerator do
          <contentMetadata objectId="druid:bc123de5678" type="image">
            <resource id="bc123de5678_1" sequence="1" type="image">
              <label>Page 1</label>
-             <file id="00001.html" mimetype="text/html" preserve="yes" publish="no" shelve="no" role="transcription">
+             <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription">
                <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
                <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
              </file>
-             <file id="00001.jp2" mimetype="image/jp2" preserve="yes" publish="yes" shelve="yes"/>
+             <file id="00001.jp2" mimetype="image/jp2"  size="149570" preserve="yes" publish="yes" shelve="yes"/>
            </resource>
            <resource id="bc123de5678_2" sequence="2" type="image">
              <label>Page 2</label>
-             <file id="00002.html" mimetype="text/html" preserve="yes" publish="yes" shelve="no"/>
-             <file id="00002.jp2" mimetype="image/jp2" preserve="yes" publish="yes" shelve="yes"/>
+             <file id="00002.html" mimetype="text/html" size="1914" preserve="yes" publish="yes" shelve="no"/>
+             <file id="00002.jp2" mimetype="image/jp2" size="111467" preserve="yes" publish="yes" shelve="yes"/>
            </resource>
          </contentMetadata>'
     end

--- a/spec/services/content_metadata_generator_spec.rb
+++ b/spec/services/content_metadata_generator_spec.rb
@@ -11,16 +11,6 @@ RSpec.describe ContentMetadataGenerator do
     Cocina::Models.build_request(JSON.parse(data))
   end
 
-  let(:data) do
-    <<~JSON
-      { "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
-        "label":"The object label","version":1,"access":{},
-        "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
-        "description":{"title":[{"primary":true,"titleFull":"the object title"}]},
-        "identification":{},"structural":{"contains":#{filesets.to_json}}}
-    JSON
-  end
-
   let(:druid) { 'druid:bc123de5678' }
 
   let(:file1) do
@@ -120,22 +110,59 @@ RSpec.describe ContentMetadataGenerator do
     ]
   end
 
-  it 'generates contentMetadata.xml' do
-    expect(generate).to be_equivalent_to '<?xml version="1.0"?>
-       <contentMetadata objectId="druid:bc123de5678" type="book">
-         <resource id="bc123de5678_1" sequence="1" type="page">
-           <label>Page 1</label>
-           <file id="00001.html" mimetype="text/html" preserve="yes" publish="no" shelve="no" role="transcription">
-             <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
-             <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
-           </file>
-           <file id="00001.jp2" mimetype="image/jp2" preserve="yes" publish="yes" shelve="yes"/>
-         </resource>
-         <resource id="bc123de5678_2" sequence="2" type="page">
-           <label>Page 2</label>
-           <file id="00002.html" mimetype="text/html" preserve="yes" publish="yes" shelve="no"/>
-           <file id="00002.jp2" mimetype="image/jp2" preserve="yes" publish="yes" shelve="yes"/>
-         </resource>
-       </contentMetadata>'
+  let(:data) do
+    <<~JSON
+      { "type":"#{object_type}",
+        "label":"The object label","version":1,"access":{},
+        "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
+        "description":{"title":[{"primary":true,"titleFull":"the object title"}]},
+        "identification":{},"structural":{"contains":#{filesets.to_json}}}
+    JSON
+  end
+
+  context 'with a book' do
+    let(:object_type) { Cocina::Models::Vocab.book }
+
+    it 'generates contentMetadata.xml' do
+      expect(generate).to be_equivalent_to '<?xml version="1.0"?>
+         <contentMetadata objectId="druid:bc123de5678" type="book">
+           <resource id="bc123de5678_1" sequence="1" type="page">
+             <label>Page 1</label>
+             <file id="00001.html" mimetype="text/html" preserve="yes" publish="no" shelve="no" role="transcription">
+               <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
+               <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
+             </file>
+             <file id="00001.jp2" mimetype="image/jp2" preserve="yes" publish="yes" shelve="yes"/>
+           </resource>
+           <resource id="bc123de5678_2" sequence="2" type="page">
+             <label>Page 2</label>
+             <file id="00002.html" mimetype="text/html" preserve="yes" publish="yes" shelve="no"/>
+             <file id="00002.jp2" mimetype="image/jp2" preserve="yes" publish="yes" shelve="yes"/>
+           </resource>
+         </contentMetadata>'
+    end
+  end
+
+  context 'with an image' do
+    let(:object_type) { Cocina::Models::Vocab.image }
+
+    it 'generates contentMetadata.xml' do
+      expect(generate).to be_equivalent_to '<?xml version="1.0"?>
+         <contentMetadata objectId="druid:bc123de5678" type="image">
+           <resource id="bc123de5678_1" sequence="1" type="image">
+             <label>Page 1</label>
+             <file id="00001.html" mimetype="text/html" preserve="yes" publish="no" shelve="no" role="transcription">
+               <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
+               <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
+             </file>
+             <file id="00001.jp2" mimetype="image/jp2" preserve="yes" publish="yes" shelve="yes"/>
+           </resource>
+           <resource id="bc123de5678_2" sequence="2" type="image">
+             <label>Page 2</label>
+             <file id="00002.html" mimetype="text/html" preserve="yes" publish="yes" shelve="no"/>
+             <file id="00002.jp2" mimetype="image/jp2" preserve="yes" publish="yes" shelve="yes"/>
+           </resource>
+         </contentMetadata>'
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?



## Was the API documentation (openapi.yml) updated?



## Does this change affect how this application integrates with other services?

If so, please confirm:
- [x] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
