### PR TITLE
Ignore duplicate validation errors when migrating new records

### DIFF
--- a/app/services/administrative_tags.rb
+++ b/app/services/administrative_tags.rb
@@ -130,7 +130,11 @@ class AdministrativeTags
         # There are a bunch of tags in production WITHOUT the padding spaces.
         # Fix that here unless already valid.
         tag_string.gsub!(':', ' : ') unless AdministrativeTag::VALID_TAG_PATTERN.match?(tag_string)
-        AdministrativeTag.create!(druid: item.pid, tag: tag_string)
+        begin
+          AdministrativeTag.create!(druid: item.pid, tag: tag_string)
+        rescue ActiveRecord::RecordInvalid
+          nil # ignore dupes when migrating new records
+        end
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

To prevent lots of HB alerts.

## Was the API documentation (openapi.yml) updated?

No.

## Does this change affect how this application integrates with other services?

No.