### PR TITLE
Restart sidekiq using systemd

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -25,9 +25,8 @@ require 'capistrano/bundler'
 require 'capistrano/honeybadger'
 require 'capistrano/passenger'
 require 'capistrano/rails/migrations'
-require 'capistrano/sidekiq'
 require 'dlss/capistrano'
 require 'whenever/capistrano'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
-Dir.glob('lib/capistrano/tasks/*.cap').each { |r| import r }
+Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'pg'
 gem 'progressbar' # for the cleaner rake task
 gem 'retries' # for ReleaseTags::PurlClient and Goobi
 gem 'ruby-cache', '~> 0.3.0'
-gem 'sidekiq', '~> 5.2'
+gem 'sidekiq', '~> 6.0'
 gem 'sidekiq-statistic'
 gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
@@ -73,6 +73,5 @@ group :deployment do
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
   gem 'capistrano-shared_configs'
-  gem 'capistrano-sidekiq'
   gem 'dlss-capistrano'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,9 +87,6 @@ GEM
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capistrano-shared_configs (0.2.2)
-    capistrano-sidekiq (1.0.3)
-      capistrano (>= 3.9.0)
-      sidekiq (>= 3.4, < 6.0)
     chronic (0.10.2)
     cocina-models (0.31.1)
       activesupport
@@ -309,7 +306,7 @@ GEM
     psych (3.1.0)
     public_suffix (4.0.4)
     puma (3.12.4)
-    rack (2.0.9)
+    rack (2.2.2)
     rack-console (1.3.1)
       rack (>= 1.1)
       rack-test
@@ -422,11 +419,11 @@ GEM
       rest-client
     safe_yaml (1.0.5)
     scrub_rb (1.0.1)
-    sidekiq (5.2.8)
-      connection_pool (~> 2.2, >= 2.2.2)
-      rack (< 2.1.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+    sidekiq (6.0.6)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
     sidekiq-statistic (1.4.0)
       sidekiq (>= 5.0)
       tilt (~> 2.0)
@@ -495,7 +492,6 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  capistrano-sidekiq
   cocina-models (~> 0.31.0)
   committee
   config
@@ -531,7 +527,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec (~> 1.32.0)
   ruby-cache (~> 0.3.0)
-  sidekiq (~> 5.2)
+  sidekiq (~> 6.0)
   sidekiq-statistic
   simplecov (~> 0.17.1)
   spring

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -36,14 +36,6 @@ set :log_level, :info
 set :linked_dirs, %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle config/certs config/settings)
 set :linked_files, %w(bin/write_marc_record config/secrets.yml config/honeybadger.yml config/newrelic.yml config/database.yml)
 
-# Sidekiq configuration (run three processes)
-# see sidekiq.yml for concurrency and queue settings
-set :sidekiq_processes, 3
-# All of our deployed environments use RAILS_ENV=production. Without this line,
-# capistrano will run sidekiq in the `stage` or `prod` env (from the capistrano
-# stage rather than the Rails environment).
-set :sidekiq_env, 'production'
-set :sidekiq_roles, :worker
 set :passenger_roles, :web
 set :rails_env, 'production'
 
@@ -55,3 +47,8 @@ set :honeybadger_env, fetch(:stage)
 
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'
+# These hooks are from capistrano-sidekiq but the sidekiq tasks themselves are defined in dor-services-app
+after 'deploy:starting',  'sidekiq:quiet'
+after 'deploy:updated',   'sidekiq:stop'
+after 'deploy:published', 'sidekiq:start'
+after 'deploy:failed', 'sidekiq:restart'

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'dor-services-prod.stanford.edu', user: 'dor_services', roles: %w(web app worker)
+server 'dor-services-prod.stanford.edu', user: 'dor_services', roles: %w(web app)
 server 'dor-services-worker-prod-a.stanford.edu', user: 'dor_services', roles: %w(app worker)
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'dor-services-stage.stanford.edu', user: 'dor_services', roles: %w(web app worker)
+server 'dor-services-stage.stanford.edu', user: 'dor_services', roles: %w(web app)
 server 'dor-services-worker-stage-a.stanford.edu', user: 'dor_services', roles: %w(app worker)
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+namespace :sidekiq do
+  desc 'Quiet Sidekiq (stop fetching new tasks from Redis)'
+  task :quiet do
+    on roles(:worker) do
+      sudo :systemctl, 'reload', 'sidekiq-*', raise_on_non_zero_exit: false
+    end
+  end
+
+  desc 'Stop Sidekiq (graceful shutdown within timeout, put unfinished tasks back to Redis)'
+  task :stop do
+    on roles(:worker) do
+      sudo :systemctl, 'stop', 'sidekiq-*'
+    end
+  end
+
+  desc 'Start Sidekiq'
+  task :start do
+    on roles(:worker) do
+      sudo :systemctl, 'start', 'sidekiq-*'
+    end
+  end
+
+  desc 'Restart Sidekiq'
+  task :restart do
+    on roles(:worker) do
+      sudo :systemctl, 'restart', 'sidekiq-*', raise_on_non_zero_exit: false
+    end
+  end
+end


### PR DESCRIPTION
BLOCKED by [related PR](https://github.com/sul-dlss/puppet/pull/5267): sets `profile::systemd_sidekiq::sidekiq_count: 3` in the dor-services-app hiera to keep 3 sidekiq processes running (the default is 5), and allows restarting sidekiq via sudo.

As part of this, remove capistrano-sidekiq dependency (because incompatible with our systemd-ified sidekiq configuration in puppet) and create a new task for restarting sidekiq.

Note that this PR also removes worker responsibility from our web boxes, which
cannot use sidekiq with systemd until they undergo OS upgrades. As we don't
currently need the extra capacity, we'll run workers on dedicated worker boxes
only (using systemd).


## Why was this change made?

To keep pace with Sidekiq.

## Was the API documentation (openapi.yml) updated?

No.

## Does this change affect how this application integrates with other services?

No.