### PR TITLE
[HOLD] Normalize administrative tags

### DIFF
--- a/app/models/administrative_tag.rb
+++ b/app/models/administrative_tag.rb
@@ -6,10 +6,7 @@ class AdministrativeTag < ApplicationRecord
 
   belongs_to :tag_label
 
-  validates :tag, format: {
-    with: VALID_TAG_PATTERN,
-    message: 'must be a series of 2 or more strings delimited with space-padded colons, e.g., "Registered By : mjgiarlo : now"'
-  }, uniqueness: {
+  validates :tag_label_id, uniqueness: {
     scope: :druid,
     message: 'has already been assigned to the given druid (no duplicate tags for a druid)'
   }

--- a/app/models/tag_label.rb
+++ b/app/models/tag_label.rb
@@ -3,6 +3,7 @@
 # This stores the tag text. This text could be applied to more than one object by an AdministrativeTag
 class TagLabel < ApplicationRecord
   VALID_TAG_PATTERN = /\A.+( : .+)+\z/.freeze
+  has_many :administrative_tags, dependent: :destroy
 
   validates :tag, format: {
     with: VALID_TAG_PATTERN,

--- a/db/migrate/20200507224637_remove_administrative_tag_string_field.rb
+++ b/db/migrate/20200507224637_remove_administrative_tag_string_field.rb
@@ -1,0 +1,7 @@
+class RemoveAdministrativeTagStringField < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key :administrative_tags, :tag_labels
+    change_column_null :administrative_tags, :tag_label_id, false
+    remove_column :administrative_tags, :tag, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -29,10 +29,9 @@ SET default_tablespace = '';
 CREATE TABLE public.administrative_tags (
     id bigint NOT NULL,
     druid character varying NOT NULL,
-    tag character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    tag_label_id bigint
+    tag_label_id bigint NOT NULL
 );
 
 
@@ -255,20 +254,6 @@ CREATE INDEX index_administrative_tags_on_druid ON public.administrative_tags US
 
 
 --
--- Name: index_administrative_tags_on_druid_and_tag; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_administrative_tags_on_druid_and_tag ON public.administrative_tags USING btree (druid, tag);
-
-
---
--- Name: index_administrative_tags_on_tag; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_administrative_tags_on_tag ON public.administrative_tags USING btree (tag);
-
-
---
 -- Name: index_administrative_tags_on_tag_label_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -304,6 +289,14 @@ CREATE UNIQUE INDEX index_tag_labels_on_tag ON public.tag_labels USING btree (ta
 
 
 --
+-- Name: administrative_tags fk_rails_98c2c99c80; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.administrative_tags
+    ADD CONSTRAINT fk_rails_98c2c99c80 FOREIGN KEY (tag_label_id) REFERENCES public.tag_labels(id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -315,6 +308,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191209192646'),
 ('20200226171829'),
 ('20200507202909'),
-('20200507202950');
+('20200507202950'),
+('20200507224637');
 
 

--- a/spec/factories/administrative_tags.rb
+++ b/spec/factories/administrative_tags.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :administrative_tag do
     druid { 'druid:xz456jk0987' }
-    tag { 'My : Object : Rules' }
+    tag_label
   end
 end

--- a/spec/factories/tag_labels.rb
+++ b/spec/factories/tag_labels.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :tag_label do
+    tag { 'My : Object : Rules' }
+  end
+end

--- a/spec/models/administrative_tag_spec.rb
+++ b/spec/models/administrative_tag_spec.rb
@@ -3,31 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe AdministrativeTag do
-  describe 'tag format validation' do
-    context 'with invalid values' do
-      ['Configured With', 'Registered By:mjg'].each do |tag_string|
-        subject(:tag) { described_class.new(tag: tag_string) }
-
-        it { is_expected.not_to be_valid }
-      end
-    end
-
-    context 'with valid values' do
-      ['Registered By : mjgiarlo', 'Process : Content Type : Map'].each do |tag_string|
-        subject(:tag) { described_class.new(tag: tag_string) }
-
-        it { is_expected.to be_valid }
-      end
-    end
-  end
-
   describe 'tag/druid uniqueness validation' do
     let!(:existing_tag) { create(:administrative_tag) }
-    let(:duplicate_tag) { described_class.create(druid: existing_tag.druid, tag: existing_tag.tag) }
+    let(:duplicate_tag) { described_class.create(druid: existing_tag.druid, tag_label: existing_tag.tag_label) }
 
     it 'prevents duplicate rows' do
       expect(duplicate_tag).not_to be_valid
-      expect(duplicate_tag.errors.full_messages).to include('Tag has already been assigned to the given druid (no duplicate tags for a druid)')
+      expect(duplicate_tag.errors.full_messages).to include('Tag label has already been assigned to the given druid (no duplicate tags for a druid)')
     end
   end
 end

--- a/spec/services/administrative_tags_spec.rb
+++ b/spec/services/administrative_tags_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe AdministrativeTags do
 
   describe '#for' do
     before do
-      create(:administrative_tag, druid: item.pid, tag: 'Foo : Bar')
-      create(:administrative_tag, druid: item.pid, tag: 'Bar : Baz : Quux')
+      create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Foo : Bar'))
+      create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Bar : Baz : Quux'))
     end
 
     it 'returns administrative tags from the database' do
@@ -97,7 +97,7 @@ RSpec.describe AdministrativeTags do
   describe '#content_type' do
     context 'with a matching row in the database' do
       before do
-        create(:administrative_tag, druid: item.pid, tag: 'Process : Content Type : Map')
+        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Process : Content Type : Map'))
       end
 
       it 'parses and returns the content type' do
@@ -107,8 +107,8 @@ RSpec.describe AdministrativeTags do
 
     context 'with more than one matching row in the database' do
       before do
-        create(:administrative_tag, druid: item.pid, tag: 'Process : Content Type : Map')
-        create(:administrative_tag, druid: item.pid, tag: 'Process : Content Type : Media')
+        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Process : Content Type : Map'))
+        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Process : Content Type : Media'))
       end
 
       it 'parses and returns the first content type' do
@@ -118,7 +118,7 @@ RSpec.describe AdministrativeTags do
 
     context 'with no content types' do
       before do
-        create(:administrative_tag, druid: item.pid, tag: 'Foo : Bar')
+        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Foo : Bar'))
       end
 
       it 'returns an empty array' do
@@ -130,7 +130,7 @@ RSpec.describe AdministrativeTags do
   describe '#project' do
     context 'with a matching row in the database' do
       before do
-        create(:administrative_tag, druid: item.pid, tag: 'Project : Google Books')
+        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Project : Google Books'))
       end
 
       it 'parses and returns the project' do
@@ -140,8 +140,8 @@ RSpec.describe AdministrativeTags do
 
     context 'with more than one matching row in the database' do
       before do
-        create(:administrative_tag, druid: item.pid, tag: 'Project : Google Books')
-        create(:administrative_tag, druid: item.pid, tag: 'Project : Fraggle Rock Collection')
+        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Project : Google Books'))
+        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Project : Fraggle Rock Collection'))
       end
 
       it 'parses and returns the first content type' do
@@ -151,7 +151,7 @@ RSpec.describe AdministrativeTags do
 
     context 'with no project' do
       before do
-        create(:administrative_tag, druid: item.pid, tag: 'Foo : Bar')
+        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Foo : Bar'))
       end
 
       it 'returns an empty array' do
@@ -171,7 +171,7 @@ RSpec.describe AdministrativeTags do
 
     context 'when one or more tags already exist' do
       before do
-        create(:administrative_tag, druid: item.pid, tag: new_tags.first)
+        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: new_tags.first))
       end
 
       it 'creates new administrative tags and returns existing ones' do
@@ -183,9 +183,9 @@ RSpec.describe AdministrativeTags do
 
     context 'when replacing tags' do
       before do
-        create(:administrative_tag, druid: item.pid, tag: 'Test : One')
-        create(:administrative_tag, druid: item.pid, tag: 'Test : Two')
-        create(:administrative_tag, druid: item.pid, tag: 'Test : Three')
+        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Test : One'))
+        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Test : Two'))
+        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Test : Three'))
       end
 
       it 'destroys and creates new administrative tags' do
@@ -198,7 +198,7 @@ RSpec.describe AdministrativeTags do
 
   describe '#update' do
     before do
-      create(:administrative_tag, druid: item.pid, tag: current_tag)
+      create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: current_tag))
     end
 
     let(:current_tag) { 'One : Two' }
@@ -214,7 +214,7 @@ RSpec.describe AdministrativeTags do
 
   describe '#destroy' do
     before do
-      create(:administrative_tag, druid: item.pid, tag: tag)
+      create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: tag))
     end
 
     let(:tag) { 'One : Two' }

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Cocina::Mapper do
       item.identityMetadata.agreementId = [agreement]
       item.descMetadata.title_info.main_title = 'Hello'
 
-      create(:administrative_tag, druid: item.pid, tag: 'Project : Google Books')
-      create(:administrative_tag, druid: item.pid, tag: type)
+      create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Project : Google Books'))
+      create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: type))
     end
 
     context 'when item has a manuscript tag' do

--- a/spec/services/release_tags/identity_metadata_spec.rb
+++ b/spec/services/release_tags/identity_metadata_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe ReleaseTags::IdentityMetadata do
 
   before do
     # Create expected tags (see item fixture above) in the database
-    create(:administrative_tag, druid: item.pid, tag: 'Project : Revs')
-    create(:administrative_tag, druid: item.pid, tag: 'Remediated By : 3.25.0')
-    create(:administrative_tag, druid: item.pid, tag: 'tag : test1')
-    create(:administrative_tag, druid: item.pid, tag: 'old : tag')
+    create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Project : Revs'))
+    create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Remediated By : 3.25.0'))
+    create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'tag : test1'))
+    create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'old : tag'))
   end
 
   describe 'Tag sorting, combining, and comparision functions' do


### PR DESCRIPTION
## Why was this change made?
There are 29,822 unique tags and 8,139,563 tag instances, so normalizing the tags would offer a significant space savings. This would also make it possible for us to provide autocomplete on tags (currently too slow).  This step was started in #853 which will allow the migration to go smoothly.

Currently holding to deploy #855 and build the new table:

```
    AdministrativeTag.all.find_each do |at|
      at.update(tag_label: TagLabel.find_or_create_by!(tag: at.tag))
    end
```

or
```ruby
 ActiveRecord::Base.connection.execute('UPDATE administrative_tags a SET tag_label_id = (SELECT id from tag_labels b WHERE a.tag = b.tag)')
```
## Was the API documentation (openapi.yml) updated?

no

## Does this change affect how this application integrates with other services?

no
