### PR TITLE
Fix rubocop error that is causing master build to fail

### DIFF
--- a/spec/services/cocina/from_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Cocina::FromFedora::Descriptive do
           }
         }
       ]
-      expect(descriptive[:contributor]).to match_array [
+      expect(descriptive[:contributor]).to match_array [{
         name: [{
           value: 'Stanford University. Libraries. Humanities and Area Studies Resource Group'
         }],
@@ -123,7 +123,7 @@ RSpec.describe Cocina::FromFedora::Descriptive do
             code: 'marcrelator'
           }
         }]
-      ]
+      }]
       expect(descriptive[:form]).to match_array [
         {
           value: 'electronic',


### PR DESCRIPTION
## Why was this change made?

Master build is failing on rubocop.

## How was this change tested?

ci

## Which documentation and/or configurations were updated?

N/A

