### PR TITLE
[Refactor] Extract UniqueSourceIdValidator

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -15,10 +15,6 @@ class ObjectsController < ApplicationController
     json_api_error(status: :bad_request, message: e.message)
   end
 
-  rescue_from(Dor::DuplicateIdError) do |e|
-    json_api_error(status: :conflict, message: e.message)
-  end
-
   rescue_from(Dry::Struct::Error) do |e|
     json_api_error(status: :internal_server_error, message: e.message)
     raise e
@@ -33,6 +29,8 @@ class ObjectsController < ApplicationController
     render status: :created, location: object_path(cocina_object.externalIdentifier), json: cocina_object
   rescue SymphonyReader::ResponseError
     json_api_error(status: :bad_gateway, title: 'Catalog connection error', message: 'Unable to read descriptive metadata from the catalog')
+  rescue Cocina::ValidationError => e
+    json_api_error(status: e.status, message: e.message)
   end
 
   def update

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -29,10 +29,10 @@ module Cocina
     private
 
     def validate(obj)
-      if obj.is_a?(Cocina::Models::RequestDRO)
-        druid = Dor::SearchService.query_by_id(obj.identification.sourceId).first
-        raise Dor::DuplicateIdError.new(obj.identification.sourceId), "An object (#{druid}) with the source ID '#{obj.identification.sourceId}' has already been registered." if druid
+      validator = Cocina::UniqueSourceIdValidator.new(obj)
+      raise ValidationError.new(validator.error, status: :conflict) unless validator.valid?
 
+      if obj.is_a?(Cocina::Models::RequestDRO)
         validator = ValidateDarkService.new(obj)
         raise Dor::ParameterError, "Not all files have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}" unless validator.valid?
       end

--- a/app/validators/cocina/unique_source_id_validator.rb
+++ b/app/validators/cocina/unique_source_id_validator.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Cocina
+  # Validates that the sourceId attribute for a new DRO has not been used before
+  class UniqueSourceIdValidator
+    # @param [#dro?] item to be validated
+    def initialize(item)
+      @item = item
+    end
+
+    attr_reader :error
+
+    # @return [Boolean] true if not a DRO (no validation necessary) or if the sourceId is unique.
+    def valid?
+      return true unless meets_preconditions?
+
+      @error = "An object (#{duplicate_druid}) with the source ID '#{item.identification.sourceId}' has already been registered." if duplicate_druid
+
+      @error.nil?
+    end
+
+    private
+
+    attr_reader :item
+
+    def duplicate_druid
+      unless @already_ran
+        @duplicate_druid = lookup_duplicate
+        # we keep track of @already_ran because lookup_duplicate could return nil
+        # and we don't want to keep looking it up
+        @already_ran = true
+      end
+
+      @duplicate_druid
+    end
+
+    def lookup_duplicate
+      Dor::SearchService.query_by_id(item.identification.sourceId).first
+    end
+
+    def meets_preconditions?
+      item.dro?
+    end
+  end
+end

--- a/app/validators/cocina/validation_error.rb
+++ b/app/validators/cocina/validation_error.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Cocina
+  # Raised when a validation fails
+  class ValidationError < StandardError
+    def initialize(message, status: :bad_request)
+      super(message)
+      @status = status
+    end
+
+    attr_reader :status
+  end
+end


### PR DESCRIPTION
There are no functional changes.

## Why was this change made?
This helps each class have a single responsibility and aligns the validators to use a similar pattern.
This also creates ValidationError, because we were previously using Dor::DuplicateIdError incorrectly because we were giving it a sourceId rather than a PID and reduces dependency on dor-services.


## How was this change tested?
Test suite


## Which documentation and/or configurations were updated?
n/a


