### PR TITLE
Cope with structural subschema not being provided on registration

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -81,7 +81,7 @@ module Cocina
       Dor::Item.new(pid: pid,
                     admin_policy_object_id: obj.administrative.hasAdminPolicy,
                     source_id: obj.identification.sourceId,
-                    collection_ids: [obj.structural.isMemberOf].compact,
+                    collection_ids: [obj.structural&.isMemberOf].compact,
                     catkey: catkey_for(obj),
                     label: obj.label).tap do |item|
         item.descMetadata.mods_title = obj.description.title.first.value if obj.description
@@ -90,7 +90,7 @@ module Cocina
         item.rightsMetadata.copyright = obj.access.copyright if obj.access.copyright
         item.rightsMetadata.use_statement = obj.access.useAndReproductionStatement if obj.access.useAndReproductionStatement
 
-        item.contentMetadata.content = ContentMetadataGenerator.generate(druid: pid, object: obj)
+        item.contentMetadata.content = ContentMetadataGenerator.generate(druid: pid, object: obj) if obj&.structural&.contains
         create_embargo(item, obj.access.embargo) if obj.access.embargo
       end
     end
@@ -118,7 +118,7 @@ module Cocina
     end
 
     def add_tags(item, obj)
-      tags = [content_type_tag(obj.type, obj.structural.hasMemberOrders&.first&.viewingDirection)]
+      tags = [content_type_tag(obj.type, obj.structural&.hasMemberOrders&.first&.viewingDirection)]
       tags << "Project : #{obj.administrative.partOfProject}" if obj.administrative.partOfProject
       AdministrativeTags.create(item: item, tags: tags)
     end

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -566,38 +566,70 @@ RSpec.describe 'Create object' do
   end
 
   context 'when no description is provided (registration use case)' do
-    let(:expected) do
-      Cocina::Models::DRO.new(type: Cocina::Models::Vocab.object,
-                              label: 'This is my label',
-                              version: 1,
-                              administrative: { hasAdminPolicy: 'druid:dd999df4567' },
-                              identification: { sourceId: 'googlebooks:999999' },
-                              externalIdentifier: 'druid:gg777gg7777',
-                              structural: {},
-                              access: { access: 'world' })
-    end
-    let(:data) do
-      <<~JSON
-        { "type":"http://cocina.sul.stanford.edu/models/object.jsonld",
-          "label":"This is my label","version":1,"access":{"access":"world"},
-          "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
-          "identification":{"sourceId":"googlebooks:999999"},
-          "structural":{}}
-      JSON
-    end
-
     before do
       allow(Dor::SearchService).to receive(:query_by_id).and_return([])
       allow_any_instance_of(Dor::Item).to receive(:save!)
     end
 
-    it 'registers the book and sets the rights' do
-      post '/v1/objects',
-           params: data,
-           headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-      expect(response.body).to eq expected.to_json
-      expect(response.status).to eq(201)
-      expect(response.location).to eq '/v1/objects/druid:gg777gg7777'
+    context 'when structural is provided' do
+      let(:expected) do
+        Cocina::Models::DRO.new(type: Cocina::Models::Vocab.object,
+                                label: 'This is my label',
+                                version: 1,
+                                administrative: { hasAdminPolicy: 'druid:dd999df4567' },
+                                identification: { sourceId: 'googlebooks:999999' },
+                                externalIdentifier: 'druid:gg777gg7777',
+                                structural: {},
+                                access: { access: 'world' })
+      end
+      let(:data) do
+        <<~JSON
+          { "type":"http://cocina.sul.stanford.edu/models/object.jsonld",
+            "label":"This is my label","version":1,"access":{"access":"world"},
+            "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
+            "identification":{"sourceId":"googlebooks:999999"},
+            "structural":{}}
+        JSON
+      end
+
+      it 'registers the object' do
+        post '/v1/objects',
+             params: data,
+             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+        expect(response.body).to eq expected.to_json
+        expect(response.status).to eq(201)
+        expect(response.location).to eq '/v1/objects/druid:gg777gg7777'
+      end
+    end
+
+    context 'when structural is not provided' do
+      let(:expected) do
+        Cocina::Models::DRO.new(type: Cocina::Models::Vocab.object,
+                                label: 'This is my label',
+                                version: 1,
+                                administrative: { hasAdminPolicy: 'druid:dd999df4567' },
+                                identification: { sourceId: 'googlebooks:999999' },
+                                externalIdentifier: 'druid:gg777gg7777',
+                                structural: {},
+                                access: { access: 'world' })
+      end
+      let(:data) do
+        <<~JSON
+          { "type":"http://cocina.sul.stanford.edu/models/object.jsonld",
+            "label":"This is my label","version":1,"access":{"access":"world"},
+            "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
+            "identification":{"sourceId":"googlebooks:999999"}}
+        JSON
+      end
+
+      it 'registers the object' do
+        post '/v1/objects',
+             params: data,
+             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+        expect(response.body).to eq expected.to_json
+        expect(response.status).to eq(201)
+        expect(response.location).to eq '/v1/objects/druid:gg777gg7777'
+      end
     end
   end
 end


### PR DESCRIPTION

## Why was this change made?

In the registration use case, the only thing that demands the structural subschema is 'isMemberOf', but this is optional, so there's nothing required in it

Fixes #775

## Was the API documentation (openapi.yml) updated?

no

## Does this change affect how this application integrates with other services?

yes, it fixes it.
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
