### PR TITLE
Ditch uniqueness validation in favor of DB constraint

### DIFF
--- a/app/controllers/administrative_tags_controller.rb
+++ b/app/controllers/administrative_tags_controller.rb
@@ -24,6 +24,12 @@ class AdministrativeTagsController < ApplicationController
                               tags: params.require(:administrative_tags),
                               replace: params[:replace])
   rescue ActiveRecord::RecordInvalid => e
+    Honeybadger.notify('[SURPRISE] AdministrativeTags.create raised AR::RecordInvalid!',
+                       context: {
+                         druid: params[:object_id],
+                         tags: params.require(:administrative_tags),
+                         replace: params[:replace]
+                       })
     render status: :conflict, plain: e.message
   else
     head :created
@@ -36,6 +42,12 @@ class AdministrativeTagsController < ApplicationController
   rescue ActiveRecord::RecordNotFound => e
     render status: :not_found, plain: e.message
   rescue ActiveRecord::RecordInvalid => e
+    Honeybadger.notify('[SURPRISE] AdministrativeTags.update raised AR::RecordInvalid!',
+                       context: {
+                         druid: params[:object_id],
+                         current: CGI.unescape(params[:id]),
+                         new: params.require(:administrative_tag)
+                       })
     render status: :conflict, plain: e.message
   else
     head :no_content

--- a/app/models/administrative_tag.rb
+++ b/app/models/administrative_tag.rb
@@ -5,9 +5,4 @@ class AdministrativeTag < ApplicationRecord
   VALID_TAG_PATTERN = /\A.+( : .+)+\z/.freeze
 
   belongs_to :tag_label
-
-  validates :tag_label_id, uniqueness: {
-    scope: :druid,
-    message: 'has already been assigned to the given druid (no duplicate tags for a druid)'
-  }
 end

--- a/app/models/tag_label.rb
+++ b/app/models/tag_label.rb
@@ -8,7 +8,7 @@ class TagLabel < ApplicationRecord
   validates :tag, format: {
     with: VALID_TAG_PATTERN,
     message: 'must be a series of 2 or more strings delimited with space-padded colons, e.g., "Registered By : mjgiarlo : now"'
-  }, uniqueness: true
+  }
 
   scope :content_type, -> { where('tag like ?', 'Process : Content Type : %') }
   scope :project, -> { where('tag like ?', 'Project : %') }

--- a/db/migrate/20200521153735_index_administrative_tags_labels.rb
+++ b/db/migrate/20200521153735_index_administrative_tags_labels.rb
@@ -1,0 +1,5 @@
+class IndexAdministrativeTagsLabels < ActiveRecord::Migration[5.2]
+  def change
+    add_index :administrative_tags, [:druid, :tag_label_id], unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -254,6 +254,13 @@ CREATE INDEX index_administrative_tags_on_druid ON public.administrative_tags US
 
 
 --
+-- Name: index_administrative_tags_on_druid_and_tag_label_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_administrative_tags_on_druid_and_tag_label_id ON public.administrative_tags USING btree (druid, tag_label_id);
+
+
+--
 -- Name: index_administrative_tags_on_tag_label_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -309,6 +316,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200226171829'),
 ('20200507202909'),
 ('20200507202950'),
-('20200507224637');
-
-
+('20200507224637'),
+('20200521153735');

--- a/spec/models/administrative_tag_spec.rb
+++ b/spec/models/administrative_tag_spec.rb
@@ -3,13 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe AdministrativeTag do
-  describe 'tag/druid uniqueness validation' do
+  describe 'tag_label/druid uniqueness' do
     let!(:existing_tag) { create(:administrative_tag) }
-    let(:duplicate_tag) { described_class.create(druid: existing_tag.druid, tag_label: existing_tag.tag_label) }
 
     it 'prevents duplicate rows' do
-      expect(duplicate_tag).not_to be_valid
-      expect(duplicate_tag.errors.full_messages).to include('Tag label has already been assigned to the given druid (no duplicate tags for a druid)')
+      expect { described_class.create(druid: existing_tag.druid, tag_label: existing_tag.tag_label) }.to raise_error(
+        ActiveRecord::RecordNotUnique,
+        /Key \(druid, tag_label_id\)=\(#{existing_tag.druid}, #{existing_tag.tag_label.id}\) already exists/
+      )
     end
   end
 end


### PR DESCRIPTION
Fixes sul-dlss/argo#2064

Would like @jcoyne to review before this is merged.

## Why was this change made?

Prefer uniqueness constraints in the database over application validations, which are prone to race conditions. As part of this work, add a new honeybadger alert if AR validation exceptions are still raised which we would no longer expect.

## How was this change tested?

I'm not sure how to test a race condition fix such as this one.

## Which documentation and/or configurations were updated?

None.