### PR TITLE
Extract a ToFedora::DROAccess class

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -82,8 +82,6 @@ module Cocina
 
         if obj.access
           Cocina::ToFedora::DROAccess.apply(item, obj.access)
-          item.rightsMetadata.copyright = obj.access.copyright if obj.access.copyright
-          item.rightsMetadata.use_statement = obj.access.useAndReproductionStatement if obj.access.useAndReproductionStatement
         else
           apply_default_access(item)
         end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -81,7 +81,7 @@ module Cocina
         add_dro_tags(pid, obj)
 
         if obj.access
-          Cocina::ToFedora::Access.apply(item, obj.access)
+          Cocina::ToFedora::DROAccess.apply(item, obj.access)
           item.rightsMetadata.copyright = obj.access.copyright if obj.access.copyright
           item.rightsMetadata.use_statement = obj.access.useAndReproductionStatement if obj.access.useAndReproductionStatement
         else

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -78,7 +78,7 @@ module Cocina
 
       add_tags(item.id, obj)
 
-      Cocina::ToFedora::Access.apply(item, obj.access)
+      Cocina::ToFedora::DROAccess.apply(item, obj.access)
       item.rightsMetadata.copyright = obj.access.copyright if obj.access.copyright
       item.rightsMetadata.use_statement = obj.access.useAndReproductionStatement if obj.access.useAndReproductionStatement
       update_content_metadata(item, obj)

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -79,8 +79,6 @@ module Cocina
       add_tags(item.id, obj)
 
       Cocina::ToFedora::DROAccess.apply(item, obj.access)
-      item.rightsMetadata.copyright = obj.access.copyright if obj.access.copyright
-      item.rightsMetadata.use_statement = obj.access.useAndReproductionStatement if obj.access.useAndReproductionStatement
       update_content_metadata(item, obj)
       Cocina::ToFedora::Identity.apply(obj, item, object_type: 'item', agreement_id: obj.structural&.hasAgreement)
     end

--- a/app/services/cocina/to_fedora/access.rb
+++ b/app/services/cocina/to_fedora/access.rb
@@ -18,13 +18,7 @@ module Cocina
         @access = access
       end
 
-      # TODO: this should be expanded to support file level rights: https://consul.stanford.edu/pages/viewpage.action?spaceKey=chimera&title=Rights+metadata+--+the+rightsMetadata+datastream
-      #       See https://argo.stanford.edu/view/druid:bb142ws0723 as an example
-      # @param [Dor::Item, Dor::Collection] item
-      # @param [Cocina::Models::DROAccess, Cocina::Models::Access] access
       def apply
-        create_embargo(access.embargo) if access.is_a?(Cocina::Models::DROAccess) && access.embargo
-
         # See https://github.com/sul-dlss/dor-services/blob/master/lib/dor/datastreams/rights_metadata_ds.rb
         Dor::RightsMetadataDS.upd_rights_xml_for_rights_type(item.rightsMetadata.ng_xml, rights_type)
         item.rightsMetadata.ng_xml_will_change!
@@ -47,13 +41,6 @@ module Cocina
         else
           access.download == 'none' ? "#{access.access}-nd" : access.access
         end
-      end
-
-      def create_embargo(embargo)
-        EmbargoService.create(item: item,
-                              release_date: embargo.releaseDate,
-                              access: embargo.access,
-                              use_and_reproduction_statement: embargo.useAndReproductionStatement)
       end
     end
   end

--- a/app/services/cocina/to_fedora/access.rb
+++ b/app/services/cocina/to_fedora/access.rb
@@ -29,8 +29,6 @@ module Cocina
       attr_reader :item, :access
 
       def rights_type
-        return 'cdl-stanford-nd'if access.is_a?(Cocina::Models::DROAccess) && access.controlledDigitalLending
-
         case access.access
         when 'location-based'
           "loc:#{access.readLocation}"

--- a/app/services/cocina/to_fedora/access.rb
+++ b/app/services/cocina/to_fedora/access.rb
@@ -2,7 +2,7 @@
 
 module Cocina
   module ToFedora
-    # This transforms the DRO.access schema to the
+    # This transforms the Access schema to the
     # Fedora 3 data model rightsMetadata
     class Access
       # TODO: this should be expanded to support file level rights: https://consul.stanford.edu/pages/viewpage.action?spaceKey=chimera&title=Rights+metadata+--+the+rightsMetadata+datastream
@@ -10,29 +10,46 @@ module Cocina
       # @param [Dor::Item, Dor::Collection] item
       # @param [Cocina::Models::DROAccess, Cocina::Models::Access] access
       def self.apply(item, access)
-        rights_type =  if access.is_a?(Cocina::Models::DROAccess) && access.controlledDigitalLending
-                         'cdl-stanford-nd'
-                       else
-                         case access.access
-                         when 'location-based'
-                           "loc:#{access.readLocation}"
-                         when 'citation-only'
-                           'none'
-                         when 'dark'
-                           'dark'
-                         else
-                           access.download == 'none' ? "#{access.access}-nd" : access.access
-                         end
-                       end
+        new(item, access).apply
+      end
 
-        create_embargo(item, access.embargo) if access.is_a?(Cocina::Models::DROAccess) && access.embargo
+      def initialize(item, access)
+        @item = item
+        @access = access
+      end
+
+      # TODO: this should be expanded to support file level rights: https://consul.stanford.edu/pages/viewpage.action?spaceKey=chimera&title=Rights+metadata+--+the+rightsMetadata+datastream
+      #       See https://argo.stanford.edu/view/druid:bb142ws0723 as an example
+      # @param [Dor::Item, Dor::Collection] item
+      # @param [Cocina::Models::DROAccess, Cocina::Models::Access] access
+      def apply
+        create_embargo(access.embargo) if access.is_a?(Cocina::Models::DROAccess) && access.embargo
 
         # See https://github.com/sul-dlss/dor-services/blob/master/lib/dor/datastreams/rights_metadata_ds.rb
         Dor::RightsMetadataDS.upd_rights_xml_for_rights_type(item.rightsMetadata.ng_xml, rights_type)
         item.rightsMetadata.ng_xml_will_change!
       end
 
-      def self.create_embargo(item, embargo)
+      private
+
+      attr_reader :item, :access
+
+      def rights_type
+        return 'cdl-stanford-nd'if access.is_a?(Cocina::Models::DROAccess) && access.controlledDigitalLending
+
+        case access.access
+        when 'location-based'
+          "loc:#{access.readLocation}"
+        when 'citation-only'
+          'none'
+        when 'dark'
+          'dark'
+        else
+          access.download == 'none' ? "#{access.access}-nd" : access.access
+        end
+      end
+
+      def create_embargo(embargo)
         EmbargoService.create(item: item,
                               release_date: embargo.releaseDate,
                               access: embargo.access,

--- a/app/services/cocina/to_fedora/dro_access.rb
+++ b/app/services/cocina/to_fedora/dro_access.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Cocina
+  module ToFedora
+    # This transforms the DROAccess schema to the
+    # Fedora 3 data model rightsMetadata
+    class DROAccess < Access
+
+    end
+  end
+end

--- a/app/services/cocina/to_fedora/dro_access.rb
+++ b/app/services/cocina/to_fedora/dro_access.rb
@@ -5,7 +5,19 @@ module Cocina
     # This transforms the DROAccess schema to the
     # Fedora 3 data model rightsMetadata
     class DROAccess < Access
+      def apply
+        create_embargo(access.embargo) if access.embargo
+        super
+      end
 
+      private
+
+      def create_embargo(embargo)
+        EmbargoService.create(item: item,
+                              release_date: embargo.releaseDate,
+                              access: embargo.access,
+                              use_and_reproduction_statement: embargo.useAndReproductionStatement)
+      end
     end
   end
 end

--- a/app/services/cocina/to_fedora/dro_access.rb
+++ b/app/services/cocina/to_fedora/dro_access.rb
@@ -21,6 +21,12 @@ module Cocina
                               access: embargo.access,
                               use_and_reproduction_statement: embargo.useAndReproductionStatement)
       end
+
+      def rights_type
+        return 'cdl-stanford-nd' if access.controlledDigitalLending
+
+        super
+      end
     end
   end
 end

--- a/app/services/cocina/to_fedora/dro_access.rb
+++ b/app/services/cocina/to_fedora/dro_access.rb
@@ -7,6 +7,9 @@ module Cocina
     class DROAccess < Access
       def apply
         create_embargo(access.embargo) if access.embargo
+        item.rightsMetadata.copyright = access.copyright if access.copyright
+        item.rightsMetadata.use_statement = access.useAndReproductionStatement if access.useAndReproductionStatement
+
         super
       end
 

--- a/spec/services/cocina/to_fedora/dro_access_spec.rb
+++ b/spec/services/cocina/to_fedora/dro_access_spec.rb
@@ -2,16 +2,16 @@
 
 require 'rails_helper'
 
-RSpec.describe Cocina::ToFedora::Access do
+RSpec.describe Cocina::ToFedora::DROAccess do
   subject(:apply) { described_class.apply(item, access) }
 
   let(:item) do
-    Dor::Collection.new
+    Dor::Item.new
   end
 
-  describe 'with stanford access' do
+  describe 'with cdl access' do
     let(:access) do
-      Cocina::Models::Access.new(access: 'stanford', download: 'none')
+      Cocina::Models::DROAccess.new(access: 'citation-only', controlledDigitalLending: true, download: 'none')
     end
 
     it 'builds the xml' do
@@ -26,7 +26,9 @@ RSpec.describe Cocina::ToFedora::Access do
             </access>
             <access type="read">
               <machine>
-                <group rule="no-download">stanford</group>
+                <cdl>
+                  <group rule="no-download">stanford</group>
+                </cdl>
               </machine>
             </access>
             <use>


### PR DESCRIPTION
This adds no new functionality


## Why was this change made?

This removes a number of conditionals and duplicate code by adding a ToFedora::DROAccess which subclasses ToFedora::Access.  This subclass only handles DROAccess so it can have fewer conditionals.  This makes the code easier to follow.

## How was this change tested?

Test suite.

## Which documentation and/or configurations were updated?



