### PR TITLE
Handles missing authorityURI for source of subject.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -41,7 +41,7 @@ module Cocina
 
         def source_attrs(subject, attrs = {})
           if subject[:valueURI]
-            attrs[:source] = { code: subject[:authority], uri: subject[:authorityURI] }
+            attrs[:source] = { code: subject[:authority], uri: subject[:authorityURI] }.compact
             attrs[:uri] = subject[:valueURI]
           elsif subject[:authority]
             attrs[:source] = { code: subject[:authority] }

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -305,6 +305,31 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     end
   end
 
+  context 'with a name subject with authority missing authorityURI' do
+    let(:xml) do
+      <<~XML
+        <subject authority="fast" valueURI="(OCoLC)fst00596994">
+          <name type="corporate">
+            <namePart>Biblioteka Polskiej Akademii Nauk w Krakowie</namePart>
+          </name>
+        </subject>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "value": 'Biblioteka Polskiej Akademii Nauk w Krakowie',
+          "type": 'person',
+          "uri": '(OCoLC)fst00596994',
+          "source": {
+            "code": 'fast'
+          }
+        }
+      ]
+    end
+  end
+
   context 'with a name subject with additional terms' do
     let(:xml) do
       <<~XML


### PR DESCRIPTION
closes #1193

## Why was this change made?
Fix mapping bug.


## How was this change tested?
Unit test


## Which documentation and/or configurations were updated?
NA


