### PR TITLE
Decouple the AdministrativeTags service from Fedora

### DIFF
--- a/app/controllers/administrative_tags_controller.rb
+++ b/app/controllers/administrative_tags_controller.rb
@@ -2,6 +2,7 @@
 
 # Administrative tags controller (nested resource under objects)
 class AdministrativeTagsController < ApplicationController
+  # This just validates that this is an existing object
   before_action :load_item, only: %i[create index update destroy]
 
   rescue_from(ActiveFedora::ObjectNotFoundError) do |e|
@@ -10,7 +11,7 @@ class AdministrativeTagsController < ApplicationController
 
   # Show administrative tags for an object
   def index
-    render json: AdministrativeTags.for(item: @item)
+    render json: AdministrativeTags.for(pid: params[:object_id])
   end
 
   def search
@@ -19,7 +20,7 @@ class AdministrativeTagsController < ApplicationController
   end
 
   def create
-    AdministrativeTags.create(item: @item,
+    AdministrativeTags.create(pid: params[:object_id],
                               tags: params.require(:administrative_tags),
                               replace: params[:replace])
   rescue ActiveRecord::RecordInvalid => e
@@ -29,7 +30,7 @@ class AdministrativeTagsController < ApplicationController
   end
 
   def update
-    AdministrativeTags.update(item: @item,
+    AdministrativeTags.update(pid: params[:object_id],
                               current: CGI.unescape(params[:id]),
                               new: params.require(:administrative_tag))
   rescue ActiveRecord::RecordNotFound => e
@@ -41,7 +42,7 @@ class AdministrativeTagsController < ApplicationController
   end
 
   def destroy
-    AdministrativeTags.destroy(item: @item, tag: CGI.unescape(params[:id]))
+    AdministrativeTags.destroy(pid: params[:object_id], tag: CGI.unescape(params[:id]))
   rescue ActiveRecord::RecordNotFound => e
     render status: :not_found, plain: e.message
   else

--- a/app/models/dor/service_item.rb
+++ b/app/models/dor/service_item.rb
@@ -79,11 +79,11 @@ module Dor
     # note, the content_type tag comes from value of the tag called "Process : Content Type"
     # @return [String] first collection name the item is in (blank if none)
     def content_type
-      @content_type ||= if AdministrativeTags.content_type(item: @druid_obj).empty?
+      @content_type ||= if AdministrativeTags.content_type(pid: @druid_obj.id).empty?
                           node = @druid_obj.datastreams['contentMetadata'].ng_xml.at_xpath('//contentMetadata/@type')
                           node.blank? ? '' : node.content
                         else
-                          AdministrativeTags.content_type(item: @druid_obj).first
+                          AdministrativeTags.content_type(pid: @druid_obj.id).first
                         end
     end
 
@@ -92,7 +92,7 @@ module Dor
     def project_name
       @project_name ||= begin
         project_tag_id = 'Project : '
-        content_tag = AdministrativeTags.for(item: @druid_obj).select { |tag| tag.include?(project_tag_id) }
+        content_tag = AdministrativeTags.for(pid: @druid_obj.id).select { |tag| tag.include?(project_tag_id) }
         content_tag.empty? ? '' : content_tag[0].gsub(project_tag_id, '').strip
       end
     end
@@ -102,7 +102,7 @@ module Dor
     def goobi_workflow_name
       @goobi_workflow_name ||= begin
         dpg_workflow_tag_id = 'DPG : Workflow : '
-        content_tag = AdministrativeTags.for(item: @druid_obj).select { |tag| tag.include?(dpg_workflow_tag_id) }
+        content_tag = AdministrativeTags.for(pid: @druid_obj.id).select { |tag| tag.include?(dpg_workflow_tag_id) }
         content_tag.empty? ? Settings.goobi.default_goobi_workflow_name : content_tag[0].split(':').last.strip
       end
     end
@@ -112,7 +112,7 @@ module Dor
     def goobi_ocr_tag_present?
       @goobi_ocr_tag_present ||= begin
         dpg_goobi_ocr_tag = 'DPG : OCR : TRUE'
-        AdministrativeTags.for(item: @druid_obj).any? { |tag| tag.casecmp(dpg_goobi_ocr_tag).zero? } # case insensitive compare
+        AdministrativeTags.for(pid: @druid_obj.id).any? { |tag| tag.casecmp(dpg_goobi_ocr_tag).zero? } # case insensitive compare
       end
     end
 
@@ -120,7 +120,7 @@ module Dor
     # the name of the tag is the first namespace part of the tag (before first colon), value of the tag is everything after this
     # @return [Array] of GoobiTag objects
     def goobi_tag_list
-      AdministrativeTags.for(item: @druid_obj).map do |tag|
+      AdministrativeTags.for(pid: @druid_obj.id).map do |tag|
         tag_split = tag.split(':', 2).map(&:strip) # only split on the first colon
         GoobiTag.new(name: tag_split[0], value: tag_split[1])
       end

--- a/app/services/cocina/dro_structural_builder.rb
+++ b/app/services/cocina/dro_structural_builder.rb
@@ -13,7 +13,7 @@ module Cocina
 
     def build
       {}.tap do |structural|
-        case AdministrativeTags.content_type(item: item).first
+        case AdministrativeTags.content_type(pid: item.id).first
         when 'Book (ltr)'
           structural[:hasMemberOrders] = [{ viewingDirection: 'left-to-right' }]
         when 'Book (rtl)'

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -92,7 +92,7 @@ module Cocina
     attr_reader :item
 
     def dro_type
-      case AdministrativeTags.content_type(item: item).first
+      case AdministrativeTags.content_type(pid: item.pid).first
       when 'Image'
         Cocina::Models::Vocab.image
       when '3D'
@@ -140,7 +140,7 @@ module Cocina
         admin[:hasAdminPolicy] = item.admin_policy_object_id if item.admin_policy_object_id
         release_tags = build_release_tags
         admin[:releaseTags] = release_tags unless release_tags.empty?
-        projects = AdministrativeTags.project(item: item)
+        projects = AdministrativeTags.project(pid: item.id)
         admin[:partOfProject] = projects.first if projects.any?
       end
     end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -88,7 +88,7 @@ module Cocina
                     catkey: catkey_for(obj),
                     label: truncate_label(obj.label)).tap do |item|
         add_description(item, obj)
-        add_dro_tags(item, obj)
+        add_dro_tags(pid, obj)
 
         if obj.access
           change_access(item, obj.access)
@@ -121,7 +121,7 @@ module Cocina
                           catkey: catkey_for(obj),
                           label: truncate_label(obj.label)).tap do |item|
         add_description(item, obj)
-        add_collection_tags(item, obj)
+        add_collection_tags(pid, obj)
         add_identity_metadata(obj, item, 'collection')
       end
     end
@@ -147,16 +147,16 @@ module Cocina
       end
     end
 
-    def add_dro_tags(item, obj)
+    def add_dro_tags(pid, obj)
       tags = [content_type_tag(obj.type, obj.structural&.hasMemberOrders&.first&.viewingDirection)]
       tags << "Project : #{obj.administrative.partOfProject}" if obj.administrative.partOfProject
-      AdministrativeTags.create(item: item, tags: tags)
+      AdministrativeTags.create(pid: pid, tags: tags)
     end
 
-    def add_collection_tags(item, obj)
+    def add_collection_tags(pid, obj)
       return unless obj.administrative.partOfProject
 
-      AdministrativeTags.create(item: item, tags: ["Project : #{obj.administrative.partOfProject}"])
+      AdministrativeTags.create(pid: pid, tags: ["Project : #{obj.administrative.partOfProject}"])
     end
 
     def content_type_tag(type, direction)

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -74,7 +74,7 @@ module Cocina
       item.catkey = catkey_for(obj)
       item.label = truncate_label(obj.label)
 
-      add_tags(item, obj)
+      add_tags(item.id, obj)
       change_access(item, obj.access.access)
       item.rightsMetadata.copyright = obj.access.copyright if obj.access.copyright
       item.rightsMetadata.use_statement = obj.access.useAndReproductionStatement if obj.access.useAndReproductionStatement
@@ -114,22 +114,22 @@ module Cocina
                             use_and_reproduction_statement: embargo.useAndReproductionStatement)
     end
 
-    def add_tags(item, obj)
-      add_tag(item, content_type_tag(obj.type, obj.structural&.hasMemberOrders&.first&.viewingDirection), 'Process : Content Type')
-      add_tag(item, "Project : #{obj.administrative.partOfProject}", 'Project') if obj.administrative.partOfProject
+    def add_tags(pid, obj)
+      add_tag(pid, content_type_tag(obj.type, obj.structural&.hasMemberOrders&.first&.viewingDirection), 'Process : Content Type')
+      add_tag(pid, "Project : #{obj.administrative.partOfProject}", 'Project') if obj.administrative.partOfProject
     end
 
-    def add_tag(item, new_tag, prefix)
-      existing_tag = tag_starting_with(item, prefix)
+    def add_tag(pid, new_tag, prefix)
+      existing_tag = tag_starting_with(pid, prefix)
       if existing_tag.nil?
-        AdministrativeTags.create(item: item, tags: [new_tag])
+        AdministrativeTags.create(pid: pid, tags: [new_tag])
       elsif existing_tag != new_tag
-        AdministrativeTags.update(item: item, current: existing_tag, new: new_tag)
+        AdministrativeTags.update(pid: pid, current: existing_tag, new: new_tag)
       end
     end
 
-    def tag_starting_with(item, prefix)
-      AdministrativeTags.for(item: item).each do |tag|
+    def tag_starting_with(pid, prefix)
+      AdministrativeTags.for(pid: pid).each do |tag|
         return tag if tag.start_with?(prefix)
       end
       nil

--- a/app/services/release_tags/identity_metadata.rb
+++ b/app/services/release_tags/identity_metadata.rb
@@ -28,7 +28,7 @@ class ReleaseTags
       # Get all release tags on the item and strip out the what = self ones, we've already processed all the self tags on this item.
       # This will be where we store all tags that apply, regardless of their timestamp:
       potential_applicable_release_tags = tags_for_what_value(release_tags_for_item_and_all_governing_sets, 'collection')
-      administrative_tags = AdministrativeTags.for(item: item) # Get admin tags once here and pass them down
+      administrative_tags = AdministrativeTags.for(pid: item.id) # Get admin tags once here and pass them down
 
       # We now have the keys for all potential releases, we need to check the tags: the most recent timestamp with an explicit true or false wins.
       # In a nil case, the lack of an explicit false tag we do nothing.
@@ -120,7 +120,7 @@ class ReleaseTags
       # We use false instead of [], since an item can have no admin_tags at
       # which point we'd be passing this var as [] and would not attempt to
       # retrieve it
-      admin_tags ||= AdministrativeTags.for(item: item)
+      admin_tags ||= AdministrativeTags.for(pid: item.id)
       admin_tags.include?(release_tag['tag'])
     end
 

--- a/spec/dor/goobi_spec.rb
+++ b/spec/dor/goobi_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Dor::Goobi do
     allow(goobi).to receive(:barcode).and_return('barcode_12345')
     allow(goobi).to receive(:collection_id).and_return('druid:oo000oo0001')
     allow(goobi).to receive(:collection_name).and_return('collection name')
-    allow(AdministrativeTags).to receive(:content_type).with(item: item).and_return(['book'])
+    allow(AdministrativeTags).to receive(:content_type).with(pid: pid).and_return(['book'])
   end
   # rubocop:enable RSpec/SubjectStub
 
@@ -74,7 +74,7 @@ RSpec.describe Dor::Goobi do
   end
 
   it 'creates the correct xml request with ocr tag present' do
-    allow(AdministrativeTags).to receive(:for).with(item: item).and_return(['DPG : Workflow : book_workflow', 'DPG : OCR : TRUE'])
+    allow(AdministrativeTags).to receive(:for).with(pid: pid).and_return(['DPG : Workflow : book_workflow', 'DPG : OCR : TRUE'])
     expect(goobi.goobi_xml_tags).to eq('<tag name="DPG" value="Workflow : book_workflow"/><tag name="DPG" value="OCR : TRUE"/>')
     expect(goobi.xml_request).to be_equivalent_to <<-END
       <stanfordCreationRequest>

--- a/spec/dor/service_item_spec.rb
+++ b/spec/dor/service_item_spec.rb
@@ -33,19 +33,19 @@ RSpec.describe Dor::ServiceItem do
     end
 
     it 'returns goobi_workflow_name from a valid identityMetadata' do
-      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['DPG : Workflow : book_workflow', 'Process : Content Type : Book (flipbook, ltr)'])
+      allow(AdministrativeTags).to receive(:for).with(pid: @dor_item.id).and_return(['DPG : Workflow : book_workflow', 'Process : Content Type : Book (flipbook, ltr)'])
       expect(si.goobi_workflow_name).to eq('book_workflow')
     end
 
     it 'returns first goobi_workflow_name if multiple are in the tags' do
       allow(AdministrativeTags).to receive(:for)
-        .with(item: @dor_item)
+        .with(pid: @dor_item.id)
         .and_return(['DPG : Workflow : book_workflow', 'DPG : Workflow : another_workflow', 'Process : Content Type : Book (flipbook, ltr)'])
       expect(si.goobi_workflow_name).to eq('book_workflow')
     end
 
     it 'returns blank for goobi_workflow_name if none are found' do
-      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['Process : Content Type : Book (flipbook, ltr)'])
+      allow(AdministrativeTags).to receive(:for).with(pid: @dor_item.id).and_return(['Process : Content Type : Book (flipbook, ltr)'])
       expect(si.goobi_workflow_name).to eq(Settings.goobi.default_goobi_workflow_name)
     end
   end
@@ -56,7 +56,7 @@ RSpec.describe Dor::ServiceItem do
     end
 
     it 'returns an array of arrays with the tags from the object in the key:value format expected to be passed to goobi' do
-      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['DPG : Workflow : book_workflow', 'Process : Content Type : Book (flipbook, ltr)', 'LAB : Map Work'])
+      allow(AdministrativeTags).to receive(:for).with(pid: @dor_item.id).and_return(['DPG : Workflow : book_workflow', 'Process : Content Type : Book (flipbook, ltr)', 'LAB : Map Work'])
       expect(si.goobi_tag_list.length).to eq 3
       si.goobi_tag_list.each { |goobi_tag| expect(goobi_tag.class).to eq Dor::GoobiTag }
       expect(si.goobi_tag_list[0]).to have_attributes(name: 'DPG', value: 'Workflow : book_workflow')
@@ -65,12 +65,12 @@ RSpec.describe Dor::ServiceItem do
     end
 
     it 'returns an empty array when there are no tags' do
-      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return([])
+      allow(AdministrativeTags).to receive(:for).with(pid: @dor_item.id).and_return([])
       expect(si.goobi_tag_list).to eq([])
     end
 
     it 'works with singleton tags (no colon, so no value, just a name)' do
-      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['Name : Some Value', 'JustName'])
+      allow(AdministrativeTags).to receive(:for).with(pid: @dor_item.id).and_return(['Name : Some Value', 'JustName'])
       expect(si.goobi_tag_list.length).to eq 2
       expect(si.goobi_tag_list[0].class).to eq Dor::GoobiTag
       expect(si.goobi_tag_list[0]).to have_attributes(name: 'Name', value: 'Some Value')
@@ -84,17 +84,17 @@ RSpec.describe Dor::ServiceItem do
     end
 
     it 'returns false if the goobi ocr tag is not present' do
-      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['DPG : Workflow : book_workflow', 'Process : Content Type : Book (flipbook, ltr)'])
+      allow(AdministrativeTags).to receive(:for).with(pid: @dor_item.id).and_return(['DPG : Workflow : book_workflow', 'Process : Content Type : Book (flipbook, ltr)'])
       expect(si.goobi_ocr_tag_present?).to be false
     end
 
     it 'returns true if the goobi ocr tag is present' do
-      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['DPG : Workflow : book_workflow', 'DPG : OCR : TRUE'])
+      allow(AdministrativeTags).to receive(:for).with(pid: @dor_item.id).and_return(['DPG : Workflow : book_workflow', 'DPG : OCR : TRUE'])
       expect(si.goobi_ocr_tag_present?).to be true
     end
 
     it 'returns true if the goobi ocr tag is present even if the case is mixed' do
-      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['DPG : Workflow : book_workflow', 'DPG : ocr : true'])
+      allow(AdministrativeTags).to receive(:for).with(pid: @dor_item.id).and_return(['DPG : Workflow : book_workflow', 'DPG : ocr : true'])
       expect(si.goobi_ocr_tag_present?).to be true
     end
   end
@@ -117,12 +117,12 @@ RSpec.describe Dor::ServiceItem do
     end
 
     it 'returns project name from a valid identityMetadata' do
-      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['Project : Batchelor Maps : Batch 1', 'Process : Content Type : Book (flipbook, ltr)'])
+      allow(AdministrativeTags).to receive(:for).with(pid: @dor_item.id).and_return(['Project : Batchelor Maps : Batch 1', 'Process : Content Type : Book (flipbook, ltr)'])
       expect(si.project_name).to eq('Batchelor Maps : Batch 1')
     end
 
     it 'returns blank for project name if not in tag' do
-      allow(AdministrativeTags).to receive(:for).with(item: @dor_item).and_return(['Process : Content Type : Book (flipbook, ltr)'])
+      allow(AdministrativeTags).to receive(:for).with(pid: @dor_item.id).and_return(['Process : Content Type : Book (flipbook, ltr)'])
       expect(si.project_name).to eq('')
     end
   end

--- a/spec/requests/administrative_tags_spec.rb
+++ b/spec/requests/administrative_tags_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Administrative tags' do
       it 'returns a 200' do
         get "/v1/objects/#{druid}/administrative_tags",
             headers: { 'Authorization' => "Bearer #{jwt}" }
-        expect(AdministrativeTags).to have_received(:for).with(item: item).once
+        expect(AdministrativeTags).to have_received(:for).with(pid: druid).once
         expect(response.status).to eq(200)
         expect(response.body).to eq(tags.to_json)
       end
@@ -59,7 +59,7 @@ RSpec.describe 'Administrative tags' do
              params: %( {"administrative_tags":#{tags.to_json}} ),
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
         expect(AdministrativeTags).to have_received(:create)
-          .with(item: item, tags: tags, replace: nil)
+          .with(pid: druid, tags: tags, replace: nil)
         expect(response.status).to eq(201)
       end
     end
@@ -70,7 +70,7 @@ RSpec.describe 'Administrative tags' do
              params: %( {"administrative_tags":#{tags.to_json},"replace":true} ),
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
         expect(AdministrativeTags).to have_received(:create)
-          .with(item: item, tags: tags, replace: true)
+          .with(pid: druid, tags: tags, replace: true)
         expect(response.status).to eq(201)
       end
     end
@@ -139,7 +139,7 @@ RSpec.describe 'Administrative tags' do
             params: %( {"administrative_tag":"#{new_tag}"} ),
             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
         expect(AdministrativeTags).to have_received(:update)
-          .with(item: item, current: current_tag, new: new_tag)
+          .with(pid: druid, current: current_tag, new: new_tag)
         expect(response.status).to eq(204)
       end
     end
@@ -256,7 +256,7 @@ RSpec.describe 'Administrative tags' do
         delete "/v1/objects/#{druid}/administrative_tags/#{CGI.escape(tag)}",
                headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(AdministrativeTags).to have_received(:destroy)
-          .with(item: item, tag: tag)
+          .with(pid: druid, tag: tag)
         expect(response.status).to eq(204)
       end
     end

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -99,8 +99,8 @@ RSpec.describe 'Update object' do
     expect(response.body).to eq expected.to_json
 
     # Tags are created.
-    expect(AdministrativeTags).to have_received(:create).with(item: item, tags: ['Process : Content Type : Book (rtl)'])
-    expect(AdministrativeTags).to have_received(:create).with(item: item, tags: ['Project : Google Books'])
+    expect(AdministrativeTags).to have_received(:create).with(pid: druid, tags: ['Process : Content Type : Book (rtl)'])
+    expect(AdministrativeTags).to have_received(:create).with(pid: druid, tags: ['Project : Google Books'])
   end
 
   context 'when tags change' do
@@ -119,8 +119,8 @@ RSpec.describe 'Update object' do
 
       # Tags are updated.
       expect(AdministrativeTags).not_to have_received(:create)
-      expect(AdministrativeTags).to have_received(:update).with(item: item, current: 'Process : Content Type : Book (ltr)', new: 'Process : Content Type : Book (rtl)')
-      expect(AdministrativeTags).to have_received(:update).with(item: item, current: 'Project : Tom Swift', new: 'Project : Google Books')
+      expect(AdministrativeTags).to have_received(:update).with(pid: druid, current: 'Process : Content Type : Book (ltr)', new: 'Process : Content Type : Book (rtl)')
+      expect(AdministrativeTags).to have_received(:update).with(pid: druid, current: 'Project : Tom Swift', new: 'Project : Google Books')
     end
   end
 

--- a/spec/services/administrative_tags_spec.rb
+++ b/spec/services/administrative_tags_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe AdministrativeTags do
-  let(:item) { Dor::Item.new(pid: 'druid:aa123bb7890') }
+  let(:pid) { 'druid:aa123bb7890' }
 
   describe '.for' do
     let(:instance) { instance_double(described_class, for: nil) }
@@ -13,7 +13,7 @@ RSpec.describe AdministrativeTags do
     end
 
     it 'calls #for on a new instance' do
-      described_class.for(item: item)
+      described_class.for(pid: pid)
       expect(instance).to have_received(:for).once
     end
   end
@@ -26,7 +26,7 @@ RSpec.describe AdministrativeTags do
     end
 
     it 'calls #content_type on a new instance' do
-      described_class.content_type(item: item)
+      described_class.content_type(pid: pid)
       expect(instance).to have_received(:content_type).once
     end
   end
@@ -39,7 +39,7 @@ RSpec.describe AdministrativeTags do
     end
 
     it 'calls #project on a new instance' do
-      described_class.project(item: item)
+      described_class.project(pid: pid)
       expect(instance).to have_received(:project).once
     end
   end
@@ -52,7 +52,7 @@ RSpec.describe AdministrativeTags do
     end
 
     it 'calls #create on a new instance' do
-      described_class.create(item: item, tags: ['What : Ever'])
+      described_class.create(pid: pid, tags: ['What : Ever'])
       expect(instance).to have_received(:create).once.with(tags: ['What : Ever'], replace: false)
     end
   end
@@ -65,7 +65,7 @@ RSpec.describe AdministrativeTags do
     end
 
     it 'calls #update on a new instance' do
-      described_class.update(item: item, current: 'What : Ever', new: 'What : Ever : 2')
+      described_class.update(pid: pid, current: 'What : Ever', new: 'What : Ever : 2')
       expect(instance).to have_received(:update).once.with(current: 'What : Ever', new: 'What : Ever : 2')
     end
   end
@@ -78,51 +78,51 @@ RSpec.describe AdministrativeTags do
     end
 
     it 'calls #destroy on a new instance' do
-      described_class.destroy(item: item, tag: 'What : Ever')
+      described_class.destroy(pid: pid, tag: 'What : Ever')
       expect(instance).to have_received(:destroy).once.with(tag: 'What : Ever')
     end
   end
 
   describe '#for' do
     before do
-      create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Foo : Bar'))
-      create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Bar : Baz : Quux'))
+      create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: 'Foo : Bar'))
+      create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: 'Bar : Baz : Quux'))
     end
 
     it 'returns administrative tags from the database' do
-      expect(described_class.for(item: item)).to eq(['Foo : Bar', 'Bar : Baz : Quux'])
+      expect(described_class.for(pid: pid)).to eq(['Foo : Bar', 'Bar : Baz : Quux'])
     end
   end
 
   describe '#content_type' do
     context 'with a matching row in the database' do
       before do
-        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Process : Content Type : Map'))
+        create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: 'Process : Content Type : Map'))
       end
 
       it 'parses and returns the content type' do
-        expect(described_class.content_type(item: item)).to eq(['Map'])
+        expect(described_class.content_type(pid: pid)).to eq(['Map'])
       end
     end
 
     context 'with more than one matching row in the database' do
       before do
-        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Process : Content Type : Map'))
-        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Process : Content Type : Media'))
+        create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: 'Process : Content Type : Map'))
+        create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: 'Process : Content Type : Media'))
       end
 
       it 'parses and returns the first content type' do
-        expect(described_class.content_type(item: item)).to eq(['Map'])
+        expect(described_class.content_type(pid: pid)).to eq(['Map'])
       end
     end
 
     context 'with no content types' do
       before do
-        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Foo : Bar'))
+        create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: 'Foo : Bar'))
       end
 
       it 'returns an empty array' do
-        expect(described_class.content_type(item: item)).to eq([])
+        expect(described_class.content_type(pid: pid)).to eq([])
       end
     end
   end
@@ -130,32 +130,32 @@ RSpec.describe AdministrativeTags do
   describe '#project' do
     context 'with a matching row in the database' do
       before do
-        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Project : Google Books'))
+        create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: 'Project : Google Books'))
       end
 
       it 'parses and returns the project' do
-        expect(described_class.project(item: item)).to eq(['Google Books'])
+        expect(described_class.project(pid: pid)).to eq(['Google Books'])
       end
     end
 
     context 'with more than one matching row in the database' do
       before do
-        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Project : Google Books'))
-        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Project : Fraggle Rock Collection'))
+        create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: 'Project : Google Books'))
+        create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: 'Project : Fraggle Rock Collection'))
       end
 
       it 'parses and returns the first content type' do
-        expect(described_class.project(item: item)).to eq(['Google Books'])
+        expect(described_class.project(pid: pid)).to eq(['Google Books'])
       end
     end
 
     context 'with no project' do
       before do
-        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Foo : Bar'))
+        create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: 'Foo : Bar'))
       end
 
       it 'returns an empty array' do
-        expect(described_class.project(item: item)).to eq([])
+        expect(described_class.project(pid: pid)).to eq([])
       end
     end
   end
@@ -164,33 +164,33 @@ RSpec.describe AdministrativeTags do
     let(:new_tags) { ['One : Two', 'A : B : C'] }
 
     it 'creates new administrative tags' do
-      expect { described_class.create(item: item, tags: new_tags) }
-        .to change { described_class.for(item: item).count }
+      expect { described_class.create(pid: pid, tags: new_tags) }
+        .to change { described_class.for(pid: pid).count }
         .by(new_tags.count)
     end
 
     context 'when one or more tags already exist' do
       before do
-        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: new_tags.first))
+        create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: new_tags.first))
       end
 
       it 'creates new administrative tags and returns existing ones' do
-        expect { described_class.create(item: item, tags: new_tags) }
-          .to change { described_class.for(item: item).count }
+        expect { described_class.create(pid: pid, tags: new_tags) }
+          .to change { described_class.for(pid: pid).count }
           .by(1)
       end
     end
 
     context 'when replacing tags' do
       before do
-        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Test : One'))
-        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Test : Two'))
-        create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: 'Test : Three'))
+        create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: 'Test : One'))
+        create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: 'Test : Two'))
+        create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: 'Test : Three'))
       end
 
       it 'destroys and creates new administrative tags' do
-        expect { described_class.create(item: item, tags: new_tags, replace: true) }
-          .to change { described_class.for(item: item).count }
+        expect { described_class.create(pid: pid, tags: new_tags, replace: true) }
+          .to change { described_class.for(pid: pid).count }
           .by(-1)
       end
     end
@@ -198,15 +198,15 @@ RSpec.describe AdministrativeTags do
 
   describe '#update' do
     before do
-      create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: current_tag))
+      create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: current_tag))
     end
 
     let(:current_tag) { 'One : Two' }
     let(:new_tag) { 'A : B : C' }
 
     it 'updates the administrative tag' do
-      expect { described_class.update(item: item, current: current_tag, new: new_tag) }
-        .to change { described_class.for(item: item) }
+      expect { described_class.update(pid: pid, current: current_tag, new: new_tag) }
+        .to change { described_class.for(pid: pid) }
         .from([current_tag])
         .to([new_tag])
     end
@@ -214,14 +214,14 @@ RSpec.describe AdministrativeTags do
 
   describe '#destroy' do
     before do
-      create(:administrative_tag, druid: item.pid, tag_label: create(:tag_label, tag: tag))
+      create(:administrative_tag, druid: pid, tag_label: create(:tag_label, tag: tag))
     end
 
     let(:tag) { 'One : Two' }
 
     it 'destroys the administrative tag' do
-      expect { described_class.destroy(item: item, tag: tag) }
-        .to change { described_class.for(item: item) }
+      expect { described_class.destroy(pid: pid, tag: tag) }
+        .to change { described_class.for(pid: pid) }
         .from([tag])
         .to([])
     end

--- a/spec/services/release_tags/identity_metadata_spec.rb
+++ b/spec/services/release_tags/identity_metadata_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ReleaseTags::IdentityMetadata do
   let(:item) { instantiate_fixture('druid:bb004bn8654', Dor::Item) }
   let(:releases) { described_class.for(item) }
-  let(:bryar_trans_am_admin_tags) { AdministrativeTags.for(item: item) }
+  let(:bryar_trans_am_admin_tags) { AdministrativeTags.for(pid: item.id) }
   let(:array_of_times) do
     ['2015-01-06 23:33:47Z', '2015-01-07 23:33:47Z', '2015-01-08 23:33:47Z', '2015-01-09 23:33:47Z'].map { |x| Time.parse(x).iso8601 }
   end


### PR DESCRIPTION
## Why was this change made?

The AdministrativeTags service doesn't depend on the full fedora object, just it's identifier.

## Was the API documentation (openapi.yml) updated?

no

## Does this change affect how this application integrates with other services?

no