### PR TITLE
Restart sidekiq using systemd

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -25,7 +25,6 @@ require 'capistrano/bundler'
 require 'capistrano/honeybadger'
 require 'capistrano/passenger'
 require 'capistrano/rails/migrations'
-require 'capistrano/sidekiq'
 require 'dlss/capistrano'
 require 'whenever/capistrano'
 

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'pg'
 gem 'progressbar' # for the cleaner rake task
 gem 'retries' # for ReleaseTags::PurlClient and Goobi
 gem 'ruby-cache', '~> 0.3.0'
-gem 'sidekiq', '~> 5.2'
+gem 'sidekiq', '~> 6.0'
 gem 'sidekiq-statistic'
 gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
@@ -73,6 +73,5 @@ group :deployment do
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
   gem 'capistrano-shared_configs'
-  gem 'capistrano-sidekiq'
   gem 'dlss-capistrano'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,9 +87,6 @@ GEM
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capistrano-shared_configs (0.2.2)
-    capistrano-sidekiq (1.0.3)
-      capistrano (>= 3.9.0)
-      sidekiq (>= 3.4, < 6.0)
     chronic (0.10.2)
     cocina-models (0.31.1)
       activesupport
@@ -309,7 +306,7 @@ GEM
     psych (3.1.0)
     public_suffix (4.0.4)
     puma (3.12.4)
-    rack (2.0.9)
+    rack (2.2.2)
     rack-console (1.3.1)
       rack (>= 1.1)
       rack-test
@@ -422,11 +419,11 @@ GEM
       rest-client
     safe_yaml (1.0.5)
     scrub_rb (1.0.1)
-    sidekiq (5.2.8)
-      connection_pool (~> 2.2, >= 2.2.2)
-      rack (< 2.1.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+    sidekiq (6.0.6)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
     sidekiq-statistic (1.4.0)
       sidekiq (>= 5.0)
       tilt (~> 2.0)
@@ -495,7 +492,6 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  capistrano-sidekiq
   cocina-models (~> 0.31.0)
   committee
   config
@@ -531,7 +527,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec (~> 1.32.0)
   ruby-cache (~> 0.3.0)
-  sidekiq (~> 5.2)
+  sidekiq (~> 6.0)
   sidekiq-statistic
   simplecov (~> 0.17.1)
   spring

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -36,14 +36,6 @@ set :log_level, :info
 set :linked_dirs, %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle config/certs config/settings)
 set :linked_files, %w(bin/write_marc_record config/secrets.yml config/honeybadger.yml config/newrelic.yml config/database.yml)
 
-# Sidekiq configuration (run three processes)
-# see sidekiq.yml for concurrency and queue settings
-set :sidekiq_processes, 3
-# All of our deployed environments use RAILS_ENV=production. Without this line,
-# capistrano will run sidekiq in the `stage` or `prod` env (from the capistrano
-# stage rather than the Rails environment).
-set :sidekiq_env, 'production'
-set :sidekiq_roles, :worker
 set :passenger_roles, :web
 set :rails_env, 'production'
 
@@ -55,3 +47,4 @@ set :honeybadger_env, fetch(:stage)
 
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'
+after 'deploy:restart', 'sidekiq:restart'

--- a/lib/capistrano/tasks/sidekiq.cap
+++ b/lib/capistrano/tasks/sidekiq.cap
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :sidekiq do
+  desc 'Restart Sidekiq using systemd'
+  task :restart do
+    on roles(:worker) do
+      sudo :systemctl, 'restart', 'sidekiq-*', raise_on_non_zero_exit: false
+    end
+  end
+end


### PR DESCRIPTION
As part of this, remove capistrano-sidekiq dependency (because incompatible with our systemd-ified sidekiq configuration in puppet) and create a new task for restarting sidekiq.

NOTES:
* Until the code here is changed to support a variable number of sidekiq processes, DSA will run 5 (instead of 3) sidekiq processes: https://github.com/sul-dlss/puppet/blob/9a5ed7d8060786b61796fb55550b4c367ae9534a/modules/profile/manifests/sidekiq_systemd.pp#L10-L20
* This requires some changes in puppet, namely switching dor-services-prod (& -stage & -qa) to using the sidekiq_systemd profile, and enabling sidekiq restarts via sudo, like here: https://github.com/sul-dlss/puppet/blob/production/hieradata/node/exhibits-worker-prod.stanford.edu.eyaml#L62-L63

## Why was this change made?

To keep pace with Sidekiq.

## Was the API documentation (openapi.yml) updated?

No.

## Does this change affect how this application integrates with other services?

No.