### PR TITLE
Stop sending techmd to preservation.

### DIFF
--- a/app/services/datastream_extractor.rb
+++ b/app/services/datastream_extractor.rb
@@ -49,7 +49,6 @@ class DatastreamExtractor
       rightsMetadata: false,
       roleMetadata: false,
       sourceMetadata: false,
-      technicalMetadata: false,
       versionMetadata: true,
       workflows: false,
       geoMetadata: false

--- a/spec/services/datastream_extractor_spec.rb
+++ b/spec/services/datastream_extractor_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe DatastreamExtractor do
       expect(instance).to have_received(:datastream_content).with(:provenanceMetadata, true)
       expect(instance).to have_received(:datastream_content).with(:relationshipMetadata, true)
       expect(instance).to have_received(:datastream_content).with(:roleMetadata, false)
-      expect(instance).to have_received(:datastream_content).with(:technicalMetadata, false)
       expect(instance).to have_received(:datastream_content).with(:sourceMetadata, false)
       expect(instance).to have_received(:datastream_content).with(:rightsMetadata, false)
       expect(instance).to have_received(:datastream_content).with(:versionMetadata, true)


### PR DESCRIPTION
closes #720

## Why was this change made?
To stop sending techmd to preservation given new techmd service.


## Was the API documentation (openapi.yml) updated?
No.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No.