### PR TITLE
fix file download for flipbook by fixing hasMemberOrders construction

### DIFF
--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -4,6 +4,11 @@ module Cocina
   module FromFedora
     # builds the Structural subschema for Cocina::Models::DRO from a Dor::Item
     class DroStructural
+      VIEWING_DIRECTION_FOR_CONTENT_TYPE = {
+        'Book (ltr)' => 'left-to-right',
+        'Book (rtl)' => 'right-to-left'
+      }.freeze
+
       def self.props(item, type:)
         new(item, type: type).props
       end
@@ -58,12 +63,8 @@ module Cocina
         else
           # Fallback to using tags.  Some books don't have bookData nodes in contentMetadata XML.
           # When we migrate from Fedora 3, we don't need to look this up from AdministrativeTags
-          case AdministrativeTags.content_type(pid: item.id).first
-          when 'Book (ltr)'
-            [{ viewingDirection: 'left-to-right' }]
-          when 'Book (rtl)'
-            [{ viewingDirection: 'right-to-left' }]
-          end
+          content_type = AdministrativeTags.content_type(pid: item.id).first
+          [{ viewingDirection: VIEWING_DIRECTION_FOR_CONTENT_TYPE[content_type] }] if VIEWING_DIRECTION_FOR_CONTENT_TYPE[content_type]
         end
       end
 

--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -6,6 +6,7 @@ module Cocina
     class DroStructural
       VIEWING_DIRECTION_FOR_CONTENT_TYPE = {
         'Book (ltr)' => 'left-to-right',
+        'Book (flipbook, ltr)' => 'left-to-right',
         'Book (rtl)' => 'right-to-left'
       }.freeze
 

--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -47,13 +47,13 @@ module Cocina
       attr_reader :item, :type
 
       def build_has_member_orders
-        ret_val = create_member_order if type == Cocina::Models::Vocab.book
+        member_orders = create_member_order if type == Cocina::Models::Vocab.book
         sequence = build_sequence(item.contentMetadata)
         if sequence.present?
-          ret_val ||= [{}]
-          ret_val.first[:members] = sequence
+          member_orders ||= [{}]
+          member_orders.first[:members] = sequence
         end
-        ret_val if defined? ret_val
+        member_orders
       end
 
       def create_member_order

--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -6,8 +6,11 @@ module Cocina
     class DroStructural
       VIEWING_DIRECTION_FOR_CONTENT_TYPE = {
         'Book (ltr)' => 'left-to-right',
+        'Book (rtl)' => 'right-to-left',
         'Book (flipbook, ltr)' => 'left-to-right',
-        'Book (rtl)' => 'right-to-left'
+        'Book (flipbook, rtl)' => 'right-to-left',
+        'Manuscript (flipbook, ltr)' => 'left-to-right',
+        'Manuscript (ltr)' => 'left-to-right'
       }.freeze
 
       def self.props(item, type:)

--- a/spec/services/cocina/from_fedora/dro_structural_spec.rb
+++ b/spec/services/cocina/from_fedora/dro_structural_spec.rb
@@ -281,6 +281,24 @@ RSpec.describe Cocina::FromFedora::DroStructural do
 
         it { is_expected.to eq 'left-to-right' }
       end
+
+      context "when content type is ['Book (flipbook, rtl)']" do
+        let(:content_type) { ['Book (flipbook, rtl)'] }
+
+        it { is_expected.to eq 'right-to-left' }
+      end
+
+      context "when content type is ['Manuscript (flipbook, ltr)']" do
+        let(:content_type) { ['Manuscript (flipbook, ltr)'] }
+
+        it { is_expected.to eq 'left-to-right' }
+      end
+
+      context "when content type is ['Manuscript (ltr)']" do
+        let(:content_type) { ['Manuscript (ltr)'] }
+
+        it { is_expected.to eq 'left-to-right' }
+      end
     end
   end
 end

--- a/spec/services/cocina/from_fedora/dro_structural_spec.rb
+++ b/spec/services/cocina/from_fedora/dro_structural_spec.rb
@@ -265,12 +265,22 @@ RSpec.describe Cocina::FromFedora::DroStructural do
 
     context "when bookData doesn't exist" do
       before do
-        allow(AdministrativeTags).to receive(:content_type).with(pid: item.id).and_return(['Book (rtl)'])
+        allow(AdministrativeTags).to receive(:content_type).with(pid: item.id).and_return(content_type)
       end
 
       let(:book_data) { nil }
 
-      it { is_expected.to eq 'right-to-left' }
+      context "when content type is ['Book (rtl)']" do
+        let(:content_type) { ['Book (rtl)'] }
+
+        it { is_expected.to eq 'right-to-left' }
+      end
+
+      context "when content type is ['Book (flipbook, ltr)']" do
+        let(:content_type) { ['Book (flipbook, ltr)'] }
+
+        it { is_expected.to eq 'left-to-right' }
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

fix a production issue where files cannot be downloaded because `hasMemberOrders` was not correctly constructed for the `'Book (flipbook, ltr)'` content type.

## How was this change tested?

unit tests, so far.  will also test on stage before deploying to prod.

## Which documentation and/or configurations were updated?

n/a, fix for regression to intended behavior