### PR TITLE
Rollback accepting an integer value in the description

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1381,7 +1381,10 @@ components:
               description: String or integer value of the descriptive element.
               oneOf:
               - type: string
-              - type: integer
+              # Title note (nonsorting character count) was supposed to be able to accept an integer value,
+              # but this triggered a bug in committee:
+              # https://github.com/interagent/committee/issues/286
+              # - type: integer
             type:
               description: Type of value provided by the descriptive element.
               type: string


### PR DESCRIPTION

## Why was this change made?

Committee can't decide which type this is.
See https://github.com/interagent/committee/issues/286
Fixes https://github.com/sul-dlss/argo/issues/2253
Ref https://github.com/sul-dlss/cocina-models/pull/144


## How was this change tested?

Test suite.

## Which documentation and/or configurations were updated?



