### PR TITLE
Adds support for project tags.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.28.0'
+gem 'cocina-models', '~> 0.29.0'
 gem 'dor-services', '~> 9.2'
 gem 'dor-workflow-client', '~> 3.17'
 gem 'marc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
       capistrano (>= 3.9.0)
       sidekiq (>= 3.4, < 6.0)
     chronic (0.10.2)
-    cocina-models (0.28.0)
+    cocina-models (0.29.0)
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
@@ -483,7 +483,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-shared_configs
   capistrano-sidekiq
-  cocina-models (~> 0.28.0)
+  cocina-models (~> 0.29.0)
   committee
   config
   deprecation

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -40,7 +40,7 @@ module Cocina
         type: dro_type,
         label: item.label,
         version: item.current_version.to_i,
-        administrative: build_administrative,
+        administrative: build_dro_administrative,
         identification: build_identification,
         access: AccessBuilder.build(item),
         structural: DroStructuralBuilder.build(item)
@@ -140,6 +140,13 @@ module Cocina
       }
     end
 
+    def build_dro_administrative
+      build_administrative.tap do |admin|
+        project = project_for(item)
+        admin[:partOfProject] = project if project
+      end
+    end
+
     def build_release_tags
       item.identityMetadata.ng_xml.xpath('//release').map do |node|
         {
@@ -168,6 +175,14 @@ module Cocina
 
     def check_source_id(props)
       raise "Item #{props[:externalIdentifier]} has a null sourceId. This item requires remediation." if props[:identification][:sourceId].nil?
+    end
+
+    def project_for(item)
+      item.tags.each do |tag|
+        split_tag = tag.split(':').map(&:strip)
+        return split_tag[1, split_tag.size - 1].join(' : ') if split_tag[0] == 'Project'
+      end
+      nil
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -85,7 +85,7 @@ module Cocina
                     catkey: catkey_for(obj),
                     label: obj.label).tap do |item|
         item.descMetadata.mods_title = obj.description.title.first.titleFull if obj.description
-        item.identityMetadata.tag = content_type_tag(obj.type, obj.structural.hasMemberOrders&.first&.viewingDirection)
+        add_tags(item, obj)
         change_access(item, obj.access.access)
         item.rightsMetadata.copyright = obj.access.copyright if obj.access.copyright
         item.rightsMetadata.use_statement = obj.access.useAndReproductionStatement if obj.access.useAndReproductionStatement
@@ -115,6 +115,12 @@ module Cocina
 
     def catkey_for(obj)
       obj.identification.catalogLinks&.find { |l| l.catalog == 'symphony' }&.catalogRecordId
+    end
+
+    def add_tags(item, obj)
+      Dor::TagService.add(item, content_type_tag(obj.type, obj.structural.hasMemberOrders&.first&.viewingDirection))
+      Dor::TagService.add(item, "Project: #{obj.administrative.partOfProject}") if obj.administrative.partOfProject
+      item.identityMetadata.ng_xml_will_change!
     end
 
     def content_type_tag(type, direction)

--- a/openapi.yml
+++ b/openapi.yml
@@ -893,6 +893,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ReleaseTag'
+        partOfProject:
+          description: Administrative or Internal project this resource is a part of
+          example: Google Books
+          type: string
     AdminPolicy:
       type: object
       properties:

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe 'Create object' do
                                 title: [{ titleFull: title, primary: true }]
                               },
                               administrative: {
-                                hasAdminPolicy: 'druid:dd999df4567'
+                                hasAdminPolicy: 'druid:dd999df4567',
+                                partOfProject: 'Google Books'
                               },
                               identification: identification,
                               externalIdentifier: druid,
@@ -44,7 +45,7 @@ RSpec.describe 'Create object' do
             "copyright":"All rights reserved unless otherwise indicated.",
             "useAndReproductionStatement":"Property rights reside with the repository..."
           },
-          "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
+          "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567","partOfProject":"Google Books"},
           "description":{"title":[{"primary":true,"titleFull":"#{title}"}]},
           "identification":#{identification.to_json},"structural":{}}
       JSON
@@ -233,7 +234,7 @@ RSpec.describe 'Create object' do
         <<~JSON
           { "type":"http://cocina.sul.stanford.edu/models/image.jsonld",
             "label":"#{label}","version":1,"access":{},
-            "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
+            "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567","partOfProject":"Google Books"},
             "description":{"title":[{"primary":true,"titleFull":"#{title}"}]},
             "identification":#{identification.to_json},"structural":{"contains":#{filesets.to_json}}}
         JSON
@@ -280,7 +281,7 @@ RSpec.describe 'Create object' do
         <<~JSON
           { "type":"http://cocina.sul.stanford.edu/models/image.jsonld",
             "label":"#{label}","version":1,"access":{},
-            "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
+            "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567","partOfProject":"Google Books"},
             "description":{"title":[{"primary":true,"titleFull":"#{title}"}]},
             "identification":#{identification.to_json},"structural":{"isMemberOf":"druid:xx888xx7777"}}
         JSON

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Cocina::Mapper do
 
     before do
       allow(item).to receive(:collection_ids).and_return([])
-      item.identityMetadata.tag = [type]
+      item.identityMetadata.tag = [type, 'Project : Google Books']
       item.identityMetadata.agreementId = [agreement]
       item.descMetadata.title_info.main_title = 'Hello'
     end
@@ -92,6 +92,10 @@ RSpec.describe Cocina::Mapper do
         expect(file1.hasMimeType).to eq 'text/plain'
         expect(file1.hasMessageDigests.first.digest).to eq '61dfac472b7904e1413e0cbf4de432bda2a97627'
         expect(file1.hasMessageDigests.first.type).to eq 'sha1'
+      end
+
+      it 'builds with object with partOfProject' do
+        expect(cocina_model.administrative.partOfProject).to eq('Google Books')
       end
     end
 


### PR DESCRIPTION
refs https://github.com/sul-dlss/google-books/issues/415

## Why was this change made?
So that Google Books can set a project tag.

## Was the API documentation (openapi.yml) updated?
Yes.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
Not yet.