### PR TITLE
Added mapping of file access and administrative.

### DIFF
--- a/app/services/cocina/dro_structural_builder.rb
+++ b/app/services/cocina/dro_structural_builder.rb
@@ -53,8 +53,6 @@ module Cocina
         height = node.xpath('imageData/@height').text.presence&.to_i
         width = node.xpath('imageData/@width').text.presence&.to_i
 
-        # TODO: Populate access and administrative - https://github.com/sul-dlss/dor-services-app/issues/749
-
         {
           externalIdentifier: "#{parent_id}/#{node['id']}",
           type: Cocina::Models::Vocab.file,
@@ -63,8 +61,11 @@ module Cocina
           size: node['size'].to_i,
           version: version,
           hasMessageDigests: [],
-          access: {},
-          administrative: { sdrPreserve: false, shelve: false }
+          access: { access: node['publish'] == 'yes' ? 'world' : 'dark' },
+          administrative: {
+            sdrPreserve: node['shelve'] == 'yes',
+            shelve: node['preserve'] == 'yes'
+          }
         }.tap do |attrs|
           # Files from Goobi and Hydrus don't have mimetype until they hit exif-collect in the assemblyWF
           attrs[:hasMimeType] = node['mimetype'] if node['mimetype']

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Cocina::Mapper do
                 <checksum type="md5">e2837b9f02e0b0b76f526eeb81c7aa7b</checksum>
                 <checksum type="sha1">61dfac472b7904e1413e0cbf4de432bda2a97627</checksum>
               </file>
-              <file mimetype="text/plain" shelve="yes" publish="yes" size="5983" preserve="yes" datetime="2012-06-15T22:58:56Z" id="folder1PuSu/story2r.txt">
+              <file mimetype="text/plain" shelve="no" publish="no" size="5983" preserve="no" datetime="2012-06-15T22:58:56Z" id="folder1PuSu/story2r.txt">
                 <checksum type="md5">dc2be64ae43f1c1db4a068603465955d</checksum>
                 <checksum type="sha1">b8a672c1848fc3d13b5f380e15835690e24600e0</checksum>
               </file>
@@ -93,6 +93,14 @@ RSpec.describe Cocina::Mapper do
         expect(file1.hasMimeType).to eq 'text/plain'
         expect(file1.hasMessageDigests.first.digest).to eq '61dfac472b7904e1413e0cbf4de432bda2a97627'
         expect(file1.hasMessageDigests.first.type).to eq 'sha1'
+        expect(file1.administrative.shelve).to eq true
+        expect(file1.administrative.sdrPreserve).to eq true
+        expect(file1.access.access).to eq('world')
+
+        file2 = folder1.structural.contains[1]
+        expect(file2.administrative.shelve).to eq false
+        expect(file2.administrative.sdrPreserve).to eq false
+        expect(file2.access.access).to eq('dark')
       end
 
       it 'builds with object with partOfProject' do


### PR DESCRIPTION
closes #749

## Why was this change made?
To fill in the mapping from Fedora to Cocina model.


## Was the API documentation (openapi.yml) updated?
No


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No