### PR TITLE
Add TagLabel model

### DIFF
--- a/app/models/tag_label.rb
+++ b/app/models/tag_label.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This stores the tag text. This text could be applied to more than one object by an AdministrativeTag
+class TagLabel < ApplicationRecord
+  VALID_TAG_PATTERN = /\A.+( : .+)+\z/.freeze
+
+  validates :tag, format: {
+    with: VALID_TAG_PATTERN,
+    message: 'must be a series of 2 or more strings delimited with space-padded colons, e.g., "Registered By : mjgiarlo : now"'
+  }, uniqueness: true
+
+  scope :content_type, -> { where('tag like ?', 'Process : Content Type : %') }
+  scope :project, -> { where('tag like ?', 'Project : %') }
+end

--- a/db/migrate/20200507202909_create_tag_labels.rb
+++ b/db/migrate/20200507202909_create_tag_labels.rb
@@ -1,0 +1,10 @@
+class CreateTagLabels < ActiveRecord::Migration[5.2]
+  def change
+    create_table :tag_labels do |t|
+      t.string :tag, null: false
+
+      t.timestamps
+    end
+    add_index :tag_labels, [:tag], unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -22,8 +22,6 @@ CREATE TYPE public.background_job_result_status AS ENUM (
 
 SET default_tablespace = '';
 
-SET default_with_oids = false;
-
 --
 -- Name: administrative_tags; Type: TABLE; Schema: public; Owner: -
 --
@@ -142,6 +140,37 @@ CREATE TABLE public.schema_migrations (
 
 
 --
+-- Name: tag_labels; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.tag_labels (
+    id bigint NOT NULL,
+    tag character varying NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: tag_labels_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.tag_labels_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: tag_labels_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.tag_labels_id_seq OWNED BY public.tag_labels.id;
+
+
+--
 -- Name: administrative_tags id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -160,6 +189,13 @@ ALTER TABLE ONLY public.background_job_results ALTER COLUMN id SET DEFAULT nextv
 --
 
 ALTER TABLE ONLY public.events ALTER COLUMN id SET DEFAULT nextval('public.events_id_seq'::regclass);
+
+
+--
+-- Name: tag_labels id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.tag_labels ALTER COLUMN id SET DEFAULT nextval('public.tag_labels_id_seq'::regclass);
 
 
 --
@@ -200,6 +236,14 @@ ALTER TABLE ONLY public.events
 
 ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: tag_labels tag_labels_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.tag_labels
+    ADD CONSTRAINT tag_labels_pkey PRIMARY KEY (id);
 
 
 --
@@ -245,6 +289,13 @@ CREATE INDEX index_events_on_event_type ON public.events USING btree (event_type
 
 
 --
+-- Name: index_tag_labels_on_tag; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_tag_labels_on_tag ON public.tag_labels USING btree (tag);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -254,6 +305,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190917215521'),
 ('20191015193638'),
 ('20191209192646'),
-('20200226171829');
+('20200226171829'),
+('20200507202909');
 
 

--- a/spec/models/tag_label_spec.rb
+++ b/spec/models/tag_label_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TagLabel, type: :model do
+  describe 'tag format validation' do
+    context 'with invalid values' do
+      ['Configured With', 'Registered By:mjg'].each do |tag_string|
+        subject(:tag) { described_class.new(tag: tag_string) }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+
+    context 'with valid values' do
+      ['Registered By : mjgiarlo', 'Process : Content Type : Map'].each do |tag_string|
+        subject(:tag) { described_class.new(tag: tag_string) }
+
+        it { is_expected.to be_valid }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

This is the first step in a two step process for tag-normalization.  This will allow us to prepopulate the tags table before cutting over all the code to requiring it. The full change is in #854.

Once we deploy this part of it we can begin the migration with:
```ruby
    AdministrativeTag.all.find_each do |at|
      at.update(tag_label: TagLabel.find_or_create_by!(tag: at.tag))
    end
```

## Was the API documentation (openapi.yml) updated?

no

## Does this change affect how this application integrates with other services?

no
