### PR TITLE
Adds access validation when creating objects, publishing, and shelving.

### DIFF
--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -13,6 +13,17 @@ class PublishJob < ApplicationJob
 
     begin
       item = Dor.find(druid)
+
+      validator = validator_for?(item)
+      unless validator.valid?
+        return LogFailureJob.perform_later(druid: druid,
+                                           background_job_result: background_job_result,
+                                           workflow: workflow,
+                                           workflow_process: 'publish-complete',
+                                           output: { errors: [{ title: 'Access mismatch',
+                                                                detail: "Not all files have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}" }] })
+      end
+
       PublishMetadataService.publish(item)
       EventFactory.create(druid: druid, event_type: 'publishing_complete', data: { background_job_result_id: background_job_result.id })
     rescue Dor::DataError => e
@@ -27,5 +38,10 @@ class PublishJob < ApplicationJob
                                 background_job_result: background_job_result,
                                 workflow: workflow,
                                 workflow_process: 'publish-complete')
+  end
+
+  def validator_for?(item)
+    model = Cocina::Mapper.build(item)
+    ValidateDarkService.new(model)
   end
 end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -27,8 +27,13 @@ module Cocina
     private
 
     def validate(obj)
-      if obj.is_a?(Cocina::Models::RequestDRO) && Dor::SearchService.query_by_id(obj.identification.sourceId).first
-        raise Dor::DuplicateIdError.new(obj.identification.sourceId), "An object with the source ID '#{obj.identification.sourceId}' has already been registered."
+      if obj.is_a?(Cocina::Models::RequestDRO)
+        if Dor::SearchService.query_by_id(obj.identification.sourceId).first
+          raise Dor::DuplicateIdError.new(obj.identification.sourceId), "An object with the source ID '#{obj.identification.sourceId}' has already been registered."
+        end
+
+        validator = ValidateDarkService.new(obj)
+        raise Dor::ParameterError, "Not all files have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}" unless validator.valid?
       end
 
       # Validate APO exists (this raises an error if it doesn't)

--- a/app/services/validate_dark_service.rb
+++ b/app/services/validate_dark_service.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Validates that shelve and publish file attributes are set to false for dark objects.
+class ValidateDarkService
+  # @param [Cocina::Models::DRO,Cocina::Models::RequestDRO] item to be validated
+  def initialize(item)
+    @item = item
+  end
+
+  def valid?
+    invalid_files.empty?
+  end
+
+  def invalid_files
+    @invalid_files ||= begin
+      [].tap do |invalid_files|
+        next unless item.access.access == 'dark'
+
+        files.each do |file|
+          invalid_files << file if file.administrative.shelve || file.access.access != 'dark'
+        end
+      end
+    end
+  end
+
+  def invalid_filenames
+    invalid_files.map { |invalid_file| invalid_file.filename || invalid_file.label }
+  end
+
+  private
+
+  attr_reader :item
+
+  def files
+    [].tap do |files|
+      next if item&.structural&.contains.nil?
+
+      item.structural.contains.each do |fileset|
+        next if fileset&.structural&.contains.nil?
+
+        fileset.structural.contains.each do |file|
+          files << file
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/publish_job_spec.rb
+++ b/spec/jobs/publish_job_spec.rb
@@ -11,11 +11,16 @@ RSpec.describe PublishJob, type: :job do
   let(:result) { create(:background_job_result) }
   let(:item) { instance_double(Dor::Item) }
   let(:workflow) { 'accessionWF' }
+  let(:validator) { instance_double(ValidateDarkService, valid?: valid, invalid_filenames: invalid_filenames) }
+  let(:valid) { true }
+  let(:invalid_filenames) { [] }
 
   before do
     allow(Dor).to receive(:find).with(druid).and_return(item)
     allow(result).to receive(:processing!)
     allow(EventFactory).to receive(:create)
+    allow(Cocina::Mapper).to receive(:build)
+    allow(ValidateDarkService).to receive(:new).and_return(validator)
   end
 
   context 'with no errors' do
@@ -65,6 +70,29 @@ RSpec.describe PublishJob, type: :job do
               workflow: 'accessionWF',
               workflow_process: 'publish-complete',
               output: { errors: [{ detail: error_message, title: 'Data error' }] })
+    end
+  end
+
+  context 'when fails dark validation' do
+    let(:valid) { false }
+    let(:invalid_filenames) { ['foo.txt', 'bar.txt'] }
+
+    before do
+      allow(LogFailureJob).to receive(:perform_later)
+      perform
+    end
+
+    it 'marks the job as processing' do
+      expect(result).to have_received(:processing!).once
+    end
+
+    it 'marks the job as complete' do
+      expect(LogFailureJob).to have_received(:perform_later)
+        .with(druid: druid,
+              background_job_result: result,
+              workflow: 'accessionWF',
+              workflow_process: 'publish-complete',
+              output: { errors: [{ detail: 'Not all files have dark access and/or are unshelved when item access is dark: ["foo.txt", "bar.txt"]', title: 'Access mismatch' }] })
     end
   end
 end

--- a/spec/services/validate_dark_service_spec.rb
+++ b/spec/services/validate_dark_service_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ValidateDarkService do
+  let(:validator) { described_class.new(item) }
+
+  let(:access) { 'dark' }
+  # Note that publish = false when file > access > access = dark
+  let(:file_access) { 'dark' }
+  let(:shelve) { false }
+
+  let(:item) do
+    Cocina::Models::DRO.new(
+      externalIdentifier: 'druid:bc123df4567',
+      label: 'The Structure of Scientific Revolutions',
+      type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
+      version: 1,
+      access: { access: access },
+      structural: {
+        contains: [
+          {
+            externalIdentifier: 'bc123df4567_1',
+            label: 'Fileset 1',
+            type: 'http://cocina.sul.stanford.edu/models/fileset.jsonld',
+            version: 1,
+            structural: {
+              contains: [
+                externalIdentifier: 'bc123df4567_1',
+                label: 'Page 1',
+                type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                version: 1,
+                access: { access: file_access },
+                administrative: {
+                  shelve: shelve,
+                  sdrPreserve: true
+                },
+                hasMessageDigests: [],
+                filename: 'page1.txt'
+              ]
+            }
+          }
+        ]
+      }
+    )
+  end
+
+  context 'when dark and shelve and publish are false' do
+    it 'is valid' do
+      expect(validator.valid?).to be true
+    end
+  end
+
+  context 'when not dark' do
+    let(:access) { 'world' }
+
+    it 'is valid' do
+      expect(validator.valid?).to be true
+    end
+  end
+
+  context 'when dark and shelve is true' do
+    let(:shelve) { true }
+
+    it 'is not valid' do
+      expect(validator.valid?).to be false
+      expect(validator.invalid_files.size).to eq(1)
+      expect(validator.invalid_files.first.externalIdentifier).to eq('bc123df4567_1')
+      expect(validator.invalid_filenames).to eq(['page1.txt'])
+    end
+  end
+
+  context 'when dark and publish is true' do
+    let(:file_access) { 'world' }
+
+    it 'is not valid' do
+      expect(validator.valid?).to be false
+      expect(validator.invalid_files.size).to eq(1)
+      expect(validator.invalid_files.first.externalIdentifier).to eq('bc123df4567_1')
+    end
+  end
+end


### PR DESCRIPTION
closes #768
closes #769

## Why was this change made?
To make sure that publish and shelve match the access for an object.

## Was the API documentation (openapi.yml) updated?
No.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
Yes.