### PR TITLE
update versioning calls to deal with new event factory

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -65,8 +65,8 @@ class ObjectsController < ApplicationController
 
     # if this is an existing versionable object, open and close it without starting accessioning
     if VersionService.can_open?(@item, params)
-      VersionService.open(params)
-      VersionService.close(params.merge(start_accession: false))
+      VersionService.open(@item, params, event_factory: EventFactory)
+      VersionService.close(@item, params.merge(start_accession: false), event_factory: EventFactory)
     end
 
     # initialize workflow

--- a/app/services/embargo_release_service.rb
+++ b/app/services/embargo_release_service.rb
@@ -46,10 +46,10 @@ class EmbargoReleaseService
 
     Rails.logger.info("Releasing #{embargo_msg} for #{druid}")
 
-    VersionService.open(ei)
+    VersionService.open(ei, event_factory: EventFactory)
     release_block.call(ei)
     ei.save!
-    VersionService.close(ei, description: "#{embargo_msg} released", significance: 'admin')
+    VersionService.close(ei, { description: "#{embargo_msg} released", significance: 'admin' }, event_factory: EventFactory)
   rescue StandardError => e
     Rails.logger.error("!!! Unable to release embargo for: #{druid}\n#{e.inspect}\n#{e.backtrace.join("\n")}")
     Honeybadger.notify "Unable to release embargo for: #{druid}", backtrace: e.backtrace

--- a/spec/requests/start_accession_spec.rb
+++ b/spec/requests/start_accession_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
   let(:object) { Dor::Item.new(pid: druid) }
   let(:workflow_client) { instance_double(Dor::Workflow::Client, create_workflow_by_name: true) }
   let(:default_start_accession_workflow) { ObjectsController.new.send(:default_start_accession_workflow) }
+  let(:event_factory) { { event_factory: EventFactory } }
 
   before do
     allow(Dor).to receive(:find).and_return(object)
@@ -52,8 +53,8 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
       post "/v1/objects/#{druid}/accession",
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(workflow_client).to have_received(:create_workflow_by_name).with(object.pid, default_start_accession_workflow, version: '1')
-      expect(VersionService).to have_received(:open).with(base_params)
-      expect(VersionService).to have_received(:close).with(base_params.merge('start_accession' => false))
+      expect(VersionService).to have_received(:open).with(object, base_params, event_factory)
+      expect(VersionService).to have_received(:close).with(object, base_params.merge('start_accession' => false), event_factory)
     end
 
     it 'can override the default workflow' do
@@ -62,8 +63,8 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
            params: params,
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(workflow_client).to have_received(:create_workflow_by_name).with(object.pid, 'accessionWF', version: '1')
-      expect(VersionService).to have_received(:open).with(base_params.merge(params))
-      expect(VersionService).to have_received(:close).with(base_params.merge(params).merge('start_accession' => false))
+      expect(VersionService).to have_received(:open).with(object, base_params.merge(params), event_factory)
+      expect(VersionService).to have_received(:close).with(object, base_params.merge(params).merge('start_accession' => false), event_factory)
     end
   end
 end

--- a/spec/services/embargo_release_service_spec.rb
+++ b/spec/services/embargo_release_service_spec.rb
@@ -165,12 +165,14 @@ RSpec.describe EmbargoReleaseService do
         EOXML
       end
       let(:client) { instance_double(Dor::Workflow::Client) }
+      let(:event_factory) { { event_factory: EventFactory } }
+      let(:close_params) { { description: 'embargo released', significance: 'admin' } }
 
       before do
         allow(Dor).to receive(:find).and_return(item)
         allow(VersionService).to receive(:can_open?).and_return(true)
-        allow(VersionService).to receive(:open).with(item)
-        allow(VersionService).to receive(:close)
+        allow(VersionService).to receive(:open).with(item, event_factory)
+        allow(VersionService).to receive(:close).with(item, close_params, event_factory)
         allow(item).to receive(:save!)
         allow(Honeybadger).to receive(:notify)
         allow(WorkflowClientFactory).to receive(:build).and_return(client)
@@ -199,9 +201,9 @@ RSpec.describe EmbargoReleaseService do
         it 'is successful' do
           release_items
           expect(VersionService).to have_received(:can_open?).with(item)
-          expect(VersionService).to have_received(:open).with(item)
+          expect(VersionService).to have_received(:open).with(item, event_factory)
           expect(item).to have_received(:save!)
-          expect(VersionService).to have_received(:close).with(item, description: 'embargo released', significance: 'admin')
+          expect(VersionService).to have_received(:close).with(item, close_params, event_factory)
         end
       end
 


### PR DESCRIPTION
## Why was this change made?

to deal with https://app.honeybadger.io/projects/50568/faults/61304607 when testing new accession call from #703 

also per-empetively fix the same issue in release service


## Was the API documentation (openapi.yml) updated?



## Does this change affect how this application integrates with other services?

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
