### PR TITLE
Call Dor::EmbargoService directly

### DIFF
--- a/app/services/embargo_release_service.rb
+++ b/app/services/embargo_release_service.rb
@@ -57,12 +57,12 @@ class EmbargoReleaseService
 
   def self.release
     release_items('embargo_status_ssim:"embargoed" AND embargo_release_dtsim:[* TO NOW]') do |item|
-      item.release_embargo('application:accessionWF:embargo-release')
+      Dor::EmbargoService.new(item).release_embargo('application:accessionWF:embargo-release')
     end
 
     release_items('twenty_pct_status_ssim:"embargoed" AND twenty_pct_visibility_release_dtsim:[* TO NOW]',
                   '20% visibility embargo') do |item|
-      item.release_20_pct_vis_embargo('application:accessionWF:embargo-release')
+      Dor::EmbargoService.new(item).release_20_pct_vis_embargo('application:accessionWF:embargo-release')
     end
   end
 end

--- a/lib/tasks/dor_services_app.rake
+++ b/lib/tasks/dor_services_app.rake
@@ -3,6 +3,6 @@
 namespace :dsa do
   desc 'Embargo release'
   task embargo_release: :environment do
-    EmbargoReleaseService.release
+    EmbargoReleaseService.release_all
   end
 end


### PR DESCRIPTION


## Why was this change made?

Rather than the indirection of Embargoable.  The embargoable methods will be deprecated in dor-services

## Was the API documentation (openapi.yml) updated?

n.a

## Does this change affect how this application integrates with other services?
no