### PR TITLE
Map originInfo to cocina Events

### DIFF
--- a/app/services/cocina/from_fedora/descriptive.rb
+++ b/app/services/cocina/from_fedora/descriptive.rb
@@ -29,11 +29,13 @@ module Cocina
         note = Notes.build(ng_xml)
         language = Language.build(ng_xml)
         contributor = Contributor.build(ng_xml)
+        events = Event.build(ng_xml)
         form = Form.build(ng_xml)
         { title: titles }.tap do |desc|
           desc[:note] = note unless note.empty?
           desc[:language] = language unless language.empty?
           desc[:contributor] = contributor unless contributor.empty?
+          desc[:event] = events unless events.empty?
           desc[:form] = form unless form.empty?
         end
       end

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -31,6 +31,9 @@ module Cocina
 
               date_captured = origin.xpath('mods:dateCaptured', mods: DESC_METADATA_NS)
               events << build_event('capture', date_captured) if date_captured.present?
+
+              date_other = origin.xpath('mods:dateOther', mods: DESC_METADATA_NS)
+              events << build_event(nil, date_other) if date_other.present?
             end
           end
         end
@@ -44,7 +47,10 @@ module Cocina
           date = { value: node.text }
           date[:encoding] = { code: node['encoding'] } if node['encoding']
           date[:status] = 'primary' if node['keyDate']
-          { type: type, date: [date] }
+          date[:note] = [{ value: node['type'], type: 'date type' }] unless type
+          { date: [date] }.tap do |event|
+            event[:type] = type if type
+          end
         end
 
         def origin_info

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Cocina
+  module FromFedora
+    class Descriptive
+      # Maps originInfo to cocina events
+      class Event
+        ORIGININFO_XPATH = '/mods:mods/mods:originInfo'
+
+        # @param [Nokogiri::XML::Document] ng_xml the descriptive metadata XML
+        # @return [Hash] a hash that can be mapped to a cocina model
+        def self.build(ng_xml)
+          new(ng_xml).build
+        end
+
+        def initialize(ng_xml)
+          @ng_xml = ng_xml
+        end
+
+        def build
+          [].tap do |events|
+            origin_info.each do |origin|
+              date_created = origin.xpath('mods:dateCreated', mods: DESC_METADATA_NS)
+              events << { type: 'creation', date: [{ value: date_created.text }] }
+            end
+          end
+        end
+
+        private
+
+        attr_reader :ng_xml
+
+        def origin_info
+          @names ||= ng_xml.xpath(ORIGININFO_XPATH, mods: DESC_METADATA_NS)
+        end
+      end
+    end
+  end
+end

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -43,13 +43,31 @@ module Cocina
         attr_reader :ng_xml
 
         def build_event(type, node_set)
-          node = node_set.first
-          date = { value: node.text }
-          date[:encoding] = { code: node['encoding'] } if node['encoding']
-          date[:status] = 'primary' if node['keyDate']
-          date[:note] = [{ value: node['type'], type: 'date type' }] unless type
+          date = if node_set.size == 1
+                   build_date(type, node_set.first)
+                 else
+                   build_structured_date(type, node_set)
+                 end
           { date: [date] }.tap do |event|
             event[:type] = type if type
+          end
+        end
+
+        def build_structured_date(type, node_set)
+          { structuredValue: [] }.tap do |date|
+            node_set.each do |node|
+              date[:structuredValue] << build_date(type, node)
+            end
+          end
+        end
+
+        def build_date(type, node)
+          {}.tap do |date|
+            date[:value] = node.text if node.text
+            date[:encoding] = { code: node['encoding'] } if node['encoding']
+            date[:status] = 'primary' if node['keyDate']
+            date[:note] = [{ value: node['type'], type: 'date type' }] unless type
+            date[:type] = node['point'] if node['point']
           end
         end
 

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -28,6 +28,9 @@ module Cocina
 
               copyright_date = origin.xpath('mods:copyrightDate', mods: DESC_METADATA_NS)
               events << build_event('copyright', copyright_date) if copyright_date.present?
+
+              date_captured = origin.xpath('mods:dateCaptured', mods: DESC_METADATA_NS)
+              events << build_event('capture', date_captured) if date_captured.present?
             end
           end
         end
@@ -40,6 +43,7 @@ module Cocina
           node = node_set.first
           date = { value: node.text }
           date[:encoding] = { code: node['encoding'] } if node['encoding']
+          date[:status] = 'primary' if node['keyDate']
           { type: type, date: [date] }
         end
 

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -43,22 +43,21 @@ module Cocina
         attr_reader :ng_xml
 
         def build_event(type, node_set)
-          date = if node_set.size == 1
-                   build_date(type, node_set.first)
-                 else
-                   build_structured_date(type, node_set)
-                 end
-          { date: [date] }.tap do |event|
+          dates = build_structured_date(type, node_set.select { |node| node['point'] })
+          node_set.reject { |node| node['point'] }.each do |node|
+            dates << build_date(type, node)
+          end
+
+          { date: dates }.tap do |event|
             event[:type] = type if type
           end
         end
 
         def build_structured_date(type, node_set)
-          { structuredValue: [] }.tap do |date|
-            node_set.each do |node|
-              date[:structuredValue] << build_date(type, node)
-            end
-          end
+          return [] if node_set.blank?
+
+          dates = node_set.map { |node| build_date(type, node) }
+          [{ structuredValue: dates }]
         end
 
         def build_date(type, node)

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -63,7 +63,8 @@ module Cocina
 
         def build_date(type, node)
           {}.tap do |date|
-            date[:value] = node.text if node.text
+            date[:value] = node.text
+            date[:qualifier] = node[:qualifier] if node[:qualifier]
             date[:encoding] = { code: node['encoding'] } if node['encoding']
             date[:status] = 'primary' if node['keyDate']
             date[:note] = [{ value: node['type'], type: 'date type' }] unless type

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -21,7 +21,10 @@ module Cocina
           [].tap do |events|
             origin_info.each do |origin|
               date_created = origin.xpath('mods:dateCreated', mods: DESC_METADATA_NS)
-              events << { type: 'creation', date: [{ value: date_created.text }] }
+              events << build_event('creation', date_created) if date_created.present?
+
+              date_issued = origin.xpath('mods:dateIssued', mods: DESC_METADATA_NS)
+              events << build_event('publication', date_issued) if date_issued.present?
             end
           end
         end
@@ -30,8 +33,15 @@ module Cocina
 
         attr_reader :ng_xml
 
+        def build_event(type, node_set)
+          node = node_set.first
+          date = { value: node.text }
+          date[:encoding] = { code: node['encoding'] } if node['encoding']
+          { type: type, date: [date] }
+        end
+
         def origin_info
-          @names ||= ng_xml.xpath(ORIGININFO_XPATH, mods: DESC_METADATA_NS)
+          @origin_info ||= ng_xml.xpath(ORIGININFO_XPATH, mods: DESC_METADATA_NS)
         end
       end
     end

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -25,6 +25,9 @@ module Cocina
 
               date_issued = origin.xpath('mods:dateIssued', mods: DESC_METADATA_NS)
               events << build_event('publication', date_issued) if date_issued.present?
+
+              copyright_date = origin.xpath('mods:copyrightDate', mods: DESC_METADATA_NS)
+              events << build_event('copyright', copyright_date) if copyright_date.present?
             end
           end
         end

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -43,7 +43,8 @@ module Cocina
         attr_reader :ng_xml
 
         def build_event(type, node_set)
-          dates = build_structured_date(type, node_set.select { |node| node['point'] })
+          points = node_set.select { |node| node['point'] }
+          dates = points.size == 1 ? [build_date(type, points.first)] : build_structured_date(type, points)
           node_set.reject { |node| node['point'] }.each do |node|
             dates << build_date(type, node)
           end

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -86,4 +86,31 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
       ]
     end
   end
+
+  context 'with a single dateCaptured (ISO 8601 encoding, keyDate)' do
+    let(:xml) do
+      <<~XML
+        <originInfo>
+          <dateCaptured keyDate="yes" encoding="iso8601">20131012231249</dateCaptured>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'capture',
+          "date": [
+            {
+              "value": '20131012231249',
+              "encoding": {
+                "code": 'iso8601'
+              },
+              "status": 'primary'
+            }
+          ]
+        }
+      ]
+    end
+  end
 end

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -24,13 +24,39 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
       XML
     end
 
-    it 'raises an error' do
+    it 'builds the cocina data structure' do
       expect(build).to eq [
         {
           "type": 'creation',
           "date": [
             {
               "value": '1980'
+            }
+          ]
+        }
+      ]
+    end
+  end
+
+  context 'with a simple dateIssued (with encoding)' do
+    let(:xml) do
+      <<~XML
+        <originInfo>
+          <dateIssued encoding="w3cdtf">1928</dateIssued>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'publication',
+          "date": [
+            {
+              "value": '1928',
+              "encoding": {
+                "code": 'w3cdtf'
+              }
             }
           ]
         }

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -291,4 +291,36 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
       ]
     end
   end
+
+  context 'with Multiple date types' do
+    let(:xml) do
+      <<~XML
+        <originInfo>
+          <dateIssued>1955</dateIssued>
+          <copyrightDate>1940</copyrightDate>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'publication',
+          "date": [
+            {
+              "value": '1955'
+            }
+          ]
+        },
+        {
+          "type": 'copyright',
+          "date": [
+            {
+              "value": '1940'
+            }
+          ]
+        }
+      ]
+    end
+  end
 end

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -63,4 +63,27 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
       ]
     end
   end
+
+  context 'with a single copyrightDate' do
+    let(:xml) do
+      <<~XML
+        <originInfo>
+          <copyrightDate>1930</copyrightDate>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'copyright',
+          "date": [
+            {
+              "value": '1930'
+            }
+          ]
+        }
+      ]
+    end
+  end
 end

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::FromFedora::Descriptive::Event do
+  subject(:build) { described_class.build(ng_xml) }
+
+  let(:ng_xml) do
+    Nokogiri::XML <<~XML
+      <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.loc.gov/mods/v3" version="3.6"
+        xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        #{xml}
+      </mods>
+    XML
+  end
+
+  context 'with a simple dateCreated' do
+    let(:xml) do
+      <<~XML
+        <originInfo>
+          <dateCreated>1980</dateCreated>
+        </originInfo>
+      XML
+    end
+
+    it 'raises an error' do
+      expect(build).to eq [
+        {
+          "type": 'creation',
+          "date": [
+            {
+              "value": '1980'
+            }
+          ]
+        }
+      ]
+    end
+  end
+end

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -175,4 +175,28 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
       ]
     end
   end
+
+  context 'with an approximate date' do
+    let(:xml) do
+      <<~XML
+        <originInfo>
+          <dateCreated qualifier="approximate">1940</dateCreated>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'creation',
+          "date": [
+            {
+              "value": '1940',
+              "qualifier": 'approximate'
+            }
+          ]
+        }
+      ]
+    end
+  end
 end

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -199,4 +199,42 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
       ]
     end
   end
+
+  context 'with a range plus single date' do
+    let(:xml) do
+      <<~XML
+        <originInfo>
+          <dateIssued keyDate="yes" point="start">1940</dateIssued>
+          <dateIssued point="end">1945</dateIssued>
+          <dateIssued>1948</dateIssued>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'publication',
+          "date": [
+            {
+              "structuredValue": [
+                {
+                  "value": '1940',
+                  "type": 'start',
+                  "status": 'primary'
+                },
+                {
+                  "value": '1945',
+                  "type": 'end'
+                }
+              ]
+            },
+            {
+              "value": '1948'
+            }
+          ]
+        }
+      ]
+    end
+  end
 end

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -113,4 +113,32 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
       ]
     end
   end
+
+  context 'with a single dateOther' do
+    let(:xml) do
+      <<~XML
+        <originInfo>
+          <dateOther type="Islamic">1441 AH</dateOther>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "date": [
+            {
+              "value": '1441 AH',
+              "note": [
+                {
+                  "value": 'Islamic',
+                  "type": 'date type'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    end
+  end
 end

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -141,4 +141,38 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
       ]
     end
   end
+
+  context 'with a date range' do
+    let(:xml) do
+      <<~XML
+        <originInfo>
+          <dateCreated keyDate="yes" point="start">1920</dateCreated>
+          <dateCreated point="end">1925</dateCreated>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'creation',
+          "date": [
+            {
+              "structuredValue": [
+                {
+                  "value": '1920',
+                  "type": 'start',
+                  "status": 'primary'
+                },
+                {
+                  "value": '1925',
+                  "type": 'end'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    end
+  end
 end

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
-  context 'with Multiple date types' do
+  context 'with multiple date types' do
     let(:xml) do
       <<~XML
         <originInfo>
@@ -317,6 +317,30 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
           "date": [
             {
               "value": '1940'
+            }
+          ]
+        }
+      ]
+    end
+  end
+
+  context 'with date range, no start point' do
+    let(:xml) do
+      <<~XML
+        <originInfo>
+          <dateIssued point="end">1980</dateIssued>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'publication',
+          "date": [
+            {
+              "value": '1980',
+              'type': 'end'
             }
           ]
         }

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -237,4 +237,32 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
       ]
     end
   end
+
+  context 'with multiple single dates' do
+    let(:xml) do
+      <<~XML
+        <originInfo>
+          <dateIssued keyDate="yes">1940</dateIssued>
+          <dateIssued>1942</dateIssued>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'publication',
+          "date": [
+            {
+              "value": '1940',
+              "status": 'primary'
+            },
+            {
+              "value": '1942'
+            }
+          ]
+        }
+      ]
+    end
+  end
 end

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -265,4 +265,30 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
       ]
     end
   end
+
+  context 'with BCE date (edtf encoding)' do
+    let(:xml) do
+      <<~XML
+        <originInfo>
+          <dateCreated encoding="edtf">-0499</dateCreated>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'creation',
+          "date": [
+            {
+              "value": '-0499',
+              "encoding": {
+                "code": 'edtf'
+              }
+            }
+          ]
+        }
+      ]
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

This increases the number of descriptive properties that can be round tripped.


## How was this change tested?



## Which documentation and/or configurations were updated?



