### PR TITLE
add geoMetadata to the legacy datastream update

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -21,7 +21,8 @@ class MetadataController < ApplicationController
                          content: 'contentMetadata',
                          rights: 'rightsMetadata',
                          identity: 'identityMetadata',
-                         provenance: 'provenanceMetadata' }
+                         provenance: 'provenanceMetadata',
+                         geo: 'geoMetadata' }
 
     datastream_names.each do |section, datastream_name|
       values = params[section]

--- a/openapi.yml
+++ b/openapi.yml
@@ -2059,6 +2059,8 @@ components:
       properties:
         descriptive:
           $ref: '#/components/schemas/LegacyDatastream'
+        geo:
+          $ref: '#/components/schemas/LegacyDatastream'
         rights:
           $ref: '#/components/schemas/LegacyDatastream'
         content:

--- a/spec/requests/legacy_metadata_update_spec.rb
+++ b/spec/requests/legacy_metadata_update_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Update the legacy (datastream) metadata' do
   let(:contentMetadata) { instance_double(Dor::ContentMetadataDS, createDate: create_date) }
   let(:provenanceMetadata) { instance_double(Dor::ProvenanceMetadataDS, createDate: create_date) }
   let(:identityMetadata) { instance_double(Dor::IdentityMetadataDS, createDate: create_date) }
+  let(:geo_metadata) { instance_double(Dor::GeoMetadataDS, createDate: create_date) }
 
   let(:datastreams) do
     {
@@ -19,7 +20,8 @@ RSpec.describe 'Update the legacy (datastream) metadata' do
       'technicalMetadata' => technicalMetadata,
       'contentMetadata' => contentMetadata,
       'provenanceMetadata' => provenanceMetadata,
-      'identityMetadata' => identityMetadata
+      'identityMetadata' => identityMetadata,
+      'geoMetadata' => geo_metadata
     }
   end
 
@@ -41,6 +43,10 @@ RSpec.describe 'Update the legacy (datastream) metadata' do
         "provenance": {
           "updated": "2019-11-08T15:15:43Z",
           "content": "<provMetadata></provMetadata>"
+        },
+        "geo": {
+          "updated": "2019-11-08T15:15:43Z",
+          "content": "<geoMetadata></geoMetadata>"
         }
       }
     JSON
@@ -80,6 +86,12 @@ RSpec.describe 'Update the legacy (datastream) metadata' do
         .with(datastream: provenanceMetadata,
               updated: Time.zone.parse('2019-11-08T15:15:43Z'),
               content: '<provMetadata></provMetadata>',
+              event_factory: EventFactory)
+
+      expect(LegacyMetadataService).to have_received(:update_datastream_if_newer)
+        .with(datastream: geo_metadata,
+              updated: Time.zone.parse('2019-11-08T15:15:43Z'),
+              content: '<geoMetadata></geoMetadata>',
               event_factory: EventFactory)
 
       expect(work).to have_received(:save!)


### PR DESCRIPTION


## Why was this change made?

This will allow decoupling of gis-robot-suite from Fedora 3

## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?

openapi.yml

