### PR TITLE
Adds support for project tags when registering collections.

### DIFF
--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -41,7 +41,7 @@ module Cocina
         # Label may have been truncated, so prefer objectLabel.
         label: item.objectLabel.first || item.label,
         version: item.current_version.to_i,
-        administrative: build_dro_administrative,
+        administrative: build_administrative,
         access: DROAccessBuilder.build(item),
         structural: DroStructuralBuilder.build(item)
       }.tap do |props|
@@ -145,11 +145,6 @@ module Cocina
         admin[:hasAdminPolicy] = item.admin_policy_object_id if item.admin_policy_object_id
         release_tags = build_release_tags
         admin[:releaseTags] = release_tags unless release_tags.empty?
-      end
-    end
-
-    def build_dro_administrative
-      build_administrative.tap do |admin|
         project = project_for(item)
         admin[:partOfProject] = project if project
       end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -88,7 +88,7 @@ module Cocina
                     catkey: catkey_for(obj),
                     label: truncate_label(obj.label)).tap do |item|
         add_description(item, obj)
-        add_tags(item, obj)
+        add_dro_tags(item, obj)
 
         if obj.access
           change_access(item, obj.access)
@@ -121,6 +121,7 @@ module Cocina
                           catkey: catkey_for(obj),
                           label: truncate_label(obj.label)).tap do |item|
         add_description(item, obj)
+        add_collection_tags(item, obj)
         add_identity_metadata(obj, item, pid, 'collection')
       end
     end
@@ -143,10 +144,16 @@ module Cocina
       end
     end
 
-    def add_tags(item, obj)
+    def add_dro_tags(item, obj)
       tags = [content_type_tag(obj.type, obj.structural&.hasMemberOrders&.first&.viewingDirection)]
       tags << "Project : #{obj.administrative.partOfProject}" if obj.administrative.partOfProject
       AdministrativeTags.create(item: item, tags: tags)
+    end
+
+    def add_collection_tags(item, obj)
+      return unless obj.administrative.partOfProject
+
+      AdministrativeTags.create(item: item, tags: ["Project : #{obj.administrative.partOfProject}"])
     end
 
     def content_type_tag(type, direction)

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -474,7 +474,8 @@ RSpec.describe 'Create object' do
                                        title: [{ value: title, status: 'primary' }]
                                      },
                                      administrative: {
-                                       hasAdminPolicy: 'druid:dd999df4567'
+                                       hasAdminPolicy: 'druid:dd999df4567',
+                                       partOfProject: 'Hydrus'
                                      },
                                      externalIdentifier: druid,
                                      access: {})
@@ -483,7 +484,7 @@ RSpec.describe 'Create object' do
       <<~JSON
         {"type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
           "label":"#{label}","version":1,"access":{},
-          "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
+          "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567","partOfProject":"Hydrus"},
           "description":{"title":[{"status":"primary","value":"#{title}"}]}}
       JSON
     end


### PR DESCRIPTION
## Why was this change made?
To allow collections to be registered with project tags.


## Was the API documentation (openapi.yml) updated?
No.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
Will be tested by Hydrus.