### PR TITLE
There is no reason to wipe out the existing access

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -2,7 +2,6 @@
 
 module Cocina
   # Given a Cocina model, create an ActiveFedora model.
-  # rubocop:disable Metrics/ClassLength
   class ObjectCreator
     # @raises SymphonyReader::ResponseError if symphony connection failed
     def self.create(obj, event_factory: EventFactory, persister: ActiveFedoraPersister)
@@ -95,7 +94,6 @@ module Cocina
           Cocina::ToFedora::Access.apply(item, obj.access)
           item.rightsMetadata.copyright = obj.access.copyright if obj.access.copyright
           item.rightsMetadata.use_statement = obj.access.useAndReproductionStatement if obj.access.useAndReproductionStatement
-          create_embargo(item, obj.access.embargo) if obj.access.embargo
         else
           apply_default_access(item)
         end
@@ -104,13 +102,6 @@ module Cocina
 
         Cocina::ToFedora::Identity.apply(obj, item, 'item')
       end
-    end
-
-    def create_embargo(item, embargo)
-      EmbargoService.create(item: item,
-                            release_date: embargo.releaseDate,
-                            access: embargo.access,
-                            use_and_reproduction_statement: embargo.useAndReproductionStatement)
     end
 
     # @param [Cocina::Models::RequestCollection] obj
@@ -177,5 +168,4 @@ module Cocina
       label.length > 254 ? label[0, 254] : label
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -76,10 +76,10 @@ module Cocina
       item.label = truncate_label(obj.label)
 
       add_tags(item.id, obj)
+
       Cocina::ToFedora::Access.apply(item, obj.access)
       item.rightsMetadata.copyright = obj.access.copyright if obj.access.copyright
       item.rightsMetadata.use_statement = obj.access.useAndReproductionStatement if obj.access.useAndReproductionStatement
-      create_embargo(item, obj.access.embargo) if obj.access.embargo
       update_content_metadata(item, obj)
 
       Cocina::ToFedora::Identity.apply(obj, item, 'item')
@@ -113,14 +113,6 @@ module Cocina
     # TODO: duplicate from ObjectCreator
     def catkey_for(obj)
       obj.identification&.catalogLinks&.find { |l| l.catalog == 'symphony' }&.catalogRecordId
-    end
-
-    # TODO: duplicate from ObjectCreator
-    def create_embargo(item, embargo)
-      EmbargoService.create(item: item,
-                            release_date: embargo.releaseDate,
-                            access: embargo.access,
-                            use_and_reproduction_statement: embargo.useAndReproductionStatement)
     end
 
     def add_tags(pid, obj)

--- a/app/services/cocina/to_fedora/access.rb
+++ b/app/services/cocina/to_fedora/access.rb
@@ -17,9 +17,18 @@ module Cocina
                         access.download == 'none' ? "#{access.access}-nd" : access.access
                       end
 
+        create_embargo(item, access.embargo) if access.embargo
+
         # See https://github.com/sul-dlss/dor-services/blob/master/lib/dor/datastreams/rights_metadata_ds.rb
         Dor::RightsMetadataDS.upd_rights_xml_for_rights_type(item.rightsMetadata.ng_xml, rights_type)
         item.rightsMetadata.ng_xml_will_change!
+      end
+
+      def self.create_embargo(item, embargo)
+        EmbargoService.create(item: item,
+                              release_date: embargo.releaseDate,
+                              access: embargo.access,
+                              use_and_reproduction_statement: embargo.useAndReproductionStatement)
       end
     end
   end

--- a/app/services/embargo_service.rb
+++ b/app/services/embargo_service.rb
@@ -23,10 +23,6 @@ class EmbargoService
   def create
     return unless release_date
 
-    # Based on https://github.com/sul-dlss/hydrus/blob/master/app/models/hydrus/item.rb#L451
-    # Except Hydrus has a slightly different model than DOR, so, not setting rightsMetadata.rmd_embargo_release_date
-    # item.rightsMetadata.rmd_embargo_release_date = release_date.utc.strftime('%FT%TZ')
-    deny_read_access
     item.rightsMetadata.embargo_release_date = release_date
 
     item.embargoMetadata.release_date = release_date
@@ -39,17 +35,6 @@ class EmbargoService
   private
 
   attr_reader :item, :release_date, :access, :use_and_reproduction_statement
-
-  def deny_read_access
-    rights_xml = item.rightsMetadata.ng_xml
-    rights_xml.search('//rightsMetadata/access[@type=\'read\']').each do |node|
-      node.children.remove
-      machine_node = Nokogiri::XML::Node.new('machine', rights_xml)
-      node.add_child(machine_node)
-      machine_node.add_child Nokogiri::XML::Node.new('none', rights_xml)
-    end
-    item.rightsMetadata.ng_xml_will_change!
-  end
 
   def generic_access_xml
     <<-XML

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -827,7 +827,7 @@ RSpec.describe 'Create object' do
                                 ]
                               },
                               access: {
-                                access: 'citation-only',
+                                access: 'stanford',
                                 download: 'none',
                                 embargo: { access: 'world', releaseDate: '2020-02-29' }
                               })
@@ -835,7 +835,7 @@ RSpec.describe 'Create object' do
     let(:data) do
       <<~JSON
         { "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
-          "label":"This is my label","version":1,"access":{"access":"world",
+          "label":"This is my label","version":1,"access":{"access":"stanford",
           "embargo":{"access":"world","releaseDate":"2020-02-29"}},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
           "description":{"title":[{"status":"primary","value":"This is my title"}]},
@@ -852,7 +852,6 @@ RSpec.describe 'Create object' do
       post '/v1/objects',
            params: data,
            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-
       expect(response.body).to eq expected.to_json
       expect(response.status).to eq(201)
       expect(response.location).to eq '/v1/objects/druid:gg777gg7777'

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -77,9 +77,9 @@ RSpec.describe 'Get the object' do
           label: 'foo',
           version: 1,
           access: {
-            access: 'citation-only',
+            access: 'world',
             copyright: 'All rights reserved unless otherwise indicated.',
-            download: 'none',
+            download: 'world',
             embargo: {
               releaseDate: '2019-09-26T07:00:00.000+00:00',
               access: 'world'

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -699,7 +699,7 @@ RSpec.describe 'Update object' do
                                 ],
                                 isMemberOf: 'druid:xx888xx7777'
                               },
-                              access: { access: 'citation-only', embargo: { access: 'world', releaseDate: '2020-02-29' } })
+                              access: { access: 'stanford', embargo: { access: 'world', releaseDate: '2020-02-29' } })
     end
     let(:data) do
       <<~JSON
@@ -707,7 +707,7 @@ RSpec.describe 'Update object' do
           "externalIdentifier": "#{druid}",
           "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
           "label":"This is my label","version":1,
-          "access":{"access":"world",
+          "access":{"access":"stanford",
             "embargo":{"access":"world","releaseDate":"2020-02-29"}
           },
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
@@ -725,7 +725,6 @@ RSpec.describe 'Update object' do
       patch "/v1/objects/#{druid}",
             params: data,
             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-
       expect(response.body).to eq expected.to_json
       expect(response.status).to eq(200)
     end

--- a/spec/services/embargo_service_spec.rb
+++ b/spec/services/embargo_service_spec.rb
@@ -8,59 +8,13 @@ RSpec.describe EmbargoService do
   end
 
   let(:item) do
-    Dor::Item.new.tap do |item|
-      rights_datastream = Dor::RightsMetadataDS.new
-      rights_datastream.content = Nokogiri::XML(rights_xml) { |config| config.default_xml.noblanks }.to_s
-      item.datastreams['rightsMetadata'] = rights_datastream
-    end
+    Dor::Item.new
   end
 
   let(:release_date) { DateTime.parse('2045-01-01') }
 
-  let(:rights_xml) do
-    <<-XML
-    <?xml version="1.0"?>
-    <rightsMetadata>
-      <access type="discover">
-        <machine>
-          <world />
-        </machine>
-      </access>
-      <access type="read">
-        <machine>
-          <group>stanford</group>
-        </machine>
-      </access>
-    </rightsMetadata>
-    XML
-  end
-
-  RSpec.shared_examples 'common embargo' do
-    it 'sets rightsMetadata to deny read' do
-      embargo
-      expect(item.datastreams['rightsMetadata'].ng_xml).to be_equivalent_to <<-XML
-            <?xml version="1.0"?>
-            <rightsMetadata>
-              <access type="discover">
-                <machine>
-                  <world/>
-                </machine>
-              </access>
-              <access type="read">
-                <machine>
-                  <embargoReleaseDate>2045-01-01T00:00:00Z</embargoReleaseDate>
-                  <none/>
-                </machine>
-              </access>
-            </rightsMetadata>
-      XML
-    end
-  end
-
   context 'when access is stanford' do
     let(:access) { 'stanford' }
-
-    it_behaves_like 'common embargo'
 
     it 'sets embargoMetadata to embargoed and release access to stanford' do
       embargo
@@ -88,8 +42,6 @@ RSpec.describe EmbargoService do
 
   context 'when access is world' do
     let(:access) { 'world' }
-
-    it_behaves_like 'common embargo'
 
     it 'sets embargoMetadata to embargoed and release access to world' do
       embargo
@@ -130,8 +82,6 @@ RSpec.describe EmbargoService do
 
   context 'when access is dark' do
     let(:access) { 'dark' }
-
-    it_behaves_like 'common embargo'
 
     it 'sets embargoMetadata to embargoed and release access to none' do
       embargo


### PR DESCRIPTION


## Why was this change made?

because the access is always provided in the create or update.
Fixes #955

## How was this change tested?

Test suite


## Which documentation and/or configurations were updated?


n/a
