### PR TITLE
Handle titles that are abbreviated but do not specify an authority

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -88,7 +88,7 @@ module Cocina
             result[:type] = 'transliterated' if title_info['transliteration']
             result[:type] = 'supplied' if title_info['supplied'] == 'yes'
 
-            result[:source] = { code: title_info[:authority] } if title_info['type'] == 'abbreviated'
+            result[:source] = { code: title_info[:authority] } if title_info['type'] == 'abbreviated' && title_info[:authority]
             result[:uri] = title_info[:valueURI] if title_info['valueURI']
 
             result[:valueLanguage] = language(title_info) if title_info['lang']

--- a/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
       end
     end
 
-    context 'when there are abbreviated titles' do
+    context 'when there are abbreviated titles with authority' do
       let(:ng_xml) do
         Nokogiri::XML <<~XML
           <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -307,6 +307,10 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
         XML
       end
 
+      it 'parses' do
+        expect { Cocina::Models::Description.new(title: build) }.not_to raise_error
+      end
+
       it 'creates simple values' do
         expect(build).to eq [
           {
@@ -319,6 +323,40 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
             "source": {
               "code": 'dnlm'
             }
+          }
+        ]
+      end
+    end
+
+    context 'when there are abbreviated titles without authority' do
+      let(:ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <titleInfo usage="primary">
+              <title>Annual report of notifiable diseases</title>
+            </titleInfo>
+            <titleInfo type="abbreviated">
+              <title>Annu. rep. notif. dis.</title>
+            </titleInfo>
+          </mods>
+        XML
+      end
+
+      it 'parses' do
+        expect { Cocina::Models::Description.new(title: build) }.not_to raise_error
+      end
+
+      it 'creates simple values' do
+        expect(build).to eq [
+          {
+            "value": 'Annual report of notifiable diseases',
+            "status": 'primary'
+          },
+          {
+            "value": 'Annu. rep. notif. dis.',
+            "type": 'abbreviated'
           }
         ]
       end


### PR DESCRIPTION
## Why was this change made?

A case came through were we were unable to map to cocina models. https://argo.stanford.edu/view/druid:xk774zs1699  This case was not made explicit in https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_titleInfo.txt

## How was this change tested?



## Which documentation and/or configurations were updated?



