### PR TITLE
Added druid to 409 error message.

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -29,9 +29,8 @@ module Cocina
 
     def validate(obj)
       if obj.is_a?(Cocina::Models::RequestDRO)
-        if Dor::SearchService.query_by_id(obj.identification.sourceId).first
-          raise Dor::DuplicateIdError.new(obj.identification.sourceId), "An object with the source ID '#{obj.identification.sourceId}' has already been registered."
-        end
+        druid = Dor::SearchService.query_by_id(obj.identification.sourceId).first
+        raise Dor::DuplicateIdError.new(obj.identification.sourceId), "An object (#{druid}) with the source ID '#{obj.identification.sourceId}' has already been registered." if druid
 
         validator = ValidateDarkService.new(obj)
         raise Dor::ParameterError, "Not all files have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}" unless validator.valid?

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -64,13 +64,14 @@ RSpec.describe 'Create object' do
     end
 
     context 'when an object already exists' do
-      let(:search_result) { ['item'] }
+      let(:search_result) { ['druid:abc123'] }
 
       it 'returns a 409 error' do
         post '/v1/objects',
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
         expect(response.status).to eq(409)
+        expect(response.body).to match(/druid:abc123/)
       end
     end
 


### PR DESCRIPTION
## Why was this change made?
To return the druid when trying to register an item with an existing source id.


## How was this change tested?
Unit tests.


## Which documentation and/or configurations were updated?
No


