### PR TITLE
Expect that ETDs have a sourceId

### DIFF
--- a/app/services/cocina/from_fedora/identification.rb
+++ b/app/services/cocina/from_fedora/identification.rb
@@ -15,15 +15,15 @@ module Cocina
       end
 
       def props
-        case item
-        when Dor::Etd
-          # ETDs don't have source_id, but we can use the dissertationid (in otherId) for this purpose
-          { sourceId: item.otherId.find { |id| id.start_with?('dissertationid:') } }
-        when Dor::Collection
-          {}
-        else
-          { sourceId: item.source_id }
-        end
+        return {} if item.is_a? Dor::Collection
+
+        return { sourceId: item.source_id } if item.source_id
+
+        # ETDs post Summer 2020 have a source id, but legacy ones don't.  In that case look for a dissertation_id.
+        dissertation = item.otherId.find { |id| id.start_with?('dissertationid:') }
+        raise "unable to resolve a sourceId for #{item.pid}" unless dissertation
+
+        { sourceId: dissertation }
       end
 
       private


### PR DESCRIPTION

## Why was this change made?

Since https://github.com/sul-dlss/hydra_etd/pull/469 was merged

## How was this change tested?

Test suite and tested on stage.


## Which documentation and/or configurations were updated?


n/a
