### PR TITLE
[Draft] Maps descriptive metadata for ETDs to Cocina model

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,14 @@ Metrics/BlockLength:
     - 'config/routes.rb'
     - 'config/initializers/dor_config.rb'
 
+Metrics/ClassLength:
+  Exclude:
+    - 'app/services/cocina/etd_description_builder.rb'
+
+Metrics/MethodLength:
+  Exclude:
+    - 'app/services/cocina/etd_description_builder.rb'
+
 RSpec/DescribeClass:
   Exclude:
     - 'spec/requests/**/*'

--- a/app/services/cocina/etd_description_builder.rb
+++ b/app/services/cocina/etd_description_builder.rb
@@ -1,0 +1,689 @@
+# frozen_string_literal: true
+
+module Cocina
+  # builds the Description subschema for ETDs
+  class EtdDescriptionBuilder
+    def self.build(item)
+      new(item).build
+    end
+
+    def initialize(item)
+      @item = item
+    end
+
+    def build
+      {
+        title: build_title,
+        contributor: build_contributors,
+        event: [build_submission, build_conferral, build_publication, build_copyright],
+        form: build_form,
+        language: build_language,
+        note: build_notes,
+        identifier: build_identifier,
+        purl: build_purl,
+        url: build_url,
+        marcEncodedData: build_marc_encoded_data,
+        adminMetadata: build_admin_metadata
+      }
+    end
+
+    private
+
+    attr_reader :item
+
+    def properties
+      @properties ||= item.datastreams['properties']
+    end
+
+    def readers
+      @readers ||= Nokogiri::XML(item.datastreams['readers'].content)
+    end
+
+    def build_title
+      [{ value: item.title, status: 'primary' }]
+    end
+
+    def build_contributors
+      [].tap do |contributors|
+        contributors << build_author
+        contributors.concat(build_advisors)
+        contributors.concat(build_readers)
+      end
+    end
+
+    def build_author
+      build_person(item.name, item.suffix).tap do |person|
+        person[:status] = 'primary'
+        person[:role] = [
+          {
+            value: 'author',
+            code: 'aut',
+            uri: 'http://id.loc.gov/vocabulary/relators/aut',
+            source: {
+              code: 'marcrelator',
+              uri: 'http://id.loc.gov/vocabulary/relators/'
+            }
+          },
+          {
+            value: 'author',
+            uri: 'http://rdaregistry.info/Elements/a/P50195',
+            source: {
+              uri: 'http://www.rdaregistry.info/Elements/a/'
+            }
+          }
+        ]
+      end
+    end
+
+    def build_advisors
+      readers.search('//reader[readerrole ="Advisor" or readerrole ="Co-Adv" or readerrole = "Dissertation Co-Advisor" or readerrole = "Co-Adv"]').map do |reader_elem|
+        build_advisor(reader_elem)
+      end
+    end
+
+    def build_advisor(reader_elem)
+      build_person(reader_elem.at('name').text, reader_elem.at('suffix').text).tap do |advisor|
+        advisor[:role] = [
+          {
+            value: reader_elem.at('readerrole').text,
+            source: {
+              value: 'ETD reader roles'
+            }
+          },
+          {
+            value: 'degree supervisor',
+            code: 'dgs',
+            uri: 'http://id.loc.gov/vocabulary/relators/dgs',
+            source: {
+              code: 'marcrelator',
+              uri: 'http://id.loc.gov/vocabulary/relators/'
+            }
+          },
+          {
+            value: 'degree supervisor',
+            uri: 'http://rdaregistry.info/Elements/a/P50091',
+            source: {
+              uri: 'http://www.rdaregistry.info/Elements/a/'
+            }
+          }
+        ]
+      end
+    end
+
+    def build_readers
+      readers.search('//reader[readerrole = "Reader" or readerrole ="Rdr" or readerrole = "Outside Reader" or readerrole = "Engineers Thesis/Project Adv"]').map do |reader_elem|
+        build_reader(reader_elem)
+      end
+    end
+
+    def build_reader(reader_elem)
+      build_person(reader_elem.at('name').text, reader_elem.at('suffix').text).tap do |advisor|
+        advisor[:role] = [
+          {
+            value: reader_elem.at('readerrole').text,
+            source: {
+              value: 'ETD reader roles'
+            }
+          },
+          {
+            value: 'thesis advisor',
+            code: 'ths',
+            uri: 'http://id.loc.gov/vocabulary/relators/ths',
+            source: {
+              code: 'marcrelator',
+              uri: 'http://id.loc.gov/vocabulary/relators/'
+            }
+          },
+          {
+            value: 'degree committee member',
+            uri: 'http://rdaregistry.info/Elements/a/P50257',
+            source: {
+              uri: 'http://www.rdaregistry.info/Elements/a/'
+            }
+          }
+        ]
+      end
+    end
+
+    def build_person(name, suffix = nil)
+      {
+        name: [
+          {
+            value: build_name(name, suffix),
+            type: 'inverted name'
+          }
+        ],
+        type: 'person'
+      }.tap do |person|
+        # Names with suffixes get a structuredValue
+        if suffix.present?
+          person[:name] << {
+            structuredValue: [
+              {
+                value: item.name,
+                type: 'inverted name'
+              },
+              {   value: item.suffix,
+                  type: 'name suffix' }
+            ]
+          }
+        end
+      end
+    end
+
+    def build_name(name, suffix)
+      return name if suffix.blank?
+
+      "#{name}, #{suffix}"
+    end
+
+    def build_reverse_name(name, suffix)
+      build_name(name.split(/, */).reverse.join(' '), suffix)
+    end
+
+    def build_submission
+      {
+        type: 'thesis submission',
+        date: [
+          {
+            value: build_submit_date
+          }
+        ],
+        contributor: [
+          {
+            name: [
+              {
+                structuredValue: [
+                  {
+                    value: 'Stanford University',
+                    type: 'university',
+                    uri: 'http://id.loc.gov/authorities/names/n79054636',
+                    source: {
+                      code: 'lcnaf',
+                      uri: 'http://id.loc.gov/authorities/names/'
+                    }
+                  },
+                  {
+                    value: item.schoolname,
+                    type: 'school'
+                  },
+                  {
+                    value: item.department,
+                    type: 'department'
+                  }
+                ]
+              }
+            ],
+            type: 'organization',
+            role: [
+              {
+                value: 'degree granting institution',
+                code: 'dgg',
+                uri: 'http://id.loc.gov/vocabulary/relators/dgg',
+                source: {
+                  code: 'marcrelator',
+                  uri: 'http://id.loc.gov/vocabulary/relators/'
+                }
+              },
+              {
+                value: 'degree granting institution',
+                uri: 'http://rdaregistry.info/Elements/a/P50003',
+                source: {
+                  uri: 'http://www.rdaregistry.info/Elements/a/'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    end
+
+    def build_conferral
+      {
+        type: 'degree conferral',
+        date: [
+          {
+            value: item.degreeconfyr,
+            encoding: %w[edtf w3cdtf marc iso8601]
+          }
+        ],
+        note: [
+          {
+            value: item.degree,
+            type: 'degree type'
+          }
+        ],
+        contributor: [
+          {
+            name: [
+              {
+                value: 'Stanford University',
+                uri: 'http://id.loc.gov/authorities/names/n79054636',
+                source: {
+                  code: 'lcnaf',
+                  uri: 'http://id.loc.gov/authorities/names/'
+                }
+              }
+            ],
+            type: 'organization',
+            role: [
+              {
+                value: 'degree granting institution',
+                code: 'dgg',
+                uri: 'http://id.loc.gov/vocabulary/relators/dgg',
+                source: {
+                  code: 'marcrelator',
+                  uri: 'http://id.loc.gov/vocabulary/relators/'
+                }
+              },
+              {
+                value: 'degree granting institution',
+                uri: 'http://rdaregistry.info/Elements/a/P50003',
+                source: {
+                  uri: 'http://www.rdaregistry.info/Elements/a/'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    end
+
+    def build_publication
+      {
+        type: 'publication',
+        date: [
+          {
+            value: build_publication_date,
+            "encoding": %w[edtf w3cdtf marc iso8601]
+          }
+        ],
+        location: [
+          {
+            value: 'Stanford (Calif.)',
+            uri: 'http://id.loc.gov/authorities/names/n50046557',
+            source: {
+              code: 'lcnaf',
+              uri: 'http://id.loc.gov/authorities/names/'
+            }
+          },
+          {
+            value: 'California',
+            code: 'cau',
+            uri: 'http://id.loc.gov/vocabulary/countries/cau',
+            source: {
+              code: 'marccountry',
+              uri: 'http://id.loc.gov/vocabulary/countries/'
+            }
+          }
+        ],
+        contributor: [
+          {
+            name: [
+              {
+                value: 'Stanford University',
+                uri: 'http://id.loc.gov/authorities/names/n79054636',
+                source: {
+                  code: 'lcnaf',
+                  uri: 'http://id.loc.gov/authorities/names/'
+                }
+              }
+            ],
+            type: 'organization',
+            role: [
+              {
+                value: 'publisher',
+                code: 'pbl',
+                uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                source: {
+                  code: 'marcrelator',
+                  uri: 'http://id.loc.gov/vocabulary/relators/'
+                }
+              },
+              {
+                value: 'publisher',
+                uri: 'http://rdaregistry.info/Elements/a/P50203',
+                source: {
+                  uri: 'http://www.rdaregistry.info/Elements/a/'
+                }
+              }
+            ]
+          }
+        ],
+        note: [
+          {
+            value: 'monographic',
+            type: 'issuance',
+            uri: 'http://id.loc.gov/vocabulary/issuance/mono',
+            source: {
+              uri: 'http://id.loc.gov/vocabulary/issuance/'
+            }
+          }
+        ],
+        structuredValue: [
+          {
+            value: '[Stanford, California]',
+            type: 'publication statement place',
+            standard: ['RDA']
+          },
+          {
+            value: '[Stanford University]',
+            type: 'publication statement publisher',
+            standard: ['RDA']
+          },
+          {
+            value: build_publication_date,
+            type: 'publication statement date',
+            standard: ['RDA']
+          }
+        ]
+      }
+    end
+
+    def build_copyright
+      {
+        type: 'copyright',
+        date: [
+          {
+            value: build_copyright_date,
+            encoding: %w[edtf w3cdtf marc iso8601]
+          }
+        ],
+        structuredValue: [
+          {
+            value: "©#{build_copyright_date}",
+            type: 'copyright statement',
+            standard: ['RDA']
+          }
+        ]
+      }
+    end
+
+    def build_form
+      [
+        {
+          value: 'computer',
+          type: 'media',
+          uri: 'http://id.loc.gov/vocabulary/mediaTypes/c',
+          source: {
+            code: 'rdamedia',
+            uri: 'http://id.loc.gov/vocabulary/mediaTypes/'
+          }
+        },
+        {
+          value: 'online resource',
+          type: 'carrier',
+          uri: 'http://id.loc.gov/vocabulary/carriers/cr',
+          source: {
+            code: 'rdacarrier',
+            uri: 'http://id.loc.gov/vocabulary/carriers/'
+          }
+        },
+        {
+          value: '1 online resource',
+          type: 'extent',
+          "standard": ['RDA']
+        },
+        {
+          value: 'text',
+          type: 'resource type',
+          source: {
+            value: 'MODS resource type'
+          }
+        },
+        {
+          value: 'text',
+          type: 'content type',
+          uri: 'http://id.loc.gov/vocabulary/contentTypes/txt',
+          source: {
+            code: 'rdacontent',
+            uri: 'http://id.loc.gov/vocabulary/contentTypes/'
+          }
+        },
+        {
+          value: 'thesis',
+          type: 'genre',
+          uri: 'http://id.loc.gov/vocabulary/marcgt/the',
+          source: {
+            code: 'marcgt',
+            uri: 'http://id.loc.gov/vocabulary/marcgt/'
+          }
+        }
+      ]
+    end
+
+    def build_language
+      [
+        {
+          value: 'English',
+          code: 'eng',
+          uri: 'http://id.loc.gov/vocabulary/iso639-2/eng',
+          source: {
+            code: 'iso239-2b',
+            uri: 'http://id.loc.gov/vocabulary/iso639-2'
+          }
+        }
+      ]
+    end
+
+    def build_notes
+      [
+        {
+          value: item.abstract,
+          type: 'summary'
+        },
+        build_submitted_to,
+        {
+          type: 'thesis',
+          structuredValue: [
+            {
+              value: 'Thesis',
+              type: 'note'
+            },
+            {
+              value: item.degree,
+              type: 'degree'
+            },
+            {
+              value: 'Stanford University',
+              type: 'university'
+            },
+            {
+              value: item.degreeconfyr,
+              type: 'date'
+            }
+          ]
+        },
+        {
+          value: "#{build_reverse_name(item.name, item.suffix)}.",
+          type: 'statement of responsibility',
+          standard: ['RDA']
+        }
+      ]
+    end
+
+    def build_submitted_to
+      name = if /Business/.match?(item.schoolname)
+               'Graduate School of Business'
+             elsif /Law/.match?(item.schoolname)
+               'School of Law'
+             elsif /Law/.match?(item.schoolname)
+               'Graduate School of Education'
+             else
+               "Department of #{item.department}"
+             end
+      {
+        value: "Submitted to the #{name}."
+      }
+    end
+
+    def build_identifier
+      [
+        {
+          value: item.dissertation_id,
+          type: 'ETD ID'
+        }
+      ]
+    end
+
+    def build_purl
+      "http://purl.stanford.edu/#{raw_druid}"
+    end
+
+    def raw_druid
+      item.pid.split(':')[1]
+    end
+
+    def build_url
+      [
+        {
+          value: "https://etd.stanford.edu/view/#{item.dissertation_id}",
+          type: 'ETD'
+        }
+      ]
+    end
+
+    def build_marc_encoded_data
+      [
+        {
+          value: '     nam a       3i',
+          type: 'leader'
+        },
+        {
+          value: "dor#{raw_druid}",
+          type: '001'
+        },
+        {
+          value: 'm        d',
+          type: '006'
+        },
+        {
+          value: 'cr un',
+          type: '007'
+        },
+        {
+          value: "170607t#{build_publication_date}#{build_copyright_date}cau     om    000 0 eng d",
+          type: '008'
+        }
+      ]
+    end
+
+    def build_admin_metadata
+      {
+        event: build_admin_events,
+        contributor: build_admin_contributors,
+        language: build_admin_language
+      }
+    end
+
+    def build_admin_events
+      # Since this is being dynamically generated, setting both to today
+      [
+        {
+          type: 'creation',
+          date: [
+            {
+              value: today,
+              "encoding": ['w3cdtf']
+            }
+          ]
+        },
+        {
+          type: 'last modification',
+          date: [
+            {
+              value: today,
+              "encoding": ['w3cdtf']
+            }
+          ]
+        }
+      ]
+    end
+
+    def build_admin_contributors
+      [
+        {
+          name: [
+            {
+              value: 'ETD application'
+            }
+          ],
+          role: [
+            {
+              value: 'data source'
+            }
+          ]
+        },
+        {
+          name: [
+            {
+              code: 'CSt',
+              uri: 'http://id.loc.gov/vocabulary/organizations/cst',
+              source: {
+                code: 'marcorg',
+                uri: 'http://id.loc.gov/vocabulary/organizations/'
+              }
+            }
+          ],
+          role: [
+            {
+              value: 'original cataloging agency'
+            }
+          ]
+        },
+        {
+          name: [
+            {
+              code: 'CSt',
+              uri: 'http://id.loc.gov/vocabulary/organizations/cst',
+              source: {
+                code: 'marcorg',
+                uri: 'http://id.loc.gov/vocabulary/organizations/'
+              }
+            }
+          ],
+          role: [
+            {
+              value: 'transcribing agency'
+            }
+          ]
+        }
+      ]
+    end
+
+    def build_admin_language
+      [
+        {
+          value: 'English',
+          code: 'eng',
+          uri: 'http://id.loc.gov/vocabulary/iso639-2/eng',
+          source: {
+            code: 'iso239-2b',
+            uri: 'http://id.loc.gov/vocabulary/iso639-2'
+          }
+        }
+      ]
+    end
+
+    def today
+      Time.zone.today.to_s
+    end
+
+    def build_copyright_date
+      if item.submit_date
+        build_submit_date
+      else
+        item.degreeconfyr
+      end
+    end
+
+    def build_submit_date
+      Time.zone.at(item.submit_date.to_i).year.to_s
+    end
+
+    def build_publication_date
+      # Note that if this wasn't a mapping, the publication date would be the current year, not the submit date.
+      build_submit_date
+    end
+  end
+end

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -123,7 +123,7 @@ module Cocina
     def build_descriptive
       case item
       when Dor::Etd
-        { title: [{ status: 'primary', value: item.properties.title.first }] }
+        Cocina::EtdDescriptionBuilder.build(item)
       else
         { title: [{ status: 'primary', value: item.full_title }] }
       end

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -223,11 +223,11 @@ RSpec.describe 'Get the object' do
     let(:object) { Etd.new(pid: 'druid:bc123df4567') }
 
     before do
-      object.properties.title = 'Test ETD'
       object.identityMetadata.other_ids = ['dissertationid:00000123']
       object.label = 'foo'
       allow(object).to receive(:collection_ids).and_return([])
       allow(object).to receive(:admin_policy_object_id).and_return('druid:df123cd4567')
+      allow(Cocina::EtdDescriptionBuilder).to receive(:build).and_return(title: [{ status: 'primary', value: 'Test ETD' }])
     end
 
     it 'returns the object' do

--- a/spec/services/cocina/etd_description_builder_spec.rb
+++ b/spec/services/cocina/etd_description_builder_spec.rb
@@ -1,0 +1,686 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::EtdDescriptionBuilder do
+  subject(:description) { described_class.build(item) }
+
+  let(:item) do
+    Dor::Etd.new(pid: 'druid:hj456dt5655').tap do |item|
+      item.add_datastream(readers_ds)
+      item.add_datastream(properties_ds)
+    end
+  end
+  let(:readers_ds) { ActiveFedora::SimpleDatastream.new(nil, 'readers').tap { |ds| ds.content = readers_xml } }
+  let(:properties_ds) { ActiveFedora::SimpleDatastream.new(nil, 'properties').tap { |ds| ds.content = properties_xml } }
+
+  let(:readers_xml) do
+    <<~XML
+      <?xml version="1.0"?>
+      <readers>
+        <reader>
+          <suffix/>
+          <univid>03079696</univid>
+          <finalreader>Yes</finalreader>
+          <name>Duffie, Darrell</name>
+          <sunetid>duffie</sunetid>
+          <prefix/>
+          <readerrole>Advisor</readerrole>
+          <type>int</type>
+        </reader>
+        <reader>
+          <suffix/>
+          <univid>05357617</univid>
+          <finalreader>No</finalreader>
+          <name>Strebulaev, Ilya A</name>
+          <sunetid>ilyas1</sunetid>
+          <prefix/>
+          <readerrole>Co-Adv</readerrole>
+          <type>int</type>
+        </reader>
+        <reader>
+          <suffix/>
+          <univid>09924523</univid>
+          <finalreader>No</finalreader>
+          <name>Zwiebel, Jeffrey</name>
+          <sunetid>zwiebel</sunetid>
+          <prefix/>
+          <readerrole>Reader</readerrole>
+          <type>int</type>
+        </reader>
+      </readers>
+    XML
+  end
+
+  let(:properties_xml) do
+    <<~XML
+      <?xml version="1.0"?>
+      <fields>
+        <abstract>My dissertation is a combination of three papers that I worked on at various stages of my doctoral studies at Stanford University Graduate School of Business. The central of theme of these papers is dynamic optimality with adjustment costs and gradualness in various economic environments. In all of these papers, I shared various tasks and responsibilities of the research with my coauthors. In Chapter 1, together with Ryota Iijima, I study a model of gradual adjustment in games, in which players can flexibly adjust and monitor their positions up until a deadline. Players' terminal and flow payoffs are influenced by their positions. I show that, unlike in one-shot games, the equilibrium is unique for a broad class of terminal payoffs when players' actions are flexible enough in the presence of (possibly small) noise. In a team-production model, the unique equilibrium selects an outcome that is approximately efficient when adjustment friction is small. I also examine the welfare implications of such gradualness in applications, including team production, hold-up problems, and dynamic contests. In Chapter 2, together with Christopher Hennessy and Ilya Streublaev, I study dynamic capital structure choice with a time-varying tax rate. Absent theoretical guidance, empiricists have been forced to rely upon numerical comparative statics from constant tax rate models in formulating testable implications of tradeoff theory in the context of natural experiments. I fill the theoretical void by solving in closed-form a dynamic tradeoff theoretic model in which corporate taxes follow a (two-state) Markov process with exogenous rate changes. I simulate ideal difference-in-differences estimations, finding that constant tax rate models offer poor guidance regarding testable implications. While constant rate models predict large symmetric responses to rate changes, my model with stochastic tax rates predicts small, asymmetric, and often statistically insignificant responses. Under plausible parameterizations with decade-long regimes, the true underlying theory -- that taxes matter -- is incorrectly rejected in about half of the simulated natural experiments. Moreover, tax response coefficients are actually smaller in simulated economies with larger tax-induced welfare losses. In Chapter 3, which is also joint work with Ryota Iijima, I consider a class of games in which players commonly observe noisy shocks and gradually adjust their actions without observing information about their opponents' behavior. Under a form of richness of the noise process, I prove equilibrium uniqueness when players' adjustment is flexible enough. In the case of potential games, the unique equilibrium approximates the global maximizer of the potential as the friction vanishes.</abstract>
+        <cclicense>4</cclicense>
+        <cclicensetype>CC Attribution Non-Commercial license</cclicensetype>
+        <containscopyright>false</containscopyright>
+        <degree>Ph.D.</degree>
+        <degreeconfyr>2017</degreeconfyr>
+        <department>Business Administration</department>
+        <dissertation_id>0000005406</dissertation_id>
+        <documentaccess>No</documentaccess>
+        <embargo>immediately</embargo>
+        <etd_type>Dissertation</etd_type>
+        <external_visibility>20</external_visibility>
+        <major>Business Administration</major>
+        <name>Kasahara, Akitada</name>
+        <prefix/>
+        <provost>Patricia J. Gumport</provost>
+        <ps_career>Graduate School of Business</ps_career>
+        <ps_plan>Business Administration</ps_plan>
+        <ps_program>Business Administration</ps_program>
+        <ps_subplan>Finance</ps_subplan>
+        <readeractiondttm>06/02/2017 20:33:37</readeractiondttm>
+        <readerapproval>Approved</readerapproval>
+        <readercomment/>
+        <regactiondttm>06/07/2017 11:05:47</regactiondttm>
+        <regapproval>Approved</regapproval>
+        <regcomment>Congratulations!</regcomment>
+        <schoolname>Graduate School of Business</schoolname>
+        <sub>deadline: 2017-06-07</sub>
+        <submit_date>1496425544</submit_date>
+        <suffix>Jr</suffix>
+        <sulicense>true</sulicense>
+        <sunetid>akitadak</sunetid>
+        <term>1176</term>
+        <title>Essays on Game Theory and Corporate Finance</title>
+        <univid>05797391</univid>
+      </fields>
+    XML
+  end
+
+  # rubocop:disable Metrics/LineLength
+  let(:expected) do
+    {
+      "title": [
+        {
+          "value": 'Essays on Game Theory and Corporate Finance',
+          "status": 'primary'
+        }
+      ],
+      "contributor": [
+        {
+          "name": [
+            {
+              "value": 'Kasahara, Akitada, Jr',
+              "type": 'inverted name'
+            },
+            {
+              "structuredValue": [
+                {
+                  "value": 'Kasahara, Akitada',
+                  "type": 'inverted name'
+                },
+                {
+                  "value": 'Jr',
+                  "type": 'name suffix'
+                }
+              ]
+            }
+          ],
+          "type": 'person',
+          "status": 'primary',
+          "role": [
+            {
+              "value": 'author',
+              "code": 'aut',
+              "uri": 'http://id.loc.gov/vocabulary/relators/aut',
+              "source": {
+                "code": 'marcrelator',
+                "uri": 'http://id.loc.gov/vocabulary/relators/'
+              }
+            },
+            {
+              "value": 'author',
+              "uri": 'http://rdaregistry.info/Elements/a/P50195',
+              "source": {
+                "uri": 'http://www.rdaregistry.info/Elements/a/'
+              }
+            }
+          ]
+        },
+        {
+          "name": [
+            {
+              "value": 'Duffie, Darrell',
+              "type": 'inverted name'
+            }
+          ],
+          "type": 'person',
+          "role": [
+            {
+              "value": 'Advisor',
+              "source": {
+                "value": 'ETD reader roles'
+              }
+            },
+            {
+              "value": 'degree supervisor',
+              "code": 'dgs',
+              "uri": 'http://id.loc.gov/vocabulary/relators/dgs',
+              "source": {
+                "code": 'marcrelator',
+                "uri": 'http://id.loc.gov/vocabulary/relators/'
+              }
+            },
+            {
+              "value": 'degree supervisor',
+              "uri": 'http://rdaregistry.info/Elements/a/P50091',
+              "source": {
+                "uri": 'http://www.rdaregistry.info/Elements/a/'
+              }
+            }
+          ]
+        },
+        {
+          "name": [
+            {
+              "value": 'Strebulaev, Ilya A',
+              "type": 'inverted name'
+            }
+          ],
+          "type": 'person',
+          "role": [
+            {
+              "value": 'Co-Adv',
+              "source": {
+                "value": 'ETD reader roles'
+              }
+            },
+            {
+              "value": 'degree supervisor',
+              "code": 'dgs',
+              "uri": 'http://id.loc.gov/vocabulary/relators/dgs',
+              "source": {
+                "code": 'marcrelator',
+                "uri": 'http://id.loc.gov/vocabulary/relators/'
+              }
+            },
+            {
+              "value": 'degree supervisor',
+              "uri": 'http://rdaregistry.info/Elements/a/P50091',
+              "source": {
+                "uri": 'http://www.rdaregistry.info/Elements/a/'
+              }
+            }
+          ]
+        },
+        {
+          "name": [
+            {
+              "value": 'Zwiebel, Jeffrey',
+              "type": 'inverted name'
+            }
+          ],
+          "type": 'person',
+          "role": [
+            {
+              "value": 'Reader',
+              "source": {
+                "value": 'ETD reader roles'
+              }
+            },
+            {
+              "value": 'thesis advisor',
+              "code": 'ths',
+              "uri": 'http://id.loc.gov/vocabulary/relators/ths',
+              "source": {
+                "code": 'marcrelator',
+                "uri": 'http://id.loc.gov/vocabulary/relators/'
+              }
+            },
+            {
+              "value": 'degree committee member',
+              "uri": 'http://rdaregistry.info/Elements/a/P50257',
+              "source": {
+                "uri": 'http://www.rdaregistry.info/Elements/a/'
+              }
+            }
+          ]
+        }
+      ],
+      "event": [
+        {
+          "type": 'thesis submission',
+          "date": [
+            {
+              "value": '2017'
+            }
+          ],
+          "contributor": [
+            {
+              "name": [
+                {
+                  "structuredValue": [
+                    {
+                      "value": 'Stanford University',
+                      "type": 'university',
+                      "uri": 'http://id.loc.gov/authorities/names/n79054636',
+                      "source": {
+                        "code": 'lcnaf',
+                        "uri": 'http://id.loc.gov/authorities/names/'
+                      }
+                    },
+                    {
+                      "value": 'Graduate School of Business',
+                      "type": 'school'
+                    },
+                    {
+                      "value": 'Business Administration',
+                      "type": 'department'
+                    }
+                  ]
+                }
+              ],
+              "type": 'organization',
+              "role": [
+                {
+                  "value": 'degree granting institution',
+                  "code": 'dgg',
+                  "uri": 'http://id.loc.gov/vocabulary/relators/dgg',
+                  "source": {
+                    "code": 'marcrelator',
+                    "uri": 'http://id.loc.gov/vocabulary/relators/'
+                  }
+                },
+                {
+                  "value": 'degree granting institution',
+                  "uri": 'http://rdaregistry.info/Elements/a/P50003',
+                  "source": {
+                    "uri": 'http://www.rdaregistry.info/Elements/a/'
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": 'degree conferral',
+          "date": [
+            {
+              "value": '2017',
+              "encoding": %w[edtf w3cdtf marc iso8601]
+            }
+          ],
+          "note": [
+            {
+              "value": 'Ph.D.',
+              "type": 'degree type'
+            }
+          ],
+          "contributor": [
+            {
+              "name": [
+                {
+                  "value": 'Stanford University',
+                  "uri": 'http://id.loc.gov/authorities/names/n79054636',
+                  "source": {
+                    "code": 'lcnaf',
+                    "uri": 'http://id.loc.gov/authorities/names/'
+                  }
+                }
+              ],
+              "type": 'organization',
+              "role": [
+                {
+                  "value": 'degree granting institution',
+                  "code": 'dgg',
+                  "uri": 'http://id.loc.gov/vocabulary/relators/dgg',
+                  "source": {
+                    "code": 'marcrelator',
+                    "uri": 'http://id.loc.gov/vocabulary/relators/'
+                  }
+                },
+                {
+                  "value": 'degree granting institution',
+                  "uri": 'http://rdaregistry.info/Elements/a/P50003',
+                  "source": {
+                    "uri": 'http://www.rdaregistry.info/Elements/a/'
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": 'publication',
+          "date": [
+            {
+              "value": '2017',
+              "encoding": %w[edtf w3cdtf marc iso8601]
+            }
+          ],
+          "location": [
+            {
+              "value": 'Stanford (Calif.)',
+              "uri": 'http://id.loc.gov/authorities/names/n50046557',
+              "source": {
+                "code": 'lcnaf',
+                "uri": 'http://id.loc.gov/authorities/names/'
+              }
+            },
+            {
+              "value": 'California',
+              "code": 'cau',
+              "uri": 'http://id.loc.gov/vocabulary/countries/cau',
+              "source": {
+                "code": 'marccountry',
+                "uri": 'http://id.loc.gov/vocabulary/countries/'
+              }
+            }
+          ],
+          "contributor": [
+            {
+              "name": [
+                {
+                  "value": 'Stanford University',
+                  "uri": 'http://id.loc.gov/authorities/names/n79054636',
+                  "source": {
+                    "code": 'lcnaf',
+                    "uri": 'http://id.loc.gov/authorities/names/'
+                  }
+                }
+              ],
+              "type": 'organization',
+              "role": [
+                {
+                  "value": 'publisher',
+                  "code": 'pbl',
+                  "uri": 'http://id.loc.gov/vocabulary/relators/pbl',
+                  "source": {
+                    "code": 'marcrelator',
+                    "uri": 'http://id.loc.gov/vocabulary/relators/'
+                  }
+                },
+                {
+                  "value": 'publisher',
+                  "uri": 'http://rdaregistry.info/Elements/a/P50203',
+                  "source": {
+                    "uri": 'http://www.rdaregistry.info/Elements/a/'
+                  }
+                }
+              ]
+            }
+          ],
+          "note": [
+            {
+              "value": 'monographic',
+              "type": 'issuance',
+              "uri": 'http://id.loc.gov/vocabulary/issuance/mono',
+              "source": {
+                "uri": 'http://id.loc.gov/vocabulary/issuance/'
+              }
+            }
+          ],
+          "structuredValue": [
+            {
+              "value": '[Stanford, California]',
+              "type": 'publication statement place',
+              "standard": ['RDA']
+            },
+            {
+              "value": '[Stanford University]',
+              "type": 'publication statement publisher',
+              "standard": ['RDA']
+            },
+            {
+              "value": '2017',
+              "type": 'publication statement date',
+              "standard": ['RDA']
+            }
+          ]
+        },
+        {
+          "type": 'copyright',
+          "date": [
+            {
+              "value": '2017',
+              "encoding": %w[edtf w3cdtf marc iso8601]
+            }
+          ],
+          "structuredValue": [
+            {
+              "value": '©2017',
+              "type": 'copyright statement',
+              "standard": ['RDA']
+            }
+          ]
+        }
+      ],
+      "form": [
+        {
+          "value": 'computer',
+          "type": 'media',
+          "uri": 'http://id.loc.gov/vocabulary/mediaTypes/c',
+          "source": {
+            "code": 'rdamedia',
+            "uri": 'http://id.loc.gov/vocabulary/mediaTypes/'
+          }
+        },
+        {
+          "value": 'online resource',
+          "type": 'carrier',
+          "uri": 'http://id.loc.gov/vocabulary/carriers/cr',
+          "source": {
+            "code": 'rdacarrier',
+            "uri": 'http://id.loc.gov/vocabulary/carriers/'
+          }
+        },
+        {
+          "value": '1 online resource',
+          "type": 'extent',
+          "standard": ['RDA']
+        },
+        {
+          "value": 'text',
+          "type": 'resource type',
+          "source": {
+            "value": 'MODS resource type'
+          }
+        },
+        {
+          "value": 'text',
+          "type": 'content type',
+          "uri": 'http://id.loc.gov/vocabulary/contentTypes/txt',
+          "source": {
+            "code": 'rdacontent',
+            "uri": 'http://id.loc.gov/vocabulary/contentTypes/'
+          }
+        },
+        {
+          "value": 'thesis',
+          "type": 'genre',
+          "uri": 'http://id.loc.gov/vocabulary/marcgt/the',
+          "source": {
+            "code": 'marcgt',
+            "uri": 'http://id.loc.gov/vocabulary/marcgt/'
+          }
+        }
+      ],
+      "language": [
+        {
+          "value": 'English',
+          "code": 'eng',
+          "uri": 'http://id.loc.gov/vocabulary/iso639-2/eng',
+          "source": {
+            "code": 'iso239-2b',
+            "uri": 'http://id.loc.gov/vocabulary/iso639-2'
+          }
+        }
+      ],
+      "note": [
+        {
+          "value": "My dissertation is a combination of three papers that I worked on at various stages of my doctoral studies at Stanford University Graduate School of Business. The central of theme of these papers is dynamic optimality with adjustment costs and gradualness in various economic environments. In all of these papers, I shared various tasks and responsibilities of the research with my coauthors. In Chapter 1, together with Ryota Iijima, I study a model of gradual adjustment in games, in which players can flexibly adjust and monitor their positions up until a deadline. Players' terminal and flow payoffs are influenced by their positions. I show that, unlike in one-shot games, the equilibrium is unique for a broad class of terminal payoffs when players' actions are flexible enough in the presence of (possibly small) noise. In a team-production model, the unique equilibrium selects an outcome that is approximately efficient when adjustment friction is small. I also examine the welfare implications of such gradualness in applications, including team production, hold-up problems, and dynamic contests. In Chapter 2, together with Christopher Hennessy and Ilya Streublaev, I study dynamic capital structure choice with a time-varying tax rate. Absent theoretical guidance, empiricists have been forced to rely upon numerical comparative statics from constant tax rate models in formulating testable implications of tradeoff theory in the context of natural experiments. I fill the theoretical void by solving in closed-form a dynamic tradeoff theoretic model in which corporate taxes follow a (two-state) Markov process with exogenous rate changes. I simulate ideal difference-in-differences estimations, finding that constant tax rate models offer poor guidance regarding testable implications. While constant rate models predict large symmetric responses to rate changes, my model with stochastic tax rates predicts small, asymmetric, and often statistically insignificant responses. Under plausible parameterizations with decade-long regimes, the true underlying theory -- that taxes matter -- is incorrectly rejected in about half of the simulated natural experiments. Moreover, tax response coefficients are actually smaller in simulated economies with larger tax-induced welfare losses. In Chapter 3, which is also joint work with Ryota Iijima, I consider a class of games in which players commonly observe noisy shocks and gradually adjust their actions without observing information about their opponents' behavior. Under a form of richness of the noise process, I prove equilibrium uniqueness when players' adjustment is flexible enough. In the case of potential games, the unique equilibrium approximates the global maximizer of the potential as the friction vanishes.",
+          "type": 'summary'
+        },
+        {
+          "value": 'Submitted to the Graduate School of Business.'
+        },
+        {
+          "type": 'thesis',
+          "structuredValue": [
+            {
+              "value": 'Thesis',
+              "type": 'note'
+            },
+            {
+              "value": 'Ph.D.',
+              "type": 'degree'
+            },
+            {
+              "value": 'Stanford University',
+              "type": 'university'
+            },
+            {
+              "value": '2017',
+              "type": 'date'
+            }
+          ]
+        },
+        {
+          "value": 'Akitada Kasahara, Jr.',
+          "type": 'statement of responsibility',
+          "standard": ['RDA']
+        }
+      ],
+      "identifier": [
+        {
+          "value": '0000005406',
+          "type": 'ETD ID'
+        }
+      ],
+      "purl": 'http://purl.stanford.edu/hj456dt5655',
+      "url": [
+        {
+          "value": 'https://etd.stanford.edu/view/0000005406',
+          "type": 'ETD'
+        }
+      ],
+      "marcEncodedData": [
+        {
+          "value": '     nam a       3i',
+          "type": 'leader'
+        },
+        {
+          "value": 'dorhj456dt5655',
+          "type": '001'
+        },
+        {
+          "value": 'm        d',
+          "type": '006'
+        },
+        {
+          "value": 'cr un',
+          "type": '007'
+        },
+        {
+          "value": '170607t20172017cau     om    000 0 eng d',
+          "type": '008'
+        }
+      ],
+      "adminMetadata": {
+        "event": [
+          {
+            "type": 'creation',
+            "date": [
+              {
+                "value": '2017-06-15',
+                "encoding": ['w3cdtf']
+              }
+            ]
+          },
+          {
+            "type": 'last modification',
+            "date": [
+              {
+                "value": '2017-06-15',
+                "encoding": ['w3cdtf']
+              }
+            ]
+          }
+        ],
+        "contributor": [
+          {
+            "name": [
+              {
+                "value": 'ETD application'
+              }
+            ],
+            "role": [
+              {
+                "value": 'data source'
+              }
+            ]
+          },
+          {
+            "name": [
+              {
+                "code": 'CSt',
+                "uri": 'http://id.loc.gov/vocabulary/organizations/cst',
+                "source": {
+                  "code": 'marcorg',
+                  "uri": 'http://id.loc.gov/vocabulary/organizations/'
+                }
+              }
+            ],
+            "role": [
+              {
+                "value": 'original cataloging agency'
+              }
+            ]
+          },
+          {
+            "name": [
+              {
+                "code": 'CSt',
+                "uri": 'http://id.loc.gov/vocabulary/organizations/cst',
+                "source": {
+                  "code": 'marcorg',
+                  "uri": 'http://id.loc.gov/vocabulary/organizations/'
+                }
+              }
+            ],
+            "role": [
+              {
+                "value": 'transcribing agency'
+              }
+            ]
+          }
+        ],
+        "language": [
+          {
+            "value": 'English',
+            "code": 'eng',
+            "uri": 'http://id.loc.gov/vocabulary/iso639-2/eng',
+            "source": {
+              "code": 'iso239-2b',
+              "uri": 'http://id.loc.gov/vocabulary/iso639-2'
+            }
+          }
+        ]
+      }
+    }
+  end
+  # rubocop:enable Metrics/LineLength
+
+  let(:tz) { Time.zone }
+
+  before do
+    allow(Time).to receive(:zone).and_return(tz)
+    allow(tz).to receive(:today).and_return(Date.parse('2017-06-15'))
+  end
+
+  it 'validates' do
+    expect { Cocina::Models::Description.new(description) }.not_to raise_error
+  end
+
+  it 'builds' do
+    expect(expected).to eq(description)
+  end
+end

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -222,8 +222,8 @@ RSpec.describe Cocina::Mapper do
     end
 
     before do
-      item.properties.title = 'Test ETD'
       allow(item).to receive(:collection_ids).and_return([])
+      allow(Cocina::EtdDescriptionBuilder).to receive(:build).and_return(title: [{ status: 'primary', value: 'Test ETD' }])
     end
 
     it 'builds the object with type object, a sourceId, and correct admin policy' do


### PR DESCRIPTION
## Why was this change made?
To map descriptive metadata for ETDs to Cocina model.


## Was the API documentation (openapi.yml) updated?
No.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

So if/when to deploy this needs to be considered, as there is the possibility that this will encounter some ETDs that cause this to error.