### PR TITLE
[Draft] Run workers on web boxes too

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'dor-services-prod.stanford.edu', user: 'dor_services', roles: %w(web app)
+server 'dor-services-prod.stanford.edu', user: 'dor_services', roles: %w(web app worker)
 server 'dor-services-worker-prod-a.stanford.edu', user: 'dor_services', roles: %w(app worker)
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'dor-services-stage.stanford.edu', user: 'dor_services', roles: %w(web app)
+server 'dor-services-stage.stanford.edu', user: 'dor_services', roles: %w(web app worker)
 server 'dor-services-worker-stage-a.stanford.edu', user: 'dor_services', roles: %w(app worker)
 
 Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
This was blocked by these boxes being on CentOS 6.

## Why was this change made?

To keep pace with sidekiq and increase worker capacity.

## Was the API documentation (openapi.yml) updated?

no

## Does this change affect how this application integrates with other services?

no