### PR TITLE
Add tag_label_id to AdministrativeTags

### DIFF
--- a/app/models/administrative_tag.rb
+++ b/app/models/administrative_tag.rb
@@ -4,6 +4,8 @@
 class AdministrativeTag < ApplicationRecord
   VALID_TAG_PATTERN = /\A.+( : .+)+\z/.freeze
 
+  belongs_to :tag_label
+
   validates :tag, format: {
     with: VALID_TAG_PATTERN,
     message: 'must be a series of 2 or more strings delimited with space-padded colons, e.g., "Registered By : mjgiarlo : now"'

--- a/db/migrate/20200507202950_add_tag_label_id_to_administrative_tags.rb
+++ b/db/migrate/20200507202950_add_tag_label_id_to_administrative_tags.rb
@@ -1,0 +1,5 @@
+class AddTagLabelIdToAdministrativeTags < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :administrative_tags, :tag_label, index: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -31,7 +31,8 @@ CREATE TABLE public.administrative_tags (
     druid character varying NOT NULL,
     tag character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    tag_label_id bigint
 );
 
 
@@ -268,6 +269,13 @@ CREATE INDEX index_administrative_tags_on_tag ON public.administrative_tags USIN
 
 
 --
+-- Name: index_administrative_tags_on_tag_label_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_administrative_tags_on_tag_label_id ON public.administrative_tags USING btree (tag_label_id);
+
+
+--
 -- Name: index_events_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -306,6 +314,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191015193638'),
 ('20191209192646'),
 ('20200226171829'),
-('20200507202909');
+('20200507202909'),
+('20200507202950');
 
 


### PR DESCRIPTION
This allows us to further the normalization of AdministrativeTags without a downtime.

Ref #854

Now we can turn off the ability to update tags in Argo, then do:
```
    AdministrativeTag.all.find_each do |at|
      at.update(tag_label: TagLabel.find_or_create_by!(tag: at.tag))
    end
```

Then it's possible to run the final migration in #854

## Why was this change made?



## Was the API documentation (openapi.yml) updated?



## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
