### PR TITLE
Generate external identifiers for resources without an ID

### DIFF
--- a/app/services/cocina/dro_structural_builder.rb
+++ b/app/services/cocina/dro_structural_builder.rb
@@ -31,12 +31,12 @@ module Cocina
     attr_reader :item
 
     def build_filesets(content_metadata_ds, version:, id:)
-      content_metadata_ds.ng_xml.xpath('//resource').map do |resource_node|
+      content_metadata_ds.ng_xml.xpath('//resource').map.with_index(1) do |resource_node, index|
         files = build_files(resource_node.xpath('file'), version: version, parent_id: id)
         structural = {}
         structural[:contains] = files if files.present?
         {
-          externalIdentifier: resource_node['id'],
+          externalIdentifier: resource_node['id'] || "#{id}_#{index}",
           type: Cocina::Models::Vocab.fileset,
           label: resource_node.xpath('label').text,
           version: version,

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -26,6 +26,70 @@ RSpec.describe Cocina::Mapper do
       create(:administrative_tag, druid: item.pid, tag: type)
     end
 
+    context 'when item has resources that lack identifiers' do
+      let(:content_metadata_ds) { instance_double(Dor::ContentMetadataDS, new?: false, ng_xml: Nokogiri::XML(xml)) }
+      let(:xml) do
+        <<~XML
+          <contentMetadata type="file" objectId="druid:dd116zh0343">
+            <resource>
+              <label>Folder 1</label>
+              <file mimetype="text/plain" shelve="yes" publish="yes" size="7888" preserve="no" datetime="2012-06-15T22:57:43Z" id="folder1PuSu/story1u.txt">
+                <checksum type="md5">e2837b9f02e0b0b76f526eeb81c7aa7b</checksum>
+                <checksum type="sha1">61dfac472b7904e1413e0cbf4de432bda2a97627</checksum>
+              </file>
+              <file mimetype="text/plain" shelve="no" publish="no" size="5983" preserve="yes" datetime="2012-06-15T22:58:56Z" id="folder1PuSu/story2r.txt">
+                <checksum type="md5">dc2be64ae43f1c1db4a068603465955d</checksum>
+                <checksum type="sha1">b8a672c1848fc3d13b5f380e15835690e24600e0</checksum>
+              </file>
+              <file mimetype="text/plain" shelve="yes" publish="yes" size="5951" preserve="yes" datetime="2012-06-15T23:00:43Z" id="folder1PuSu/story3m.txt">
+                <checksum type="md5">3d67f52e032e36b641d0cad40816f048</checksum>
+                <checksum type="sha1">548f349c79928b6d0996b7ff45990bdce5ee9753</checksum>
+              </file>
+              <file mimetype="text/plain" shelve="yes" publish="yes" size="6307" preserve="yes" datetime="2012-06-15T23:02:22Z" id="folder1PuSu/story4d.txt">
+                <checksum type="md5">34f3f646523b0a8504f216483a57bce4</checksum>
+                <checksum type="sha1">d498b513add5bb138ed4f6205453a063a2434dc4</checksum>
+              </file>
+            </resource>
+            <resource>
+              <file mimetype="text/plain" shelve="no" publish="yes" size="2534" preserve="yes" datetime="2012-06-15T23:05:03Z" id="folder2PdSa/story6u.txt">
+                <checksum type="md5">1f15cc786bfe832b2fa1e6f047c500ba</checksum>
+                <checksum type="sha1">bf3af01de2afa15719d8c42a4141e3b43d06fef6</checksum>
+              </file>
+              <file mimetype="text/plain" shelve="no" publish="yes" size="17074" preserve="yes" datetime="2012-06-15T23:08:35Z" id="folder2PdSa/story7r.txt">
+                <checksum type="md5">205271287477c2309512eb664eff9130</checksum>
+                <checksum type="sha1">b23aa592ab673030ace6178e29fad3cf6a45bd32</checksum>
+              </file>
+              <file mimetype="text/plain" shelve="no" publish="yes" size="5643" preserve="yes" datetime="2012-06-15T23:09:26Z" id="folder2PdSa/story8m.txt">
+                <checksum type="md5">ce474f4c512953f20a8c4c5b92405cf7</checksum>
+                <checksum type="sha1">af9cbf5ab4f020a8bb17b180fbd5c41598d89b37</checksum>
+              </file>
+              <file mimetype="text/plain" shelve="no" publish="yes" size="19599" preserve="yes" datetime="2012-06-15T23:14:32Z" id="folder2PdSa/story9d.txt">
+                <checksum type="md5">135cb2db6a35afac590687f452053baf</checksum>
+                <checksum type="sha1">e74274d7bc06ef44a408a008f5160b3756cb2ab0</checksum>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      end
+
+      before do
+        allow(item).to receive(:contentMetadata).and_return(content_metadata_ds)
+      end
+
+      it 'builds the object with filesets and files' do
+        expect(cocina_model).to be_kind_of Cocina::Models::DRO
+        expect(cocina_model.structural.contains.size).to eq 2
+
+        resource1 = cocina_model.structural.contains.first
+        expect(resource1.label).to eq 'Folder 1'
+        expect(resource1.externalIdentifier).to eq "#{item.pid}_1"
+
+        resource2 = cocina_model.structural.contains.second
+        expect(resource2.label).to eq ''
+        expect(resource2.externalIdentifier).to eq "#{item.pid}_2"
+      end
+    end
+
     context 'with files that have exif data' do
       let(:content_metadata_ds) { instance_double(Dor::ContentMetadataDS, new?: false, ng_xml: Nokogiri::XML(xml)) }
       let(:xml) do


### PR DESCRIPTION
**HOLD** until further testing. This is the un-reverted version of https://github.com/sul-dlss/dor-services-app/pull/836.

Fixes sul-dlss/was-registrar-app#221

## Why was this change made?

This should help us map and accession WAS seed and crawl objects. One assumption
in this PR I want to call out for reviewers: We prefer a base index of 1 over a base index of 0. True?

## Was the API documentation (openapi.yml) updated?

No

## Does this change affect how this application integrates with other services?

I will deploy to stage and 1) run integration specs, and 2) test that some test objects map cleanly to the Cocina model in the Argo UI, do not generate HB alerts, and go through `accessionWF` cleanly.

Can you help me identify 3-5 such objects, @andrewjbtw? They should have `contentMetadata` with ID-less resources, and should be in the error state as described in the ticket. cc: @justinlittman 