### PR TITLE
Upgrade to cocina-models 0.34.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.33.0'
+gem 'cocina-models', '~> 0.34.1'
 gem 'dor-services', '~> 9.5'
 gem 'dor-workflow-client', '~> 3.17'
 gem 'marc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
       capistrano-bundler (~> 1.1)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.33.0)
+    cocina-models (0.34.1)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -494,7 +494,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.33.0)
+  cocina-models (~> 0.34.1)
   committee
   config
   deprecation

--- a/app/services/cocina/from_fedora/apo.rb
+++ b/app/services/cocina/from_fedora/apo.rb
@@ -36,7 +36,7 @@ module Cocina
           registration_workflow = item.administrativeMetadata.ng_xml.xpath('//administrativeMetadata/dissemination/workflow/@id').text
           admin[:defaultObjectRights] = item.defaultObjectRights.content
           admin[:registrationWorkflow] = registration_workflow if registration_workflow.present?
-          admin[:hasAdminPolicy] = item.admin_policy_object_id if item.admin_policy_object_id
+          admin[:hasAdminPolicy] = item.admin_policy_object_id
         end
       end
     end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -79,7 +79,6 @@ module Cocina
     # @param [Cocina::Models::RequestDRO] obj
     # @return [Dor::Item] a persisted Item model
     # @raises SymphonyReader::ResponseError if symphony connection failed
-    # rubocop:disable Metrics/AbcSize
     def create_dro(obj)
       pid = Dor::SuriService.mint_id
       Dor::Item.new(pid: pid,
@@ -103,7 +102,6 @@ module Cocina
         Cocina::ToFedora::Identity.apply(obj, item, object_type: 'item', agreement_id: obj.structural&.hasAgreement)
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     # @param [Cocina::Models::RequestCollection] obj
     # @return [Dor::Collection] a persisted Collection model

--- a/openapi.yml
+++ b/openapi.yml
@@ -1130,6 +1130,8 @@ components:
           description: Administrative or Internal project this resource is a part of
           example: Google Books
           type: string
+      required:
+        - hasAdminPolicy
     AdminPolicy:
       type: object
       additionalProperties: true
@@ -1166,6 +1168,8 @@ components:
           type: string
         hasAdminPolicy:
           type: string
+      required:
+        - hasAdminPolicy
     AppliesTo:
       description: Property model for indicating the parts, aspects, or versions of the resource to which a
         descriptive element is applicable.

--- a/spec/requests/collections_for_object_spec.rb
+++ b/spec/requests/collections_for_object_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Get the object' do
   before do
     allow(Dor).to receive(:find).and_return(object)
+    allow(collection).to receive(:admin_policy_object_id).and_return('druid:df123cd4567')
   end
 
   let(:object) { instance_double(Dor::Item, collections: [collection]) }
@@ -27,7 +28,9 @@ RSpec.describe 'Get the object' do
             access: 'dark',
             download: 'none'
           },
-          administrative: {},
+          administrative: {
+            hasAdminPolicy: 'druid:df123cd4567'
+          },
           description: {
             title: [
               { status: 'primary',

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Get the object' do
   before do
     allow(Dor).to receive(:find).and_return(object)
+    allow(object).to receive(:admin_policy_object_id).and_return('druid:df123cd4567')
   end
 
   context 'when the requested object is an item' do
@@ -34,7 +35,9 @@ RSpec.describe 'Get the object' do
             download: 'world',
             useAndReproductionStatement: 'Property rights reside with the repository...'
           },
-          administrative: {},
+          administrative: {
+            hasAdminPolicy: 'druid:df123cd4567'
+          },
           description: {
             title: [
               { status: 'primary',
@@ -87,6 +90,7 @@ RSpec.describe 'Get the object' do
             useAndReproductionStatement: 'Property rights reside with the repository...'
           },
           administrative: {
+            hasAdminPolicy: 'druid:df123cd4567',
             releaseTags: [
               {
                 to: 'Searchworks',
@@ -186,7 +190,9 @@ RSpec.describe 'Get the object' do
             download: 'world',
             useAndReproductionStatement: 'Property rights reside with the repository...'
           },
-          administrative: {},
+          administrative: {
+            hasAdminPolicy: 'druid:df123cd4567'
+          },
           description: {
             title: [
               { status: 'primary',
@@ -289,7 +295,9 @@ RSpec.describe 'Get the object' do
           access: 'world',
           download: 'world'
         },
-        administrative: {},
+        administrative: {
+          hasAdminPolicy: 'druid:df123cd4567'
+        },
         description: {
           title: [
             { status: 'primary',
@@ -316,7 +324,6 @@ RSpec.describe 'Get the object' do
       before do
         object.descMetadata.title_info.main_title = 'Hello'
         object.label = 'foo'
-        allow(object).to receive(:admin_policy_object_id).and_return('druid:df123cd4567')
       end
 
       it 'returns the object' do
@@ -372,7 +379,6 @@ RSpec.describe 'Get the object' do
       object.identityMetadata.other_ids = ['dissertationid:00000123']
       object.label = 'foo'
       allow(object).to receive(:collection_ids).and_return([])
-      allow(object).to receive(:admin_policy_object_id).and_return('druid:df123cd4567')
     end
 
     it 'returns the object' do

--- a/spec/validators/cocina/validate_dark_service_spec.rb
+++ b/spec/validators/cocina/validate_dark_service_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe Cocina::ValidateDarkService do
       label: 'The Structure of Scientific Revolutions',
       type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
       version: 1,
+      administrative: {
+        hasAdminPolicy: 'druid:df123cd4567'
+      },
       access: { access: access },
       structural: {
         contains: [


### PR DESCRIPTION
## Why was this change made?

Because the clients are using 0.34.1


## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?

openapi.yml.  AdminPolicy is now required in the administrative schema.

