### PR TITLE
object type is a multivalued solr field; model the response correctly in the test

### DIFF
--- a/spec/requests/members_for_collection_spec.rb
+++ b/spec/requests/members_for_collection_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe 'Get the members' do
     {
       'response' => {
         'docs' => [
-          { 'id' => 'druid:xx222xx3282', 'objectType_ssim' => 'collection' },
-          { 'id' => 'druid:xx828xx3282', 'objectType_ssim' => 'item' }
+          { 'id' => 'druid:xx222xx3282', 'objectType_ssim' => ['collection'] },
+          { 'id' => 'druid:xx828xx3282', 'objectType_ssim' => ['item'] }
         ]
       }
     }
@@ -34,11 +34,11 @@ RSpec.describe 'Get the members' do
       members: [
         {
           externalIdentifier: 'druid:xx222xx3282',
-          type: 'collection'
+          type: ['collection']
         },
         {
           externalIdentifier: 'druid:xx828xx3282',
-          type: 'item'
+          type: ['item']
         }
       ]
     }


### PR DESCRIPTION
## Why was this change made?

Object type is actually a multivalued solr field and returns an array, and thus needs to be parsed correctly by consumers (such as common-accessioning in the release robots).  This just makes the mocked data in the test reflect what is actually happening in the real world.

Also see sul-dlss/common-accessioning#695

## How was this change tested?

Test suite

## Which documentation and/or configurations were updated?



