### PR TITLE
lower case openapi enum for versioning significance values

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -210,9 +210,9 @@ paths:
           schema:
             type: string
             enum:
-              - Minor
-              - Major
-              - Admin
+              - minor
+              - major
+              - admin
             example: Admin
         - name: description
           in: query


### PR DESCRIPTION
## Why was this change made?

openapi enums are case sensitive, and the significance should come in as lower case (and currently does from argo, and new accession method from dor-services-app)

## Was the API documentation (openapi.yml) updated?

yes

## Does this change affect how this application integrates with other services?

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
