### PR TITLE
Correct typo in OpenAPI spec description

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -184,7 +184,7 @@ paths:
       operationId: 'objects#accession'
       responses:
         '201':
-          description: Accessiong/re-accessioning started
+          description: Accessioning/re-accessioning started
       parameters:
         - name: id
           in: path


### PR DESCRIPTION
## Why was this change made?

To correct the typo.

## Was the API documentation (openapi.yml) updated?

Yes.

## Does this change affect how this application integrates with other services?

No.