### PR TITLE
Remove obosolete value from the map

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -15,7 +15,6 @@ module Cocina
         NAME_PART = {
           'family' => 'surname',
           'given' => 'forename',
-          'terms of address' => 'term of address',
           'termsOfAddress' => 'term of address',
           'date' => 'life dates'
         }.freeze


### PR DESCRIPTION

## Why was this change made?
Should have been removed as part of https://github.com/sul-dlss/dor-services-app/commit/cf3225d275a1f227e7e191d6246be98afb385dea

Fixes #1209 


## How was this change tested?



## Which documentation and/or configurations were updated?



