### PR TITLE
Update the sdr-ingest-transfer step rather than preservation-ingest-i…

### DIFF
--- a/app/jobs/preserve_job.rb
+++ b/app/jobs/preserve_job.rb
@@ -10,7 +10,7 @@ class PreserveJob < ApplicationJob
     LogFailureJob.perform_later(druid: opts[:druid],
                                 background_job_result: opts[:background_job_result],
                                 workflow: 'accessionWF',
-                                workflow_process: 'preservation-ingest-initiated',
+                                workflow_process: 'sdr-ingest-transfer',
                                 output: { errors: [{ title: 'Preservation error', detail: error.message }] })
   end
 

--- a/app/jobs/start_preservation_workflow_job.rb
+++ b/app/jobs/start_preservation_workflow_job.rb
@@ -17,7 +17,7 @@ class StartPreservationWorkflowJob < ApplicationJob
     LogSuccessJob.perform_later(druid: druid,
                                 workflow: 'accessionWF',
                                 background_job_result: background_job_result,
-                                workflow_process: 'preservation-ingest-initiated')
+                                workflow_process: 'sdr-ingest-transfer')
   end
 
   private

--- a/spec/jobs/preserve_job_spec.rb
+++ b/spec/jobs/preserve_job_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe PreserveJob, type: :job do
         .with(druid: druid,
               background_job_result: result,
               workflow: 'accessionWF',
-              workflow_process: 'preservation-ingest-initiated',
+              workflow_process: 'sdr-ingest-transfer',
               output: { errors: [{ detail: error_message, title: 'Preservation error' }] })
       expect(Honeybadger).to have_received(:context).with(background_job_result_id: result.id)
     end

--- a/spec/jobs/start_preservation_workflow_job_spec.rb
+++ b/spec/jobs/start_preservation_workflow_job_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe StartPreservationWorkflowJob, type: :job do
         druid: druid,
         background_job_result: result,
         workflow: 'accessionWF',
-        workflow_process: 'preservation-ingest-initiated'
+        workflow_process: 'sdr-ingest-transfer'
       )
   end
 end


### PR DESCRIPTION
…nitiated


## Why was this change made?

preservation-ingest-initiated is going away https://github.com/sul-dlss/workflow-server-rails/pull/381 which will enable this step to be reset.


## How was this change tested?
-  infra-integration-tests

## Which documentation and/or configurations were updated?
none