### PR TITLE
Add contentMetadata to ETDs

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -5,4 +5,12 @@
 # and return a Dor::Item.
 # This is necessary for the Cocina::Mapper because Etds do not use descMetadata
 # like ever other object.
-class Etd < Dor::Etd; end
+class Etd < Dor::Etd
+  # This is required so that LegacyMetadataService can write contentMetadata.
+  # We need it because Dor::Etd's parent is Dor::Abstract rather than Dor::Item
+  # The other-metadata robot in the etdSubmitWF calls the legacy metadata update.
+  has_metadata name: 'contentMetadata',
+               type: Dor::ContentMetadataDS,
+               label: 'Content Metadata',
+               control_group: 'M'
+end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -3,5 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe Etd do
-  it 'exists as a constant', skip: true
+  subject(:instance) { described_class.new }
+
+  describe '#datastreams' do
+    subject(:datastreams) { instance.datastreams }
+
+    it 'has a contentMetadata' do
+      expect(datastreams['contentMetadata']).to be_instance_of Dor::ContentMetadataDS
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

So that the legacy metadata update endpoint can be used

## Was the API documentation (openapi.yml) updated?
 n/a


## Does this change affect how this application integrates with other services?

Yes, it fixes etd robots.

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
