### PR TITLE
Truncates label and adds identity metadata when registering with coci…

### DIFF
--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -38,7 +38,8 @@ module Cocina
       {
         externalIdentifier: item.pid,
         type: dro_type,
-        label: item.label,
+        # Label may have been truncated, so prefer objectLabel.
+        label: item.objectLabel.first || item.label,
         version: item.current_version.to_i,
         administrative: build_dro_administrative,
         access: DROAccessBuilder.build(item),

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -210,6 +210,16 @@ RSpec.describe Cocina::Mapper do
         expect { cocina_model }.to raise_error(/has a null sourceId/)
       end
     end
+
+    context 'when item has identityMetadata objectLabel' do
+      before do
+        item.identityMetadata.objectLabel = 'Use me'
+      end
+
+      it 'prefers objectLabel' do
+        expect(cocina_model.label).to eq('Use me')
+      end
+    end
   end
 
   context 'when item is an Etd' do


### PR DESCRIPTION
…na model.

closes #785
closes #779

## Why was this change made?
So that Fedora can persist long titles, but the long title is not lost.


## Was the API documentation (openapi.yml) updated?
No.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No.