### PR TITLE
When registering an object, immediately index to Solr

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -14,6 +14,10 @@ module Cocina
       validate(obj)
       af_model = create_from_model(obj)
 
+      # Fedora 3 has no unique constrains, so
+      # index right away to reduce the likelyhood of duplicate sourceIds
+      SynchronousIndexer.reindex_remotely(af_model.pid)
+
       event_factory.create(druid: af_model.pid, event_type: 'registration', data: params)
 
       # This will rebuild the cocina model from fedora, which shows we are only returning persisted data

--- a/app/services/registration_service.rb
+++ b/app/services/registration_service.rb
@@ -13,6 +13,11 @@ class RegistrationService
       request = RegistrationRequest.new(dor_params)
       dor_obj = register_object(request)
       pid = dor_obj.pid
+
+      # Fedora 3 has no unique constrains, so
+      # Index right away to reduce the likelyhood of duplicate sourceIds
+      SynchronousIndexer.reindex_remotely(pid)
+
       event_factory.create(druid: pid, event_type: 'legacy-registration', data: params)
       location = URI.parse(Dor::Config.fedora.safeurl.sub(%r{/*$}, '/')).merge("objects/#{pid}").to_s
 

--- a/app/services/synchronous_indexer.rb
+++ b/app/services/synchronous_indexer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Most of the indexing happens when Fedora sends an activeMQ message to dor_indexing_app
+# When we can't have latency in the indexing, we can use this class to directly call dor-indexing-app
+class SynchronousIndexer
+  def self.reindex_remotely(pid)
+    connection.post("/reindex/#{pid}")
+  end
+
+  def self.connection
+    Faraday.new(url: Settings.dor_indexing.url) do |conn|
+      conn.headers[:user_agent] = 'dor-services-app'
+      conn.request(:retry, max: 3,
+                           methods: [:post],
+                           exceptions: Faraday::Request::Retry::DEFAULT_EXCEPTIONS + [Faraday::ConnectionFailed])
+      conn.adapter(:net_http) # NB: Last middleware must be the adapter
+    end
+  end
+  private_class_method :connection
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,6 +26,8 @@ workflow:
 fedora_url: 'https://user:password@fedora.example.com:1000/fedora'
 solr:
   url: 'https://solr.example.com/solr/collection'
+dor_indexing:
+  url: 'https://dor-indexing-app.server'
 
 workflow_url: 'https://workflow.example.com/workflow'
 sdr_url: 'http://user:password@sdr-services.example.com/sdr'

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Create object' do
   before do
     allow(Dor::SuriService).to receive(:mint_id).and_return(druid)
     allow(Dor).to receive(:find).and_return(object)
+    stub_request(:post, 'https://dor-indexing-app.server/reindex/druid:gg777gg7777')
   end
 
   context 'when an image is provided' do
@@ -87,12 +88,13 @@ RSpec.describe 'Create object' do
           allow(RefreshMetadataAction).to receive(:run)
         end
 
-        it 'registers the object with the registration service' do
+        it 'registers the object with the registration service and immediately indexes' do
           expect do
             post '/v1/objects',
                  params: data,
                  headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
           end.to change(Event, :count).by(1)
+          expect(a_request(:post, 'https://dor-indexing-app.server/reindex/druid:gg777gg7777')).to have_been_made
           expect(response.body).to eq expected.to_json
           expect(response.status).to eq(201)
           expect(response.location).to eq "/v1/objects/#{druid}"
@@ -110,11 +112,11 @@ RSpec.describe 'Create object' do
           allow_any_instance_of(Dor::Item).to receive(:save!)
         end
 
-        it 'registers the object with the registration service' do
+        it 'registers the object with the registration service and immediately indexes' do
           post '/v1/objects',
                params: data,
                headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-
+          expect(a_request(:post, 'https://dor-indexing-app.server/reindex/druid:gg777gg7777')).to have_been_made
           expect(response.body).to eq expected.to_json
           expect(response.status).to eq(201)
           expect(response.location).to eq "/v1/objects/#{druid}"


### PR DESCRIPTION


## Why was this change made?

Since Fedora 3 has no unique constraints, we have to check Solr to see if a sourceId has already been used.  If several requests for one sourceId come in during the latency in the asynch indexing, then we can violate the "source ids should be unique" constraint.  Doing synchronous indexing, narrows the window of time in which such a problem could occur.

Fixes sul-dlss/argo#1845

## Was the API documentation (openapi.yml) updated?
n/a


## Does this change affect how this application integrates with other services?
n/a

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
