### PR TITLE
Handle identifier without source.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
+++ b/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
@@ -50,11 +50,10 @@ module Cocina
           return unless identifier
 
           [{
-            source: {
-              value: identifier['source']
-            },
             value: identifier.text
-          }]
+          }.tap do |model|
+            model[:source] = { value: identifier['source'] } if identifier['source']
+          end]
         end
 
         def build_note

--- a/spec/services/cocina/from_fedora/descriptive/admin_metadata_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/admin_metadata_spec.rb
@@ -175,4 +175,24 @@ RSpec.describe Cocina::FromFedora::Descriptive::AdminMetadata do
   context 'with recordInfo converted from ISO 19139' do
     xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_recordInfo.txt#L213'
   end
+
+  context 'with recordIdentifier missing source' do
+    let(:xml) do
+      <<~XML
+        <recordInfo>
+          <recordIdentifier>a12374669</recordIdentifier>
+        </recordInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq(
+        "identifier": [
+          {
+            "value": 'a12374669'
+          }
+        ]
+      )
+    end
+  end
 end


### PR DESCRIPTION
closes #1229

## Why was this change made?
Allow an identifier to be missing a source.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


