### PR TITLE
Use relative path when POSTing to reindex remotely

### DIFF
--- a/app/services/synchronous_indexer.rb
+++ b/app/services/synchronous_indexer.rb
@@ -4,7 +4,7 @@
 # When we can't have latency in the indexing, we can use this class to directly call dor-indexing-app
 class SynchronousIndexer
   def self.reindex_remotely(pid)
-    connection.post("/reindex/#{pid}")
+    connection.post("reindex/#{pid}")
   end
 
   def self.connection

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,7 +27,7 @@ fedora_url: 'https://user:password@fedora.example.com:1000/fedora'
 solr:
   url: 'https://solr.example.com/solr/collection'
 dor_indexing:
-  url: 'https://dor-indexing-app.server'
+  url: 'https://dor-indexing-app.example.edu/dor'
 
 workflow_url: 'https://workflow.example.com/workflow'
 sdr_url: 'http://user:password@sdr-services.example.com/sdr'

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Create object' do
   before do
     allow(Dor::SuriService).to receive(:mint_id).and_return(druid)
     allow(Dor).to receive(:find).and_return(object)
-    stub_request(:post, 'https://dor-indexing-app.server/reindex/druid:gg777gg7777')
+    stub_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:gg777gg7777')
   end
 
   context 'when an image is provided' do
@@ -96,7 +96,7 @@ RSpec.describe 'Create object' do
                  params: data,
                  headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
           end.to change(Event, :count).by(1)
-          expect(a_request(:post, 'https://dor-indexing-app.server/reindex/druid:gg777gg7777')).to have_been_made
+          expect(a_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:gg777gg7777')).to have_been_made
           expect(response.body).to eq expected.to_json
           expect(response.status).to eq(201)
           expect(response.location).to eq "/v1/objects/#{druid}"
@@ -118,7 +118,7 @@ RSpec.describe 'Create object' do
           post '/v1/objects',
                params: data,
                headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-          expect(a_request(:post, 'https://dor-indexing-app.server/reindex/druid:gg777gg7777')).to have_been_made
+          expect(a_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:gg777gg7777')).to have_been_made
           expect(response.body).to eq expected.to_json
           expect(response.status).to eq(201)
           expect(response.location).to eq "/v1/objects/#{druid}"

--- a/spec/services/registration_service_spec.rb
+++ b/spec/services/registration_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RegistrationService do
     allow(apo).to receive(:new_record?).and_return false
     allow(Dor).to receive(:find).with('druid:fg890hi1234').and_return(apo)
     allow(EventFactory).to receive(:create)
-    stub_request(:post, 'https://dor-indexing-app.server/reindex/druid:ab123cd4567')
+    stub_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:ab123cd4567')
   end
 
   describe '#register_object' do
@@ -381,7 +381,7 @@ RSpec.describe RegistrationService do
                            source_id: 'sul:SOMETHING-www.example.org')
           )
         expect(item.rightsMetadata.content).to be_equivalent_to apo.defaultObjectRights.content
-        expect(a_request(:post, 'https://dor-indexing-app.server/reindex/druid:ab123cd4567')).to have_been_made
+        expect(a_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:ab123cd4567')).to have_been_made
         expect(EventFactory).to have_received(:create)
       end
 


### PR DESCRIPTION
## Why was this change made?

When the "/" character is first, Faraday assumes an absolute URL, which causes problems when the Faraday connection was initiated with a base path specified. Uncovered this while testing administrative tags work.

## Was the API documentation (openapi.yml) updated?

No.

## Does this change affect how this application integrates with other services?

It does. And it *works* now!