### PR TITLE
Don't validate sourceId on legacy objects

### DIFF
--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -29,7 +29,6 @@ module Cocina
               else
                 raise "unable to build '#{klass}'"
               end
-      check_source_id(props) if klass == Cocina::Models::DRO
       klass.new(props)
     end
 
@@ -169,10 +168,6 @@ module Cocina
       else
         raise UnsupportedObjectType, "Unknown type for #{item.class}"
       end
-    end
-
-    def check_source_id(props)
-      raise "Item #{props[:externalIdentifier]} has a null sourceId. This item requires remediation." if props[:identification][:sourceId].nil?
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -97,14 +97,6 @@ RSpec.describe Cocina::Mapper do
       end
     end
 
-    context 'when item has null sourceId' do
-      let(:source_id) { nil }
-
-      it 'raises' do
-        expect { cocina_model }.to raise_error(/has a null sourceId/)
-      end
-    end
-
     context 'when item has identityMetadata objectLabel' do
       before do
         item.identityMetadata.objectLabel = 'Use me'


### PR DESCRIPTION
## Why was this change made?

We know we have many legacy objects without sourceId.
See conclusions in https://github.com/sul-dlss/dor-services-app/issues/852#issuecomment-626853346

## How was this change tested

Test suite

## Which documentation and/or configurations were updated?

none

