### PR TITLE
ETDs now have mods title and no longer rely on properties.

### DIFF
--- a/app/services/cocina/from_fedora/title_mapper.rb
+++ b/app/services/cocina/from_fedora/title_mapper.rb
@@ -13,9 +13,7 @@ module Cocina
       end
 
       def build
-        if item.is_a? Dor::Etd
-          item.properties.title.first
-        elsif item.label == 'Hydrus'
+        if item.label == 'Hydrus'
           # Some hydrus items don't have titles, so using label. See https://github.com/sul-dlss/hydrus/issues/421
           item.label
         elsif item.full_title

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe 'Get the object' do
     let(:object) { Etd.new(pid: 'druid:bc123df4567') }
 
     before do
-      object.properties.title = 'Test ETD'
+      object.descMetadata.mods_title = 'Test ETD'
       object.identityMetadata.other_ids = ['dissertationid:00000123']
       object.label = 'foo'
       allow(object).to receive(:collection_ids).and_return([])

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Cocina::Mapper do
     end
 
     before do
-      item.properties.title = 'Test ETD'
+      item.descMetadata.mods_title = 'Test ETD'
       allow(item).to receive(:collection_ids).and_return([])
     end
 


### PR DESCRIPTION
## Why was this change made?

The ETD project has recently undergone updates where the properties are stored in a database and not fedora.  The object is given a proper mods title when it is registered in the SDR.

## How was this change tested?
Test suite.


## Which documentation and/or configurations were updated?



