### PR TITLE
Fix a new production XML data wrinkle

### DIFF
--- a/app/services/administrative_tags.rb
+++ b/app/services/administrative_tags.rb
@@ -131,7 +131,7 @@ class AdministrativeTags
         # There are a bunch of tags in production WITHOUT the padding spaces.
         # Fix that here unless already valid.
         tag_string.gsub!(':', ' : ') unless AdministrativeTag::VALID_TAG_PATTERN.match?(tag_string)
-        tag_string.strip!
+        tag_string.squish! # remove leading and trailing whitespace and remove double/triple/etc. spaces throughout
         begin
           AdministrativeTag.create!(druid: item.pid, tag: tag_string)
         rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique

--- a/spec/services/administrative_tags_spec.rb
+++ b/spec/services/administrative_tags_spec.rb
@@ -88,10 +88,13 @@ RSpec.describe AdministrativeTags do
         LegacyTagService.add(item_without_db_tags, 'One : Two : Three')
         LegacyTagService.add(item_without_db_tags, 'Two:Three:Four') # test weirdo tags
         LegacyTagService.add(item_without_db_tags, ' Three:Four:Five') # test weirdo tags
+        LegacyTagService.add(item_without_db_tags, 'Four :  Five :  Six') # test weirdo tags
       end
 
       it 'returns administrative tags from identity metadata XML' do
-        expect(described_class.for(item: item_without_db_tags)).to eq(['One : Two : Three', 'Two : Three : Four', 'Three : Four : Five'])
+        expect(described_class.for(item: item_without_db_tags)).to eq(
+          ['One : Two : Three', 'Two : Three : Four', 'Three : Four : Five', 'Four : Five : Six']
+        )
       end
     end
   end


### PR DESCRIPTION
Namely, multiple consecutive whitespace characters in the middle of a tag

## Why was this change made?

To fix a production issue.

## Was the API documentation (openapi.yml) updated?

No.

## Does this change affect how this application integrates with other services?

No.
