### PR TITLE
Handle missing coordinates.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -33,7 +33,7 @@ module Cocina
             next hierarchical_geographic(node, attrs) if node.name == 'hierarchicalGeographic'
 
             simple_item(node, attrs)
-          end
+          end.compact
         end
 
         private
@@ -78,6 +78,8 @@ module Cocina
             attrs.merge(code: node.text, type: 'place', source: { code: node['authority'] })
           when 'cartographics'
             coords = node.xpath('mods:coordinates', mods: DESC_METADATA_NS).first
+            return nil if coords.nil?
+
             attrs.merge(value: coords.text, type: 'map coordinates', encoding: { value: 'DMS' })
           else
             attrs.merge(value: node.text, type: NODE_TYPE.fetch(node.name))

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -611,6 +611,23 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     end
   end
 
+  context 'with a cartographic subject missing coordinates' do
+    let(:xml) do
+      <<~XML
+        <subject>
+          <cartographics>
+            <scale>1:22,000,000</scale>
+            <projection>Conic proj</projection>
+          </cartographics>
+        </subject>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq []
+    end
+  end
+
   context 'with a geographic code subject' do
     let(:xml) do
       <<~XML


### PR DESCRIPTION
closes #1184

## Why was this change made?
To handle cases in which coordinates is missing from a geo subject.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


