### PR TITLE
Update the response from the members service so that it matches the a…

### DIFF
--- a/app/views/members/index.json.jbuilder
+++ b/app/views/members/index.json.jbuilder
@@ -2,5 +2,5 @@
 
 json.members @members do |member|
   json.externalIdentifier member['id']
-  json.type member['objectType_ssim']
+  json.type member['objectType_ssim'].first
 end

--- a/spec/requests/members_for_collection_spec.rb
+++ b/spec/requests/members_for_collection_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe 'Get the members' do
       members: [
         {
           externalIdentifier: 'druid:xx222xx3282',
-          type: ['collection']
+          type: 'collection'
         },
         {
           externalIdentifier: 'druid:xx828xx3282',
-          type: ['item']
+          type: 'item'
         }
       ]
     }


### PR DESCRIPTION
…pi spec

## Why was this change made?
The API spec says the type value should be a string not an array: https://github.com/sul-dlss/dor-services-app/blob/master/openapi.yml#L605

Ref https://github.com/sul-dlss/argo/issues/2243


## How was this change tested?



## Which documentation and/or configurations were updated?



