### PR TITLE
Completely disable dark validation for shelve and publish.

### DIFF
--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -14,16 +14,17 @@ class PublishJob < ApplicationJob
     begin
       item = Dor.find(druid)
 
-      validator = validator_for?(item)
-      unless validator.valid?
-        Honeybadger.notify("Not all files for '#{druid}' have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}")
-        # return LogFailureJob.perform_later(druid: druid,
-        #                                    background_job_result: background_job_result,
-        #                                    workflow: workflow,
-        #                                    workflow_process: 'publish-complete',
-        #                                    output: { errors: [{ title: 'Access mismatch',
-        #                                                         detail: "Not all files have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}" }] })
-      end
+      # Disabling validation until pre-assembly and WAS handle this correctly.
+      # validator = validator_for?(item)
+      # unless validator.valid?
+      # Honeybadger.notify("Not all files for '#{druid}' have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}")
+      # return LogFailureJob.perform_later(druid: druid,
+      #                                    background_job_result: background_job_result,
+      #                                    workflow: workflow,
+      #                                    workflow_process: 'publish-complete',
+      #                                    output: { errors: [{ title: 'Access mismatch',
+      #                                                         detail: "Not all files have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}" }] })
+      # end
 
       PublishMetadataService.publish(item)
       EventFactory.create(druid: druid, event_type: 'publishing_complete', data: { background_job_result_id: background_job_result.id })

--- a/app/jobs/shelve_job.rb
+++ b/app/jobs/shelve_job.rb
@@ -12,16 +12,17 @@ class ShelveJob < ApplicationJob
     begin
       item = Dor.find(druid)
 
-      validator = validator_for?(item)
-      unless validator.valid?
-        Honeybadger.notify("Not all files for '#{druid}' have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}")
-        # return LogFailureJob.perform_later(druid: druid,
-        #                                    background_job_result: background_job_result,
-        #                                    workflow: 'accessionWF',
-        #                                    workflow_process: 'shelve-complete',
-        #                                    output: { errors: [{ title: 'Access mismatch',
-        #                                                         detail: "Not all files have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}" }] })
-      end
+      # Disabling validation until pre-assembly and WAS handle this correctly.
+      # validator = validator_for?(item)
+      # unless validator.valid?
+      # Honeybadger.notify("Not all files for '#{druid}' have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}")
+      # return LogFailureJob.perform_later(druid: druid,
+      #                                    background_job_result: background_job_result,
+      #                                    workflow: 'accessionWF',
+      #                                    workflow_process: 'shelve-complete',
+      #                                    output: { errors: [{ title: 'Access mismatch',
+      #                                                         detail: "Not all files have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}" }] })
+      # end
 
       ShelvingService.shelve(item)
       EventFactory.create(druid: druid, event_type: 'shelving_complete', data: { background_job_result_id: background_job_result.id })


### PR DESCRIPTION
## Why was this change made?
This was honeybadgering up a storm.


## Was the API documentation (openapi.yml) updated?
No


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No