### PR TITLE
Map copyright and use and reproduction statement to Cocina model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.25.0'
+gem 'cocina-models', '~> 0.26.0'
 gem 'dor-services', '~> 9.0'
 gem 'dor-workflow-client', '~> 3.17'
 gem 'marc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
       capistrano (>= 3.9.0)
       sidekiq (>= 3.4, < 6.0)
     chronic (0.10.2)
-    cocina-models (0.25.0)
+    cocina-models (0.26.0)
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
@@ -484,7 +484,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-shared_configs
   capistrano-sidekiq
-  cocina-models (~> 0.25.0)
+  cocina-models (~> 0.26.0)
   committee
   config
   deprecation

--- a/app/services/cocina/access_builder.rb
+++ b/app/services/cocina/access_builder.rb
@@ -15,6 +15,8 @@ module Cocina
       { access: access_rights }.tap do |access|
         embargo = build_embargo
         access[:embargo] = embargo unless embargo.empty?
+        access[:useAndReproductionStatement] = item.rightsMetadata.use_statement.first if item.rightsMetadata.use_statement.first.present?
+        access[:copyright] = item.rightsMetadata.copyright.first if item.rightsMetadata.copyright.first.present?
       end
     end
 

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -82,6 +82,9 @@ module Cocina
         item.descMetadata.mods_title = obj.description.title.first.titleFull if obj.description
         item.identityMetadata.tag = content_type_tag(obj.type, obj.structural.hasMemberOrders&.first&.viewingDirection)
         change_access(item, obj.access.access)
+        item.rightsMetadata.copyright = obj.access.copyright if obj.access.copyright
+        item.rightsMetadata.use_statement = obj.access.useAndReproductionStatement if obj.access.useAndReproductionStatement
+
         item.contentMetadata.content = ContentMetadataGenerator.generate(druid: pid, object: obj)
         if obj.access.embargo
           EmbargoService.embargo(item: item,
@@ -128,13 +131,11 @@ module Cocina
     end
 
     def change_access(item, access)
-      # 'world', 'stanford', 'location-based', 'citation-only', 'dark'
       raise 'location-based access not implemented' if access == 'location-based'
 
       # See https://github.com/sul-dlss/dor-services/blob/master/lib/dor/datastreams/rights_metadata_ds.rb
       rights_type = access == 'citation-only' ? 'none' : access
       Dor::RightsMetadataDS.upd_rights_xml_for_rights_type(item.rightsMetadata.ng_xml, rights_type)
-
       item.rightsMetadata.ng_xml_will_change!
     end
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -855,6 +855,12 @@ components:
             - 'location-based'
             - 'citation-only'
             - 'dark'
+        copyright:
+          description: The human readable copyright statement that applies
+          type: string
+        useAndReproductionStatement:
+          description: The human readable use and reproduction statement that applies
+          type: string
         embargo:
           $ref: '#/components/schemas/Embargo'
     EmptyAdministrative:

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe 'Create object' do
       Cocina::Models::DRO.new(type: Cocina::Models::Vocab.image,
                               label: expected_label,
                               version: 1,
+                              access: {
+                                copyright: 'All rights reserved unless otherwise indicated.',
+                                useAndReproductionStatement: 'Property rights reside with the repository...'
+                              },
                               description: {
                                 title: [{ titleFull: title, primary: true }]
                               },
@@ -33,7 +37,11 @@ RSpec.describe 'Create object' do
     let(:data) do
       <<~JSON
         { "type":"http://cocina.sul.stanford.edu/models/image.jsonld",
-          "label":"#{label}","version":1,"access":{},
+          "label":"#{label}","version":1,
+          "access":{
+            "copyright":"All rights reserved unless otherwise indicated.",
+            "useAndReproductionStatement":"Property rights reside with the repository..."
+          },
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
           "description":{"title":[{"primary":true,"titleFull":"#{title}"}]},
           "identification":#{identification.to_json},"structural":{}}
@@ -232,7 +240,10 @@ RSpec.describe 'Create object' do
         Dor::Item.new(pid: druid,
                       admin_policy_object_id: 'druid:dd999df4567',
                       source_id: 'googlebooks:999999',
-                      label: 'This is my label')
+                      label: 'This is my label').tap do |i|
+          i.rightsMetadata.copyright = 'All rights reserved unless otherwise indicated.'
+          i.rightsMetadata.use_statement = 'Property rights reside with the repository...'
+        end
       end
 
       before do
@@ -300,7 +311,6 @@ RSpec.describe 'Create object' do
       post '/v1/objects',
            params: data,
            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-
       expect(response.body).to eq expected.to_json
       expect(response.status).to eq(201)
       expect(response.location).to eq "/v1/objects/#{druid}"

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe 'Get the object' do
       Dor::Item.new(pid: 'druid:1234',
                     source_id: 'src:99999',
                     label: 'foo',
-                    read_rights: 'world')
+                    read_rights: 'world').tap do |i|
+        i.rightsMetadata.copyright = 'All rights reserved unless otherwise indicated.'
+        i.rightsMetadata.use_statement = 'Property rights reside with the repository...'
+      end
     end
 
     context 'when the object exists with minimal metadata' do
@@ -27,7 +30,9 @@ RSpec.describe 'Get the object' do
           label: 'foo',
           version: 1,
           access: {
-            access: 'world'
+            access: 'world',
+            copyright: 'All rights reserved unless otherwise indicated.',
+            useAndReproductionStatement: 'Property rights reside with the repository...'
           },
           administrative: {
             releaseTags: [],
@@ -75,6 +80,8 @@ RSpec.describe 'Get the object' do
           version: 1,
           access: {
             access: 'citation-only',
+            copyright: 'All rights reserved unless otherwise indicated.',
+            useAndReproductionStatement: 'Property rights reside with the repository...',
             embargo: {
               releaseDate: '2019-09-26T07:00:00.000+00:00',
               access: 'world'

--- a/spec/services/cocina/access_builder_spec.rb
+++ b/spec/services/cocina/access_builder_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::AccessBuilder do
+  subject(:access) { described_class.build(item) }
+
+  let(:item) do
+    Dor::Item.new
+  end
+  let(:rights_metadata_ds) { Dor::RightsMetadataDS.new.tap { |ds| ds.content = xml } }
+
+  before do
+    allow(item).to receive(:rightsMetadata).and_return(rights_metadata_ds)
+  end
+
+  context 'with useAndReproduction and no copyright' do
+    # From https://argo.stanford.edu/view/druid:bb000kg4251
+    let(:xml) do
+      <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction">Property rights reside with the repository. Literary rights reside with  the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).</human>
+          </use>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the hash' do
+      expect(access).to eq(access: 'world',
+                           useAndReproductionStatement: 'Property rights reside with the repository. '\
+                           'Literary rights reside with  the creators of the documents or their heirs. ' \
+                           'To obtain permission to publish or reproduce, please contact the Public ' \
+                           'Services Librarian of the Dept. of Special Collections ' \
+                           '(http://library.stanford.edu/spc).')
+    end
+  end
+
+  describe 'with copyright' do
+    # from https://argo.stanford.edu/view/druid:bb003dn0409
+    let(:xml) do
+      <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction">Official WTO documents are free for public use.</human>
+            <human type="creativeCommons"/>
+            <machine type="creativeCommons"/>
+          </use>
+          <copyright>
+            <human>Copyright &#xA9; World Trade Organization</human>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the hash' do
+      expect(access).to eq(access: 'world',
+                           copyright: 'Copyright © World Trade Organization',
+                           useAndReproductionStatement: 'Official WTO documents are free for public use.')
+    end
+  end
+
+  describe 'with copyright but no use statement (contrived example)' do
+    let(:xml) do
+      <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <copyright>
+            <human>Copyright &#xA9; DLSS</human>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the hash' do
+      expect(access).to eq(access: 'world',
+                           copyright: 'Copyright © DLSS')
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

So that GB can add these properties.

ref sul-dlss/google-books#331
ref sul-dlss/google-books#333

## Was the API documentation (openapi.yml) updated?
yes

## Does this change affect how this application integrates with other services?

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
