### PR TITLE
When mapping contributor, limit search for name nodes.

### DIFF
--- a/app/services/cocina/from_fedora/contributor_mapper.rb
+++ b/app/services/cocina/from_fedora/contributor_mapper.rb
@@ -5,7 +5,7 @@ module Cocina
     # Maps contributors
     class ContributorMapper
       DESC_METADATA_NS = Dor::DescMetadataDS::MODS_NS
-      NAME_XPATH = '//mods:name'
+      NAME_XPATH = '/mods:mods/mods:name'
       NAME_PART_XPATH = './mods:namePart'
       ROLE_CODE_XPATH = './mods:role/mods:roleTerm[@type="code"]'
       ROLE_TEXT_XPATH = './mods:role/mods:roleTerm[@type="text"]'

--- a/spec/services/cocina/from_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive_spec.rb
@@ -51,6 +51,16 @@ RSpec.describe Cocina::FromFedora::Descriptive do
             <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects" valueURI="http://id.loc.gov/authorities/subjects/sh85041557">Elections</topic>
             <geographic authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n79061287">Mauritania</geographic>
           </subject>
+          <relatedItem type="otherFormat">
+            <titleInfo>
+              <title>Bulletin of the American Mathematical Society</title>
+            </titleInfo>
+            <name>
+              <namePart>American Mathematical Society.</namePart>
+            </name>
+            <identifier type="issn">0002-9904</identifier>
+            <identifier type="local">(OCoLC)11471303</identifier>
+          </relatedItem>
           <location>
             <physicalLocation type="repository" authority="naf" valueURI="http://id.loc.gov/authorities/names/n81070667">Stanford University. Libraries</physicalLocation>
             <url usage="primary display">https://purl.stanford.edu/bb196dd3409</url>


### PR DESCRIPTION
closes #1030

## Why was this change made?
To limit where in DescMetadata names are found.


## How was this change tested?
Unit test.


## Which documentation and/or configurations were updated?
No.


