### PR TITLE
Extract identityMetadata mapping

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -76,7 +76,7 @@ module Cocina
         admin_node.add_child "<dissemination><workflow id=\"#{obj.administrative.registrationWorkflow}\"></dissemination>"
         item.administrativeMetadata.ng_xml_will_change!
 
-        add_identity_metadata(obj, item, 'adminPolicy')
+        Cocina::ToFedora::Identity.apply(obj, item, 'adminPolicy')
       end
     end
 
@@ -105,7 +105,7 @@ module Cocina
 
         item.contentMetadata.content = ContentMetadataGenerator.generate(druid: pid, object: obj)
 
-        add_identity_metadata(obj, item, 'item')
+        Cocina::ToFedora::Identity.apply(obj, item, 'item')
       end
     end
 
@@ -126,7 +126,7 @@ module Cocina
                           label: truncate_label(obj.label)).tap do |item|
         add_description(item, obj)
         add_collection_tags(pid, obj)
-        add_identity_metadata(obj, item, 'collection')
+        Cocina::ToFedora::Identity.apply(obj, item, 'collection')
       end
     end
 
@@ -191,15 +191,6 @@ module Cocina
       apo = Dor.find(item.admin_policy_object_id)
       rights_xml = apo.defaultObjectRights.ng_xml
       item.rightsMetadata.content = rights_xml.to_s
-    end
-
-    def add_identity_metadata(obj, item, object_type)
-      item.objectId = item.pid
-      item.objectCreator = 'DOR'
-      # May have already been set when setting descriptive metadata.
-      item.objectLabel = obj.label if item.objectLabel.empty?
-      item.objectType = object_type
-      # Not currently mapping other ids.
     end
 
     def truncate_label(label)

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -56,7 +56,7 @@ module Cocina
       admin_node.add_child "<dissemination><workflow id=\"#{obj.administrative.registrationWorkflow}\"></dissemination>"
       item.administrativeMetadata.ng_xml_will_change!
 
-      add_identity_metadata(obj, item, 'adminPolicy')
+      Cocina::ToFedora::Identity.apply(obj, item, 'adminPolicy')
     end
 
     def update_collection
@@ -64,7 +64,7 @@ module Cocina
       item.catkey = catkey_for(obj)
       item.label = truncate_label(obj.label)
 
-      add_identity_metadata(obj, item, 'collection')
+      Cocina::ToFedora::Identity.apply(obj, item, 'collection')
     end
 
     def update_dro
@@ -81,7 +81,7 @@ module Cocina
       create_embargo(item, obj.access.embargo) if obj.access.embargo
       update_content_metadata(item, obj)
 
-      add_identity_metadata(obj, item, 'item')
+      Cocina::ToFedora::Identity.apply(obj, item, 'item')
     end
 
     def update_content_metadata(item, obj)
@@ -152,16 +152,6 @@ module Cocina
       rights_type = access == 'citation-only' ? 'none' : access
       Dor::RightsMetadataDS.upd_rights_xml_for_rights_type(item.rightsMetadata.ng_xml, rights_type)
       item.rightsMetadata.ng_xml_will_change!
-    end
-
-    # TODO: duplicate from ObjectCreator
-    def add_identity_metadata(obj, item, object_type)
-      item.objectId = item.pid
-      item.objectCreator = 'DOR'
-      # May have already been set when setting descriptive metadata.
-      item.objectLabel = obj.label if item.objectLabel.empty?
-      item.objectType = object_type
-      # Not currently mapping other ids.
     end
 
     # TODO: duplicate from ObjectCreator

--- a/app/services/cocina/to_fedora/identity.rb
+++ b/app/services/cocina/to_fedora/identity.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Cocina
+  module ToFedora
+    # This transforms the DRO.access schema to the
+    # Fedora 3 data model identityMetadata
+    class Identity
+      def self.apply(obj, item, object_type)
+        item.objectId = item.pid
+        item.objectCreator = 'DOR'
+        # May have already been set when setting descriptive metadata.
+        item.objectLabel = obj.label if item.objectLabel.empty?
+        item.objectType = object_type
+        # Not currently mapping other ids.
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

This reduces duplication between the create & update methods. No functional changes.

## How was this change tested?
Test suite


## Which documentation and/or configurations were updated?

n/a

