### PR TITLE
Switch all errors from objects controller to use JSON-API

### DIFF
--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -409,8 +409,11 @@ RSpec.describe 'Create object' do
           post '/v1/objects',
                params: data,
                headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-          expect(response.status).to eq(400)
-          expect(response.body).to eq('Not all files have dark access and/or are unshelved when item access is dark: ["00001.jp2", "00002.html", "00002.jp2"]')
+          expect(response.status).to eq 400
+          expect(response.body).to eq '{"errors":[' \
+            '{"status":"400","title":"Bad Request",' \
+            '"detail":"Not all files have dark access and/or are unshelved when item access is dark: ' \
+            '[\\"00001.jp2\\", \\"00002.html\\", \\"00002.jp2\\"]"}]}'
         end
       end
     end

--- a/spec/requests/notify_goobi_spec.rb
+++ b/spec/requests/notify_goobi_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe 'Notify Goobi' do
 
     it 'returns the conflict code' do
       post "/v1/objects/#{druid}/notify_goobi", headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response.status).to eq(409)
-      expect(response.body).to eq('conflict')
+      expect(response.status).to eq 409
+      expect(response.body).to eq '{"errors":[{"status":"409","title":"Conflict","detail":"conflict"}]}'
     end
   end
 end

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -407,8 +407,11 @@ RSpec.describe 'Update object' do
           patch "/v1/objects/#{druid}",
                 params: data,
                 headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-          expect(response.status).to eq(400)
-          expect(response.body).to eq('Not all files have dark access and/or are unshelved when item access is dark: ["00001.jp2", "00002.html", "00002.jp2"]')
+          expect(response.status).to eq 400
+          expect(response.body).to eq '{"errors":[' \
+            '{"status":"400","title":"Bad Request",' \
+            '"detail":"Not all files have dark access and/or are unshelved when item access is dark: ' \
+            '[\\"00001.jp2\\", \\"00002.html\\", \\"00002.jp2\\"]"}]}'
         end
       end
     end


### PR DESCRIPTION

## Why was this change made?
This gives us the ability to provide structured information to the consumers about what is wrong and what they might do to fix it. This ensures all errors are reported in a consistent manner.

## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?

n/a

