### PR TITLE
Trap for missing expected MODS attribute

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -57,6 +57,10 @@ class ObjectsController < ApplicationController
     json_api_error(status: :unprocessable_entity,
                    title: 'Missing sourceId',
                    message: e)
+  rescue Cocina::Mapper::InvalidDescMetadata => e
+    json_api_error(status: :unprocessable_entity,
+                   title: 'Invalid descMetadata',
+                   message: e)
   end
 
   # Initialize specified workflow (assemblyWF by default), and also version if needed

--- a/app/services/cocina/from_fedora/descriptive.rb
+++ b/app/services/cocina/from_fedora/descriptive.rb
@@ -8,6 +8,7 @@ module Cocina
 
       # @param [Dor::Item,Dor::Etd] item
       # @return [Hash] a hash that can be mapped to a cocina administrative model
+      # @raises [Cocina::Mapper::InvalidDescMetadata] if some assumption about descMetadata is violated
       def self.props(item)
         new(item).props
       end

--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -56,6 +56,8 @@ module Cocina
 
           {}.tap do |role|
             if role_code.present?
+              raise Cocina::Mapper::InvalidDescMetadata, "#{ROLE_CODE_XPATH} is missing required authority attribute" unless role_code.attribute('authority')
+
               role[:code] = role_code.content unless role_code.nil?
               role[:source] = { code: role_code.attribute('authority').value }
             end

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -12,6 +12,9 @@ module Cocina
     # Raised when this object is missing a sourceID, so it can't be mapped to cocina.
     class MissingSourceID < StandardError; end
 
+    # Raised when assumptions about descMetadata are violated
+    class InvalidDescMetadata < StandardError; end
+
     # @param [Dor::Abstract] item the Fedora object to convert to a cocina object
     # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]
     # @raises [SolrConnectionError,UnsupportedObjectType,MissingTitle,MissingSourceID]

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -276,6 +276,47 @@ RSpec.describe 'Get the object' do
       end
     end
 
+    context 'when the object has invalid mods' do
+      let(:object) do
+        Dor::Item.new(pid: 'druid:bc123df4567',
+                      source_id: 'src:99999',
+                      label: 'foo',
+                      read_rights: 'world').tap do |i|
+          i.descMetadata.content = xml
+        end
+      end
+      let(:xml) do
+        <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <titleInfo>
+              <title>journal of stuff</title>
+            </titleInfo>
+            <name valueURI="corporate">
+              <namePart>Selective Service System</namePart>
+              <role>
+                <roleTerm type="code">isb</roleTerm>
+              </role>
+            </name>
+          </mods>
+        XML
+      end
+
+      let(:expected) do
+        {
+          errors: [{ detail: './mods:role/mods:roleTerm[@type="code"] is missing required authority attribute', status: '422', title: 'Invalid descMetadata' }]
+        }
+      end
+
+      it 'returns the error' do
+        get '/v1/objects/druid:bc123df4567',
+            headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response_model).to eq expected
+      end
+    end
+
     context 'when there is a solr error' do
       before do
         allow(Cocina::Mapper).to receive(:build).and_raise(SolrConnectionError, 'broken')

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
+  let(:object) { Dor::Item.new }
+
+  describe '.build' do
+    subject(:build) { described_class.build(ng_xml) }
+
+    context 'when the role is missing the authority' do
+      let(:ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <name valueURI="corporate">
+              <namePart>Selective Service System</namePart>
+              <role>
+                <roleTerm type="code">isb</roleTerm>
+              </role>
+            </name>
+          </mods>
+        XML
+      end
+
+      it 'raises an error' do
+        expect { build }.to raise_error Cocina::Mapper::InvalidDescMetadata, './mods:role/mods:roleTerm[@type="code"] is missing required authority attribute'
+      end
+    end
+  end
+end


### PR DESCRIPTION


## Why was this change made?
Raise an error that is useful in Argo rather than a NoMethodError


## How was this change tested?
Test suite


## Which documentation and/or configurations were updated?



