### PR TITLE
When using the new deposit endpoint record embargo date in rightsMeta…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
 gem 'cocina-models', '~> 0.28.0'
-gem 'dor-services', '~> 9.1'
+gem 'dor-services', '~> 9.2'
 gem 'dor-workflow-client', '~> 3.17'
 gem 'marc'
 gem 'moab-versioning', '~> 4.0', require: 'moab/stanford'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.4.0)
       nokogiri
-    dor-services (9.1.0)
+    dor-services (9.2.0)
       active-fedora (>= 8.7.0, < 9)
       activesupport (~> 5.1)
       deprecation (~> 0)
@@ -488,7 +488,7 @@ DEPENDENCIES
   config
   deprecation
   dlss-capistrano
-  dor-services (~> 9.1)
+  dor-services (~> 9.2)
   dor-workflow-client (~> 3.17)
   dry-schema (~> 1.4)
   equivalent-xml

--- a/app/services/cocina/access_builder.rb
+++ b/app/services/cocina/access_builder.rb
@@ -32,10 +32,10 @@ module Cocina
     end
 
     def build_embargo
-      return {} unless item.respond_to?(:embargoMetadata) && item.embargoMetadata.release_date
+      return {} unless item.respond_to?(:embargoMetadata) && item.embargoMetadata.release_date.any?
 
       {
-        releaseDate: item.embargoMetadata.release_date.iso8601,
+        releaseDate: item.embargoMetadata.release_date.first.utc.iso8601,
         access: build_embargo_access
       }.tap do |embargo|
         embargo[:useAndReproductionStatement] = item.embargoMetadata.use_and_reproduction_statement.first if item.embargoMetadata.use_and_reproduction_statement.present?

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -96,10 +96,10 @@ module Cocina
     end
 
     def create_embargo(item, embargo)
-      EmbargoService.embargo(item: item,
-                             release_date: embargo.releaseDate,
-                             access: embargo.access,
-                             use_and_reproduction_statement: embargo.useAndReproductionStatement)
+      EmbargoService.create(item: item,
+                            release_date: embargo.releaseDate,
+                            access: embargo.access,
+                            use_and_reproduction_statement: embargo.useAndReproductionStatement)
     end
 
     # @param [Cocina::Models::RequestCollection] obj

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Get the object' do
         allow(object).to receive(:collection_ids).and_return(['druid:xx888xx7777'])
 
         object.descMetadata.title_info.main_title = 'Hello'
-        EmbargoService.embargo(item: object, release_date: DateTime.parse('2019-09-26T07:00:00Z'), access: 'world')
+        EmbargoService.create(item: object, release_date: DateTime.parse('2019-09-26T07:00:00Z'), access: 'world')
         ReleaseTags.create(object, release: true,
                                    what: 'self',
                                    to: 'Searchworks',

--- a/spec/services/cocina/access_builder_spec.rb
+++ b/spec/services/cocina/access_builder_spec.rb
@@ -112,11 +112,10 @@ RSpec.describe Cocina::AccessBuilder do
 
   context 'with an embargo' do
     before do
-      # access":"world","releaseDate":"2020-02-29
-      EmbargoService.embargo(item: item,
-                             release_date: DateTime.parse('2029-02-28'),
-                             access: 'world',
-                             use_and_reproduction_statement: 'in public domain')
+      EmbargoService.create(item: item,
+                            release_date: DateTime.parse('2029-02-28'),
+                            access: 'world',
+                            use_and_reproduction_statement: 'in public domain')
     end
     # from https://argo.stanford.edu/view/druid:bb003dn0409
 

--- a/spec/services/embargo_service_spec.rb
+++ b/spec/services/embargo_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe EmbargoService do
   subject(:embargo) do
-    described_class.embargo(item: item, release_date: release_date, access: access)
+    described_class.create(item: item, release_date: release_date, access: access)
   end
 
   let(:item) do
@@ -15,7 +15,7 @@ RSpec.describe EmbargoService do
     end
   end
 
-  let(:release_date) { Time.gm(2045) }
+  let(:release_date) { DateTime.parse('2045-01-01') }
 
   let(:rights_xml) do
     <<-XML
@@ -47,7 +47,10 @@ RSpec.describe EmbargoService do
                 </machine>
               </access>
               <access type="read">
-                <machine><none/></machine>
+                <machine>
+                  <embargoReleaseDate>2045-01-01T00:00:00Z</embargoReleaseDate>
+                  <none/>
+                </machine>
               </access>
             </rightsMetadata>
       XML
@@ -113,10 +116,10 @@ RSpec.describe EmbargoService do
 
     context 'when use_and_reproduction_statement is provided' do
       before do
-        described_class.embargo(item: item,
-                                release_date: release_date,
-                                access: access,
-                                use_and_reproduction_statement: 'in public domain')
+        described_class.create(item: item,
+                               release_date: release_date,
+                               access: access,
+                               use_and_reproduction_statement: 'in public domain')
       end
 
       it 'sets use_and_reproduction_statement' do


### PR DESCRIPTION
…data and embargoMetadata


## Why was this change made?

Because two places is better than one, right?
Ref https://github.com/sul-dlss/google-books/issues/399


## Was the API documentation (openapi.yml) updated?

n/a

## Does this change affect how this application integrates with other services?

yes

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
