### PR TITLE
Fixes creating administrative tags from administrative tags endpoint.

### DIFF
--- a/app/services/administrative_tags.rb
+++ b/app/services/administrative_tags.rb
@@ -17,5 +17,6 @@ class AdministrativeTags
   # @return [Array<Nokogiri::XML::Node>]
   def self.create(item:, tags:)
     tags.map { |tag| Dor::TagService.add(item, tag) }
+    item.save!
   end
 end

--- a/spec/services/administrative_tags_spec.rb
+++ b/spec/services/administrative_tags_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe AdministrativeTags do
   before do
+    allow(item).to receive(:save!)
     described_class.create(item: item, tags: tags)
   end
 
@@ -24,6 +25,7 @@ RSpec.describe AdministrativeTags do
           <tag>Bar : Baz : Quux</tag>
         </identityMetadata>
       XML
+      expect(item).to have_received(:save!)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?
Administrative tags are not persisting when created via the administrative tags endpoint.

```
2.6.5 :004 > client.object('druid:nn225zd9469').administrative_tags.create(tags: ["barcode : 20503407474"])
 => true 
2.6.5 :005 > client.object('druid:nn225zd9469').administrative_tags.list
 => ["Process : Content Type : Book (ltr)", "Project : Google Books"] 
```

## Was the API documentation (openapi.yml) updated?
No


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
Yes