### PR TITLE
[Refactor] Call ObjectCreator and ObjectUpdate with the cocina model

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -27,7 +27,8 @@ class ObjectsController < ApplicationController
   def create
     return json_api_error(status: :service_unavailable, message: 'Registration is temporarily disabled') unless Settings.enabled_features.registration
 
-    cocina_object = Cocina::ObjectCreator.create(params.except(:action, :controller).to_unsafe_h)
+    model_request = Cocina::Models.build_request(params.except(:action, :controller).to_unsafe_h)
+    cocina_object = Cocina::ObjectCreator.create(model_request)
 
     render status: :created, location: object_path(cocina_object.externalIdentifier), json: cocina_object
   rescue SymphonyReader::ResponseError
@@ -36,7 +37,8 @@ class ObjectsController < ApplicationController
 
   def update
     obj = Dor.find(params[:id])
-    cocina_object = Cocina::ObjectUpdater.run(obj, params.except(:action, :controller, :id).to_unsafe_h)
+    update_request = Cocina::Models.build(params.except(:action, :controller, :id).to_unsafe_h)
+    cocina_object = Cocina::ObjectUpdater.run(obj, update_request)
 
     render json: cocina_object
   end

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -7,15 +7,15 @@ module Cocina
     class NotImplemented < StandardError; end
 
     # @param [ActiveFedora::Base] item
-    # @param [Hash] params the cocina model represented as a hash
+    # @param [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAdminPolicy] obj the cocina model
     # @param [#create] event_factory creates events
-    def self.run(item, params, event_factory: EventFactory)
-      new(item, params).run(event_factory: event_factory)
+    def self.run(item, obj, event_factory: EventFactory)
+      new(item, obj).run(event_factory: event_factory)
     end
 
-    def initialize(item, params)
+    def initialize(item, obj)
       @params = params
-      @obj = Cocina::Models.build(params)
+      @obj = obj
       @item = item
     end
 
@@ -36,7 +36,7 @@ module Cocina
 
       item.save!
 
-      event_factory.create(druid: item.pid, event_type: 'update', data: params)
+      event_factory.create(druid: item.pid, event_type: 'update', data: obj.to_h)
 
       # This will rebuild the cocina model from fedora, which shows we are only returning persisted data
       Mapper.build(item)

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,1 +1,3 @@
-fedora_url: 'http://fedoraAdmin:fedoraAdmin@localhost:8983/fedora'
+fedora_url: http://fedoraAdmin:fedoraAdmin@localhost:8983/fedora
+solr:
+  url: https://localhost:89843/solr/dorservices

--- a/spec/services/cocina/object_creator_spec.rb
+++ b/spec/services/cocina/object_creator_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Cocina::ObjectCreator do
   end
 
   context 'when item is a Dor::Item' do
-    let(:request) do
+    let(:params) do
       {
         'type' => 'http://cocina.sul.stanford.edu/models/media.jsonld',
         'label' => ':auto',
@@ -35,6 +35,8 @@ RSpec.describe Cocina::ObjectCreator do
         }
       }
     end
+
+    let(:request) { Cocina::Models.build_request(params) }
 
     context 'when the access is dark' do
       it 'creates dark access' do


### PR DESCRIPTION

## Why was this change made?

This relieves these already overburdened classes of the responsibility of how to build the cocina models. No functional changes


## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?
n/a


