### PR TITLE
some objects (in stage at least) have no object type, this guards against it

### DIFF
--- a/app/views/members/index.json.jbuilder
+++ b/app/views/members/index.json.jbuilder
@@ -2,5 +2,5 @@
 
 json.members @members do |member|
   json.externalIdentifier member['id']
-  json.type member['objectType_ssim'].first
+  json.type member['objectType_ssim']&.first
 end

--- a/spec/requests/members_for_collection_spec.rb
+++ b/spec/requests/members_for_collection_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe 'Get the members' do
       'response' => {
         'docs' => [
           { 'id' => 'druid:xx222xx3282', 'objectType_ssim' => ['collection'] },
-          { 'id' => 'druid:xx828xx3282', 'objectType_ssim' => ['item'] }
+          { 'id' => 'druid:xx828xx3282', 'objectType_ssim' => ['item'] },
+          { 'id' => 'druid:xx939xx4389' }
         ]
       }
     }
@@ -39,6 +40,10 @@ RSpec.describe 'Get the members' do
         {
           externalIdentifier: 'druid:xx828xx3282',
           type: 'item'
+        },
+        {
+          externalIdentifier: 'druid:xx939xx4389',
+          type: nil
         }
       ]
     }


### PR DESCRIPTION
##  Why was this change made?

It appears that some objects (at least in stage) do not have an object type.  This prevents the members call from failing in those cases, instead just returning nil for the object type.

See this as an example of an object in stage that has no object type (missing `objectType_ssim` field): https://argo-stage.stanford.edu/view/druid:vq127xv4292.json

It belongs to this collection: druid:jt898xc8096, which if run the raw solr query, you get this:

```ruby
pid='druid:jt898xc8096'

solr_params={q: "is_member_of_collection_ssim:\"#{ActiveFedora::Base.internal_uri(pid)}\" published_dttsim:[* TO *]",wt::json,fl: 'id,objectType_ssim',rows: 100_000_000}

response = ActiveFedora::SolrService.instance.conn.get 'select', params: solr_params

puts response['response']['docs']

{"id"=>"druid:zr532tp7700", "objectType_ssim"=>["item"]}
{"id"=>"druid:xc222xn7637", "objectType_ssim"=>["item"]}
{"id"=>"druid:yc935kv2199"}
{"id"=>"druid:hx013yf6680", "objectType_ssim"=>["item"]}
{"id"=>"druid:vq127xv4292"}
{"id"=>"druid:rj881kq9882", "objectType_ssim"=>["item"]}
{"id"=>"druid:bp737qj9661", "objectType_ssim"=>["item"]}
{"id"=>"druid:qv743zv4960", "objectType_ssim"=>["item"]}
```

This PR guards against this, added test cases for a nil or empty array objectType_ssim as well, though we don't expect this to occur.

## How was this change tested?

Updated test suite

## Which documentation and/or configurations were updated?

none

