### PR TITLE
Re-enable embargo release scheduled task

### DIFF
--- a/app/services/embargo_release_service.rb
+++ b/app/services/embargo_release_service.rb
@@ -5,6 +5,9 @@
 #
 # Should run once a day from cron
 class EmbargoReleaseService
+  RELEASEABLE_NOW_QUERY = 'embargo_status_ssim:"embargoed" AND embargo_release_dtsim:[* TO NOW]'
+  TWENTY_PERCENT_RELEASEABLE_NOW_QUERY = 'twenty_pct_status_ssim:"embargoed" AND twenty_pct_visibility_release_dtsim:[* TO NOW]'
+
   # Finds druids from solr based on the passed in query
   # It will then load each item from Dor, and call the block with the item
   # @param [String] query used to locate druids of items to release from solr
@@ -55,13 +58,12 @@ class EmbargoReleaseService
     Honeybadger.notify "Unable to release embargo for: #{druid}", backtrace: e.backtrace
   end
 
-  def release_all
-    release_items('embargo_status_ssim:"embargoed" AND embargo_release_dtsim:[* TO NOW]') do |item|
+  def self.release_all
+    release_items(RELEASEABLE_NOW_QUERY) do |item|
       new(item).release('application:accessionWF:embargo-release')
     end
 
-    release_items('twenty_pct_status_ssim:"embargoed" AND twenty_pct_visibility_release_dtsim:[* TO NOW]',
-                  '20% visibility embargo') do |item|
+    release_items(TWENTY_PERCENT_RELEASEABLE_NOW_QUERY, '20% visibility embargo') do |item|
       new(item).release_20_pct_vis_embargo('application:accessionWF:embargo-release')
     end
   end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -36,6 +36,10 @@ set :log_level, :info
 set :linked_dirs, %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle config/certs config/settings)
 set :linked_files, %w(config/secrets.yml config/honeybadger.yml config/newrelic.yml config/database.yml)
 
+# Namespace crontab entries by application and stage
+set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
+set :whenever_roles, [:scheduler]
+
 set :passenger_roles, :web
 set :rails_env, 'production'
 

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'dor-services-prod.stanford.edu', user: 'dor_services', roles: %w(web app)
+server 'dor-services-prod.stanford.edu', user: 'dor_services', roles: %w(web app scheduler)
 server 'dor-services-worker-prod-a.stanford.edu', user: 'dor_services', roles: %w(app worker)
 server 'dor-services-worker-prod-b.stanford.edu', user: 'dor_services', roles: %w(app worker)
 

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'dor-services-qa.stanford.edu', user: 'dor_services', roles: %w(web app)
+server 'dor-services-qa.stanford.edu', user: 'dor_services', roles: %w(web app scheduler)
 server 'dor-services-worker-qa-a.stanford.edu', user: 'dor_services', roles: %w(app worker)
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'dor-services-stage.stanford.edu', user: 'dor_services', roles: %w(web app)
+server 'dor-services-stage.stanford.edu', user: 'dor_services', roles: %w(web app scheduler)
 server 'dor-services-worker-stage-a.stanford.edu', user: 'dor_services', roles: %w(app worker)
 
 Capistrano::OneTimeKey.generate_one_time_key!

--- a/spec/services/embargo_release_service_spec.rb
+++ b/spec/services/embargo_release_service_spec.rb
@@ -204,6 +204,20 @@ RSpec.describe EmbargoReleaseService do
     end
   end
 
+  describe '.release_all' do
+    before do
+      allow(described_class).to receive(:release_items)
+    end
+
+    it 'releases all items that are releaseable currently' do
+      described_class.release_all
+      expect(described_class).to have_received(:release_items)
+        .once.with(described_class::RELEASEABLE_NOW_QUERY)
+      expect(described_class).to have_received(:release_items)
+        .once.with(described_class::TWENTY_PERCENT_RELEASEABLE_NOW_QUERY, '20% visibility embargo')
+    end
+  end
+
   describe '.release_items' do
     subject(:release_items) { described_class.release_items(query, &block) }
 


### PR DESCRIPTION
Fixes sul-dlss/hydra_etd#471

## Why was this change made?

Because the daily embargo release task is not being run, because it isn't scheduled. There were two bugs here:

* Finish setup of whenever gem (needed `whenever_roles` to be set)
* Make EmbargoReleaseService.release_all a class method, as that is how it is in invoked in the dsa:embargo_release task (and that's the only place it's invoked)

## How was this change tested?

Deployed to QA and stage and tested that 1) the expected crontab entry exists, and 2) the rake command in the crontab entry is runnable w/o error.

## Which documentation and/or configurations were updated?

None.