### PR TITLE
[HOLD] Retry when symphony times out

### DIFF
--- a/app/models/dor/goobi.rb
+++ b/app/models/dor/goobi.rb
@@ -17,9 +17,9 @@ module Dor
     end
 
     def register
-      with_retries(max_tries: Settings.goobi.max_tries,
-                   base_sleep_seconds: Settings.goobi.base_sleep_seconds,
-                   max_sleep_seconds: Settings.goobi.max_sleep_seconds,
+      with_retries(max_tries: Settings.request.max_tries,
+                   base_sleep_seconds: Settings.request.base_sleep_seconds,
+                   max_sleep_seconds: Settings.request.max_sleep_seconds,
                    rescue: RETRIABLE_EXCEPTIONS) do |_attempt|
         response = Faraday.post(Settings.goobi.url, xml_request, 'Content-Type' => 'application/xml')
         # When we upgrade to Faraday 1.0, we can rely on Faraday::ServerError

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -57,9 +57,6 @@ goobi:
   url: 'https://goobi-env.stanford.edu:9292/goobi/api/process/stanfordcreate?token=faketoken'
   dpg_workflow_name: 'goobiWF'
   default_goobi_workflow_name: 'Example_Workflow'
-  max_tries: 3
-  max_sleep_seconds: 20
-  base_sleep_seconds: 2
 
 catalog:
   symphony:
@@ -69,3 +66,9 @@ catalog:
     headers:
       SD-ORIGINATING-APP-ID: DOR-SERVICES-APP
       SD-PREFERRED-ROLE: GUEST
+
+# General settings for retrying HTTP requests
+request:
+  max_tries: 3
+  max_sleep_seconds: 20
+  base_sleep_seconds: 2

--- a/spec/models/symphony_reader_spec.rb
+++ b/spec/models/symphony_reader_spec.rb
@@ -153,21 +153,6 @@ RSpec.describe SymphonyReader do
           expect { marc_reader.to_marc }.to raise_error(SymphonyReader::ResponseError, msg_regex)
         end
       end
-
-      context 'when Faraday::Timeout' do
-        let(:faraday_msg) { 'faraday failed' }
-
-        before do
-          stub_request(:get, format(marc_url, catkey: catkey)).to_raise(Faraday::TimeoutError.new(faraday_msg))
-        end
-
-        it 'raises ResponseError and notifies Honeybadger' do
-          msg_regex = %r{^Timeout for Symphony response for API call https:\/\/sirsi.example.com\/symws\/catalog\/bib\/key\/catkey\?includeFields=bib: #{faraday_msg}}
-          allow(Honeybadger).to receive(:notify)
-          expect { marc_reader.to_marc }.to raise_error(SymphonyReader::ResponseError, msg_regex)
-          expect(Honeybadger).to have_received(:notify).with(msg_regex)
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #421 

If the request to symphony times out, retry.

Note: I've moved the existing goobi based retry settings (max_retries, base_sleep_seconds, max_sleep_seconds) into a generic `request` config to be shared with the symphony requests. If we prefer different backoffs and retries for these two services, I'm happy to put those back and make symphony specific ones.

## How was this change tested?

Unit test.

## Which documentation and/or configurations were updated?

Settings.yml updated with small comment.


