### PR TITLE
Use bookData from contentMetadata to get the viewing order

### DIFF
--- a/app/services/cocina/from_fedora/dro.rb
+++ b/app/services/cocina/from_fedora/dro.rb
@@ -24,7 +24,7 @@ module Cocina
           version: item.current_version.to_i,
           administrative: FromFedora::Administrative.props(item),
           access: DROAccess.props(item),
-          structural: DroStructural.props(item)
+          structural: DroStructural.props(item, type: dro_type)
         }.tap do |props|
           description = FromFedora::Descriptive.props(item)
           props[:description] = description unless description.nil?

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe Cocina::Mapper do
     context 'when item has a book tag' do
       let(:content_type) { 'book' }
 
+      before do
+        allow(AdministrativeTags).to receive(:content_type).with(pid: item.id).and_return(['Book (rtl)'])
+      end
+
       it 'builds the object with type book' do
         expect(cocina_model).to be_kind_of Cocina::Models::DRO
         expect(cocina_model.type).to eq Cocina::Models::Vocab.book


### PR DESCRIPTION
Fallback to using AdminTags

## Why was this change made?
Fixes #966 
Previously we were not using Fedora for the source of this data, using AdminTags instead.  This is not the correct behavior because AdminTags should be considered ephemeral.  The cannonical source should be Fedora.  We need to fall-back to Admin tags because the google-books (2020) have not been storing this value (#1004)


## How was this change tested?
Test suite.


## Which documentation and/or configurations were updated?



