### PR TITLE
Handles creating items without process tags.

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -150,9 +150,11 @@ module Cocina
     end
 
     def add_dro_tags(pid, obj)
-      tags = [ToFedora::ProcessTag.map(obj.type, obj.structural&.hasMemberOrders&.first&.viewingDirection)]
+      tags = []
+      process_tag = ToFedora::ProcessTag.map(obj.type, obj.structural&.hasMemberOrders&.first&.viewingDirection)
+      tags << process_tag if process_tag
       tags << "Project : #{obj.administrative.partOfProject}" if obj.administrative.partOfProject
-      AdministrativeTags.create(pid: pid, tags: tags)
+      AdministrativeTags.create(pid: pid, tags: tags) if tags.any?
     end
 
     def add_collection_tags(pid, obj)

--- a/app/services/cocina/to_fedora/process_tag.rb
+++ b/app/services/cocina/to_fedora/process_tag.rb
@@ -24,11 +24,9 @@ module Cocina
                 'Document'
               when Cocina::Models::Vocab.object
                 'File'
-              else
-                raise "unable to find process tag for #{type}"
               end
 
-        "Process : Content Type : #{tag}"
+        "Process : Content Type : #{tag}" if tag
       end
     end
   end


### PR DESCRIPTION
closes #907

## Why was this change made?
So items do not have process tags (e.g., WARCs). This should be allowed, rather than raise.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
No


