### PR TITLE
Load the Descriptive::Event class not the Event class

### DIFF
--- a/app/services/cocina/from_fedora/descriptive.rb
+++ b/app/services/cocina/from_fedora/descriptive.rb
@@ -10,7 +10,7 @@ module Cocina
         note: Notes,
         language: Language,
         contributor: Contributor,
-        event: Event,
+        event: Descriptive::Event,
         subject: Subject,
         form: Form,
         identifier: Identifier,


### PR DESCRIPTION


## Why was this change made?
It is resolving the wrong class in production mode


## How was this change tested?



## Which documentation and/or configurations were updated?



