### PR TITLE
need to require shellwords to use

### DIFF
--- a/app/models/dor/update_marc_record_service.rb
+++ b/app/models/dor/update_marc_record_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'open3'
+require 'shellwords'
 
 module Dor
   class UpdateMarcRecordService < ServiceItem


### PR DESCRIPTION
## Why was this change made?

Writing service marc records needs to require shellwords to use it on the rails console.  This method is tested, so unclear why it wasn't caught.

Problem on rails console that is fixed with the require statement:

```
2.5.0 :001 > @item = Dor.find('druid:bb181jh4180')
 => #<Dor::Item pid: "druid:bb181jh4180", admin_policy_object_id: "druid:xs835jp8197">
2.5.0 :002 > Dor::UpdateMarcRecordService.new(@item).update
  AdministrativeTag Exists (0.7ms)  SELECT  1 AS one FROM "administrative_tags" WHERE "administrative_tags"."druid" = $1 LIMIT $2  [["druid", "druid:bb181jh4180"], ["LIMIT", 1]]
   (0.4ms)  SELECT "administrative_tags"."tag" FROM "administrative_tags" WHERE "administrative_tags"."druid" = $1  [["druid", "druid:bb181jh4180"]]
Traceback (most recent call last):
        6: from (irb):2
        5: from app/models/dor/update_marc_record_service.rb:11:in `update'
        4: from app/models/dor/update_marc_record_service.rb:20:in `push_symphony_records'
        3: from app/models/dor/update_marc_record_service.rb:58:in `write_symphony_records'
        2: from app/models/dor/update_marc_record_service.rb:58:in `each'
        1: from app/models/dor/update_marc_record_service.rb:59:in `block in write_symphony_records'
NameError (uninitialized constant Shellwords)
```

## Was the API documentation (openapi.yml) updated?

n/a

## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

n/a