### PR TITLE
adjust collection member solr query to correctly return collection members

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -5,7 +5,7 @@ class MembersController < ApplicationController
   # Return the published members of this collection
   def index
     solr_params = {
-      q: "is_member_of_collection_ssim:\"#{params[:id]}\" published_dttsim:[* TO *]",
+      q: "is_member_of_collection_ssim:\"#{ActiveFedora::Base.internal_uri(params[:object_id])}\" published_dttsim:[* TO *]",
       wt: :json,
       fl: 'id,objectType_ssim',
       rows: 100_000_000

--- a/spec/requests/members_for_collection_spec.rb
+++ b/spec/requests/members_for_collection_spec.rb
@@ -7,6 +7,17 @@ RSpec.describe 'Get the members' do
     allow(ActiveFedora::SolrService.instance.conn).to receive(:get).and_return(solr_response)
   end
 
+  let(:druid) { 'druid:mk420bs7601' }
+
+  let(:solr_params) do
+    {
+      fl: 'id,objectType_ssim',
+      q: "is_member_of_collection_ssim:\"#{ActiveFedora::Base.internal_uri(druid)}\" published_dttsim:[* TO *]",
+      rows: 100_000_000,
+      wt: :json
+    }
+  end
+
   let(:solr_response) do
     {
       'response' => {
@@ -35,9 +46,10 @@ RSpec.describe 'Get the members' do
 
   let(:response_model) { JSON.parse(response.body).deep_symbolize_keys }
 
-  it 'returns the druid & type of the members' do
-    get '/v1/objects/druid:mk420bs7601/members',
+  it 'sends the correct solr params, returns the druid & type of the members' do
+    get "/v1/objects/#{druid}/members",
         headers: { 'Authorization' => "Bearer #{jwt}" }
+    expect(ActiveFedora::SolrService.instance.conn).to have_received(:get).with('select', params: solr_params)
     expect(response).to be_successful
     expect(response_model).to eq expected
   end


### PR DESCRIPTION
## Why was this change made?

Fixes sul-dlss/argo#2243

Basically, the collection member solr query wasn't returning anything, preventing collection member release from working correctly.

## How was this change tested?

Tested on -stage, by running a call from argo-stage.


## Which documentation and/or configurations were updated?



