### PR TITLE
Special handling for registering hydrus items.

### DIFF
--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -126,6 +126,9 @@ module Cocina
       if item.is_a? Dor::Etd
         # This is for etds that haven't yet gone through the other-metadata workflow step
         { title: [{ status: 'primary', value: item.properties.title.first }] }
+      elsif item.label == 'Hydrus'
+        # Some hydrus items don't have titles, so using label. See https://github.com/sul-dlss/hydrus/issues/421
+        { title: [{ status: 'primary', value: item.label }] }
       else
         { title: [{ status: 'primary', value: item.full_title }] }
       end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -131,6 +131,9 @@ module Cocina
     end
 
     def add_description(item, obj)
+      # Hydrus doesn't set description. See https://github.com/sul-dlss/hydrus/issues/421
+      return if obj.label == 'Hydrus'
+
       # Synch from symphony if a catkey is present
       if item.catkey
         RefreshMetadataAction.run(identifiers: ["catkey:#{item.catkey}"], datastream: item.descMetadata)


### PR DESCRIPTION
## Why was this change made?
Hydrus requires special handling of descriptive metadata. See https://github.com/sul-dlss/hydrus/issues/421


## Was the API documentation (openapi.yml) updated?
No


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
Tested by hydrus.