### PR TITLE
Remove outdated token header warning

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,9 +13,6 @@ class ApplicationController < ActionController::API
 
   before_action :check_auth_token
 
-  # Since Basic auth was already using the Authorization header, we used something
-  # non-standard:
-  OLD_TOKEN_HEADER = 'X-Auth'
   TOKEN_HEADER = 'Authorization'
 
   private
@@ -26,9 +23,6 @@ class ApplicationController < ActionController::API
     return render json: { error: 'Not Authorized' }, status: :unauthorized unless token
 
     Honeybadger.context(invoked_by: token[:sub])
-    return unless request.headers[OLD_TOKEN_HEADER]
-
-    Honeybadger.notify("Warning: Deprecated authorization header '#{OLD_TOKEN_HEADER}' was provided, but '#{TOKEN_HEADER}' is expected")
   end
 
   def decoded_auth_token
@@ -41,10 +35,9 @@ class ApplicationController < ActionController::API
   end
 
   def http_auth_header
-    return if request.headers[OLD_TOKEN_HEADER].blank? && request.headers[TOKEN_HEADER].blank?
+    return if request.headers[TOKEN_HEADER].blank?
 
-    field = request.headers[TOKEN_HEADER] || request.headers[OLD_TOKEN_HEADER]
-    field.split(' ').last
+    request.headers[TOKEN_HEADER].split(' ').last
   end
 
   def load_item

--- a/spec/requests/authorization_spec.rb
+++ b/spec/requests/authorization_spec.rb
@@ -20,16 +20,6 @@ RSpec.describe 'Authorization' do
     end
   end
 
-  context 'with a bearer token in the old field' do
-    it 'Logs tokens to honeybadger' do
-      get '/v1/objects/druid:mk420bs7601/versions/current',
-          headers: { 'X-Auth' => "Bearer #{jwt}" }
-      expect(response.body).to eq '5'
-      expect(Honeybadger).to have_received(:notify).with("Warning: Deprecated authorization header 'X-Auth' was provided, but 'Authorization' is expected")
-      expect(Honeybadger).to have_received(:context).with(invoked_by: 'argo')
-    end
-  end
-
   context 'with a bearer token' do
     it 'Logs tokens to honeybadger' do
       get '/v1/objects/druid:mk420bs7601/versions/current',


### PR DESCRIPTION
## Why was this change made?

This should now be a dead code path. We have not had any code using the old token header for months. Remove it and clean up the code.


## Was the API documentation (openapi.yml) updated?

no

## Does this change affect how this application integrates with other services?

Nope, it shouldn't.