### PR TITLE
Tell Committee not to parse response by content type

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,8 @@ module DorServices
   class Application < Rails::Application
     accept_proc = proc { |request| request.path.start_with?('/v1') }
     config.middleware.use Committee::Middleware::RequestValidation, schema_path: 'openapi.yml', strict: true,
-                                                                    error_class: JSONAPIError, accept_request_filter: accept_proc
+                                                                    error_class: JSONAPIError, accept_request_filter: accept_proc,
+                                                                    parse_response_by_content_type: false
 
     # TODO: we can uncomment this at a later date to ensure we are passing back valid responses
     # config.middleware.use Committee::Middleware::ResponseValidation, schema: schema


### PR DESCRIPTION

## Why was this change made?

This value will default to `true` in the next version of committee, so turn this off explicitly.

## How was this change tested?

Unit tests

## Which documentation and/or configurations were updated?

None


