### PR TITLE
Add extended commend related to iso-639

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'faraday', '~> 1.0'
 gem 'faraday_middleware', '~> 1.0.0.rc1' # dependency of dor-workflow-client. remove when release > 0.14.0
 gem 'honeybadger'
 # iso-639 0.3.0 isn't compatible with ruby 2.5.  This declaration can be dropped when we upgrade to 2.6
+# see https://github.com/alphabetum/iso-639/issues/12
+# iso-639 is used by dor-services gem via stanford-mods gem
 gem 'iso-639', '~> 0.2.8'
 gem 'jbuilder'
 gem 'jwt'


### PR DESCRIPTION
## Why was this change made?

Clarifying comment as suggested by @ndushay 

