### PR TITLE
Update URL path by removing v1

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -64,7 +64,7 @@ goobi:
 catalog:
   barcode_search_url: "https://searchworks.stanford.edu/barcode/%{barcode}"
   symphony:
-    json_url: "https://sirsi.example.com/symws/v1/catalog/bib/key/%{catkey}?includeFields=bib"
+    json_url: "https://sirsi.example.com/symws/catalog/bib/key/%{catkey}?includeFields=bib"
     headers:
       SD-ORIGINATING-APP-ID: DOR-SERVICES-APP
       SD-PREFERRED-ROLE: GUEST


### PR DESCRIPTION
## Why was this change made?
The `v1` part of the SymWS URL is deprecated and will be removed in the next version of SymWS.

## How was this change tested?
I did not find a test in this repo that references this specific URL path.

## Which documentation and/or configurations were updated?
`config/setting.yml`

