### PR TITLE
Handle objects that don't provide access subschema

### DIFF
--- a/app/services/validate_dark_service.rb
+++ b/app/services/validate_dark_service.rb
@@ -14,7 +14,7 @@ class ValidateDarkService
   def invalid_files
     @invalid_files ||= begin
       [].tap do |invalid_files|
-        next unless item.access.access == 'dark'
+        next unless item.access&.access == 'dark'
 
         files.each do |file|
           invalid_files << file if file.administrative.shelve || file.access.access != 'dark'


### PR DESCRIPTION

## Why was this change made?

This indicates they should use the default provided by the APO

Fixes #776


## Was the API documentation (openapi.yml) updated?
no


## Does this change affect how this application integrates with other services?

yes, it fixes it.
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
