### PR TITLE
Suppress warnings to avoid unnecessary cron emails

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -21,6 +21,9 @@
 
 # Learn more: http://github.com/javan/whenever
 
+# Suppress warnings to avoid unnecessary cron emails.
+env 'RUBYOPT', '-W0'
+
 every :day, at: '2:16am' do
   rake 'dsa:embargo_release'
 end


### PR DESCRIPTION
## Why was this change made?

Cron emails are getting sent with a bunch of warnings and no useful content.

## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?



