### PR TITLE
Fix warning about missing location headers

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -125,7 +125,7 @@ paths:
         '201':
           description: Virtual merge action started
           headers:
-            Location:
+            location:
               description: the status of the action is found at this URI
               schema:
                 type: string
@@ -154,7 +154,7 @@ paths:
         '201':
           description: Publishing action started
           headers:
-            Location:
+            location:
               description: the status of the action is found at this URI
               schema:
                 type: string
@@ -238,7 +238,7 @@ paths:
         '201':
           description: Preservation action started
           headers:
-            Location:
+            location:
               description: the status of the action is found at this URI
               schema:
                 type: string
@@ -699,7 +699,7 @@ paths:
         '201':
           description: Shelving action started
           headers:
-            Location:
+            location:
               description: the status of the action is found at this URI
               schema:
                 type: string


### PR DESCRIPTION
Caused by them being uppercase. This did the trick in suri-rails work.

## Why was this change made?

To see less noise when validating the API spec.

## Was the API documentation (openapi.yml) updated?

Yes.

## Does this change affect how this application integrates with other services?

Nope.