### PR TITLE
Prevent cocina model validation error when mime-type isn't present

### DIFF
--- a/app/services/cocina/dro_structural_builder.rb
+++ b/app/services/cocina/dro_structural_builder.rb
@@ -61,12 +61,13 @@ module Cocina
           label: node['id'],
           filename: node['id'],
           size: node['size'].to_i,
-          hasMimeType: node['mimetype'],
           version: version,
           hasMessageDigests: [],
           access: {},
           administrative: { sdrPreserve: false, shelve: false }
         }.tap do |attrs|
+          # Files from Goobi and Hydrus don't have mimetype until they hit exif-collect in the assemblyWF
+          attrs[:hasMimeType] = node['mimetype'] if node['mimetype']
           attrs[:presentation] = { height: height, width: width } if height && width
           attrs[:hasMessageDigests] << { type: 'sha1', digest: sha1 } if sha1
           attrs[:hasMessageDigests] << { type: 'md5', digest: md5 } if md5

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Cocina::Mapper do
       item.descMetadata.title_info.main_title = 'Hello'
     end
 
-    context 'with files' do
+    context 'with files that have exif data' do
       let(:content_metadata_ds) { instance_double(Dor::ContentMetadataDS, new?: false, ng_xml: Nokogiri::XML(xml)) }
       let(:xml) do
         <<~XML
@@ -97,6 +97,30 @@ RSpec.describe Cocina::Mapper do
 
       it 'builds with object with partOfProject' do
         expect(cocina_model.administrative.partOfProject).to eq('Google Books')
+      end
+    end
+
+    context "with files that don't have exif data" do
+      let(:content_metadata_ds) { instance_double(Dor::ContentMetadataDS, new?: false, ng_xml: Nokogiri::XML(xml)) }
+      let(:xml) do
+        <<~XML
+          <contentMetadata objectId="ck831vq4558" type="file">
+            <resource id="ck831vq4558_1" sequence="1" type="file">
+              <file id="sul-logo.png" publish="yes" preserve="yes" shelve="yes"/>
+            </resource>
+          </contentMetadata>
+        XML
+      end
+
+      before do
+        allow(item).to receive(:contentMetadata).and_return(content_metadata_ds)
+      end
+
+      it 'builds the object with filesets and files' do
+        expect(cocina_model.structural.contains.size).to eq 1
+        resource1 = cocina_model.structural.contains.first
+        file1 = resource1.structural.contains.first
+        expect(file1.filename).to eq 'sul-logo.png'
       end
     end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #752 


## Was the API documentation (openapi.yml) updated?

no

## Does this change affect how this application integrates with other services?

yes, fixes it.
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
