### PR TITLE
Include a high-level rights characterization in the 856 sent to Symphony

### DIFF
--- a/spec/dor/update_marc_record_service_spec.rb
+++ b/spec/dor/update_marc_record_service_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
       it 'generates a single symphony record' do
         # rubocop:disable Layout/LineLength
         expect(generate_symphony_records).to eq [
-          "8832162\taa111aa1111\t.856. 41|uhttp://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label & A Special character"
+          "8832162\taa111aa1111\t.856. 41|uhttp://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label & A Special character|xrights:world"
         ]
       end
     end
@@ -121,7 +121,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
       it 'generates symphony record with a z subfield' do
         expect(generate_symphony_records).to match_array [
-          "8832162\taa111aa1111\t.856. 41|zAvailable to Stanford-affiliated users.|uhttp://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label & A Special character"
+          "8832162\taa111aa1111\t.856. 41|zAvailable to Stanford-affiliated users.|uhttp://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label & A Special character|xrights:group=stanford"
         ]
       end
     end
@@ -143,7 +143,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
         expect(generate_symphony_records).to match_array [
           "123\taa111aa1111\t",
           "456\taa111aa1111\t",
-          "8832162\taa111aa1111\t.856. 41|uhttp://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label & A Special character"
+          "8832162\taa111aa1111\t.856. 41|uhttp://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label & A Special character|xrights:world"
         ]
       end
     end
@@ -177,7 +177,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
       let(:umrs) { described_class.new(collection) }
 
       it 'generates a single symphony record' do
-        expect(generate_symphony_records).to match_array ["8832162\tcc111cc1111\t.856. 41|uhttp://purl.stanford.edu/cc111cc1111|xSDR-PURL|xcollection"]
+        expect(generate_symphony_records).to match_array ["8832162\tcc111cc1111\t.856. 41|uhttp://purl.stanford.edu/cc111cc1111|xSDR-PURL|xcollection|xrights:world"]
       end
     end
   end
@@ -510,6 +510,143 @@ RSpec.describe Dor::UpdateMarcRecordService do
       it 'returns the label from the first title' do
         expect(umrs.get_x2_part_info).to eq '|xlabel:Issue #3. 2011'
       end
+    end
+  end
+
+  describe '#get_x2_rights_info' do
+    subject(:rights_info) { umrs.get_x2_rights_info }
+
+    let(:dor_item) { Dor::Item.new(pid: 'druid:aa111aa1111') }
+
+    before do
+      dor_item.rightsMetadata.content = xml
+    end
+
+    context 'world rights' do
+      let(:xml) do
+        '<rightsMetadata>
+           <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+           </access>
+           <access type="read">
+            <machine>
+              <world/>
+            </machine>
+           </access>
+        </rightsMetadata>
+        '
+      end
+
+      it { is_expected.to eq '|xrights:world' }
+    end
+
+    context 'stanford-only rights' do
+      let(:xml) do
+        '<rightsMetadata>
+           <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+           </access>
+           <access type="read">
+            <machine>
+              <group>Stanford</group>
+            </machine>
+           </access>
+        </rightsMetadata>
+        '
+      end
+
+      it { is_expected.to eq '|xrights:group=stanford' }
+    end
+
+    context 'CDL rights' do
+      let(:xml) do
+        '<rightsMetadata>
+           <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+           </access>
+           <access type="read">
+            <machine>
+              <cdl>
+                <group>Stanford</group>
+              </cdl>
+            </machine>
+           </access>
+        </rightsMetadata>
+        '
+      end
+
+      it { is_expected.to eq '|xrights:cdl' }
+    end
+
+    context 'location rights' do
+      let(:xml) do
+        '<rightsMetadata>
+           <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+           </access>
+           <access type="read">
+            <machine>
+              <location>spec</location>
+            </machine>
+           </access>
+        </rightsMetadata>
+        '
+      end
+
+      it { is_expected.to eq '|xrights:location=spec' }
+    end
+
+    context 'agent rights' do
+      let(:xml) do
+        '<rightsMetadata>
+           <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+           </access>
+           <access type="read">
+            <machine>
+              <agent>ai</agent>
+            </machine>
+           </access>
+        </rightsMetadata>
+        '
+      end
+
+      it { is_expected.to eq '|xrights:agent=ai' }
+    end
+
+    context 'citation rights' do
+      let(:xml) do
+        '<rightsMetadata>
+           <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+           </access>
+        </rightsMetadata>
+        '
+      end
+
+      it { is_expected.to eq '|xrights:citation' }
+    end
+
+    context 'no rights' do
+      let(:xml) do
+        '<rightsMetadata>
+        </rightsMetadata>
+        '
+      end
+
+      it { is_expected.to eq '|xrights:dark' }
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

For controlled digital lending, Searchworks needs to know (from the MARC record)  whether there's an SDR object with CDL  rights available. We've heard other use cases for additional rights information (e.g. "show me all the world accessible data")

## How was this change tested?

- [x] With tests?
- [x] confirming with libsys that their processes will handle the new data
- [x] Vitus: "I don't see any problem with sending that type of information in a |x of the managed purl"

## Which documentation and/or configurations were updated?



