### PR TITLE
Add useAndReproductionStatement to the embargo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
 gem 'cocina-models', '~> 0.28.0'
-gem 'dor-services', '~> 9.0'
+gem 'dor-services', '~> 9.1'
 gem 'dor-workflow-client', '~> 3.17'
 gem 'marc'
 gem 'moab-versioning', '~> 4.0', require: 'moab/stanford'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,12 +123,11 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.4.0)
       nokogiri
-    dor-services (9.0.0)
+    dor-services (9.1.0)
       active-fedora (>= 8.7.0, < 9)
       activesupport (~> 5.1)
       deprecation (~> 0)
       dor-rights-auth (~> 1.0, >= 1.2.0)
-      druid-tools (>= 0.4.1)
       json (>= 1.8.1)
       nokogiri (~> 1.6)
       om (~> 3.0)
@@ -489,7 +488,7 @@ DEPENDENCIES
   config
   deprecation
   dlss-capistrano
-  dor-services (~> 9.0)
+  dor-services (~> 9.1)
   dor-workflow-client (~> 3.17)
   dry-schema (~> 1.4)
   equivalent-xml

--- a/app/services/cocina/access_builder.rb
+++ b/app/services/cocina/access_builder.rb
@@ -37,7 +37,9 @@ module Cocina
       {
         releaseDate: item.embargoMetadata.release_date.iso8601,
         access: build_embargo_access
-      }
+      }.tap do |embargo|
+        embargo[:useAndReproductionStatement] = item.embargoMetadata.use_and_reproduction_statement.first if item.embargoMetadata.use_and_reproduction_statement.present?
+      end
     end
 
     def build_embargo_access

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -91,12 +91,15 @@ module Cocina
         item.rightsMetadata.use_statement = obj.access.useAndReproductionStatement if obj.access.useAndReproductionStatement
 
         item.contentMetadata.content = ContentMetadataGenerator.generate(druid: pid, object: obj)
-        if obj.access.embargo
-          EmbargoService.embargo(item: item,
-                                 release_date: obj.access.embargo.releaseDate,
-                                 access: obj.access.embargo.access)
-        end
+        create_embargo(item, obj.access.embargo) if obj.access.embargo
       end
+    end
+
+    def create_embargo(item, embargo)
+      EmbargoService.embargo(item: item,
+                             release_date: embargo.releaseDate,
+                             access: embargo.access,
+                             use_and_reproduction_statement: embargo.useAndReproductionStatement)
     end
 
     # @param [Cocina::Models::RequestCollection] obj

--- a/app/services/embargo_service.rb
+++ b/app/services/embargo_service.rb
@@ -2,14 +2,18 @@
 
 # Sets an embargo for an item.
 class EmbargoService
-  def self.embargo(item:, release_date:, access:)
-    new(item: item, release_date: release_date, access: access).embargo
+  def self.embargo(item:, release_date:, access:, use_and_reproduction_statement: nil)
+    new(item: item,
+        release_date: release_date,
+        access: access,
+        use_and_reproduction_statement: use_and_reproduction_statement).embargo
   end
 
-  def initialize(item:, release_date:, access:)
+  def initialize(item:, release_date:, access:, use_and_reproduction_statement:)
     @item = item
     @release_date = release_date
     @access = access
+    @use_and_reproduction_statement = use_and_reproduction_statement
   end
 
   def embargo
@@ -22,12 +26,13 @@ class EmbargoService
     item.embargoMetadata.status = 'embargoed'
 
     item.embargoMetadata.release_access_node = Nokogiri::XML(generic_access_xml)
+    item.embargoMetadata.use_and_reproduction_statement = use_and_reproduction_statement if use_and_reproduction_statement
     deny_read_access
   end
 
   private
 
-  attr_reader :item, :release_date, :access
+  attr_reader :item, :release_date, :access, :use_and_reproduction_statement
 
   def deny_read_access
     rights_xml = item.rightsMetadata.ng_xml

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,4 +1,3 @@
-
 openapi: 3.0.0
 info:
   description: Backend API for the Stanford digital repository
@@ -865,9 +864,11 @@ components:
             - 'dark'
         copyright:
           description: The human readable copyright statement that applies
+          example: Copyright © World Trade Organization
           type: string
         useAndReproductionStatement:
           description: The human readable use and reproduction statement that applies
+          example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
           type: string
         embargo:
           $ref: '#/components/schemas/Embargo'
@@ -1022,6 +1023,10 @@ components:
             - location-based
             - citation-only
             - dark
+        useAndReproductionStatement:
+          description: The human readable use and reproduction statement that applies when the embargo expires.
+          example: These materials are in the public domain.
+          type: string
       required:
         - releaseDate
         - access

--- a/spec/services/cocina/access_builder_spec.rb
+++ b/spec/services/cocina/access_builder_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Cocina::AccessBuilder do
             </machine>
           </access>
           <use>
-            <human type="useAndReproduction">Property rights reside with the repository. Literary rights reside with  the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).</human>
+            <human type="useAndReproduction">Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).</human>
           </use>
         </rightsMetadata>
       XML
@@ -40,7 +40,7 @@ RSpec.describe Cocina::AccessBuilder do
     it 'builds the hash' do
       expect(access).to eq(access: 'world',
                            useAndReproductionStatement: 'Property rights reside with the repository. '\
-                           'Literary rights reside with  the creators of the documents or their heirs. ' \
+                           'Literary rights reside with the creators of the documents or their heirs. ' \
                            'To obtain permission to publish or reproduce, please contact the Public ' \
                            'Services Librarian of the Dept. of Special Collections ' \
                            '(http://library.stanford.edu/spc).')
@@ -107,6 +107,39 @@ RSpec.describe Cocina::AccessBuilder do
     it 'builds the hash' do
       expect(access).to eq(access: 'world',
                            copyright: 'Copyright © DLSS')
+    end
+  end
+
+  context 'with an embargo' do
+    before do
+      # access":"world","releaseDate":"2020-02-29
+      EmbargoService.embargo(item: item,
+                             release_date: DateTime.parse('2029-02-28'),
+                             access: 'world',
+                             use_and_reproduction_statement: 'in public domain')
+    end
+    # from https://argo.stanford.edu/view/druid:bb003dn0409
+
+    let(:xml) do
+      <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'has embargo' do
+      expect(access).to include(embargo: { access: 'world', releaseDate: '2029-02-28T00:00:00Z', useAndReproductionStatement: 'in public domain' })
     end
   end
 end

--- a/spec/services/embargo_service_spec.rb
+++ b/spec/services/embargo_service_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe EmbargoService do
+  subject(:embargo) do
+    described_class.embargo(item: item, release_date: release_date, access: access)
+  end
+
   let(:item) do
     Dor::Item.new.tap do |item|
       rights_datastream = Dor::RightsMetadataDS.new
@@ -31,12 +35,9 @@ RSpec.describe EmbargoService do
     XML
   end
 
-  before do
-    described_class.embargo(item: item, release_date: release_date, access: access)
-  end
-
   RSpec.shared_examples 'common embargo' do
     it 'sets rightsMetadata to deny read' do
+      embargo
       expect(item.datastreams['rightsMetadata'].ng_xml).to be_equivalent_to <<-XML
             <?xml version="1.0"?>
             <rightsMetadata>
@@ -59,6 +60,7 @@ RSpec.describe EmbargoService do
     it_behaves_like 'common embargo'
 
     it 'sets embargoMetadata to embargoed and release access to stanford' do
+      embargo
       expect(item.datastreams['embargoMetadata'].ng_xml).to be_equivalent_to <<-XML
             <?xml version="1.0"?>
             <embargoMetadata>
@@ -87,6 +89,7 @@ RSpec.describe EmbargoService do
     it_behaves_like 'common embargo'
 
     it 'sets embargoMetadata to embargoed and release access to world' do
+      embargo
       expect(item.datastreams['embargoMetadata'].ng_xml).to be_equivalent_to <<-XML
             <?xml version="1.0"?>
             <embargoMetadata>
@@ -107,6 +110,19 @@ RSpec.describe EmbargoService do
             </embargoMetadata>\n"
       XML
     end
+
+    context 'when use_and_reproduction_statement is provided' do
+      before do
+        described_class.embargo(item: item,
+                                release_date: release_date,
+                                access: access,
+                                use_and_reproduction_statement: 'in public domain')
+      end
+
+      it 'sets use_and_reproduction_statement' do
+        expect(item.embargoMetadata.use_and_reproduction_statement).to eq ['in public domain']
+      end
+    end
   end
 
   context 'when access is dark' do
@@ -115,6 +131,7 @@ RSpec.describe EmbargoService do
     it_behaves_like 'common embargo'
 
     it 'sets embargoMetadata to embargoed and release access to none' do
+      embargo
       expect(item.datastreams['embargoMetadata'].ng_xml).to be_equivalent_to <<-XML
             <?xml version="1.0"?>
             <embargoMetadata>


### PR DESCRIPTION
## Why was this change made?

So that the useAndReproduction can be changed when the embargo expires
Ref: https://github.com/sul-dlss/google-books/issues/398

## Was the API documentation (openapi.yml) updated?

yes

## Does this change affect how this application integrates with other services?

Yes

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
