### PR TITLE
Download and location access

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.31.0'
+gem 'cocina-models', '~> 0.32.0'
 gem 'dor-services', '~> 9.2'
 gem 'dor-workflow-client', '~> 3.17'
 gem 'marc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
       capistrano-bundler (~> 1.1)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.31.1)
+    cocina-models (0.32.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -492,7 +492,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.31.0)
+  cocina-models (~> 0.32.0)
   committee
   config
   deprecation

--- a/app/services/cocina/access_builder.rb
+++ b/app/services/cocina/access_builder.rb
@@ -12,18 +12,44 @@ module Cocina
     end
 
     def build
-      { access: access_rights }
+      { access: access_rights }.tap do |h|
+        h[:readLocation] = location if location
+        h[:download] = download? ? h[:access] : 'none'
+      end
     end
 
     private
 
     attr_reader :item
 
+    def rights_object
+      item.rightsMetadata.dra_object.obj_lvl
+    end
+
+    # @return [Bool] true unless the rule="no-download" has been set or if the access is citation-only or dark
+    def download?
+      return false if %w[citation-only dark].include? access_rights
+
+      !rights_object.world.rule && !rights_object.group.fetch(:stanford).rule
+    end
+
+    def location
+      @location ||= rights_object.location.keys.first
+    end
+
     # Map values from dor-services
     # https://github.com/sul-dlss/dor-services/blob/b9b4768eac560ef99b4a8d03475ea31fe4ae2367/lib/dor/datastreams/rights_metadata_ds.rb#L221-L228
     # to https://github.com/sul-dlss/cocina-models/blob/master/docs/maps/DRO.json#L102
     def access_rights
-      item.rights.sub('None', 'citation-only').downcase
+      @access_rights ||= if rights != 'None'
+                           rights.downcase
+                         elsif location
+                           'location-based'
+                         else
+                           rights.sub('None', 'citation-only').downcase
+                         end
     end
+
+    delegate :rights, to: :item
   end
 end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -91,7 +91,7 @@ module Cocina
         add_tags(item, obj)
 
         if obj.access
-          change_access(item, obj.access.access)
+          change_access(item, obj.access)
           item.rightsMetadata.copyright = obj.access.copyright if obj.access.copyright
           item.rightsMetadata.use_statement = obj.access.useAndReproductionStatement if obj.access.useAndReproductionStatement
           create_embargo(item, obj.access.embargo) if obj.access.embargo
@@ -171,10 +171,16 @@ module Cocina
     end
 
     def change_access(item, access)
-      raise 'location-based access not implemented' if access == 'location-based'
+      rights_type = case access.access
+                    when 'location-based'
+                      "loc:#{access.readLocation}"
+                    when 'citation-only'
+                      'none'
+                    else
+                      access.download == 'none' ? "#{access.access}-nd" : access.access
+                    end
 
       # See https://github.com/sul-dlss/dor-services/blob/master/lib/dor/datastreams/rights_metadata_ds.rb
-      rights_type = access == 'citation-only' ? 'none' : access
       Dor::RightsMetadataDS.upd_rights_xml_for_rights_type(item.rightsMetadata.ng_xml, rights_type)
       item.rightsMetadata.ng_xml_will_change!
     end

--- a/openapi.yml
+++ b/openapi.yml
@@ -983,6 +983,7 @@ components:
     Access:
       description: Access metadata
       type: object
+      additionalProperties: false
       properties:
         access:
           description: Access level
@@ -994,6 +995,25 @@ components:
             - 'citation-only'
             - 'dark'
           default: 'dark'
+        download:
+          description: Download access level for a file
+          type: string
+          enum:
+            - 'world'
+            - 'stanford'
+            - 'location-based'
+            - 'none'
+          default: 'none'
+        readLocation:
+          description: If access is "location-based", which location should have access.
+          type: string
+          enum:
+            - 'spec'
+            - 'music'
+            - 'ars'
+            - 'art'
+            - 'hoover'
+            - 'm&m'
     Administrative:
       type: object
       properties:
@@ -1330,6 +1350,7 @@ components:
         - access
     DROAccess:
       type: object
+      additionalProperties: false
       properties:
         access:
           type: string
@@ -1344,12 +1365,39 @@ components:
           description: The human readable copyright statement that applies
           example: Copyright World Trade Organization
           type: string
+        embargo:
+          $ref: '#/components/schemas/Embargo'
+        download:
+          description: >
+            Download access level. This is used in the transition from Fedora as
+            a way to set a default download level at registration that is copied
+            down to all the files.
+
+          type: string
+          enum:
+            - 'world'
+            - 'stanford'
+            - 'location-based'
+            - 'none'
+          default: 'none'
+        readLocation:
+          description: >
+            If access is "location-based", which location should have access.
+            This is used in the transition from Fedora as a way to set a default
+            readLocation at registration that is copied down to all the files.
+
+          type: string
+          enum:
+            - 'spec'
+            - 'music'
+            - 'ars'
+            - 'art'
+            - 'hoover'
+            - 'm&m'
         useAndReproductionStatement:
           description: The human readable use and reproduction statement that applies
           example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
           type: string
-        embargo:
-          $ref: '#/components/schemas/Embargo'
     DROStructural:
       description: Structural metadata
       type: object

--- a/spec/requests/collections_for_object_spec.rb
+++ b/spec/requests/collections_for_object_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe 'Get the object' do
           label: 'collection #1',
           version: 1,
           access: {
-            access: 'dark'
+            access: 'dark',
+            download: 'none'
           },
           administrative: {},
           description: {

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -430,7 +430,10 @@ RSpec.describe 'Create object' do
                                   { viewingDirection: 'right-to-left' }
                                 ]
                               },
-                              access: { access: 'world' })
+                              access: {
+                                access: 'world',
+                                download: 'world'
+                              })
     end
     let(:data) do
       <<~JSON
@@ -631,7 +634,11 @@ RSpec.describe 'Create object' do
                                   { viewingDirection: 'right-to-left' }
                                 ]
                               },
-                              access: { access: 'citation-only', embargo: { access: 'world', releaseDate: '2020-02-29' } })
+                              access: {
+                                access: 'citation-only',
+                                download: 'none',
+                                embargo: { access: 'world', releaseDate: '2020-02-29' }
+                              })
     end
     let(:data) do
       <<~JSON

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe 'Get the object' do
           access: {
             access: 'world',
             copyright: 'All rights reserved unless otherwise indicated.',
+            download: 'none',
             useAndReproductionStatement: 'Property rights reside with the repository...'
           },
           administrative: {},
@@ -81,11 +82,12 @@ RSpec.describe 'Get the object' do
           access: {
             access: 'citation-only',
             copyright: 'All rights reserved unless otherwise indicated.',
-            useAndReproductionStatement: 'Property rights reside with the repository...',
+            download: 'none',
             embargo: {
               releaseDate: '2019-09-26T07:00:00.000+00:00',
               access: 'world'
-            }
+            },
+            useAndReproductionStatement: 'Property rights reside with the repository...'
           },
           administrative: {
             releaseTags: [
@@ -142,7 +144,8 @@ RSpec.describe 'Get the object' do
         label: 'foo',
         version: 1,
         access: {
-          access: 'world'
+          access: 'world',
+          download: 'none'
         },
         administrative: {},
         description: {
@@ -240,7 +243,7 @@ RSpec.describe 'Get the object' do
       expect(json['type']).to eq 'http://cocina.sul.stanford.edu/models/object.jsonld'
       expect(json['label']).to eq 'foo'
       expect(json['version']).to eq 1
-      expect(json['access']).to eq('access' => 'dark')
+      expect(json['access']).to eq('access' => 'dark', 'download' => 'none')
       expect(json['identification']).to eq('sourceId' => 'dissertationid:00000123')
       expect(json['structural']).to eq({})
     end

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Get the object' do
           access: {
             access: 'world',
             copyright: 'All rights reserved unless otherwise indicated.',
-            download: 'none',
+            download: 'world',
             useAndReproductionStatement: 'Property rights reside with the repository...'
           },
           administrative: {},
@@ -145,7 +145,7 @@ RSpec.describe 'Get the object' do
         version: 1,
         access: {
           access: 'world',
-          download: 'none'
+          download: 'world'
         },
         administrative: {},
         description: {

--- a/spec/services/cocina/access_builder_spec.rb
+++ b/spec/services/cocina/access_builder_spec.rb
@@ -34,7 +34,54 @@ RSpec.describe Cocina::AccessBuilder do
     end
 
     it 'builds the hash' do
-      expect(access).to eq(access: 'world')
+      expect(access).to eq(access: 'world', download: 'world')
+    end
+  end
+
+  context 'with location access' do
+    let(:xml) do
+      <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <location>spec</location>
+            </machine>
+          </access>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the hash' do
+      expect(access).to eq(access: 'location-based', readLocation: 'spec', download: 'location-based')
+    end
+  end
+
+  context 'with no-download' do
+    let(:xml) do
+      <<~XML
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <world rule="no-download"/>
+            </machine>
+          </access>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the hash' do
+      expect(access).to eq(access: 'world', download: 'none')
     end
   end
 end

--- a/spec/services/cocina/dro_access_builder_spec.rb
+++ b/spec/services/cocina/dro_access_builder_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Cocina::DROAccessBuilder do
 
     it 'builds the hash' do
       expect(access).to eq(access: 'world',
+                           download: 'world',
                            useAndReproductionStatement: 'Property rights reside with the repository. '\
                            'Literary rights reside with the creators of the documents or their heirs. ' \
                            'To obtain permission to publish or reproduce, please contact the Public ' \
@@ -77,6 +78,7 @@ RSpec.describe Cocina::DROAccessBuilder do
 
     it 'builds the hash' do
       expect(access).to eq(access: 'world',
+                           download: 'world',
                            copyright: 'Copyright © World Trade Organization',
                            useAndReproductionStatement: 'Official WTO documents are free for public use.')
     end
@@ -106,6 +108,7 @@ RSpec.describe Cocina::DROAccessBuilder do
 
     it 'builds the hash' do
       expect(access).to eq(access: 'world',
+                           download: 'world',
                            copyright: 'Copyright © DLSS')
     end
   end


### PR DESCRIPTION
## Why was this change made?

This will allow us to do object registration.

## Was the API documentation (openapi.yml) updated?

yes

## Does this change affect how this application integrates with other services?
yes, all create requests must pass "download" now or they will default to no-download.

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
