### PR TITLE
Fix tags with known-weird pattern when migrating

### DIFF
--- a/app/models/administrative_tag.rb
+++ b/app/models/administrative_tag.rb
@@ -2,8 +2,10 @@
 
 # Administrative tags for an object
 class AdministrativeTag < ApplicationRecord
+  VALID_TAG_PATTERN = /\A.+( : .+)+\z/.freeze
+
   validates :tag, format: {
-    with: /\A.+( : .+)+\z/,
+    with: VALID_TAG_PATTERN,
     message: 'must be a series of 2 or more strings delimited with space-padded colons, e.g., "Registered By : mjgiarlo : now"'
   }, uniqueness: {
     scope: :druid,

--- a/app/services/administrative_tags.rb
+++ b/app/services/administrative_tags.rb
@@ -126,8 +126,11 @@ class AdministrativeTags
     return if AdministrativeTag.where(druid: item.pid).any?
 
     ActiveRecord::Base.transaction do
-      legacy_tags.each do |tag|
-        AdministrativeTag.create!(druid: item.pid, tag: tag)
+      legacy_tags.each do |tag_string|
+        # There are a bunch of tags in production WITHOUT the padding spaces.
+        # Fix that here unless already valid.
+        tag_string.gsub!(':', ' : ') unless AdministrativeTag::VALID_TAG_PATTERN.match?(tag_string)
+        AdministrativeTag.create!(druid: item.pid, tag: tag_string)
       end
     end
   end

--- a/spec/services/administrative_tags_spec.rb
+++ b/spec/services/administrative_tags_spec.rb
@@ -86,10 +86,11 @@ RSpec.describe AdministrativeTags do
     context 'without matching rows in the database' do
       before do
         Dor::TagService.add(item_without_db_tags, 'One : Two : Three')
+        Dor::TagService.add(item_without_db_tags, 'Two:Three:Four') # test weirdo tags
       end
 
       it 'returns administrative tags from identity metadata XML' do
-        expect(described_class.for(item: item_without_db_tags)).to eq(['One : Two : Three'])
+        expect(described_class.for(item: item_without_db_tags)).to eq(['One : Two : Three', 'Two : Three : Four'])
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

To deal with known bad data on production

## Was the API documentation (openapi.yml) updated?

No

## Does this change affect how this application integrates with other services?

Yes, it should make for less error-ful interaction