### PR TITLE
image files populate presentation attribute in cocina-model

### DIFF
--- a/app/services/cocina/dro_structural_builder.rb
+++ b/app/services/cocina/dro_structural_builder.rb
@@ -49,6 +49,9 @@ module Cocina
         # The old google books use these upcased versions. See https://argo.stanford.edu/view/druid:dd116zh0343
         md5 = node.xpath('checksum[@type="md5"]').text.presence || node.xpath('checksum[@type="MD5"]').text
         sha1 = node.xpath('checksum[@type="sha1"]').text.presence || node.xpath('checksum[@type="SHA-1"]').text
+        height = node.xpath('imageData/@height').text.presence
+        width = node.xpath('imageData/@width').text.presence
+
         Cocina::Models::File.new(
           {
             externalIdentifier: "#{parent_id}/#{node['id']}",
@@ -59,6 +62,7 @@ module Cocina
             version: version,
             hasMessageDigests: []
           }.tap do |attrs|
+            attrs[:presentation] = { height: height, width: width } if height && width
             attrs[:hasMessageDigests] << { type: 'sha1', digest: sha1 } if sha1
             attrs[:hasMessageDigests] << { type: 'md5', digest: md5 } if md5
           end

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -4,7 +4,7 @@ module Cocina
   # Maps Dor::Items to Cocina objects
   # rubocop:disable Metrics/ClassLength
   class Mapper
-    # Raised when called on something other than an item or collection
+    # Raised when called on something other than an item (DRO), etd, collection, or adminPolicy (APO)
     class UnsupportedObjectType < StandardError; end
     # @param [Dor::Abstract] item the Fedora object to convert to a cocina object
     # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]


### PR DESCRIPTION
## Why was this change made?

When a file has image height and width, they need to be mapped to the cocina model.

fixes #692 

## Was the API documentation (openapi.yml) updated?

n/a

## Does this change affect how this application integrates with other services?

DOES this need to be tested in stage?  There is already a ticket to add an integration test to that suite:  sul-dlss/infrastructure-integration-test#23

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
