### PR TITLE
Map CDL to a valid cocina model

### DIFF
--- a/spec/services/cocina/from_fedora/dro_access_spec.rb
+++ b/spec/services/cocina/from_fedora/dro_access_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Cocina::FromFedora::DROAccess do
     end
 
     it 'builds the hash' do
-      expect(access).to eq(access: 'controlled digital lending', download: 'none', controlled_digital_lending: true)
+      expect(access).to eq(access: 'citation-only', download: 'none', controlledDigitalLending: true)
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

To allow controlled digital lending objects to correctly map to cocina models

## How was this change tested?

Tested on stage

## Which documentation and/or configurations were updated?



