### PR TITLE
Book data should be recorded in content metadata

### DIFF
--- a/spec/services/cocina/to_fedora/content_metadata_generator_spec.rb
+++ b/spec/services/cocina/to_fedora/content_metadata_generator_spec.rb
@@ -140,6 +140,10 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
     ]
   end
 
+  let(:structural) do
+    { contains: filesets }
+  end
+
   let(:data) do
     <<~JSON
       { "type":"#{object_type}",
@@ -147,12 +151,18 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
         "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
         "description":{"title":[{"status":"primary","value":"the object title"}]},
         "identification":{"sourceId":"sul:9999999"},
-        "structural":{"contains":#{filesets.to_json}}}
+        "structural":#{structural.to_json}}
     JSON
   end
 
   context 'with a book' do
     let(:object_type) { Cocina::Models::Vocab.book }
+    let(:structural) do
+      {
+        contains: filesets,
+        hasMemberOrders: [{ viewingDirection: 'right-to-left' }]
+      }
+    end
 
     let(:filesets) do
       [
@@ -181,6 +191,7 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
     it 'generates contentMetadata.xml' do
       expect(generate).to be_equivalent_to '<?xml version="1.0"?>
          <contentMetadata objectId="druid:bc123de5678" type="book">
+           <bookData readingOrder="rtl" />
            <resource id="bc123de5678_1" sequence="1" type="page">
              <label>Page 1</label>
              <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription">


### PR DESCRIPTION
Ref #966
See https://consul.stanford.edu/pages/viewpage.action?spaceKey=chimera&title=DOR+content+types%2C+resource+types+and+interpretive+metadata

## Why was this change made?

We were not recording bookData from cocina models. Purl uses this https://github.com/sul-dlss/purl/blob/27d793382d0d7802bd3898d63bf956a9369b0e1d/app/models/content_metadata.rb#L14-L20

## How was this change tested?

Test suite


## Which documentation and/or configurations were updated?



