### PR TITLE
Map Cocina::Models::Description to descMetadata XML

### DIFF
--- a/app/services/cocina/to_fedora/descriptive.rb
+++ b/app/services/cocina/to_fedora/descriptive.rb
@@ -28,10 +28,15 @@ module Cocina
                    'version' => '3.6',
                    'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd') do
             descriptive.title.each do |title|
-              xml.titleInfo do
+              title_info_attrs = {}
+              title_info_attrs[:usage] = 'primary' if title.status == 'primary'
+              title_info_attrs[:type] = title.type if title.type
+
+              xml.titleInfo(title_info_attrs) do
                 title.structuredValue&.each do |component|
                   xml.public_send(TAG_NAME.fetch(component.type), component.value) if component.type
                 end
+
                 xml.title(title.value) if title.value
               end
             end

--- a/app/services/cocina/to_fedora/descriptive.rb
+++ b/app/services/cocina/to_fedora/descriptive.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Cocina
+  module ToFedora
+    # This transforms the DRO.descriptive schema to the
+    # Fedora 3 data model descMetadata
+    class Descriptive
+      TAG_NAME = {
+        'nonsorting characters' => :nonSort,
+        'main title' => :title,
+        'part name' => 'partName',
+        'part number' => 'partNumber'
+      }.freeze
+      # @param [Cocina::Models::Descriptive] descriptive
+      # @return [Nokogiri::XML::Document]
+      def self.transform(descriptive)
+        new(descriptive).transform
+      end
+
+      def initialize(descriptive)
+        @descriptive = descriptive
+      end
+
+      def transform
+        Nokogiri::XML::Builder.new do |xml|
+          xml.mods('xmlns' => 'http://www.loc.gov/mods/v3',
+                   'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+                   'version' => '3.6',
+                   'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd') do
+            descriptive.title.each do |title|
+              xml.titleInfo do
+                title.structuredValue.each do |component|
+                  xml.public_send(TAG_NAME.fetch(component.type), component.value) if component.type
+                end
+              end
+            end
+          end
+        end
+      end
+
+      private
+
+      attr_reader :descriptive
+    end
+  end
+end

--- a/app/services/cocina/to_fedora/descriptive.rb
+++ b/app/services/cocina/to_fedora/descriptive.rb
@@ -21,28 +21,59 @@ module Cocina
         @descriptive = descriptive
       end
 
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/BlockLength
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/PerceivedComplexity
       def transform
         Nokogiri::XML::Builder.new do |xml|
           xml.mods('xmlns' => 'http://www.loc.gov/mods/v3',
                    'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
                    'version' => '3.6',
                    'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd') do
-            descriptive.title.each do |title|
-              title_info_attrs = {}
-              title_info_attrs[:usage] = 'primary' if title.status == 'primary'
-              title_info_attrs[:type] = title.type if title.type
+            descriptive.title.each_with_index do |title, alt_rep_group|
+              if title.parallelValue
+                title.parallelValue.each_with_index do |descriptive_value, i|
+                  title_info_attrs = { altRepGroup: alt_rep_group }
+                  title_info_attrs[:lang] = descriptive_value.valueLanguage.code if descriptive_value.valueLanguage
+                  title_info_attrs[:usage] = 'primary' if i.zero?
+                  title_info_attrs[:type] = 'translated' if i.positive?
 
-              xml.titleInfo(title_info_attrs) do
-                title.structuredValue&.each do |component|
-                  xml.public_send(TAG_NAME.fetch(component.type), component.value) if component.type
+                  xml.titleInfo(title_info_attrs) do
+                    descriptive_value.structuredValue&.each do |component|
+                      xml.public_send(TAG_NAME.fetch(component.type), component.value) if component.type
+                    end
+
+                    xml.title(descriptive_value.value) if descriptive_value.value
+                  end
                 end
+              elsif title.structuredValue
+                title_info_attrs = {}
+                title_info_attrs[:usage] = 'primary' if title.status == 'primary'
+                title_info_attrs[:type] = title.type if title.type
 
-                xml.title(title.value) if title.value
+                xml.titleInfo(title_info_attrs) do
+                  title.structuredValue&.each do |component|
+                    xml.public_send(TAG_NAME.fetch(component.type), component.value) if component.type
+                  end
+                end
+              elsif title.value
+                title_info_attrs = {}
+                title_info_attrs[:usage] = 'primary' if title.status == 'primary'
+                title_info_attrs[:type] = title.type if title.type
+
+                xml.titleInfo(title_info_attrs) do
+                  xml.title(title.value)
+                end
               end
             end
           end
         end
       end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/BlockLength
+      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/PerceivedComplexity
 
       private
 

--- a/app/services/cocina/to_fedora/descriptive.rb
+++ b/app/services/cocina/to_fedora/descriptive.rb
@@ -29,9 +29,10 @@ module Cocina
                    'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd') do
             descriptive.title.each do |title|
               xml.titleInfo do
-                title.structuredValue.each do |component|
+                title.structuredValue&.each do |component|
                   xml.public_send(TAG_NAME.fetch(component.type), component.value) if component.type
                 end
+                xml.title(title.value) if title.value
               end
             end
           end

--- a/spec/services/cocina/to_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive_spec.rb
@@ -5,6 +5,28 @@ require 'rails_helper'
 RSpec.describe Cocina::ToFedora::Descriptive do
   subject(:xml) { described_class.transform(descriptive).to_xml }
 
+  context 'when the title is a basic value' do
+    let(:descriptive) do
+      Cocina::Models::Description.new(
+        title: [
+          { value: "Gaudy night" }
+        ]
+      )
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <titleInfo>
+            <title>Gaudy night</title>
+          </titleInfo>
+        </mods>
+      XML
+    end
+  end
+
   context 'when the title has a structured value' do
     let(:descriptive) do
       Cocina::Models::Description.new(

--- a/spec/services/cocina/to_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::ToFedora::Descriptive do
+  subject(:xml) { described_class.transform(descriptive).to_xml }
+
+  context 'when the title has a structured value' do
+    let(:descriptive) do
+      Cocina::Models::Description.new(
+        title: [
+          { structuredValue: [{ type: 'nonsorting characters', value: 'The' },
+                              { type: 'main title', value: 'journal of stuff' },
+                              { type: 'part number', value: 'volume 5' },
+                              { type: 'part name', value: 'special issue' },
+                              { note: [{ type: 'nonsorting character count', value: '4' }] }] }
+        ]
+      )
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <titleInfo>
+            <nonSort>The</nonSort>
+            <title>journal of stuff</title>
+            <partNumber>volume 5</partNumber>
+            <partName>special issue</partName>
+          </titleInfo>
+        </mods>
+      XML
+    end
+  end
+end

--- a/spec/services/cocina/to_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive_spec.rb
@@ -87,4 +87,88 @@ RSpec.describe Cocina::ToFedora::Descriptive do
       XML
     end
   end
+
+  context 'when the title is translated' do
+    let(:descriptive) do
+      Cocina::Models::Description.new(
+        title: [
+          {
+            "parallelValue": [
+              {
+                "structuredValue": [
+                  {
+                    "value": 'Les',
+                    "type": 'nonsorting characters'
+                  },
+                  {
+                    "value": 'misérables',
+                    "type": 'main title'
+                  },
+                  {
+                    "note": [
+                      {
+                        "value": '4',
+                        "type": 'nonsorting character count'
+                      }
+                    ]
+                  }
+                ],
+                "status": 'primary',
+                "valueLanguage": {
+                  "code": 'fre',
+                  "source": {
+                    "code": 'iso639-2b'
+                  }
+                }
+              },
+              {
+                "structuredValue": [
+                  {
+                    "value": 'The',
+                    "type": 'nonsorting characters'
+                  },
+                  {
+                    "value": 'wretched',
+                    "type": 'main title'
+                  },
+                  {
+                    "note": [
+                      {
+                        "value": '4',
+                        "type": 'nonsorting character count'
+                      }
+                    ]
+                  }
+                ],
+                "type": 'translated',
+                "valueLanguage": {
+                  "code": 'eng',
+                  "source": {
+                    "code": 'iso639-2b'
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      )
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <titleInfo usage="primary" lang="fre" altRepGroup="0">
+            <nonSort>Les</nonSort>
+            <title>mis&#xE9;rables</title>
+          </titleInfo>
+          <titleInfo type="translated" lang="eng" altRepGroup="0">
+            <nonSort>The</nonSort>
+            <title>wretched</title>
+          </titleInfo>
+        </mods>
+      XML
+    end
+  end
 end

--- a/spec/services/cocina/to_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Cocina::ToFedora::Descriptive do
     let(:descriptive) do
       Cocina::Models::Description.new(
         title: [
-          { value: "Gaudy night" }
+          { value: 'Gaudy night' }
         ]
       )
     end
@@ -50,6 +50,38 @@ RSpec.describe Cocina::ToFedora::Descriptive do
             <title>journal of stuff</title>
             <partNumber>volume 5</partNumber>
             <partName>special issue</partName>
+          </titleInfo>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when the title has an alternative' do
+    let(:descriptive) do
+      Cocina::Models::Description.new(
+        title: [
+          {
+            value: 'Five red herrings',
+            status: 'primary'
+          },
+          {
+            value: 'Suspicious characters',
+            type: 'alternative'
+          }
+        ]
+      )
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <titleInfo usage="primary">
+            <title>Five red herrings</title>
+          </titleInfo>
+          <titleInfo type="alternative">
+            <title>Suspicious characters</title>
           </titleInfo>
         </mods>
       XML


### PR DESCRIPTION
## Why was this change made?
This allows us to have a round-trip mapping of descMetadata so that we can begin to evaluate where the mapping is incomplete.


## How was this change tested?

Test suite.

Tested on Stage.

## Which documentation and/or configurations were updated?



