### PR TITLE
Get imageData from techmd service

### DIFF
--- a/app/services/publish/content_metadata_with_image_sizes.rb
+++ b/app/services/publish/content_metadata_with_image_sizes.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Publish
+  # For presentation, we need to know the image dimensions
+  # see https://github.com/sul-dlss/purl/blob/27b881991f2dfc53dd5f151f7f67726a2d355e93/app/models/content_metadata.rb#L125-L127
+  # We retrieve this data from the technical metadata service.
+  class ContentMetadataWithImageSizes
+    def initialize(content_metadata)
+      @content_metadata = content_metadata
+    end
+
+    def to_xml
+      content_metadata.ng_xml.xpath('//contentMetadata/resource/file').each do |file|
+        next unless image? file['mimetype']
+
+        data = technical_metadata.find { |i| i['filename'] == file['id'] }
+        next unless data && data['image_metadata']
+
+        file.search('imageData').each(&:remove)
+        file.add_child("  <imageData height=\"#{data.dig('image_metadata', 'height')}\" width=\"#{data.dig('image_metadata', 'height')}\" />\n")
+      end
+      content_metadata.to_xml
+    end
+
+    private
+
+    attr_reader :content_metadata
+
+    # @return [Symbol] the type of object, could be :application (for PDF or Word, etc), :audio, :image, :message, :model, :multipart, :text or :video
+    def object_type(mimetype)
+      lookup = MIME::Types[mimetype][0]
+      lookup.nil? ? :other : lookup.media_type.to_sym
+    end
+
+    # @return [Boolean] if object is an image
+    def image?(mimetype)
+      object_type(mimetype) == :image
+    end
+
+    def technical_metadata
+      @technical_metadata ||= TechmdService.techmd_for(druid: content_metadata.pid)
+    end
+  end
+end

--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -31,8 +31,9 @@ module Publish
     # @raise [Dor::DataError]
     def transfer_metadata(release_tags)
       transfer_to_document_store(DublinCoreService.new(item).ng_xml.to_xml(&:no_declaration), 'dc')
+      transfer_to_document_store(ContentMetadataWithImageSizes.new(item.contentMetadata).to_xml, 'contentMetadata') if item.datastreams['contentMetadata']
 
-      %w[identityMetadata contentMetadata rightsMetadata].each do |stream|
+      %w[identityMetadata rightsMetadata].each do |stream|
         transfer_to_document_store(item.datastreams[stream].content.to_s, stream) if item.datastreams[stream]
       end
       transfer_to_document_store(PublicXmlService.new(item, released_for: release_tags).to_xml, 'public')

--- a/app/services/publish/techmd_service.rb
+++ b/app/services/publish/techmd_service.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Publish
+  # Retrieves technical metadata from the Technical Metadata Service
+  class TechmdService
+    def self.techmd_for(druid:)
+      resp = Faraday.get("#{Settings.tech_md_service.url}/v1/technical-metadata/druid/#{druid}") do |req|
+        req.headers['Accept'] = 'application/json'
+        req.headers['Authorization'] = "Bearer #{Settings.tech_md_service.token}"
+      end
+      return JSON.parse(resp.body) if resp.status == 200
+      return [] if resp.status == 404
+
+      raise "Unexpected response (#{resp.status}) from technical-metadata-service for #{druid}: #{resp.body}"
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,6 +26,12 @@ workflow:
   shift_age: 'weekly'
   timeout: 60
 
+tech_md_service:
+  url: 'http://metadata.stanford.edu:8080'
+  # To generate the token run: rake generate_token
+  token: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhcmdvLXRlc3QifQ.nhJQsj8V98agZxzDP2OSCVPkIb70yE9_dyLUiTzcKko'
+
+
 # URLs
 fedora_url: 'https://user:password@fedora.example.com:1000/fedora'
 solr:

--- a/spec/services/publish/content_metadata_with_image_sizes_spec.rb
+++ b/spec/services/publish/content_metadata_with_image_sizes_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Publish::ContentMetadataWithImageSizes do
+  subject(:service) { described_class.new(item.contentMetadata) }
+
+  let(:item) { instantiate_fixture('druid:cg767mn6478', Dor::Item) }
+  let(:response) do
+    [
+      {"druid"=>"druid:cg767mn6478",
+    "filename"=>"2542A.tif",
+    "filetype"=>"fmt/353",
+    "mimetype"=>"image/tiff",
+    "bytes"=>46135534,
+    "file_modification"=>"2020-08-13T16:28:56.690Z",
+    "image_metadata"=>{"width"=>4484, "height"=>5641}},
+    {"druid"=>"druid:cg767mn6478",
+    "filename"=>"2542A.jp2",
+    "filetype"=>"fmt/353",
+    "mimetype"=>"image/tiff",
+    "bytes"=>46135534,
+    "file_modification"=>"2020-08-13T16:28:56.690Z",
+    "image_metadata"=>{"width"=>7000, "height"=>8000}},
+  ].to_json
+  end
+  before do
+    stub_request(:get, 'http://metadata.stanford.edu:8080/v1/technical-metadata/druid/druid:cg767mn6478')
+      .with(
+        headers: {
+          'Accept' => 'application/json',
+          'Authorization' => 'Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhcmdvLXRlc3QifQ.nhJQsj8V98agZxzDP2OSCVPkIb70yE9_dyLUiTzcKko'
+        }
+      ).to_return(status: 200, body: response, headers: {})
+  end
+
+  it 'replaces imageData nodes with values from technical_metadata service' do
+    expect(service.to_xml).to include '<imageData width="4484" height="5641"/>'
+    expect(service.to_xml).to include '<imageData width="7000" height="8000"/>'
+  end
+end


### PR DESCRIPTION
Unfortunately, we don't have the technicalMetadata service fully populated, so if new "metadata-only" versions are made, we would lose the dataImage tag.  One possibility is to create stub records in the techMd for every druid that is not already represented using contentMetadata as a source.

at present there are 363291 druids represented in the techmd service:

```
DroFile.distinct.count('druid')
   (27024.4ms)  SELECT COUNT(DISTINCT "dro_files"."druid") FROM "dro_files"
 => 363291
```

We have 1341143 images, 802251 books, 244543 maps in Argo (~2.1 million objects)

So we have about 1.8 million objects that would need to be transferred to the techmd service.

This could be done by calling this rake task for each object:
```
RAILS_ENV=production bin/rake techmd:generate_for_moab['druid:bb000kg4251']
```
or by calling `MoabProcessingService.process(druid)`


## Why was this change made?
Fixes #975

The only reason contentMetadata needs imageData is so that purl can generate IIIF info.  This allows us to get this info from tech-metadata service and will allow us to remove it from the assembly workflow.


## How was this change tested?



## Which documentation and/or configurations were updated?



