### PR TITLE
Allow collections to be set by the create endpoint

### DIFF
--- a/app/services/cocina/dro_structural_builder.rb
+++ b/app/services/cocina/dro_structural_builder.rb
@@ -22,6 +22,7 @@ module Cocina
 
         structural[:contains] = build_filesets(item.contentMetadata, version: item.current_version, id: item.pid) unless item.is_a?(Dor::Etd) || item.contentMetadata.new?
         structural[:hasAgreement] = item.identityMetadata.agreementId.first unless item.identityMetadata.agreementId.empty?
+        structural[:isMemberOf] = item.collection_ids.first if item.collection_ids.present?
       end
     end
 

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -77,6 +77,7 @@ module Cocina
       Dor::Item.new(pid: pid,
                     admin_policy_object_id: obj.administrative.hasAdminPolicy,
                     source_id: obj.identification.sourceId,
+                    collection_ids: [obj.structural.isMemberOf].compact,
                     catkey: catkey_for(obj),
                     label: obj.label).tap do |item|
         item.descMetadata.mods_title = obj.description.title.first.titleFull if obj.description

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,3 +1,4 @@
+
 openapi: 3.0.0
 info:
   description: Backend API for the Stanford digital repository
@@ -1366,6 +1367,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Sequence'
+        isMemberOf:
+          description: Collection that this DRO is a member of
+          $ref: '#/components/schemas/Druid'
     RequestDROStructural:
       type: object
       properties:
@@ -1377,6 +1381,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Sequence'
+        isMemberOf:
+          $ref: '#/components/schemas/Druid'
     FileSetStructural:
       type: object
       properties:

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'Get the object' do
 
     context 'when the object exists with minimal metadata' do
       before do
+        allow(object).to receive(:collection_ids).and_return([])
         object.descMetadata.title_info.main_title = 'Hello'
       end
 
@@ -63,6 +64,8 @@ RSpec.describe 'Get the object' do
 
     context 'when the object exists with full metadata' do
       before do
+        allow(object).to receive(:collection_ids).and_return(['druid:xx888xx7777'])
+
         object.descMetadata.title_info.main_title = 'Hello'
         EmbargoService.embargo(item: object, release_date: DateTime.parse('2019-09-26T07:00:00Z'), access: 'world')
         ReleaseTags.create(object, release: true,
@@ -108,7 +111,9 @@ RSpec.describe 'Get the object' do
           identification: {
             sourceId: 'src:99999'
           },
-          structural: {}
+          structural: {
+            isMemberOf: 'druid:xx888xx7777'
+          }
         }
       end
 
@@ -236,6 +241,7 @@ RSpec.describe 'Get the object' do
       object.properties.title = 'Test ETD'
       object.identityMetadata.other_ids = ['dissertationid:00000123']
       object.label = 'foo'
+      allow(object).to receive(:collection_ids).and_return([])
       allow(object).to receive(:admin_policy_object_id).and_return('druid:ab123cd4567')
     end
 

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Cocina::Mapper do
     let(:agreement) { 'druid:666' }
 
     before do
+      allow(item).to receive(:collection_ids).and_return([])
       item.identityMetadata.tag = [type]
       item.identityMetadata.agreementId = [agreement]
       item.descMetadata.title_info.main_title = 'Hello'
@@ -176,6 +177,7 @@ RSpec.describe Cocina::Mapper do
 
     before do
       item.properties.title = 'Test ETD'
+      allow(item).to receive(:collection_ids).and_return([])
     end
 
     it 'builds the object with type object, a sourceId, and correct admin policy' do


### PR DESCRIPTION
And returned by the show endpoint.


## Why was this change made?

Fixes https://github.com/sul-dlss/google-books/issues/391

## Was the API documentation (openapi.yml) updated?
yes


## Does this change affect how this application integrates with other services?
yes

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
it will be tested on stage.