### PR TITLE
Cast note value to String until cocina-models 0.40.0 is used

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -111,13 +111,14 @@ module Cocina
 
           unsortable = child_nodes.select { |node| node.name == 'nonSort' }
           if unsortable.any?
+            count = unsortable.sum do |node|
+              add = node.text.end_with?('-') || node.text.end_with?("'") ? 0 : 1
+              node.text.size + add
+            end
             new_nodes << {
               "note": [
                 {
-                  "value": unsortable.sum do |node|
-                    add = node.text.end_with?('-') || node.text.end_with?("'") ? 0 : 1
-                    node.text.size + add
-                  end,
+                  "value": count.to_s,  # cast to String until cocina-models 0.40.0 is used. See https://github.com/sul-dlss/cocina-models/pull/146
                   "type": 'nonsorting character count'
                 }
               ]

--- a/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
                               { type: 'main title', value: 'journal of stuff' },
                               { type: 'part number', value: 'volume 5' },
                               { type: 'part name', value: 'special issue' },
-                              { note: [{ type: 'nonsorting character count', value: 4 }] }] }
+                              { note: [{ type: 'nonsorting character count', value: '4' }] }] }
         ]
       end
     end
@@ -102,7 +102,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
                   {
                     "note": [
                       {
-                        "value": 4,
+                        "value": '4',
                         "type": 'nonsorting character count'
                       }
                     ]
@@ -131,7 +131,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
                   {
                     "note": [
                       {
-                        "value": 4,
+                        "value": '4',
                         "type": 'nonsorting character count'
                       }
                     ]


### PR DESCRIPTION

## Why was this change made?

The dor-services-client can't support values as integers yet.
See https://github.com/sul-dlss/cocina-models/pull/146


## How was this change tested?
Updated https://argo-stage.stanford.edu/view/druid:bb149mb1196 so that it had a title with nonSort characters
and ran the integration test suite.


## Which documentation and/or configurations were updated?



