### PR TITLE
Load ETDs as ETDs

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -47,6 +47,10 @@ class ObjectsController < ApplicationController
   end
 
   def show
+    # Etds are not mapping to Etd by default (see adapt_to_cmodel in Dor::Abstract)
+    # This hack overrides that behavior and ensures Etds can be mapped to Cocina.
+    models = ActiveFedora::ContentModel.models_asserted_by(@item)
+    @item = @item.adapt_to(Etd) if models.include?('info:fedora/afmodel:Etd')
     render json: Cocina::Mapper.build(@item)
   end
 

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -228,4 +228,30 @@ RSpec.describe 'Get the object' do
       end
     end
   end
+
+  context 'when the requested object is an ETD' do
+    let(:object) { Etd.new(pid: 'druid:1234') }
+
+    before do
+      object.properties.title = 'Test ETD'
+      object.identityMetadata.other_ids = ['dissertationid:00000123']
+      object.label = 'foo'
+      allow(object).to receive(:admin_policy_object_id).and_return('druid:ab123cd4567')
+    end
+
+    it 'returns the object' do
+      get '/v1/objects/druid:mk420bs7601',
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+
+      expect(json['externalIdentifier']).to eq 'druid:1234'
+      expect(json['type']).to eq 'http://cocina.sul.stanford.edu/models/object.jsonld'
+      expect(json['label']).to eq 'foo'
+      expect(json['version']).to eq 1
+      expect(json['access']).to eq('access' => 'dark')
+      expect(json['identification']).to eq('sourceId' => 'dissertationid:00000123')
+      expect(json['structural']).to eq({})
+    end
+  end
 end


### PR DESCRIPTION


## Why was this change made?

Previously when you call `Dor.find` on a ETD druid it would load it as a `Dor::Item`, which causes the mapper to produce an invalid Cocina model

Ref sul-dlss/hydra_etd#327

## Was the API documentation (openapi.yml) updated?

n/a

## Does this change affect how this application integrates with other services?
yes

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
