### PR TITLE
Expand tag normalization when migrating legacy tags

### DIFF
--- a/app/services/administrative_tags.rb
+++ b/app/services/administrative_tags.rb
@@ -131,6 +131,7 @@ class AdministrativeTags
         # There are a bunch of tags in production WITHOUT the padding spaces.
         # Fix that here unless already valid.
         tag_string.gsub!(':', ' : ') unless AdministrativeTag::VALID_TAG_PATTERN.match?(tag_string)
+        tag_string.strip!
         begin
           AdministrativeTag.create!(druid: item.pid, tag: tag_string)
         rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique

--- a/spec/services/administrative_tags_spec.rb
+++ b/spec/services/administrative_tags_spec.rb
@@ -87,10 +87,11 @@ RSpec.describe AdministrativeTags do
       before do
         LegacyTagService.add(item_without_db_tags, 'One : Two : Three')
         LegacyTagService.add(item_without_db_tags, 'Two:Three:Four') # test weirdo tags
+        LegacyTagService.add(item_without_db_tags, ' Three:Four:Five') # test weirdo tags
       end
 
       it 'returns administrative tags from identity metadata XML' do
-        expect(described_class.for(item: item_without_db_tags)).to eq(['One : Two : Three', 'Two : Three : Four'])
+        expect(described_class.for(item: item_without_db_tags)).to eq(['One : Two : Three', 'Two : Three : Four', 'Three : Four : Five'])
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

To cover a case in production where legacy tags look like " Remediated By:Foo". The leading space was not dealt with before.


## Was the API documentation (openapi.yml) updated?

no

## Does this change affect how this application integrates with other services?

Yes, should fix integration with indexing and Argo facets.