### PR TITLE
Add a feature flipper to disable registration

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -25,6 +25,8 @@ class ObjectsController < ApplicationController
   end
 
   def create
+    return json_api_error(status: :service_unavailable, message: 'Registration is temporarily disabled') unless Settings.enabled_features.registration
+
     cocina_object = Cocina::ObjectCreator.create(params.except(:action, :controller).to_unsafe_h)
 
     render status: :created, location: object_path(cocina_object.externalIdentifier), json: cocina_object

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,7 @@
+# Feature flippers
+enabled_features:
+  registration: true
+
 content:
   base_dir: '/dor/workspace'
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -971,14 +971,40 @@ paths:
           description: OK
         '400':
           description: Invalid DOR parameter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: Object not found in DOR
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '409':
           description: Object with that sourceId already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '502':
           description: Error connecting to Symphony
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service temporarily disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   '/v1/objects/{id}':
     patch:
       tags:

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -63,6 +63,22 @@ RSpec.describe 'Create object' do
       allow(Dor::SearchService).to receive(:query_by_id).and_return(search_result)
     end
 
+    context 'when the service is disabled' do
+      before do
+        allow(Settings.enabled_features).to receive(:registration).and_return(false)
+      end
+
+      let(:search_result) { ['druid:abc123'] }
+
+      it 'returns a 503 error' do
+        post '/v1/objects',
+             params: data,
+             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+        expect(response.status).to eq 503
+        expect(response.body).to eq '{"errors":[{"status":"503","title":"Service Unavailable","detail":"Registration is temporarily disabled"}]}'
+      end
+    end
+
     context 'when an object already exists' do
       let(:search_result) { ['druid:abc123'] }
 


### PR DESCRIPTION
## Why was this change made?

This will enable us to take registration offline while we migrate the data from suri2 to suri-rails


## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?

config/settings.yml was updated and this was documented in openapi.yml

