### PR TITLE
Map cocina descriptive when there are no subjects

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -19,7 +19,7 @@ module Cocina
 
         def initialize(xml:, subjects:, forms:)
           @xml = xml
-          @subjects = subjects
+          @subjects = Array(subjects)
           @forms = forms
         end
 

--- a/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
@@ -16,6 +16,19 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
     end
   end
 
+  context 'when subject is nil' do
+    let(:subjects) { nil }
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        </mods>
+      XML
+    end
+  end
+
   context 'when it has a single-term topic subject' do
     let(:subjects) do
       [


### PR DESCRIPTION
## Why was this change made?

Running the test mapper in prod was failing when there were no subjects.

## How was this change tested?



## Which documentation and/or configurations were updated?



