### PR TITLE
Stop sending workflows to preservation

### DIFF
--- a/app/services/datastream_extractor.rb
+++ b/app/services/datastream_extractor.rb
@@ -50,7 +50,6 @@ class DatastreamExtractor
       roleMetadata: false,
       sourceMetadata: false,
       versionMetadata: true,
-      workflows: false,
       geoMetadata: false
     }.freeze
 


### PR DESCRIPTION
## Why was this change made?
New objects don't make a workflows datastream.


## Was the API documentation (openapi.yml) updated?

no
