### PR TITLE
Tweaks to descriptive metadata for collections.

### DIFF
--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -127,7 +127,7 @@ module Cocina
         # This is for etds that haven't yet gone through the other-metadata workflow step
         { title: [{ status: 'primary', value: item.properties.title.first }] }
       else
-        { title: [{ status: 'primary', value: item.full_title }] }
+        { title: [{ status: 'primary', value: item.full_title || item.label }] }
       end
     end
 

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -553,6 +553,8 @@ RSpec.describe 'Create object' do
     end
 
     context 'when the catkey is not provided and save is successful' do
+      let(:title) { label }
+
       before do
         allow_any_instance_of(Dor::Collection).to receive(:save!)
       end


### PR DESCRIPTION
## Why was this change made?
So that descreptive metadata for collections works as expected by hydrus.


## Was the API documentation (openapi.yml) updated?
No


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
Testing in hydrus.