### PR TITLE
Fix for reaccession issues

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -61,7 +61,7 @@ class VersionsController < ApplicationController
     params.permit(
       :description,
       :significance,
-      :accession,
+      :start_accession,
       :user_name,
       :version_num
     ).to_h.symbolize_keys

--- a/openapi.yml
+++ b/openapi.yml
@@ -759,6 +759,13 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
+        - name: start_accession
+          in: query
+          schema:
+            type: boolean
+            default: true
+          required: false
+          description: Indicates if accessionWF should be started after closing the version
   '/v1/objects/{object_id}/versions':
     post:
       tags:


### PR DESCRIPTION
## Why was this change made?

to fix a regression introduced in #703 

fixes sul-dlss/argo#1843

basically I inadvertently renamed one of the permitted params in the "close" method to match my new endpoint name, when it should have been left alone ... renaming it caused the existing parameter to be ignored, triggering accessionWF in all cases (even when you didn't want to be triggered with a close version)

## Was the API documentation (openapi.yml) updated?

n/a

## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
