### PR TITLE
Ignore errors about existing archived directory when resetting workspace

### DIFF
--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -28,14 +28,14 @@ class WorkspacesController < ApplicationController
   end
 
   # Once an object has been transferred to preservation, reset the workspace by
-  # renaming the druid-tree to a versioned directory
+  # renaming the druid-tree to a versioned directory.
   def reset
     ResetWorkspaceService.reset(druid: params[:object_id], version: @item.current_version)
     head :no_content
-  rescue ResetWorkspaceService::DirectoryAlreadyExists => e
-    render build_error('Archive directory already exists', e)
-  rescue ResetWorkspaceService::BagAlreadyExists => e
-    render build_error('Archive bag already exists', e)
+  rescue ResetWorkspaceService::DirectoryAlreadyExists, ResetWorkspaceService::BagAlreadyExists
+    # We're trapping errors and doing nothing, because the belief is that these indicate
+    # this API has already been called and completed.
+    head :no_content
   end
 
   private

--- a/openapi.yml
+++ b/openapi.yml
@@ -676,12 +676,6 @@ paths:
       responses:
         '204':
           description: OK
-        '422':
-          description: The workspace was in a state where it could not be reset
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
       parameters:
         - name: object_id
           in: path

--- a/spec/requests/reset_workspace_spec.rb
+++ b/spec/requests/reset_workspace_spec.rb
@@ -23,23 +23,18 @@ RSpec.describe 'Reset workspace' do
   end
 
   context 'when an archive directory exists' do
-    let(:errmsg) { '{"errors":[{"status":"422","title":"Archive directory already exists","detail":"dir already exists"}]}' }
-
     before do
       allow(ResetWorkspaceService).to receive(:reset)
         .and_raise(ResetWorkspaceService::DirectoryAlreadyExists.new('dir already exists'))
     end
 
-    it 'returns a 422 error' do
+    it 'returns nothing' do
       post "/v1/objects/#{druid}/workspace/reset", headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response.status).to eq(422)
-      expect(response.body).to eq(errmsg)
+      expect(response).to be_no_content
     end
   end
 
   context 'when an archive bag exists' do
-    let(:errmsg) { '{"errors":[{"status":"422","title":"Archive bag already exists","detail":"bag already exists"}]}' }
-
     before do
       allow(ResetWorkspaceService).to receive(:reset)
         .and_raise(ResetWorkspaceService::BagAlreadyExists.new('bag already exists'))
@@ -47,8 +42,7 @@ RSpec.describe 'Reset workspace' do
 
     it 'returns a 422 error' do
       post "/v1/objects/#{druid}/workspace/reset", headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response.status).to eq(422)
-      expect(response.body).to eq(errmsg)
+      expect(response).to be_no_content
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

This prevents a robot error state if another process has called this previously.
Fixes sul-dlss/argo#1896

## Was the API documentation (openapi.yml) updated?

yes

## Does this change affect how this application integrates with other services?
no

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
