### PR TITLE
Allow blank descriptive metadata when registering

### DIFF
--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -120,14 +120,19 @@ module Cocina
       end
     end
 
+    # rubocop:disable Style/EmptyElse
     def build_descriptive
-      case item
-      when Dor::Etd
+      if item.is_a? Dor::Etd
+        # This is for etds that haven't yet gone through the other-metadata workflow step
         { title: [{ status: 'primary', value: item.properties.title.first }] }
-      else
+      elsif item.full_title
         { title: [{ status: 'primary', value: item.full_title }] }
+      else
+        # Items that are registered but haven't gone through assemblyWF don't have descriptive metadata
+        nil
       end
     end
+    # rubocop:enable Style/EmptyElse
 
     def build_apo_administrative
       {}.tap do |admin|

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -564,4 +564,40 @@ RSpec.describe 'Create object' do
       expect(response.location).to eq '/v1/objects/druid:gg777gg7777'
     end
   end
+
+  context 'when no description is provided (registration use case)' do
+    let(:expected) do
+      Cocina::Models::DRO.new(type: Cocina::Models::Vocab.object,
+                              label: 'This is my label',
+                              version: 1,
+                              administrative: { hasAdminPolicy: 'druid:dd999df4567' },
+                              identification: { sourceId: 'googlebooks:999999' },
+                              externalIdentifier: 'druid:gg777gg7777',
+                              structural: {},
+                              access: { access: 'world' })
+    end
+    let(:data) do
+      <<~JSON
+        { "type":"http://cocina.sul.stanford.edu/models/object.jsonld",
+          "label":"This is my label","version":1,"access":{"access":"world"},
+          "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
+          "identification":{"sourceId":"googlebooks:999999"},
+          "structural":{}}
+      JSON
+    end
+
+    before do
+      allow(Dor::SearchService).to receive(:query_by_id).and_return([])
+      allow_any_instance_of(Dor::Item).to receive(:save!)
+    end
+
+    it 'registers the book and sets the rights' do
+      post '/v1/objects',
+           params: data,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+      expect(response.body).to eq expected.to_json
+      expect(response.status).to eq(201)
+      expect(response.location).to eq '/v1/objects/druid:gg777gg7777'
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #752

## Was the API documentation (openapi.yml) updated?
no


## Does this change affect how this application integrates with other services?
yes, it fixes it.
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
