### PR TITLE
Use the 2.7.2 ruby docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 jobs:
   test:
     docker:
-    - image: circleci/ruby:2.7.1-node
+    - image: circleci/ruby:2.7.2-node
       environment:
         BUNDLE_JOBS: 3
         BUNDLE_RETRY: 3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is optimized for running in development. That means it trades
 # build speed for size. If we were using this for production, we might instead
 # optimize for a smaller size at the cost of a slower build.
-FROM ruby:2.7.1-alpine
+FROM ruby:2.7.2-alpine
 
 # Provide SSL defaults that work in dev/test environments where we do not require connections to secured services
 # These values are overrideable at both buildtime and runtime (hence the ARG/ENV combo).


### PR DESCRIPTION
## Why was this change made?

Ruby 2.7.2 suppresses a lot of unnecessary deprecation warnings.

## How was this change tested?



## Which documentation and/or configurations were updated?



