### PR TITLE
Trap for the case when an object does not have a title

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -45,6 +45,10 @@ class ObjectsController < ApplicationController
     models = ActiveFedora::ContentModel.models_asserted_by(@item)
     @item = @item.adapt_to(Etd) if models.include?('info:fedora/afmodel:Etd')
     render json: Cocina::Mapper.build(@item)
+  rescue Cocina::Mapper::MissingTitle
+    json_api_error(status: :unprocessable_entity,
+                   title: 'Missing title',
+                   message: "All objects are required to have a title, but #{params[:id]} appears to be malformed as a title cannot be found.")
   end
 
   # Initialize specified workflow (assemblyWF by default), and also version if needed

--- a/app/services/cocina/from_fedora/title_mapper.rb
+++ b/app/services/cocina/from_fedora/title_mapper.rb
@@ -18,8 +18,10 @@ module Cocina
         elsif item.label == 'Hydrus'
           # Some hydrus items don't have titles, so using label. See https://github.com/sul-dlss/hydrus/issues/421
           item.label
-        else
+        elsif item.full_title
           item.full_title
+        else
+          raise Mapper::MissingTitle
         end
       end
 

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -5,6 +5,10 @@ module Cocina
   class Mapper
     # Raised when called on something other than an item (DRO), etd, collection, or adminPolicy (APO)
     class UnsupportedObjectType < StandardError; end
+
+    # Raised when we can't figure out the title for the object.
+    class MissingTitle < StandardError; end
+
     # @param [Dor::Abstract] item the Fedora object to convert to a cocina object
     # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]
     def self.build(item)

--- a/openapi.yml
+++ b/openapi.yml
@@ -1034,6 +1034,12 @@ paths:
                   - $ref: '#/components/schemas/DRO'
                   - $ref: '#/components/schemas/Collection'
                   - $ref: '#/components/schemas/AdminPolicy'
+        '422':
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
       parameters:
         - name: id
           in: path

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -20,10 +20,6 @@ RSpec.describe 'Get the object' do
     end
 
     context 'when the object exists with minimal metadata' do
-      before do
-        allow(object).to receive(:collection_ids).and_return([])
-      end
-
       let(:expected) do
         {
           externalIdentifier: 'druid:bc123df4567',
@@ -230,6 +226,30 @@ RSpec.describe 'Get the object' do
         get '/v1/objects/druid:mk420bs7601',
             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status(:ok)
+        expect(response_model).to eq expected
+      end
+    end
+
+    context 'when the object exists without a title' do
+      let(:object) do
+        Dor::Item.new(pid: 'druid:bc123df4567',
+                      source_id: 'src:99999',
+                      label: 'foo',
+                      read_rights: 'world')
+      end
+
+      let(:expected) do
+        {
+          errors: [{ detail: 'All objects are required to have a title, but druid:mk420bs7601 appears to be malformed as a title cannot be found.', status: '422', title: 'Missing title' }]
+        }
+      end
+
+      let(:response_model) { JSON.parse(response.body).deep_symbolize_keys }
+
+      it 'returns the object' do
+        get '/v1/objects/druid:mk420bs7601',
+            headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response_model).to eq expected
       end
     end

--- a/spec/services/cocina/from_fedora/title_mapper_spec.rb
+++ b/spec/services/cocina/from_fedora/title_mapper_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::FromFedora::TitleMapper do
+  describe '.build' do
+    subject(:build) { described_class.build(object) }
+
+    context 'when the object has no title' do
+      let(:object) { Dor::Item.new }
+
+      it 'raises and error' do
+        expect { build }.to raise_error Cocina::Mapper::MissingTitle
+      end
+    end
+  end
+end


### PR DESCRIPTION
and display a more helpful error. 

## Why was this change made?
 The current error:
```
Cocina::Models::ValidationError: #/components/schemas/DescriptiveBasicValue/properties/value does not allow null values
```
is rather opaque as to what the problem is.



## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?

openapi.yml and generated docs.
