### PR TITLE
Publish collection membership data to purl

### DIFF
--- a/app/services/publish_metadata_service.rb
+++ b/app/services/publish_metadata_service.rb
@@ -20,6 +20,7 @@ class PublishMetadataService
     release_tags = ReleaseTags.for(item: item)
 
     transfer_metadata(release_tags)
+    bookkeep_collections
     publish_notify_on_success
   end
 
@@ -37,8 +38,61 @@ class PublishMetadataService
     transfer_to_document_store(PublicDescMetadataService.new(item).to_xml, 'mods')
   end
 
+  # Maintain bidirectional symlinks from:
+  #  - an item to the collections it belongs to
+  #  - a collection to the items within
+  def bookkeep_collections
+    FileUtils.mkdir_p(item_collections_dir)
+    existing_collections = Dir.children(item_collections_dir)
+
+    # Write bidirectional symlinks for collection membership
+    item.collections.each do |coll|
+      Rails.logger.debug("[Publish][#{item.pid}] Adding collection association with #{coll.pid}")
+      collection_items_dir = collection_member_dir(coll.pid)
+      FileUtils.mkdir_p(collection_items_dir)
+      FileUtils.ln_s(item.content_dir, File.join(collection_items_dir, local_part(item.pid)), force: true)
+      FileUtils.ln_s(coll.content_dir, File.join(item_collections_dir, local_part(coll.pid)), force: true)
+    end
+
+    # Remove bidirectional collection membership for collections no longer asserted
+    (existing_collections - item.collections.map { |coll| local_part(coll.pid) }).each do |coll_pid|
+      Rails.logger.debug("[Publish][#{item.pid}] Removing collection association with #{coll_pid}")
+      FileUtils.rm(File.join(item_collections_dir, coll_pid), force: true)
+
+      collection_items_dir = collection_member_dir(coll_pid)
+      next unless Dir.exist? collection_items_dir
+
+      FileUtils.rm(File.join(collection_items_dir, local_part(item.pid)), force: true)
+    end
+  end
+
+  # Remove all collection membership symlinks
+  def unbookkeep_collections
+    return unless Dir.exist? item_collections_dir
+
+    existing_collections = Dir.children(item_collections_dir)
+    existing_collections.each do |coll_pid|
+      collection_items_dir = collection_member_dir(coll_pid)
+      next unless Dir.exist? collection_items_dir
+
+      FileUtils.rm(File.join(collection_items_dir, local_part(item.pid)))
+    end
+
+    members_dir = collection_member_dir(item.pid)
+    if Dir.exist? members_dir
+      existing_members = Dir.children(members_dir)
+      existing_members.each do |item_pid|
+        item_dir = item_collections_dir(item_pid)
+        next unless Dir.exist? item_dir
+
+        FileUtils.rm(File.join(item_dir, local_part(item.pid)))
+      end
+    end
+  end
+
   # Clear out the document cache for this item
   def unpublish
+    unbookkeep_collections
     PruneService.new(druid: purl_druid).prune!
     publish_delete_on_success
   end
@@ -62,6 +116,24 @@ class PublishMetadataService
     @purl_druid ||= DruidTools::PurlDruid.new item.pid, Settings.stacks.local_document_cache_root
   end
 
+  # Get the collection membership directory for an item
+  def item_collections_dir(item_pid = nil)
+    item_druid = if item_pid
+      DruidTools::PurlDruid.new item_pid, Settings.stacks.local_document_cache_root
+    else
+      purl_druid
+    end
+
+    File.join(item_druid.content_dir, 'is_member_of_collection')
+  end
+
+  # Get the collection members directory for a collection
+  def collection_member_dir(collection_pid)
+    collection_druid = DruidTools::PurlDruid.new collection_pid, Settings.stacks.local_document_cache_root
+    File.join(collection_druid.content_dir, 'has_member_of_collection')
+  end
+
+
   ##
   # When publishing a PURL, we notify purl-fetcher of changes.
   #
@@ -77,10 +149,12 @@ class PublishMetadataService
   end
 
   def purl_services_url
-    id = item.pid.gsub(/^druid:/, '')
-
     raise 'You have not configured perl-fetcher (Settings.purl_services_url).' unless Settings.purl_services_url
 
-    "#{Settings.purl_services_url}/purls/#{id}"
+    "#{Settings.purl_services_url}/purls/#{local_part(item.pid)}"
+  end
+
+  def local_part(pid)
+    Dor::PidUtils.remove_druid_prefix(pid)
   end
 end


### PR DESCRIPTION
This supports several desirable features in PURL, but most particularly generating IIIF collection manifests for our collections.  Before going further I'd like some validation of the approach and some indication this is worth pursuing (over, say, querying purl-fetcher.. which we've resisted in order to keep the PURL application querying static filesystem-based resources instead of those new-fangled databases people keep talking about)

The symlinks from an item to its collection duplicate information from the public xml, but are necessary (in this approach) in order to clean up inbound relationship links from the collection to the items. A separate file or something could be used instead, but this approach struck me as more resilient to potential concurrency issues.

TODO:
- [ ] finish writing tests... planning to do it in the integration-test style used everywhere else in the spec except `#transfer_metadata` (formerly `#publish`, but the amount of stubbing was killing me)