### PR TITLE
Store administrative tags in the database

### DIFF
--- a/app/controllers/administrative_tags_controller.rb
+++ b/app/controllers/administrative_tags_controller.rb
@@ -14,7 +14,32 @@ class AdministrativeTagsController < ApplicationController
   end
 
   def create
-    AdministrativeTags.create(item: @item, tags: params.require(:administrative_tags))
+    AdministrativeTags.create(item: @item,
+                              tags: params.require(:administrative_tags),
+                              replace: params[:replace])
+  rescue ActiveRecord::RecordInvalid => e
+    render status: :conflict, plain: e.message
+  else
     head :created
+  end
+
+  def update
+    AdministrativeTags.update(item: @item,
+                              current: CGI.unescape(params[:id]),
+                              new: params.require(:administrative_tag))
+  rescue ActiveRecord::RecordNotFound => e
+    render status: :not_found, plain: e.message
+  rescue ActiveRecord::RecordInvalid => e
+    render status: :conflict, plain: e.message
+  else
+    head :no_content
+  end
+
+  def destroy
+    AdministrativeTags.destroy(item: @item, tag: CGI.unescape(params[:id]))
+  rescue ActiveRecord::RecordNotFound => e
+    render status: :not_found, plain: e.message
+  else
+    head :no_content
   end
 end

--- a/app/models/administrative_tag.rb
+++ b/app/models/administrative_tag.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Administrative tags for an object
+class AdministrativeTag < ApplicationRecord
+  validates :tag, format: {
+    with: /\A.+( : .+)+\z/,
+    message: 'must be a series of 2 or more strings delimited with space-padded colons, e.g., "Registered By : mjgiarlo : now"'
+  }, uniqueness: {
+    scope: :druid,
+    message: 'has already been assigned to the given druid (no duplicate tags for a druid)'
+  }
+end

--- a/app/services/administrative_tags.rb
+++ b/app/services/administrative_tags.rb
@@ -5,18 +5,134 @@ class AdministrativeTags
   # Retrieve the administrative tags for an item
   #
   # @param item [Dor::Item] the item to list administrative tags for
-  # @return [Array<String>] an array of tags (strings), possibly empty
+  # @return [Array<String>] an array of tag strings (possibly empty)
   def self.for(item:)
-    item.identityMetadata.ng_xml.search('//tag').map(&:content)
+    new(item: item).for
+  end
+
+  # Retrieve the content type tag for an item
+  #
+  # @param item [Dor::Item] the item to get the content type of
+  # @return [Array<String>] an array of tag strings (possibly empty)
+  def self.content_type(item:)
+    new(item: item).content_type
   end
 
   # Add one or more administrative tags for an item
   #
   # @param item [Dor::Item]  the item to create administrative tag(s) for
   # @param tags [Array<String>] a non-empty array of tags (strings)
-  # @return [Array<Nokogiri::XML::Node>]
-  def self.create(item:, tags:)
-    tags.map { |tag| Dor::TagService.add(item, tag) }
-    item.save!
+  # @param replace [Boolean] replace current tags? default: false
+  # @return [Array<AdministrativeTag>]
+  def self.create(item:, tags:, replace: false)
+    new(item: item).create(tags: tags, replace: replace)
+  end
+
+  # Update an administrative tag for an item
+  #
+  # @param item [Dor::Item]  the item to update an administrative tag for
+  # @param current [String] the current administrative tag
+  # @param new [String] the replacement administrative tag
+  # @return [Boolean] true if successful
+  # @raise [ActiveRecord::RecordNotFound] if row not found for druid/tag combination
+  def self.update(item:, current:, new:)
+    new(item: item).update(current: current, new: new)
+  end
+
+  # Destroy an administrative tag for an item
+  #
+  # @param item [Dor::Item]  the item to delete an administrative tag for
+  # @param tag [String] the administrative tag to delete
+  # @return [Boolean] true if successful
+  # @raise [ActiveRecord::RecordNotFound] if row not found for druid/tag combination
+  def self.destroy(item:, tag:)
+    new(item: item).destroy(tag: tag)
+  end
+
+  # @param item [Dor::Item] the item to list administrative tags for
+  def initialize(item:)
+    @item = item
+  end
+
+  # @return [Array<String>] an array of tags (strings), possibly empty
+  def for
+    populate_database_tags_from_datastream!
+
+    AdministrativeTag.where(druid: item.pid).pluck(:tag)
+  end
+
+  # @return [Array<String>] an array of tags (strings), possibly empty
+  def content_type
+    populate_database_tags_from_datastream!
+
+    AdministrativeTag
+      .where(druid: item.pid)
+      .where(tags_relation.matches('Process : Content Type : %'))
+      .limit(1) # "THERE CAN BE ONLY ONE!"
+      .pluck(:tag)
+      .map { |tag| tag.split(' : ').last }
+  end
+
+  # @param tags [Array<String>] a non-empty array of tags (strings)
+  # @param replace [Boolean] replace current tags? default: false
+  # @return [Array<AdministrativeTag>]
+  # @raise [ActiveRecord::RecordInvalid] if any druid/tag rows are duplicates
+  def create(tags:, replace: false)
+    populate_database_tags_from_datastream!
+
+    ActiveRecord::Base.transaction do
+      AdministrativeTag.where(druid: item.pid).destroy_all if replace
+
+      tags.map do |tag|
+        AdministrativeTag.create!(druid: item.pid, tag: tag)
+      end
+    end
+  end
+
+  # Update an administrative tag for an item
+  #
+  # @param current [String] the current administrative tag
+  # @param new [String] the replacement administrative tag
+  # @return [Boolean] true if successful
+  # @raise [ActiveRecord::RecordNotFound] if row not found for druid/tag combination
+  # @raise [ActiveRecord::RecordInvalid] if any druid/tag rows are duplicates
+  def update(current:, new:)
+    populate_database_tags_from_datastream!
+
+    AdministrativeTag.find_by!(druid: item.pid, tag: current).update!(tag: new)
+  end
+
+  # Destroy an administrative tag for an item
+  #
+  # @param item [Dor::Item]  the item to delete an administrative tag for
+  # @param tag [String] the administrative tag to delete
+  # @return [AdministrativeTag] the tag instance
+  # @raise [ActiveRecord::RecordNotFound] if row not found for druid/tag combination
+  def destroy(tag:)
+    populate_database_tags_from_datastream!
+
+    AdministrativeTag.find_by!(druid: item.pid, tag: tag).destroy!
+  end
+
+  private
+
+  attr_reader :item
+
+  def legacy_tags
+    item.identityMetadata.ng_xml.search('//tag').map(&:content)
+  end
+
+  def populate_database_tags_from_datastream!
+    return if AdministrativeTag.where(druid: item.pid).any?
+
+    ActiveRecord::Base.transaction do
+      legacy_tags.each do |tag|
+        AdministrativeTag.create!(druid: item.pid, tag: tag)
+      end
+    end
+  end
+
+  def tags_relation
+    AdministrativeTag.arel_table[:tag]
   end
 end

--- a/app/services/cocina/dro_structural_builder.rb
+++ b/app/services/cocina/dro_structural_builder.rb
@@ -13,7 +13,7 @@ module Cocina
 
     def build
       {}.tap do |structural|
-        case item.content_type_tag
+        case AdministrativeTags.content_type(item: item).first
         when 'Book (ltr)'
           structural[:hasMemberOrders] = [{ viewingDirection: 'left-to-right' }]
         when 'Book (rtl)'

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -90,7 +90,7 @@ module Cocina
     attr_reader :item
 
     def dro_type
-      case item.content_type_tag
+      case AdministrativeTags.content_type(item: item).first
       when 'Image'
         Cocina::Models::Vocab.image
       when '3D'
@@ -184,7 +184,7 @@ module Cocina
     end
 
     def project_for(item)
-      item.tags.each do |tag|
+      AdministrativeTags.for(item: item).each do |tag|
         split_tag = tag.split(':').map(&:strip)
         return split_tag[1, split_tag.size - 1].join(' : ') if split_tag[0] == 'Project'
       end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -118,9 +118,9 @@ module Cocina
     end
 
     def add_tags(item, obj)
-      Dor::TagService.add(item, content_type_tag(obj.type, obj.structural.hasMemberOrders&.first&.viewingDirection))
-      Dor::TagService.add(item, "Project: #{obj.administrative.partOfProject}") if obj.administrative.partOfProject
-      item.identityMetadata.ng_xml_will_change!
+      tags = [content_type_tag(obj.type, obj.structural.hasMemberOrders&.first&.viewingDirection)]
+      tags << "Project : #{obj.administrative.partOfProject}" if obj.administrative.partOfProject
+      AdministrativeTags.create(item: item, tags: tags)
     end
 
     def content_type_tag(type, direction)

--- a/app/services/registration_service.rb
+++ b/app/services/registration_service.rb
@@ -101,7 +101,6 @@ class RegistrationService
       idmd.objectCreator = 'DOR'
       idmd.objectLabel = request.label
       idmd.objectType = request.object_type
-      idmd.tag = request.tags
       request.other_ids.each_pair { |name, value| idmd.add_otherId("#{name}:#{value}") }
 
       new_item.add_collection(request.collection) if request.collection
@@ -114,6 +113,7 @@ class RegistrationService
       end
 
       new_item.save!
+      AdministrativeTags.create(item: new_item, tags: request.tags)
       new_item
     end
 

--- a/app/services/release_tags/identity_metadata.rb
+++ b/app/services/release_tags/identity_metadata.rb
@@ -28,7 +28,7 @@ class ReleaseTags
       # Get all release tags on the item and strip out the what = self ones, we've already processed all the self tags on this item.
       # This will be where we store all tags that apply, regardless of their timestamp:
       potential_applicable_release_tags = tags_for_what_value(release_tags_for_item_and_all_governing_sets, 'collection')
-      administrative_tags = item.tags # Get admin tags once here and pass them down
+      administrative_tags = AdministrativeTags.for(item: item) # Get admin tags once here and pass them down
 
       # We now have the keys for all potential releases, we need to check the tags: the most recent timestamp with an explicit true or false wins.
       # In a nil case, the lack of an explicit false tag we do nothing.
@@ -117,7 +117,10 @@ class ReleaseTags
       # Is the tag global or restricted
       return true if release_tag['tag'].nil? # no specific tag specificied means this tag is global to all members of the collection
 
-      admin_tags ||= item.tags # We use false instead of [], since an item can have no admin_tags at which point we'd be passing this var as [] and would not attempt to retrieve it
+      # We use false instead of [], since an item can have no admin_tags at
+      # which point we'd be passing this var as [] and would not attempt to
+      # retrieve it
+      admin_tags ||= AdministrativeTags.for(item: item)
       admin_tags.include?(release_tag['tag'])
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     resources :objects, only: [:create, :show] do
       resource :release_tags, only: [:create, :show]
       resource :administrative_tags, only: [:create, :show]
+      resources :administrative_tags, only: [:update, :destroy]
 
       member do
         post 'publish'

--- a/db/migrate/20200226171829_create_administrative_tags.rb
+++ b/db/migrate/20200226171829_create_administrative_tags.rb
@@ -1,0 +1,14 @@
+class CreateAdministrativeTags < ActiveRecord::Migration[5.2]
+  def change
+    create_table :administrative_tags do |t|
+      t.string :druid, null: false
+      t.string :tag, null: false
+
+      t.timestamps
+    end
+
+    add_index :administrative_tags, :druid
+    add_index :administrative_tags, :tag
+    add_index :administrative_tags, [:druid, :tag], unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -25,6 +25,38 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
+-- Name: administrative_tags; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.administrative_tags (
+    id bigint NOT NULL,
+    druid character varying NOT NULL,
+    tag character varying NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: administrative_tags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.administrative_tags_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: administrative_tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.administrative_tags_id_seq OWNED BY public.administrative_tags.id;
+
+
+--
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -110,6 +142,13 @@ CREATE TABLE public.schema_migrations (
 
 
 --
+-- Name: administrative_tags id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.administrative_tags ALTER COLUMN id SET DEFAULT nextval('public.administrative_tags_id_seq'::regclass);
+
+
+--
 -- Name: background_job_results id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -121,6 +160,14 @@ ALTER TABLE ONLY public.background_job_results ALTER COLUMN id SET DEFAULT nextv
 --
 
 ALTER TABLE ONLY public.events ALTER COLUMN id SET DEFAULT nextval('public.events_id_seq'::regclass);
+
+
+--
+-- Name: administrative_tags administrative_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.administrative_tags
+    ADD CONSTRAINT administrative_tags_pkey PRIMARY KEY (id);
 
 
 --
@@ -156,6 +203,27 @@ ALTER TABLE ONLY public.schema_migrations
 
 
 --
+-- Name: index_administrative_tags_on_druid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_administrative_tags_on_druid ON public.administrative_tags USING btree (druid);
+
+
+--
+-- Name: index_administrative_tags_on_druid_and_tag; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_administrative_tags_on_druid_and_tag ON public.administrative_tags USING btree (druid, tag);
+
+
+--
+-- Name: index_administrative_tags_on_tag; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_administrative_tags_on_tag ON public.administrative_tags USING btree (tag);
+
+
+--
 -- Name: index_events_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -185,6 +253,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20190917215521'),
 ('20191015193638'),
-('20191209192646');
+('20191209192646'),
+('20200226171829');
 
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -342,7 +342,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: string
+                  $ref: '#/components/schemas/AdministrativeTag'
         '404':
           description: Object not found
       parameters:
@@ -355,7 +355,7 @@ paths:
     post:
       tags:
         - objects
-      summary: Create one or more administrative tags
+      summary: Create (or replace) one or more administrative tags
       description: ''
       operationId: 'administrative_tags#create'
       responses:
@@ -363,6 +363,10 @@ paths:
           description: Created
         '400':
           description: Bad request
+        '404':
+          description: Object not found
+        '409':
+          description: Request would result in a duplicate tag
       parameters:
         - name: object_id
           in: path
@@ -379,11 +383,119 @@ paths:
               required:
                 - administrative_tags
               properties:
+                replace:
+                  type: boolean
+                  default: false
                 administrative_tags:
                   type: array
                   minItems: 1
                   items:
-                    type: string
+                    $ref: '#/components/schemas/AdministrativeTag'
+  '/v1/objects/{object_id}/administrative_tags/{id}':
+    delete:
+      tags:
+        - objects
+      summary: Delete an administrative tag for an object
+      description: ''
+      operationId: 'administrative_tags#destroy'
+      responses:
+        '204':
+          description: Deleted
+        '400':
+          description: Bad request
+        '404':
+          description: Object or tag not found
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: id
+          in: path
+          description: ID of tag to remove
+          required: true
+          schema:
+            $ref: '#/components/schemas/AdministrativeTagEscaped'
+    put:
+      tags:
+        - objects
+      summary: Update one administrative tag
+      description: ''
+      operationId: 'administrative_tags#update (PUT)'
+      responses:
+        '204':
+          description: Updated
+        '400':
+          description: Bad request
+        '404':
+          description: Object or tag not found
+        '409':
+          description: Request would result in a duplicate tag
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: id
+          in: path
+          description: ID of tag to replace
+          required: true
+          schema:
+            $ref: '#/components/schemas/AdministrativeTagEscaped'
+      requestBody:
+        description: A replacement administrative tag
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - administrative_tag
+              properties:
+                administrative_tag:
+                  $ref: '#/components/schemas/AdministrativeTag'
+    patch:
+      tags:
+        - objects
+      summary: Update one administrative tag
+      description: ''
+      operationId: 'administrative_tags#update (PATCH)'
+      responses:
+        '204':
+          description: Updated
+        '400':
+          description: Bad request
+        '404':
+          description: Object or tag not found
+        '409':
+          description: Request would result in a duplicate tag
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: id
+          in: path
+          description: ID of tag to replace
+          required: true
+          schema:
+            $ref: '#/components/schemas/AdministrativeTagEscaped'
+      requestBody:
+        description: A replacement administrative tag
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - administrative_tag
+              properties:
+                administrative_tag:
+                  $ref: '#/components/schemas/AdministrativeTag'
   '/v1/objects/{id}/refresh_metadata':
     post:
       tags:
@@ -875,6 +987,16 @@ components:
           description: Administrative or Internal project this resource is a part of
           example: Google Books
           type: string
+    AdministrativeTag:
+      type: string
+      pattern: '^.+( : .+)+$'
+      example: 'Foo : Bar : Baz'
+    AdministrativeTagEscaped:
+      type: string
+      # allow CGI-escaped and bare colons to allow for differences between local
+      # environments and deployed environments that use Apache & Passenger
+      pattern: '^.+(\+(?:%3A|:)\+.+)+$'
+      example: 'Foo+%3A+Bar+%3A+Baz'
     AdminPolicy:
       type: object
       properties:

--- a/spec/dor/goobi_spec.rb
+++ b/spec/dor/goobi_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Dor::Goobi do
     allow(Dor::Item).to receive(:find).and_return(item)
     allow(item).to receive(:source_id).and_return('some_source_id')
     allow(item).to receive(:label).and_return('Object Title & A Special character')
-    allow(item).to receive(:content_type_tag).and_return('book')
     allow(goobi).to receive(:project_name).and_return('Project Name')
     allow(goobi).to receive(:object_type).and_return('item')
     allow(goobi).to receive(:ckey).and_return('ckey_12345')
@@ -23,6 +22,7 @@ RSpec.describe Dor::Goobi do
     allow(goobi).to receive(:barcode).and_return('barcode_12345')
     allow(goobi).to receive(:collection_id).and_return('druid:oo000oo0001')
     allow(goobi).to receive(:collection_name).and_return('collection name')
+    allow(AdministrativeTags).to receive(:content_type).with(item: item).and_return(['book'])
   end
   # rubocop:enable RSpec/SubjectStub
 
@@ -47,7 +47,7 @@ RSpec.describe Dor::Goobi do
   end
 
   it 'creates the correct xml request without ocr tag present' do
-    allow(item).to receive(:tags).and_return(['DPG : Workflow : book_workflow & stuff', 'Process : Content Type : Book', 'LAB : MAPS'])
+    allow(AdministrativeTags).to receive(:for).and_return(['DPG : Workflow : book_workflow & stuff', 'Process : Content Type : Book', 'LAB : MAPS'])
     expect(goobi.goobi_xml_tags).to eq('<tag name="DPG" value="Workflow : book_workflow &amp; stuff"/><tag name="Process" value="Content Type : Book"/><tag name="LAB" value="MAPS"/>')
     expect(goobi.xml_request).to be_equivalent_to <<-END
       <stanfordCreationRequest>
@@ -74,7 +74,7 @@ RSpec.describe Dor::Goobi do
   end
 
   it 'creates the correct xml request with ocr tag present' do
-    allow(item).to receive(:tags).and_return(['DPG : Workflow : book_workflow', 'DPG : OCR : TRUE'])
+    allow(AdministrativeTags).to receive(:for).with(item: item).and_return(['DPG : Workflow : book_workflow', 'DPG : OCR : TRUE'])
     expect(goobi.goobi_xml_tags).to eq('<tag name="DPG" value="Workflow : book_workflow"/><tag name="DPG" value="OCR : TRUE"/>')
     expect(goobi.xml_request).to be_equivalent_to <<-END
       <stanfordCreationRequest>

--- a/spec/dor/service_item_spec.rb
+++ b/spec/dor/service_item_spec.rb
@@ -33,17 +33,19 @@ RSpec.describe Dor::ServiceItem do
     end
 
     it 'returns goobi_workflow_name from a valid identityMetadata' do
-      allow(@dor_item).to receive(:tags).and_return(['DPG : Workflow : book_workflow', 'Process : Content Type : Book (flipbook, ltr)'])
+      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['DPG : Workflow : book_workflow', 'Process : Content Type : Book (flipbook, ltr)'])
       expect(si.goobi_workflow_name).to eq('book_workflow')
     end
 
     it 'returns first goobi_workflow_name if multiple are in the tags' do
-      allow(@dor_item).to receive(:tags).and_return(['DPG : Workflow : book_workflow', 'DPG : Workflow : another_workflow', 'Process : Content Type : Book (flipbook, ltr)'])
+      allow(AdministrativeTags).to receive(:for)
+        .with(item: @dor_item)
+        .and_return(['DPG : Workflow : book_workflow', 'DPG : Workflow : another_workflow', 'Process : Content Type : Book (flipbook, ltr)'])
       expect(si.goobi_workflow_name).to eq('book_workflow')
     end
 
     it 'returns blank for goobi_workflow_name if none are found' do
-      allow(@dor_item).to receive(:tags).and_return(['Process : Content Type : Book (flipbook, ltr)'])
+      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['Process : Content Type : Book (flipbook, ltr)'])
       expect(si.goobi_workflow_name).to eq(Settings.goobi.default_goobi_workflow_name)
     end
   end
@@ -54,7 +56,7 @@ RSpec.describe Dor::ServiceItem do
     end
 
     it 'returns an array of arrays with the tags from the object in the key:value format expected to be passed to goobi' do
-      allow(@dor_item).to receive(:tags).and_return(['DPG : Workflow : book_workflow', 'Process : Content Type : Book (flipbook, ltr)', 'LAB : Map Work'])
+      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['DPG : Workflow : book_workflow', 'Process : Content Type : Book (flipbook, ltr)', 'LAB : Map Work'])
       expect(si.goobi_tag_list.length).to eq 3
       si.goobi_tag_list.each { |goobi_tag| expect(goobi_tag.class).to eq Dor::GoobiTag }
       expect(si.goobi_tag_list[0]).to have_attributes(name: 'DPG', value: 'Workflow : book_workflow')
@@ -63,12 +65,12 @@ RSpec.describe Dor::ServiceItem do
     end
 
     it 'returns an empty array when there are no tags' do
-      allow(@dor_item).to receive(:tags).and_return([])
+      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return([])
       expect(si.goobi_tag_list).to eq([])
     end
 
     it 'works with singleton tags (no colon, so no value, just a name)' do
-      allow(@dor_item).to receive(:tags).and_return(['Name : Some Value', 'JustName'])
+      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['Name : Some Value', 'JustName'])
       expect(si.goobi_tag_list.length).to eq 2
       expect(si.goobi_tag_list[0].class).to eq Dor::GoobiTag
       expect(si.goobi_tag_list[0]).to have_attributes(name: 'Name', value: 'Some Value')
@@ -82,17 +84,17 @@ RSpec.describe Dor::ServiceItem do
     end
 
     it 'returns false if the goobi ocr tag is not present' do
-      allow(@dor_item).to receive(:tags).and_return(['DPG : Workflow : book_workflow', 'Process : Content Type : Book (flipbook, ltr)'])
+      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['DPG : Workflow : book_workflow', 'Process : Content Type : Book (flipbook, ltr)'])
       expect(si.goobi_ocr_tag_present?).to be false
     end
 
     it 'returns true if the goobi ocr tag is present' do
-      allow(@dor_item).to receive(:tags).and_return(['DPG : Workflow : book_workflow', 'DPG : OCR : TRUE'])
+      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['DPG : Workflow : book_workflow', 'DPG : OCR : TRUE'])
       expect(si.goobi_ocr_tag_present?).to be true
     end
 
     it 'returns true if the goobi ocr tag is present even if the case is mixed' do
-      allow(@dor_item).to receive(:tags).and_return(['DPG : Workflow : book_workflow', 'DPG : ocr : true'])
+      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['DPG : Workflow : book_workflow', 'DPG : ocr : true'])
       expect(si.goobi_ocr_tag_present?).to be true
     end
   end
@@ -115,12 +117,12 @@ RSpec.describe Dor::ServiceItem do
     end
 
     it 'returns project name from a valid identityMetadata' do
-      allow(@dor_item).to receive(:tags).and_return(['Project : Batchelor Maps : Batch 1', 'Process : Content Type : Book (flipbook, ltr)'])
+      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['Project : Batchelor Maps : Batch 1', 'Process : Content Type : Book (flipbook, ltr)'])
       expect(si.project_name).to eq('Batchelor Maps : Batch 1')
     end
 
     it 'returns blank for project name if not in tag' do
-      allow(@dor_item).to receive(:tags).and_return(['Process : Content Type : Book (flipbook, ltr)'])
+      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['Process : Content Type : Book (flipbook, ltr)'])
       expect(si.project_name).to eq('')
     end
   end
@@ -176,12 +178,12 @@ RSpec.describe Dor::ServiceItem do
     end
 
     it 'returns the content_type_tag from dor-services if the value exists' do
-      allow(item).to receive(:content_type_tag).and_return('Process Value')
+      allow(AdministrativeTags).to receive(:content_type).and_return(['Process Value'])
       expect(Dor::ServiceItem.new(item).content_type).to eq('Process Value')
     end
 
     it 'returns the type from contentMetadata if content_type_tag from dor-services does not have a value' do
-      allow(item).to receive(:content_type_tag).and_return('')
+      allow(AdministrativeTags).to receive(:content_type).and_return([])
       expect(Dor::ServiceItem.new(item).content_type).to eq('map')
     end
   end

--- a/spec/factories/administrative_tags.rb
+++ b/spec/factories/administrative_tags.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :administrative_tag do
+    druid { 'druid:xz456jk0987' }
+    tag { 'My : Object : Rules' }
+  end
+end

--- a/spec/models/administrative_tag_spec.rb
+++ b/spec/models/administrative_tag_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AdministrativeTag do
+  describe 'tag format validation' do
+    context 'with invalid values' do
+      ['Configured With', 'Registered By:mjg'].each do |tag_string|
+        subject(:tag) { described_class.new(tag: tag_string) }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+
+    context 'with valid values' do
+      ['Registered By : mjgiarlo', 'Process : Content Type : Map'].each do |tag_string|
+        subject(:tag) { described_class.new(tag: tag_string) }
+
+        it { is_expected.to be_valid }
+      end
+    end
+  end
+
+  describe 'tag/druid uniqueness validation' do
+    let!(:existing_tag) { create(:administrative_tag) }
+    let(:duplicate_tag) { described_class.create(druid: existing_tag.druid, tag: existing_tag.tag) }
+
+    it 'prevents duplicate rows' do
+      expect(duplicate_tag).not_to be_valid
+      expect(duplicate_tag.errors.full_messages).to include('Tag has already been assigned to the given druid (no duplicate tags for a druid)')
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,8 +6,9 @@ require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
-require 'rspec/matchers'
+
 require 'equivalent-xml/rspec_matchers'
+require 'rspec/matchers'
 require 'rspec/rails'
 require 'support/foxml_helper'
 require 'support/factory_bot'
@@ -54,6 +55,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include AuthHelper
+  config.use_transactional_fixtures = true
 
   config.before :suite do
     WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/requests/administrative_tags_spec.rb
+++ b/spec/requests/administrative_tags_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Administrative tags' do
     allow(Dor).to receive(:find).and_return(item)
   end
 
-  describe 'display' do
+  describe '#show' do
     context 'when item is not found' do
       before do
         allow(Dor).to receive(:find)
@@ -28,7 +28,6 @@ RSpec.describe 'Administrative tags' do
       it 'returns a 404' do
         get "/v1/objects/#{druid}/administrative_tags",
             headers: { 'Authorization' => "Bearer #{jwt}" }
-
         expect(response.status).to eq(404)
         expect(response.body).to eq('Unable to find \'druid:mx123qw2323\' in fedora. See logger for details.')
       end
@@ -42,7 +41,6 @@ RSpec.describe 'Administrative tags' do
       it 'returns a 200' do
         get "/v1/objects/#{druid}/administrative_tags",
             headers: { 'Authorization' => "Bearer #{jwt}" }
-
         expect(AdministrativeTags).to have_received(:for).with(item: item).once
         expect(response.status).to eq(200)
         expect(response.body).to eq(tags.to_json)
@@ -50,19 +48,45 @@ RSpec.describe 'Administrative tags' do
     end
   end
 
-  describe 'creation' do
+  describe '#create' do
     before do
       allow(AdministrativeTags).to receive(:create)
     end
 
-    context 'when happy path' do
+    context 'when happy path (without replacement)' do
       it 'adds administrative tags' do
         post "/v1/objects/#{druid}/administrative_tags",
              params: %( {"administrative_tags":#{tags.to_json}} ),
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
         expect(AdministrativeTags).to have_received(:create)
-          .with(item: item, tags: tags)
+          .with(item: item, tags: tags, replace: nil)
         expect(response.status).to eq(201)
+      end
+    end
+
+    context 'when happy path (with replacement)' do
+      it 'replaces administrative tags' do
+        post "/v1/objects/#{druid}/administrative_tags",
+             params: %( {"administrative_tags":#{tags.to_json},"replace":true} ),
+             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+        expect(AdministrativeTags).to have_received(:create)
+          .with(item: item, tags: tags, replace: true)
+        expect(response.status).to eq(201)
+      end
+    end
+
+    context 'when item is not found' do
+      before do
+        allow(Dor).to receive(:find)
+          .and_raise(ActiveFedora::ObjectNotFoundError, "Unable to find '#{druid}' in fedora. See logger for details.")
+      end
+
+      it 'returns a 404' do
+        post "/v1/objects/#{druid}/administrative_tags",
+             params: %( {"administrative_tags":#{tags.to_json}} ),
+             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+        expect(response.status).to eq(404)
+        expect(response.body).to eq('Unable to find \'druid:mx123qw2323\' in fedora. See logger for details.')
       end
     end
 
@@ -97,6 +121,207 @@ RSpec.describe 'Administrative tags' do
         expect(response.body).to eq('{"errors":[{"status":"bad_request","detail":' \
                                     '"#/paths/~1v1~1objects~1{object_id}~1administrative_tags/post/requestBody/content/application~1json/schema' \
                                     '/properties/administrative_tags [] contains fewer than min items"}]}')
+      end
+    end
+
+    context 'when one or more tags already exist' do
+      # NOTE: Yep, this is pretty gross. Faking ActiveModel::Errors here. Why is it gross?
+      #       First, you can't raise ActiveRecord::RecordInvalid with a string. An instance must be supplied
+      #       that responds to `#errors`, and what is returned by `#errors` must itself respond to `#full_messages`.
+      #       A fun added complication is that the class of what is returned at the top level must respond
+      #       to `#i18n_scope` (at the class level, not the instance level). We get that here by virtue of
+      #       subclassing `AdministrativeTag` in the anonymous class. (FWIW, the return value of that method
+      #       in this context? `:activerecord`.)
+      let(:fake_invalid_record) do
+        Class.new(AdministrativeTag) do
+          def errors
+            Class.new do
+              def full_messages
+                [
+                  'Tag has already been assigned to the given druid (no duplicate tags for a druid)'
+                ]
+              end
+            end.new
+          end
+        end.new
+      end
+
+      before do
+        allow(AdministrativeTags).to receive(:create)
+          .and_raise(ActiveRecord::RecordInvalid.new(fake_invalid_record))
+      end
+
+      it 'adds no new administrative tags' do
+        post "/v1/objects/#{druid}/administrative_tags",
+             params: %( {"administrative_tags":#{tags.to_json}} ),
+             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+        expect(response.status).to eq(409)
+        expect(response.body).to eq('Validation failed: Tag has already been assigned to the given druid (no duplicate tags for a druid)')
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:current_tag) { 'Replace : Me' }
+    let(:new_tag) { 'Much : Better : Tag' }
+
+    before do
+      allow(AdministrativeTags).to receive(:update)
+    end
+
+    context 'when happy path' do
+      it 'updates an administrative tag' do
+        put "/v1/objects/#{druid}/administrative_tags/#{CGI.escape(current_tag)}",
+            params: %( {"administrative_tag":"#{new_tag}"} ),
+            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+        expect(AdministrativeTags).to have_received(:update)
+          .with(item: item, current: current_tag, new: new_tag)
+        expect(response.status).to eq(204)
+      end
+    end
+
+    context 'when item is not found' do
+      before do
+        allow(Dor).to receive(:find)
+          .and_raise(ActiveFedora::ObjectNotFoundError, "Unable to find '#{druid}' in fedora. See logger for details.")
+      end
+
+      it 'returns a 404' do
+        put "/v1/objects/#{druid}/administrative_tags/#{CGI.escape(current_tag)}",
+            params: %( {"administrative_tag":"#{new_tag}"} ),
+            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+        expect(response.status).to eq(404)
+        expect(response.body).to eq('Unable to find \'druid:mx123qw2323\' in fedora. See logger for details.')
+      end
+    end
+
+    context 'when tag is not found' do
+      before do
+        allow(AdministrativeTags).to receive(:update)
+          .and_raise(ActiveRecord::RecordNotFound, "Couldn't find AdministrativeTag")
+      end
+
+      it 'returns a 404' do
+        put "/v1/objects/#{druid}/administrative_tags/#{CGI.escape(current_tag)}",
+            params: %( {"administrative_tag":"#{new_tag}"} ),
+            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+        expect(response.status).to eq(404)
+        expect(response.body).to eq('Couldn\'t find AdministrativeTag')
+      end
+    end
+
+    context 'without JSON content-type' do
+      it 'returns an error' do
+        put "/v1/objects/#{druid}/administrative_tags/#{CGI.escape(current_tag)}",
+            params: %( {"administrative_tag":"#{new_tag}"} ),
+            headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response.status).to eq(400)
+        expect(response.body).to eq('{"errors":[{"status":"bad_request","detail":"\"Content-Type\" request header must be set to \"application/json\"."}]}')
+      end
+    end
+
+    context 'when administrative tag param is missing' do
+      it 'returns an error' do
+        put "/v1/objects/#{druid}/administrative_tags/#{CGI.escape(current_tag)}",
+            params: %( {"foo":"bar"} ),
+            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+        expect(response.status).to eq(400)
+        expect(response.body).to eq('{"errors":[{"status":"bad_request","detail":' \
+                                    '"#/paths/~1v1~1objects~1{object_id}~1administrative_tags~1{id}/put/requestBody/content/application~1json/schema ' \
+                                    'missing required parameters: administrative_tag"}]}')
+      end
+    end
+
+    context 'when administrative tag params is empty' do
+      it 'returns an error' do
+        put "/v1/objects/#{druid}/administrative_tags/#{CGI.escape(current_tag)}",
+            params: %( {"administrative_tag":""} ),
+            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+        expect(response.status).to eq(400)
+        expect(response.body).to eq('{"errors":[{"status":"bad_request","detail":' \
+                                    '"#/components/schemas/AdministrativeTag pattern ^.+( : .+)+$ does not match value: , example: Foo : Bar : Baz"}]}')
+      end
+    end
+
+    context 'when the new tag already exists' do
+      # NOTE: Yep, this is pretty gross. Faking ActiveModel::Errors here. Why is it gross?
+      #       First, you can't raise ActiveRecord::RecordInvalid with a string. An instance must be supplied
+      #       that responds to `#errors`, and what is returned by `#errors` must itself respond to `#full_messages`.
+      #       A fun added complication is that the class of what is returned at the top level must respond
+      #       to `#i18n_scope` (at the class level, not the instance level). We get that here by virtue of
+      #       subclassing `AdministrativeTag` in the anonymous class. (FWIW, the return value of that method
+      #       in this context? `:activerecord`.)
+      let(:fake_invalid_record) do
+        Class.new(AdministrativeTag) do
+          def errors
+            Class.new do
+              def full_messages
+                [
+                  'Tag has already been assigned to the given druid (no duplicate tags for a druid)'
+                ]
+              end
+            end.new
+          end
+        end.new
+      end
+
+      before do
+        allow(AdministrativeTags).to receive(:update)
+          .and_raise(ActiveRecord::RecordInvalid.new(fake_invalid_record))
+      end
+
+      it 'adds no new administrative tags' do
+        put "/v1/objects/#{druid}/administrative_tags/#{CGI.escape(current_tag)}",
+            params: %( {"administrative_tag":"#{new_tag}"} ),
+            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+        expect(response.status).to eq(409)
+        expect(response.body).to eq('Validation failed: Tag has already been assigned to the given druid (no duplicate tags for a druid)')
+      end
+    end
+  end
+
+  describe '#destroy' do
+    let(:tag) { 'Delete : Me' }
+
+    before do
+      allow(AdministrativeTags).to receive(:destroy)
+    end
+
+    context 'when happy path' do
+      it 'destroys an administrative tag' do
+        delete "/v1/objects/#{druid}/administrative_tags/#{CGI.escape(tag)}",
+               headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(AdministrativeTags).to have_received(:destroy)
+          .with(item: item, tag: tag)
+        expect(response.status).to eq(204)
+      end
+    end
+
+    context 'when item is not found' do
+      before do
+        allow(Dor).to receive(:find)
+          .and_raise(ActiveFedora::ObjectNotFoundError, "Unable to find '#{druid}' in fedora. See logger for details.")
+      end
+
+      it 'returns a 404' do
+        delete "/v1/objects/#{druid}/administrative_tags/#{CGI.escape(tag)}",
+               headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response.status).to eq(404)
+        expect(response.body).to eq('Unable to find \'druid:mx123qw2323\' in fedora. See logger for details.')
+      end
+    end
+
+    context 'when tag is not found' do
+      before do
+        allow(AdministrativeTags).to receive(:destroy)
+          .and_raise(ActiveRecord::RecordNotFound, "Couldn't find AdministrativeTag")
+      end
+
+      it 'returns an error' do
+        delete "/v1/objects/#{druid}/administrative_tags/#{CGI.escape(tag)}",
+               headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response.status).to eq(404)
+        expect(response.body).to eq('Couldn\'t find AdministrativeTag')
       end
     end
   end

--- a/spec/services/administrative_tags_spec.rb
+++ b/spec/services/administrative_tags_spec.rb
@@ -3,29 +3,270 @@
 require 'rails_helper'
 
 RSpec.describe AdministrativeTags do
-  before do
-    allow(item).to receive(:save!)
-    described_class.create(item: item, tags: tags)
-  end
-
-  let(:item) { Dor::Item.new(pid: 'druid:aa123bb7890') }
-  let(:tags) { ['Foo : Bar', 'Bar : Baz : Quux'] }
+  let(:item_with_db_tags) { Dor::Item.new(pid: 'druid:aa123bb7890') }
+  let(:item_without_db_tags) { Dor::Item.new(pid: 'druid:bc234dg8901') }
 
   describe '.for' do
-    it 'returns the array of administrative tags' do
-      expect(described_class.for(item: item)).to eq(tags)
+    let(:instance) { instance_double(described_class, for: nil) }
+
+    before do
+      allow(described_class).to receive(:new).and_return(instance)
+    end
+
+    it 'calls #for on a new instance' do
+      described_class.for(item: item_with_db_tags)
+      expect(instance).to have_received(:for).once
+    end
+  end
+
+  describe '.content_type' do
+    let(:instance) { instance_double(described_class, content_type: nil) }
+
+    before do
+      allow(described_class).to receive(:new).and_return(instance)
+    end
+
+    it 'calls #content_type on a new instance' do
+      described_class.content_type(item: item_with_db_tags)
+      expect(instance).to have_received(:content_type).once
     end
   end
 
   describe '.create' do
-    it 'persists tags to identity metadata' do
-      expect(item.identityMetadata.to_xml).to be_equivalent_to <<-XML
-        <identityMetadata>
-          <tag>Foo : Bar</tag>
-          <tag>Bar : Baz : Quux</tag>
-        </identityMetadata>
-      XML
-      expect(item).to have_received(:save!)
+    let(:instance) { instance_double(described_class, create: nil) }
+
+    before do
+      allow(described_class).to receive(:new).and_return(instance)
+    end
+
+    it 'calls #create on a new instance' do
+      described_class.create(item: item_with_db_tags, tags: ['What : Ever'])
+      expect(instance).to have_received(:create).once.with(tags: ['What : Ever'], replace: false)
+    end
+  end
+
+  describe '.update' do
+    let(:instance) { instance_double(described_class, update: nil) }
+
+    before do
+      allow(described_class).to receive(:new).and_return(instance)
+    end
+
+    it 'calls #update on a new instance' do
+      described_class.update(item: item_with_db_tags, current: 'What : Ever', new: 'What : Ever : 2')
+      expect(instance).to have_received(:update).once.with(current: 'What : Ever', new: 'What : Ever : 2')
+    end
+  end
+
+  describe '.destroy' do
+    let(:instance) { instance_double(described_class, destroy: nil) }
+
+    before do
+      allow(described_class).to receive(:new).and_return(instance)
+    end
+
+    it 'calls #destroy on a new instance' do
+      described_class.destroy(item: item_with_db_tags, tag: 'What : Ever')
+      expect(instance).to have_received(:destroy).once.with(tag: 'What : Ever')
+    end
+  end
+
+  describe '#for' do
+    before do
+      create(:administrative_tag, druid: item_with_db_tags.pid, tag: 'Foo : Bar')
+      create(:administrative_tag, druid: item_with_db_tags.pid, tag: 'Bar : Baz : Quux')
+    end
+
+    context 'with matching rows in the database' do
+      it 'returns administrative tags from the database' do
+        expect(described_class.for(item: item_with_db_tags)).to eq(['Foo : Bar', 'Bar : Baz : Quux'])
+      end
+    end
+
+    context 'without matching rows in the database' do
+      before do
+        Dor::TagService.add(item_without_db_tags, 'One : Two : Three')
+      end
+
+      it 'returns administrative tags from identity metadata XML' do
+        expect(described_class.for(item: item_without_db_tags)).to eq(['One : Two : Three'])
+      end
+    end
+  end
+
+  describe '#content_type' do
+    context 'with a matching row in the database' do
+      before do
+        create(:administrative_tag, druid: item_with_db_tags.pid, tag: 'Process : Content Type : Map')
+      end
+
+      it 'parses and returns the content type' do
+        expect(described_class.content_type(item: item_with_db_tags)).to eq(['Map'])
+      end
+    end
+
+    context 'with more than one matching row in the database' do
+      before do
+        create(:administrative_tag, druid: item_with_db_tags.pid, tag: 'Process : Content Type : Map')
+        create(:administrative_tag, druid: item_with_db_tags.pid, tag: 'Process : Content Type : Media')
+      end
+
+      it 'parses and returns the first content type' do
+        expect(described_class.content_type(item: item_with_db_tags)).to eq(['Map'])
+      end
+    end
+
+    context 'with no content types' do
+      before do
+        create(:administrative_tag, druid: item_with_db_tags.pid, tag: 'Foo : Bar')
+      end
+
+      it 'returns an empty array' do
+        expect(described_class.content_type(item: item_with_db_tags)).to eq([])
+      end
+    end
+
+    context 'without matching rows in the database' do
+      before do
+        Dor::TagService.add(item_without_db_tags, 'Process : Content Type : Media')
+      end
+
+      it 'returns administrative tags from identity metadata XML' do
+        expect(described_class.content_type(item: item_without_db_tags)).to eq(['Media'])
+      end
+    end
+  end
+
+  describe '#create' do
+    before do
+      # Don't actually manipulate the database
+      allow(AdministrativeTag).to receive(:create!)
+    end
+
+    let(:new_tags) { ['One : Two', 'A : B : C'] }
+
+    it 'creates new administrative tags' do
+      described_class.create(item: item_with_db_tags, tags: new_tags)
+
+      expect(AdministrativeTag).to have_received(:create!)
+        .with(druid: item_with_db_tags.pid, tag: 'One : Two').once
+      expect(AdministrativeTag).to have_received(:create!)
+        .with(druid: item_with_db_tags.pid, tag: 'A : B : C').once
+    end
+
+    context 'when replacing tags' do
+      before do
+        allow(AdministrativeTag).to receive(:where).and_return(fake_relation)
+      end
+
+      let(:fake_relation) { instance_double(ActiveRecord::Relation, destroy_all: true, any?: false) }
+
+      it 'destroys and creates new administrative tags' do
+        described_class.create(item: item_with_db_tags, tags: new_tags, replace: true)
+
+        expect(fake_relation).to have_received(:destroy_all).once
+        expect(AdministrativeTag).to have_received(:create!)
+          .with(druid: item_with_db_tags.pid, tag: 'One : Two').once
+        expect(AdministrativeTag).to have_received(:create!)
+          .with(druid: item_with_db_tags.pid, tag: 'A : B : C').once
+      end
+    end
+
+    context 'when no tags for druid exist but legacy tags do exist' do
+      before do
+        Dor::TagService.add(item_without_db_tags, 'One : Two : Three')
+        Dor::TagService.add(item_without_db_tags, 'One : Two : Three : Four')
+      end
+
+      it 'adds tags from Fedora to the database' do
+        described_class.create(item: item_without_db_tags, tags: new_tags)
+
+        expect(AdministrativeTag).to have_received(:create!)
+          .with(druid: item_without_db_tags.pid, tag: 'One : Two : Three').once
+        expect(AdministrativeTag).to have_received(:create!)
+          .with(druid: item_without_db_tags.pid, tag: 'One : Two : Three : Four').once
+      end
+    end
+  end
+
+  describe '#update' do
+    before do
+      # Don't actually manipulate the database
+      allow(AdministrativeTag).to receive(:find_by!).and_return(fake_record)
+    end
+
+    let(:current_tag) { 'One : Two' }
+    let(:fake_record) { instance_double(AdministrativeTag, update!: nil) }
+    let(:new_tag) { 'A : B : C' }
+
+    it 'updates the administrative tag' do
+      described_class.update(item: item_with_db_tags, current: current_tag, new: new_tag)
+
+      expect(AdministrativeTag).to have_received(:find_by!)
+        .with(druid: item_with_db_tags.pid, tag: current_tag).once
+      expect(fake_record).to have_received(:update!)
+        .with(tag: new_tag).once
+    end
+
+    context 'when no tags for druid exist but legacy tags do exist' do
+      before do
+        Dor::TagService.add(item_without_db_tags, current_tag)
+        Dor::TagService.add(item_without_db_tags, 'One : Two : Three : Four')
+        # Don't actually manipulate the database
+        allow(AdministrativeTag).to receive(:create!)
+      end
+
+      it 'adds tags from Fedora to the database then updates one' do
+        described_class.update(item: item_without_db_tags, current: current_tag, new: new_tag)
+
+        expect(AdministrativeTag).to have_received(:create!)
+          .with(druid: item_without_db_tags.pid, tag: current_tag).once
+        expect(AdministrativeTag).to have_received(:create!)
+          .with(druid: item_without_db_tags.pid, tag: 'One : Two : Three : Four').once
+        expect(AdministrativeTag).to have_received(:find_by!)
+          .with(druid: item_without_db_tags.pid, tag: current_tag).once
+        expect(fake_record).to have_received(:update!)
+          .with(tag: new_tag).once
+      end
+    end
+  end
+
+  describe '#destroy' do
+    before do
+      # Don't actually manipulate the database
+      allow(AdministrativeTag).to receive(:find_by!).and_return(fake_record)
+    end
+
+    let(:tag) { 'One : Two' }
+    let(:fake_record) { instance_double(AdministrativeTag, destroy!: nil) }
+
+    it 'destroys the administrative tag' do
+      described_class.destroy(item: item_with_db_tags, tag: tag)
+
+      expect(AdministrativeTag).to have_received(:find_by!)
+        .with(druid: item_with_db_tags.pid, tag: tag).once
+      expect(fake_record).to have_received(:destroy!).once
+    end
+
+    context 'when no tags for druid exist but legacy tags do exist' do
+      before do
+        Dor::TagService.add(item_without_db_tags, tag)
+        Dor::TagService.add(item_without_db_tags, 'One : Two : Three : Four')
+        # Don't actually manipulate the database
+        allow(AdministrativeTag).to receive(:create!)
+      end
+
+      it 'adds tags from Fedora to the database then destroys one' do
+        described_class.destroy(item: item_without_db_tags, tag: tag)
+
+        expect(AdministrativeTag).to have_received(:create!)
+          .with(druid: item_without_db_tags.pid, tag: tag).once
+        expect(AdministrativeTag).to have_received(:create!)
+          .with(druid: item_without_db_tags.pid, tag: 'One : Two : Three : Four').once
+        expect(AdministrativeTag).to have_received(:find_by!)
+          .with(druid: item_without_db_tags.pid, tag: tag).once
+        expect(fake_record).to have_received(:destroy!).once
+      end
     end
   end
 end

--- a/spec/services/release_tags/identity_metadata_spec.rb
+++ b/spec/services/release_tags/identity_metadata_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ReleaseTags::IdentityMetadata do
   let(:item) { instantiate_fixture('druid:bb004bn8654', Dor::Item) }
   let(:releases) { described_class.for(item) }
-  let(:bryar_trans_am_admin_tags) { item.tags }
+  let(:bryar_trans_am_admin_tags) { AdministrativeTags.for(item: item) }
   let(:array_of_times) do
     ['2015-01-06 23:33:47Z', '2015-01-07 23:33:47Z', '2015-01-08 23:33:47Z', '2015-01-09 23:33:47Z'].map { |x| Time.parse(x).iso8601 }
   end


### PR DESCRIPTION
Connects to #679

## Why was this change made?

This change allows reading administrative tags from the database OR Fedora, and only writes them TO the database, which will give us some time to pull off the migration of tags from Fedora to the database, making a gradual transition.

## Was the API documentation (openapi.yml) updated?

Yes.

## Does this change affect how this application integrates with other services?

I don't think it does. Tested in stage and in this integration test: https://github.com/sul-dlss/infrastructure-integration-test/pull/34