### PR TITLE
Report a sensible error if an object is missing a required sourceId

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -53,6 +53,10 @@ class ObjectsController < ApplicationController
     json_api_error(status: :unprocessable_entity,
                    title: 'Missing title',
                    message: "All objects are required to have a title, but #{params[:id]} appears to be malformed as a title cannot be found.")
+  rescue Cocina::Mapper::MissingSourceID => e
+    json_api_error(status: :unprocessable_entity,
+                   title: 'Missing sourceId',
+                   message: e)
   end
 
   # Initialize specified workflow (assemblyWF by default), and also version if needed

--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -15,6 +15,7 @@ module Cocina
 
         # @param [Nokogiri::XML::Document] ng_xml the descriptive metadata XML
         # @return [Hash] a hash that can be mapped to a cocina model
+        # @raises [Mapper::MissingTitle]
         def self.build(ng_xml)
           new(ng_xml).build
         end

--- a/app/services/cocina/from_fedora/identification.rb
+++ b/app/services/cocina/from_fedora/identification.rb
@@ -6,6 +6,7 @@ module Cocina
     class Identification
       # @param [Dor::Item,Dor::Etd] item
       # @return [Hash] a hash that can be mapped to a cocina administrative model
+      # @raises [Mapper::MissingSourceID]
       def self.props(item)
         new(item).props
       end
@@ -21,7 +22,7 @@ module Cocina
 
         # ETDs post Summer 2020 have a source id, but legacy ones don't.  In that case look for a dissertation_id.
         dissertation = item.otherId.find { |id| id.start_with?('dissertationid:') }
-        raise "unable to resolve a sourceId for #{item.pid}" unless dissertation
+        raise Mapper::MissingSourceID, "unable to resolve a sourceId for #{item.pid}" unless dissertation
 
         { sourceId: dissertation }
       end

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -9,9 +9,12 @@ module Cocina
     # Raised when we can't figure out the title for the object.
     class MissingTitle < StandardError; end
 
+    # Raised when this object is missing a sourceID, so it can't be mapped to cocina.
+    class MissingSourceID < StandardError; end
+
     # @param [Dor::Abstract] item the Fedora object to convert to a cocina object
     # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]
-    # @raises [SolrConnectionError,UnsupportedObjectType]
+    # @raises [SolrConnectionError,UnsupportedObjectType,MissingTitle,MissingSourceID]
     def self.build(item)
       new(item).build
     end

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Get the object' do
       end
 
       it 'returns the object' do
-        get '/v1/objects/druid:mk420bs7601',
+        get '/v1/objects/druid:bc123df4567',
             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status(:ok)
         expect(response_model).to eq expected
@@ -115,7 +115,7 @@ RSpec.describe 'Get the object' do
       end
 
       it 'returns the object' do
-        get '/v1/objects/druid:mk420bs7601',
+        get '/v1/objects/druid:bc123df4567',
             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status(:ok)
         expect(response_model).to eq expected
@@ -222,7 +222,7 @@ RSpec.describe 'Get the object' do
       end
 
       it 'returns the object' do
-        get '/v1/objects/druid:mk420bs7601',
+        get '/v1/objects/druid:bc123df4567',
             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status(:ok)
         expect(response_model).to eq expected
@@ -239,12 +239,37 @@ RSpec.describe 'Get the object' do
 
       let(:expected) do
         {
-          errors: [{ detail: 'All objects are required to have a title, but druid:mk420bs7601 appears to be malformed as a title cannot be found.', status: '422', title: 'Missing title' }]
+          errors: [{ detail: 'All objects are required to have a title, but druid:bc123df4567 appears to be malformed as a title cannot be found.', status: '422', title: 'Missing title' }]
         }
       end
 
       it 'returns the error' do
-        get '/v1/objects/druid:mk420bs7601',
+        get '/v1/objects/druid:bc123df4567',
+            headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response_model).to eq expected
+      end
+    end
+
+    context 'when the object exists without a sourceId' do
+      let(:object) do
+        Dor::Item.new(pid: 'druid:bc123df4567',
+                      label: 'foo',
+                      read_rights: 'world').tap do |i|
+          i.rightsMetadata.copyright = 'All rights reserved unless otherwise indicated.'
+          i.rightsMetadata.use_statement = 'Property rights reside with the repository...'
+          i.descMetadata.title_info.main_title = 'Hello'
+        end
+      end
+
+      let(:expected) do
+        {
+          errors: [{ detail: 'unable to resolve a sourceId for druid:bc123df4567', status: '422', title: 'Missing sourceId' }]
+        }
+      end
+
+      it 'returns the error' do
+        get '/v1/objects/druid:bc123df4567',
             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response_model).to eq expected
@@ -263,7 +288,7 @@ RSpec.describe 'Get the object' do
       end
 
       it 'returns the error' do
-        get '/v1/objects/druid:mk420bs7601',
+        get '/v1/objects/druid:bc123df4567',
             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status(:internal_server_error)
         expect(response_model).to eq expected
@@ -306,7 +331,7 @@ RSpec.describe 'Get the object' do
     let(:response_model) { JSON.parse(response.body).deep_symbolize_keys }
 
     it 'returns the object' do
-      get '/v1/objects/druid:mk420bs7601',
+      get '/v1/objects/druid:bc123df4567',
           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to have_http_status(:ok)
       expect(response_model).to eq expected
@@ -323,7 +348,7 @@ RSpec.describe 'Get the object' do
       end
 
       it 'returns the object' do
-        get '/v1/objects/druid:mk420bs7601',
+        get '/v1/objects/druid:bc123df4567',
             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)
@@ -352,7 +377,7 @@ RSpec.describe 'Get the object' do
       end
 
       it 'returns the object' do
-        get '/v1/objects/druid:mk420bs7601',
+        get '/v1/objects/druid:bc123df4567',
             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)
@@ -378,7 +403,7 @@ RSpec.describe 'Get the object' do
     end
 
     it 'returns the object' do
-      get '/v1/objects/druid:mk420bs7601',
+      get '/v1/objects/druid:bc123df4567',
           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to have_http_status(:ok)
       json = JSON.parse(response.body)


### PR DESCRIPTION


## Why was this change made?

This will show a message in argo that one can use rather than having to dig through honeybadger to find out why the request to dor-services-app failed.

## How was this change tested?



## Which documentation and/or configurations were updated?



