### PR TITLE
Use person rather than name or personal name for titles

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -13,6 +13,8 @@ module Cocina
           'partName' => 'part name'
         }.freeze
 
+        PERSON_TYPE = 'person'
+
         # @param [Nokogiri::XML::Document] ng_xml the descriptive metadata XML
         # @return [Hash] a hash that can be mapped to a cocina model
         # @raises [Mapper::MissingTitle]
@@ -81,7 +83,7 @@ module Cocina
           parts = node.xpath("//mods:name[@nameTitleGroup='#{name_title_group}']/mods:namePart", mods: DESC_METADATA_NS)
           raise "name not found for #{name_title_group}" if parts.blank?
 
-          vals = parts.map { |part| { value: part.text, type: Contributor::NAME_PART.fetch(part['type'], 'name') } }
+          vals = parts.map { |part| { value: part.text, type: Contributor::NAME_PART.fetch(part['type'], PERSON_TYPE) } }
 
           with_attributes({ structuredValue: vals + [{ value: title, type: 'title' }] },
                           node,

--- a/app/services/cocina/to_fedora/descriptive/title.rb
+++ b/app/services/cocina/to_fedora/descriptive/title.rb
@@ -5,13 +5,8 @@ module Cocina
     class Descriptive
       # Maps titles from cocina to MODS XML
       class Title
-        TAG_NAME = {
-          'nonsorting characters' => :nonSort,
-          'main title' => :title,
-          'subtitle' => :subTitle,
-          'part name' => 'partName',
-          'part number' => 'partNumber'
-        }.freeze
+        TAG_NAME = FromFedora::Descriptive::Titles::TYPES.invert.freeze
+
         # @params [Nokogiri::XML::Builder] xml
         # @params [Array<Cocina::Models::DescriptiveValueRequired>] titles
         def self.write(xml:, titles:)
@@ -71,7 +66,7 @@ module Cocina
           title_info_attrs[:usage] = 'primary' if structured_node.status == 'primary'
           title_info_attrs[:type] = structured_node.type if structured_node.type
 
-          names = structured_node.structuredValue.group_by { |component| component.type == 'personal name' }
+          names = structured_node.structuredValue.group_by { |component| component.type == FromFedora::Descriptive::Titles::PERSON_TYPE }
 
           title_info_attrs[:nameTitleGroup] = name_title_group if names[true].present?
 

--- a/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
             "structuredValue": [
               {
                 "value": 'Shakespeare, William, 1564-1616',
-                "type": 'name'
+                "type": 'person'
               },
               {
                 "value": 'Hamlet',
@@ -349,7 +349,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
             "structuredValue": [
               {
                 "value": 'Spinoza, Benedictus de',
-                "type": 'name'
+                "type": 'person'
               },
               {
                 "value": '1632-1677',

--- a/spec/services/cocina/to_fedora/descriptive/title_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/title_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Title do
             "structuredValue": [
               {
                 "value": 'Shakespeare, William, 1564-1616',
-                "type": 'personal name',
+                "type": 'person',
                 "uri": 'http://id.loc.gov/authorities/names/n78095332',
                 "source": {
                   "uri": 'http://id.loc.gov/authorities/names/',


### PR DESCRIPTION


## Why was this change made?

See https://github.com/sul-dlss-labs/cocina-descriptive-metadata/commit/9792d5dc04e9a11ad67b328c8f9baf1a09a4ed7f

Fixes #1156

## How was this change tested?



## Which documentation and/or configurations were updated?



