### PR TITLE
Log the request regardless of the outcome

### DIFF
--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -11,7 +11,7 @@ module Cocina
 
     # @param [Dor::Abstract] item the Fedora object to convert to a cocina object
     # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]
-    # @raises [SolrConnectionError]
+    # @raises [SolrConnectionError,UnsupportedObjectType]
     def self.build(item)
       new(item).build
     end
@@ -22,7 +22,7 @@ module Cocina
     end
 
     # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]
-    # @raises [SolrConnectionError]
+    # @raises [SolrConnectionError, UnsupportedObjectType]
     def build
       klass = cocina_klass
       props = if klass == Cocina::Models::DRO


### PR DESCRIPTION


## Why was this change made?
This makes the log more useful when debugging


## How was this change tested?



## Which documentation and/or configurations were updated?



