### PR TITLE
Change rights before applying embargo.

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -80,12 +80,12 @@ module Cocina
                     label: obj.label).tap do |item|
         item.descMetadata.mods_title = obj.description.title.first.titleFull if obj.description
         item.identityMetadata.tag = content_type_tag(obj.type, obj.structural.hasMemberOrders&.first&.viewingDirection)
+        change_access(item, obj.access.access)
         if obj.access.embargo
           EmbargoService.embargo(item: item,
                                  release_date: obj.access.embargo.releaseDate,
                                  access: obj.access.embargo.access)
         end
-        change_access(item, obj.access.access)
       end
     end
 

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -286,4 +286,52 @@ RSpec.describe 'Create object' do
       end
     end
   end
+
+  context 'when an embargo is provided' do
+    let(:expected) do
+      Cocina::Models::DRO.new(type: Cocina::Models::Vocab.book,
+                              label: 'This is my label',
+                              version: 1,
+                              description: {
+                                title: [{ titleFull: 'This is my title', primary: true }]
+                              },
+                              administrative: {
+                                hasAdminPolicy: 'druid:dd999df4567'
+                              },
+                              identification: { sourceId: 'googlebooks:999999' },
+                              externalIdentifier: 'druid:gg777gg7777',
+                              structural: {
+                                hasMemberOrders: [
+                                  { viewingDirection: 'right-to-left' }
+                                ]
+                              },
+                              access: { access: 'citation-only', embargo: { access: 'world', releaseDate: '2020-02-29' } })
+    end
+    let(:data) do
+      <<~JSON
+        { "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
+          "label":"This is my label","version":1,"access":{"access":"world",
+          "embargo":{"access":"world","releaseDate":"2020-02-29"}},
+          "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
+          "description":{"title":[{"primary":true,"titleFull":"This is my title"}]},
+          "identification":{"sourceId":"googlebooks:999999"},
+          "structural":{"hasMemberOrders":[{"viewingDirection":"right-to-left"}]}}
+      JSON
+    end
+
+    before do
+      allow(Dor::SearchService).to receive(:query_by_id).and_return([])
+      allow_any_instance_of(Dor::Item).to receive(:save!)
+    end
+
+    it 'registers the book and sets the rights' do
+      post '/v1/objects',
+           params: data,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+
+      expect(response.body).to eq expected.to_json
+      expect(response.status).to eq(201)
+      expect(response.location).to eq '/v1/objects/druid:gg777gg7777'
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?
To correct the order in which rights and embargo were applied. (Rights should be set before embargo, as embargo modifies the rights.)

## Was the API documentation (openapi.yml) updated?
No


## Does this change affect how this application integrates with other services?
No

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
