### PR TITLE
Pin iso-639 to 0.2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ gem 'dry-schema', '~> 1.4'
 gem 'faraday', '~> 1.0'
 gem 'faraday_middleware', '~> 1.0.0.rc1' # dependency of dor-workflow-client. remove when release > 0.14.0
 gem 'honeybadger'
+# iso-639 0.3.0 isn't compatible with ruby 2.5.  This declaration can be dropped when we upgrade to 2.6
+gem 'iso-639', '~> 0.2.8'
 gem 'jbuilder'
 gem 'jwt'
 gem 'okcomputer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    iso-639 (0.3.1)
+    iso-639 (0.2.10)
     jaro_winkler (1.5.4)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
@@ -497,6 +497,7 @@ DEPENDENCIES
   faraday (~> 1.0)
   faraday_middleware (~> 1.0.0.rc1)
   honeybadger
+  iso-639 (~> 0.2.8)
   jbuilder
   jwt
   listen (~> 3.0.5)


### PR DESCRIPTION
## Why was this change made?

Pin iso-639 until we upgrade to ruby 2.6

