### PR TITLE
Derive type from contentType

### DIFF
--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -91,21 +91,31 @@ module Cocina
     attr_reader :item
 
     def dro_type
-      case AdministrativeTags.content_type(pid: item.pid).first
-      when 'Image'
-        Cocina::Models::Vocab.image
-      when '3D'
-        Cocina::Models::Vocab.three_dimensional
-      when 'Map'
-        Cocina::Models::Vocab.map
-      when 'Media'
-        Cocina::Models::Vocab.media
-      when /^Manuscript/ # Manuscript is a subtype of image
-        Cocina::Models::Vocab.manuscript
-      when 'Book (ltr)', 'Book (rtl)'
+      case item.contentMetadata.contentType.first
+      when 'image'
+        if AdministrativeTags.content_type(pid: item.pid).first =~ /^Manuscript/
+          Cocina::Models::Vocab.manuscript
+        else
+          Cocina::Models::Vocab.image
+        end
+      when 'book'
         Cocina::Models::Vocab.book
-      else
+      when 'media'
+        Cocina::Models::Vocab.media
+      when 'map'
+        Cocina::Models::Vocab.map
+      when 'geo'
+        Cocina::Models::Vocab.geo
+      when 'webarchive-seed'
+        Cocina::Models::Vocab.webarchive_seed
+      when '3d'
+        Cocina::Models::Vocab.three_dimensional
+      when 'document'
+        Cocina::Models::Vocab.document
+      when 'file', nil
         Cocina::Models::Vocab.object
+      else
+        raise "Unknown content type #{item.contentMetadata.contentType.first}"
       end
     end
 

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -98,7 +98,7 @@ module Cocina
           apply_default_access(item)
         end
 
-        item.contentMetadata.content = ContentMetadataGenerator.generate(druid: pid, object: obj) if obj&.structural&.contains
+        item.contentMetadata.content = ContentMetadataGenerator.generate(druid: pid, object: obj)
 
         add_identity_metadata(obj, item, 'item')
       end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -147,7 +147,7 @@ module Cocina
     end
 
     def add_dro_tags(pid, obj)
-      tags = [content_type_tag(obj.type, obj.structural&.hasMemberOrders&.first&.viewingDirection)]
+      tags = [ToFedora::ProcessTag.map(obj.type, obj.structural&.hasMemberOrders&.first&.viewingDirection)]
       tags << "Project : #{obj.administrative.partOfProject}" if obj.administrative.partOfProject
       AdministrativeTags.create(pid: pid, tags: tags)
     end
@@ -156,27 +156,6 @@ module Cocina
       return unless obj.administrative.partOfProject
 
       AdministrativeTags.create(pid: pid, tags: ["Project : #{obj.administrative.partOfProject}"])
-    end
-
-    def content_type_tag(type, direction)
-      tag = case type
-            when Cocina::Models::Vocab.image
-              'Image'
-            when Cocina::Models::Vocab.three_dimensional
-              '3D'
-            when Cocina::Models::Vocab.map
-              'Map'
-            when Cocina::Models::Vocab.media
-              'Media'
-            when Cocina::Models::Vocab.manuscript
-              'Manuscript'
-            when Cocina::Models::Vocab.book
-              short_dir = direction == 'right-to-left' ? 'rtl' : 'ltr'
-              "Book (#{short_dir})"
-            else
-              Cocina::Models::Vocab.object
-            end
-      "Process : Content Type : #{tag}"
     end
 
     def change_access(item, access)

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -124,7 +124,7 @@ module Cocina
     end
 
     def add_tags(pid, obj)
-      add_tag(pid, content_type_tag(obj.type, obj.structural&.hasMemberOrders&.first&.viewingDirection), 'Process : Content Type')
+      add_tag(pid, ToFedora::ProcessTag.map(obj.type, obj.structural&.hasMemberOrders&.first&.viewingDirection), 'Process : Content Type')
       add_tag(pid, "Project : #{obj.administrative.partOfProject}", 'Project') if obj.administrative.partOfProject
     end
 
@@ -142,28 +142,6 @@ module Cocina
         return tag if tag.start_with?(prefix)
       end
       nil
-    end
-
-    # TODO: duplicate from ObjectCreator
-    def content_type_tag(type, direction)
-      tag = case type
-            when Cocina::Models::Vocab.image
-              'Image'
-            when Cocina::Models::Vocab.three_dimensional
-              '3D'
-            when Cocina::Models::Vocab.map
-              'Map'
-            when Cocina::Models::Vocab.media
-              'Media'
-            when Cocina::Models::Vocab.manuscript
-              'Manuscript'
-            when Cocina::Models::Vocab.book
-              short_dir = direction == 'right-to-left' ? 'rtl' : 'ltr'
-              "Book (#{short_dir})"
-            else
-              Cocina::Models::Vocab.object
-            end
-      "Process : Content Type : #{tag}"
     end
 
     # TODO: duplicate from ObjectCreator

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -79,9 +79,18 @@ module Cocina
       item.rightsMetadata.copyright = obj.access.copyright if obj.access.copyright
       item.rightsMetadata.use_statement = obj.access.useAndReproductionStatement if obj.access.useAndReproductionStatement
       create_embargo(item, obj.access.embargo) if obj.access.embargo
-      item.contentMetadata.content = ContentMetadataGenerator.generate(druid: item.pid, object: obj) if obj&.structural&.contains
+      update_content_metadata(item, obj)
 
       add_identity_metadata(obj, item, 'item')
+    end
+
+    def update_content_metadata(item, obj)
+      # We don't want to overwrite contentMetadata unless they provided structural.contains
+      if obj.structural&.contains
+        item.contentMetadata.content = ContentMetadataGenerator.generate(druid: item.pid, object: obj)
+      else
+        item.contentMetadata.contentType = ToFedora::ContentType.map(obj.type)
+      end
     end
 
     def validate

--- a/app/services/cocina/to_fedora/content_type.rb
+++ b/app/services/cocina/to_fedora/content_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cocina
   module ToFedora
     # This tranforms the DRO.type attribute to the

--- a/app/services/cocina/to_fedora/content_type.rb
+++ b/app/services/cocina/to_fedora/content_type.rb
@@ -1,0 +1,30 @@
+module Cocina
+  module ToFedora
+    # This tranforms the DRO.type attribute to the
+    # Fedora 3 data model contentMetadata#contentType value
+    class ContentType
+      def self.map(object_type)
+        case object_type
+        when Cocina::Models::Vocab.image, Cocina::Models::Vocab.manuscript
+          'image'
+        when Cocina::Models::Vocab.book
+          'book'
+        when Cocina::Models::Vocab.map
+          'map'
+        when Cocina::Models::Vocab.three_dimensional
+          '3d'
+        when Cocina::Models::Vocab.media
+          'media'
+        when Cocina::Models::Vocab.webarchive_seed
+          'webarchive-seed'
+        when Cocina::Models::Vocab.geo
+          'geo'
+        when Cocina::Models::Vocab.document
+          'document'
+        else
+          'file'
+        end
+      end
+    end
+  end
+end

--- a/app/services/cocina/to_fedora/process_tag.rb
+++ b/app/services/cocina/to_fedora/process_tag.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Cocina
+  module ToFedora
+    # This tranforms the DRO.type attribute to the process tag value
+    class ProcessTag
+      def self.map(type, direction)
+        tag = case type
+              when Cocina::Models::Vocab.image
+                'Image'
+              when Cocina::Models::Vocab.three_dimensional
+                '3D'
+              when Cocina::Models::Vocab.map
+                'Map'
+              when Cocina::Models::Vocab.media
+                'Media'
+              when Cocina::Models::Vocab.manuscript
+                'Manuscript'
+              when Cocina::Models::Vocab.book
+                short_dir = direction == 'right-to-left' ? 'rtl' : 'ltr'
+                "Book (#{short_dir})"
+              else
+                Cocina::Models::Vocab.object
+              end
+        "Process : Content Type : #{tag}"
+      end
+    end
+  end
+end

--- a/app/services/cocina/to_fedora/process_tag.rb
+++ b/app/services/cocina/to_fedora/process_tag.rb
@@ -4,6 +4,7 @@ module Cocina
   module ToFedora
     # This tranforms the DRO.type attribute to the process tag value
     class ProcessTag
+      # TODO: add Software
       def self.map(type, direction)
         tag = case type
               when Cocina::Models::Vocab.image
@@ -19,9 +20,14 @@ module Cocina
               when Cocina::Models::Vocab.book
                 short_dir = direction == 'right-to-left' ? 'rtl' : 'ltr'
                 "Book (#{short_dir})"
+              when Cocina::Models::Vocab.document
+                'Document'
+              when Cocina::Models::Vocab.object
+                'File'
               else
-                Cocina::Models::Vocab.object
+                raise "unable to find process tag for #{type}"
               end
+
         "Process : Content Type : #{tag}"
       end
     end

--- a/app/services/content_metadata_generator.rb
+++ b/app/services/content_metadata_generator.rb
@@ -12,15 +12,16 @@ class ContentMetadataGenerator
 
   def initialize(druid:, object:)
     @druid = druid
-    @object = object
+    @object_type = object.type
+    @resources = object&.structural&.contains || []
   end
 
   def generate
     @xml_doc = Nokogiri::XML('<contentMetadata />')
     @xml_doc.root['objectId'] = druid
-    @xml_doc.root['type'] = object_type
+    @xml_doc.root['type'] = Cocina::ToFedora::ContentType.map(object_type)
 
-    object.structural.contains&.each_with_index do |cocina_fileset, index|
+    resources.each_with_index do |cocina_fileset, index|
       # each resource type description gets its own incrementing counter
       resource_type_counters[resource_type(cocina_fileset)] += 1
       @xml_doc.root.add_child create_resource_node(cocina_fileset, index + 1)
@@ -31,34 +32,10 @@ class ContentMetadataGenerator
 
   private
 
-  attr_reader :object, :druid
-
-  def object_type
-    # image, file, book, map, 3d
-    case object.type
-    when Cocina::Models::Vocab.image, Cocina::Models::Vocab.manuscript
-      'image'
-    when Cocina::Models::Vocab.book
-      'book'
-    when Cocina::Models::Vocab.map
-      'map'
-    when Cocina::Models::Vocab.three_dimensional
-      '3d'
-    when Cocina::Models::Vocab.media
-      'media'
-    when Cocina::Models::Vocab.webarchive_seed
-      'webarchive-seed'
-    when Cocina::Models::Vocab.geo
-      'geo'
-    when Cocina::Models::Vocab.document
-      'document'
-    else
-      'file'
-    end
-  end
+  attr_reader :object_type, :resources, :druid
 
   def resource_type(file_set)
-    case object.type
+    case object_type
     when Cocina::Models::Vocab.image, Cocina::Models::Vocab.map
       'image'
     when Cocina::Models::Vocab.book

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe 'Update object' do
   let(:item) do
     Dor::Item.new(pid: druid).tap do |item|
       item.descMetadata.title_info.main_title = title
+
+      # We swap these two lines after https://github.com/sul-dlss/dor-services/pull/706
+      # item.contentMetadata.contentType = ['book']
+      item.contentMetadata.content = '<contentMetadata type="book" />'
     end
   end
 


### PR DESCRIPTION
## Why was this change made?
Previously we were deriving this from tags, but tags are not repository items, we should be using the contentType from contentMetadata instead.

This adds support for geo and webarchive_seed.


## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?
n/a


