### PR TITLE
Contrib roles

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor.rb
@@ -34,6 +34,8 @@ module Cocina
         attr_reader :xml, :contributors
 
         def name_attributes(contributor)
+          return {} if contributor.type.nil?
+
           { type: NAME_TYPE.fetch(contributor.type) }.tap do |attributes|
             attributes[:usage] = 'primary' if contributor.status == 'primary'
           end
@@ -42,6 +44,26 @@ module Cocina
         def write_basic(contributor)
           xml.name name_attributes(contributor) do
             xml.namePart contributor.name.first.value
+            write_roles_for(contributor)
+          end
+        end
+
+        def write_roles_for(contributor)
+          Array(contributor.role).each do |role|
+            xml.role do
+              attributes = {}
+              if role.value.present?
+                attributes[:type] = 'text'
+                value = role.value
+              elsif role.code.present?
+                attributes[:type] = 'code'
+                value = role.code
+              end
+              attributes[:valueURI] = role.uri
+              attributes[:authority] = role.source&.code
+              attributes[:authorityURI] = role.source&.uri
+              xml.roleTerm value, attributes if value
+            end
           end
         end
 

--- a/spec/services/cocina/from_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive_spec.rb
@@ -139,8 +139,10 @@ RSpec.describe Cocina::FromFedora::Descriptive do
         role: [{
           value: 'collector',
           code: 'col',
+          uri: 'http://id.loc.gov/vocabulary/relators/col',
           source: {
-            code: 'marcrelator'
+            code: 'marcrelator',
+            uri: 'http://id.loc.gov/vocabulary/relators'
           }
         }]
       }, {


### PR DESCRIPTION
## Why was this change made?

Fixes #1105 - implement from_ and to_ fedora mapping for contributor roles
Fixes #1161 - cocina mapping error for role when namePart is empty

Note that #1161 refers to the stage object https://argo-stage.stanford.edu/view/druid:pd967mn2579 which has funky empty name stuff:

```
  <name>
    <namePart/>
    <role>
      <roleTerm authority="marcrelator" type="text"/>
    </role>
```

Note that roleTerm has attributes but no value, so it is, effectively, no information.

Since contributor roles and all that were already defined fully in cocina-models, I believe I have no openapi changes and no type checking to add - please let me know if that's wrong.

## How was this change tested?

unit tests.  Made a point of using the same starting xml in "from_fedora" specs that I expected in "to_fedora specs.

## Which documentation and/or configurations were updated?



