### PR TITLE
Raises informative error when no sourceId.

### DIFF
--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -29,6 +29,7 @@ module Cocina
               else
                 raise "unable to build '#{klass}'"
               end
+      check_source_id(props) if klass == Cocina::Models::DRO
       klass.new(props)
     end
 
@@ -151,7 +152,7 @@ module Cocina
       end
     end
 
-    # @todo This should have more speicific type such as found in identityMetadata.objectType
+    # @todo This should have more specific type such as found in identityMetadata.objectType
     def cocina_klass
       case item
       when Dor::Item, Dor::Etd
@@ -163,6 +164,10 @@ module Cocina
       else
         raise UnsupportedObjectType, "Unknown type for #{item.class}"
       end
+    end
+
+    def check_source_id(props)
+      raise "Item #{props[:externalIdentifier]} has a null sourceId. This item requires remediation." if props[:identification][:sourceId].nil?
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -8,13 +8,14 @@ RSpec.describe Cocina::Mapper do
   context 'when item is a Dor::Item' do
     let(:item) do
       Dor::Item.new(pid: 'druid:mx000xm0000',
-                    source_id: 'whaever:8888',
+                    source_id: source_id,
                     label: 'test object',
                     admin_policy_object_id: 'druid:sc012gz0974')
     end
 
     let(:type) { 'Process : Content Type : 3D' }
     let(:agreement) { 'druid:666' }
+    let(:source_id) { 'whaever:8888' }
 
     before do
       item.identityMetadata.tag = [type]
@@ -161,6 +162,14 @@ RSpec.describe Cocina::Mapper do
       it 'files without imageData have empty presentation attribute' do
         file2 = fileSet1.structural.contains.second
         expect(file2.presentation).to eq nil
+      end
+    end
+
+    context 'when item has null sourceId' do
+      let(:source_id) { nil }
+
+      it 'raises' do
+        expect { cocina_model }.to raise_error(/has a null sourceId/)
       end
     end
   end


### PR DESCRIPTION
closes #695

## Why was this change made?
To provide a more informative error when no sourceId.


## Was the API documentation (openapi.yml) updated?
No.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No.