### PR TITLE
Do not raise an error if name.type is missing

### DIFF
--- a/app/services/cocina/from_fedora/contributor_mapper.rb
+++ b/app/services/cocina/from_fedora/contributor_mapper.rb
@@ -21,11 +21,12 @@ module Cocina
       def build
         [].tap do |contributors|
           names.each do |name|
-            contributors << { name: name_parts(name),
-                              type: name.attribute('type').value }
-            contributors.last[:status] = name.attribute('usage').value if name.attribute('usage').present?
-            roles = [roles_for(name)]
-            contributors.last[:role] = roles unless roles.flatten.empty?
+            contributors << { name: name_parts(name) }.tap do |contributor_hash|
+              contributor_hash[:type] = name.attribute('type').value if name.attribute('type').present?
+              contributor_hash[:status] = name.attribute('usage').value if name.attribute('usage').present?
+              roles = [roles_for(name)]
+              contributor_hash[:role] = roles unless roles.flatten.empty?
+            end
           end
         end
       end

--- a/spec/services/cocina/from_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe Cocina::FromFedora::Descriptive do
           <titleInfo>
             <title>Messaoud Ould Boulkheir - Mauritania 2009 Presidential Election</title>
           </titleInfo>
+          <name>
+            <namePart>Joe McNopart</namePart>
+          </name>
           <name type="corporate">
             <namePart>Stanford University. Libraries. Humanities and Area Studies Resource Group</namePart>
             <role>
@@ -132,6 +135,10 @@ RSpec.describe Cocina::FromFedora::Descriptive do
           source: {
             code: 'marcrelator'
           }
+        }]
+      }, {
+        name: [{
+          value: 'Joe McNopart'
         }]
       }]
       expect(descriptive[:form]).to match_array [


### PR DESCRIPTION
## Why was this change made?

Fixes a production bug where translating descMetada with a namePart that is missing the type attribute throws a 500 up through argo.

## How was this change tested?

Unit

## Which documentation and/or configurations were updated?

N/A

