### PR TITLE
Add administrative, relationships and versions metadata to legacy endpoint

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -16,13 +16,18 @@ class MetadataController < ApplicationController
 
   # This supports the Legacy Fedora 3 data model. This is used by the accessionWF.
   def update_legacy_metadata
-    datastream_names = { descriptive: 'descMetadata',
-                         technical: 'technicalMetadata',
-                         content: 'contentMetadata',
-                         rights: 'rightsMetadata',
-                         identity: 'identityMetadata',
-                         provenance: 'provenanceMetadata',
-                         geo: 'geoMetadata' }
+    datastream_names = {
+      administrative: 'administrativeMetadata',
+      content: 'contentMetadata',
+      descriptive: 'descMetadata',
+      geo: 'geoMetadata',
+      identity: 'identityMetadata',
+      provenance: 'provenanceMetadata',
+      relationships: 'RELS-EXT',
+      rights: 'rightsMetadata',
+      technical: 'technicalMetadata',
+      version: 'versionMetadata'
+    }
 
     datastream_names.each do |section, datastream_name|
       values = params[section]

--- a/openapi.yml
+++ b/openapi.yml
@@ -2069,19 +2069,25 @@ components:
     UpdateLegacyMetadata:
       type: object
       properties:
+        administrative:
+          $ref: '#/components/schemas/LegacyDatastream'
         descriptive:
-          $ref: '#/components/schemas/LegacyDatastream'
-        geo:
-          $ref: '#/components/schemas/LegacyDatastream'
-        rights:
           $ref: '#/components/schemas/LegacyDatastream'
         content:
           $ref: '#/components/schemas/LegacyDatastream'
-        technical:
+        geo:
           $ref: '#/components/schemas/LegacyDatastream'
         identity:
           $ref: '#/components/schemas/LegacyDatastream'
         provenance:
+          $ref: '#/components/schemas/LegacyDatastream'
+        relationships:
+          $ref: '#/components/schemas/LegacyDatastream'
+        rights:
+          $ref: '#/components/schemas/LegacyDatastream'
+        technical:
+          $ref: '#/components/schemas/LegacyDatastream'
+        version:
           $ref: '#/components/schemas/LegacyDatastream'
     LegacyDatastream:
       type: object


### PR DESCRIPTION


## Why was this change made?

This will enable argo to do datastream updates without directly talking to Fedora 3.
See https://github.com/sul-dlss/argo/blob/master/config/settings.yml#L107-L114



## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?



