### PR TITLE
Fix bug related to structured titles

### DIFF
--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -107,7 +107,8 @@ module Cocina
       # Can't currently roundtrip desc metadata, including title.
       # Note that title is the only desc metadata field handled by the mapper. However, the mapped title is composed from
       # several MODS fields which makes writing back to the MODS problematic.
-      raise NotImplemented, 'Updating descriptive metadata not supported' if obj.description.title.first.value != FromFedora::Descriptive.props(item).fetch(:title).first.fetch(:value)
+      raise NotImplemented, 'Updating descriptive metadata not supported' if
+        obj.description.title != FromFedora::Descriptive.props(item).fetch(:title).map { |value| Cocina::Models::DescriptiveValueRequired.new(value) }
     end
 
     # TODO: duplicate from ObjectCreator


### PR DESCRIPTION
Connects to https://app.honeybadger.io/projects/50568/faults/67768441

## Why was this change made?

This allows us to raise the expected exception (`NotImplemented`) when titles mismatch with both simple and structured values.


## How was this change tested?

CI

## Which documentation and/or configurations were updated?



None