### PR TITLE
Upgrade to faraday-middleware 1.0.0.rc1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'config'
 gem 'deprecation'
 gem 'dry-schema', '~> 1.4'
 gem 'faraday', '~> 1.0'
-gem 'faraday_middleware', github: 'lostisland/faraday_middleware' # dependency of dor-workflow-client. remove when release > 0.14.0
+gem 'faraday_middleware', '~> 1.0.0.rc1' # dependency of dor-workflow-client. remove when release > 0.14.0
 gem 'honeybadger'
 gem 'jbuilder'
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/lostisland/faraday_middleware.git
-  revision: 13e29232f0fb083173e12f8a26b278c5e7869e10
-  specs:
-    faraday_middleware (1.0.0)
-      faraday (~> 1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -210,6 +203,8 @@ GEM
       railties (>= 4.2.0)
     faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (1.0.0.rc1)
+      faraday (~> 1.0)
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -500,7 +495,7 @@ DEPENDENCIES
   equivalent-xml
   factory_bot_rails
   faraday (~> 1.0)
-  faraday_middleware!
+  faraday_middleware (~> 1.0.0.rc1)
   honeybadger
   jbuilder
   jwt


### PR DESCRIPTION
## Why was this change made?

Tracking a git branch is less stable than using a tagged release like this.

## Was the API documentation (openapi.yml) updated?

n/a

## Does this change affect how this application integrates with other services?

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
