### PR TITLE
Fix how the embargo release service queries for 20% releaseable items

### DIFF
--- a/app/services/embargo_release_service.rb
+++ b/app/services/embargo_release_service.rb
@@ -6,7 +6,7 @@
 # Should run once a day from cron
 class EmbargoReleaseService
   RELEASEABLE_NOW_QUERY = 'embargo_status_ssim:"embargoed" AND embargo_release_dtsim:[* TO NOW]'
-  TWENTY_PERCENT_RELEASEABLE_NOW_QUERY = 'twenty_pct_status_ssim:"embargoed" AND twenty_pct_visibility_release_dtsim:[* TO NOW]'
+  TWENTY_PERCENT_RELEASEABLE_NOW_QUERY = 'twenty_pct_status_ssim:"embargoed" AND twenty_pct_release_embargo_release_dtsim:[* TO NOW]'
 
   # Finds druids from solr based on the passed in query
   # It will then load each item from Dor, and call the block with the item


### PR DESCRIPTION
Connects to sul-dlss/hydra_etd#471


## Why was this change made?

This field changed at some point in the past and this code was not updated, preventing 20% releases.


## How was this change tested?

Manually on server

## Which documentation and/or configurations were updated?

None

