### PR TITLE
version_service: can't close version if active assemblyWF

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
 --color
---format progress


### PR DESCRIPTION
## Why was this change made?

Closes sul-dlss/argo/issues/2093

 versions should not be closable if there is an active assemblyWF.

## How was this change tested?

wrote rspec tests; test suite

## Which documentation and/or configurations were updated?

n/a
