### PR TITLE
Create stub MODS when catkey and descriptive are not provided

### DIFF
--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -60,9 +60,10 @@ module Cocina
         label: item.label,
         version: item.current_version.to_i,
         administrative: build_administrative,
-        description: build_descriptive,
         access: AccessBuilder.build(item)
       }.tap do |props|
+        description = build_descriptive
+        props[:description] = description unless description.nil?
         identification = build_identification
         identification[:catalogLinks] = [{ catalog: 'symphony', catalogRecordId: item.catkey }] if item.catkey
         props[:identification] = identification unless identification.empty?
@@ -120,19 +121,14 @@ module Cocina
       end
     end
 
-    # rubocop:disable Style/EmptyElse
     def build_descriptive
       if item.is_a? Dor::Etd
         # This is for etds that haven't yet gone through the other-metadata workflow step
         { title: [{ status: 'primary', value: item.properties.title.first }] }
-      elsif item.full_title
-        { title: [{ status: 'primary', value: item.full_title }] }
       else
-        # Items that are registered but haven't gone through assemblyWF don't have descriptive metadata
-        nil
+        { title: [{ status: 'primary', value: item.full_title }] }
       end
     end
-    # rubocop:enable Style/EmptyElse
 
     def build_apo_administrative
       {}.tap do |admin|

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -53,13 +53,6 @@ module Cocina
                   else
                     raise "unsupported type #{obj.type}"
                   end
-
-      # Synch from symphony if a catkey is present
-      if af_object.catkey
-        RefreshMetadataAction.run(identifiers: ["catkey:#{af_object.catkey}"], datastream: af_object.descMetadata)
-        af_object.label = MetadataService.label_from_mods(af_object.descMetadata.ng_xml)
-      end
-
       af_object.save!
       af_object
     end
@@ -71,7 +64,7 @@ module Cocina
                                  admin_policy_object_id: obj.administrative.hasAdminPolicy,
                                  # source_id: obj.identification.sourceId,
                                  label: obj.label).tap do |item|
-        item.descMetadata.mods_title = obj.description.title.first.value if obj.description
+        add_description(item, obj)
 
         admin_node = item.administrativeMetadata.ng_xml.xpath('//administrativeMetadata').first
         admin_node.add_child "<dissemination><workflow id=\"#{obj.administrative.registrationWorkflow}\"></dissemination>"
@@ -89,7 +82,7 @@ module Cocina
                     collection_ids: [obj.structural&.isMemberOf].compact,
                     catkey: catkey_for(obj),
                     label: obj.label).tap do |item|
-        item.descMetadata.mods_title = obj.description.title.first.value if obj.description
+        add_description(item, obj)
         add_tags(item, obj)
         change_access(item, obj.access.access)
         item.rightsMetadata.copyright = obj.access.copyright if obj.access.copyright
@@ -114,12 +107,24 @@ module Cocina
                           admin_policy_object_id: obj.administrative.hasAdminPolicy,
                           catkey: catkey_for(obj),
                           label: obj.label).tap do |item|
-        item.descMetadata.mods_title = obj.description.title.first.value if obj.description
+        add_description(item, obj)
       end
     end
 
     def catkey_for(obj)
       obj.identification&.catalogLinks&.find { |l| l.catalog == 'symphony' }&.catalogRecordId
+    end
+
+    def add_description(item, obj)
+      # Synch from symphony if a catkey is present
+      if item.catkey
+        RefreshMetadataAction.run(identifiers: ["catkey:#{item.catkey}"], datastream: item.descMetadata)
+        item.label = MetadataService.label_from_mods(item.descMetadata.ng_xml)
+      elsif obj.description
+        item.descMetadata.mods_title = obj.description.title.first.value
+      else
+        item.descMetadata.mods_title = obj.label
+      end
     end
 
     def add_tags(item, obj)


### PR DESCRIPTION
## Why was this change made?
This follows with how the old registration service created stub mods when no catkey was provided. See https://github.com/sul-dlss/dor-services-app/blob/master/app/services/registration_service.rb#L153


## Was the API documentation (openapi.yml) updated?
no


## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
