### PR TITLE
Turn off validation of dark until pre-assembly can make valid objects

### DIFF
--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -16,12 +16,13 @@ class PublishJob < ApplicationJob
 
       validator = validator_for?(item)
       unless validator.valid?
-        return LogFailureJob.perform_later(druid: druid,
-                                           background_job_result: background_job_result,
-                                           workflow: workflow,
-                                           workflow_process: 'publish-complete',
-                                           output: { errors: [{ title: 'Access mismatch',
-                                                                detail: "Not all files have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}" }] })
+        Honeybadger.notify("Not all files for '#{druid}' have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}")
+        # return LogFailureJob.perform_later(druid: druid,
+        #                                    background_job_result: background_job_result,
+        #                                    workflow: workflow,
+        #                                    workflow_process: 'publish-complete',
+        #                                    output: { errors: [{ title: 'Access mismatch',
+        #                                                         detail: "Not all files have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}" }] })
       end
 
       PublishMetadataService.publish(item)

--- a/app/jobs/shelve_job.rb
+++ b/app/jobs/shelve_job.rb
@@ -14,12 +14,13 @@ class ShelveJob < ApplicationJob
 
       validator = validator_for?(item)
       unless validator.valid?
-        return LogFailureJob.perform_later(druid: druid,
-                                           background_job_result: background_job_result,
-                                           workflow: 'accessionWF',
-                                           workflow_process: 'shelve-complete',
-                                           output: { errors: [{ title: 'Access mismatch',
-                                                                detail: "Not all files have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}" }] })
+        Honeybadger.notify("Not all files for '#{druid}' have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}")
+        # return LogFailureJob.perform_later(druid: druid,
+        #                                    background_job_result: background_job_result,
+        #                                    workflow: 'accessionWF',
+        #                                    workflow_process: 'shelve-complete',
+        #                                    output: { errors: [{ title: 'Access mismatch',
+        #                                                         detail: "Not all files have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}" }] })
       end
 
       ShelvingService.shelve(item)

--- a/spec/jobs/publish_job_spec.rb
+++ b/spec/jobs/publish_job_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe PublishJob, type: :job do
     end
   end
 
-  context 'when fails dark validation' do
+  context 'when fails dark validation', skip: true do
     let(:valid) { false }
     let(:invalid_filenames) { ['foo.txt', 'bar.txt'] }
 

--- a/spec/jobs/shelve_job_spec.rb
+++ b/spec/jobs/shelve_job_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ShelveJob, type: :job do
     end
   end
 
-  context 'when fails dark validation' do
+  context 'when fails dark validation', skip: true do
     let(:valid) { false }
     let(:invalid_filenames) { ['foo.txt', 'bar.txt'] }
 


### PR DESCRIPTION
## Why was this change made?

Fixes #787

## Was the API documentation (openapi.yml) updated?
n/a


## Does this change affect how this application integrates with other services?
n/a
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
