### PR TITLE
Switched to item.collection from item.collection_ids.

### DIFF
--- a/app/services/cocina/dro_structural_builder.rb
+++ b/app/services/cocina/dro_structural_builder.rb
@@ -22,7 +22,8 @@ module Cocina
 
         structural[:contains] = build_filesets(item.contentMetadata, version: item.current_version.to_i, id: item.pid) unless item.contentMetadata.new?
         structural[:hasAgreement] = item.identityMetadata.agreementId.first unless item.identityMetadata.agreementId.empty?
-        structural[:isMemberOf] = item.collection_ids.first if item.collection_ids.present?
+        # Note that there is a bug with item.collection_ids that returns [] until item.collections is called. Below side-steps this.
+        structural[:isMemberOf] = item.collections.first.id if item.collections.present?
       end
     end
 

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'Create object' do
 
         before do
           allow(Dor::Item).to receive(:new).and_return(item)
-          allow(item).to receive(:collection_ids).and_return([])
+          allow(item).to receive(:collections).and_return([])
           allow(item).to receive(:save!)
         end
 
@@ -171,7 +171,7 @@ RSpec.describe 'Create object' do
 
         before do
           allow(Dor::Item).to receive(:new).and_return(item)
-          allow(item).to receive(:collection_ids).and_return([])
+          allow(item).to receive(:collections).and_return([])
           allow(item).to receive(:save!)
         end
 
@@ -226,7 +226,7 @@ RSpec.describe 'Create object' do
 
       before do
         allow(Dor::Item).to receive(:new).and_return(item)
-        allow(item).to receive(:collection_ids).and_return([])
+        allow(item).to receive(:collections).and_return([])
         allow(item).to receive(:save!)
       end
 
@@ -379,7 +379,7 @@ RSpec.describe 'Create object' do
 
       before do
         allow(Dor::Item).to receive(:new).and_return(item)
-        allow(item).to receive(:collection_ids).and_return([])
+        allow(item).to receive(:collections).and_return([])
         allow(item).to receive(:save!)
       end
 
@@ -438,9 +438,11 @@ RSpec.describe 'Create object' do
         end
       end
 
+      let(:collection) { Dor::Collection.new(pid: 'druid:xx888xx7777') }
+
       before do
         allow(Dor::Item).to receive(:new).and_return(item)
-        allow(item).to receive(:collection_ids).and_return(['druid:xx888xx7777'])
+        allow(item).to receive(:collections).and_return([collection])
         allow(item).to receive(:save!)
       end
 

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Get the object' do
 
     context 'when the object exists with full metadata' do
       before do
-        allow(object).to receive(:collection_ids).and_return(['druid:xx888xx7777'])
+        allow(object).to receive(:collections).and_return([collection])
 
         object.descMetadata.title_info.main_title = 'Hello'
         EmbargoService.create(item: object, release_date: DateTime.parse('2019-09-26T07:00:00Z'), access: 'world')
@@ -72,6 +72,8 @@ RSpec.describe 'Get the object' do
                                    who: 'petucket',
                                    when: '2014-08-30T01:06:28Z')
       end
+
+      let(:collection) { Dor::Collection.new(pid: 'druid:xx888xx7777') }
 
       let(:expected) do
         {

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -12,13 +12,14 @@ RSpec.describe 'Update object' do
     # Stub out AF for ObjectUpdater
     allow(item.association(:collections)).to receive(:ids_writer).and_return(true)
     # Stub out AF for ObjectMapper
-    allow(item).to receive(:collection_ids).and_return ['druid:xx888xx7777']
+    allow(item).to receive(:collections).and_return [collection]
     allow(AdministrativeTags).to receive(:create)
     allow(AdministrativeTags).to receive(:project).and_return(['Google Books'])
     allow(AdministrativeTags).to receive(:content_type).and_return(['Book (rtl)'])
     allow(AdministrativeTags).to receive(:for).and_return([])
   end
 
+  let(:collection) { Dor::Collection.new(pid: 'druid:xx888xx7777') }
   let(:apo) { Dor::AdminPolicyObject.new(pid: apo_druid) }
   let(:item) do
     Dor::Item.new(pid: druid).tap do |item|


### PR DESCRIPTION
closes #845

## Why was this change made?
collection_ids doesn't work properly.


## Was the API documentation (openapi.yml) updated?
No


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No