### PR TITLE
Handles form note without displayLabel.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/form.rb
+++ b/app/services/cocina/from_fedora/descriptive/form.rb
@@ -89,7 +89,7 @@ module Cocina
         def add_note(forms, physical_description)
           physical_description.xpath('mods:note', mods: DESC_METADATA_NS).each do |node|
             forms << {
-              note: [{ value: node.content, displayLabel: node['displayLabel'] }]
+              note: [{ value: node.content, displayLabel: node['displayLabel'] }.compact]
             }
           end
         end

--- a/spec/services/cocina/from_fedora/descriptive/form_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/form_spec.rb
@@ -315,6 +315,33 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
       end
     end
 
+    context 'when note does not have displayLabel' do
+      let(:xml) do
+        <<~XML
+          <physicalDescription>
+            <form>ink on paper</form>
+            <note>Small tear at top right corner.</note>
+          </physicalDescription>
+        XML
+      end
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq [
+          {
+            "value": 'ink on paper',
+            "type": 'form'
+          },
+          {
+            "note": [
+              {
+                "value": 'Small tear at top right corner.'
+              }
+            ]
+          }
+        ]
+      end
+    end
+
     context 'when it has displayLabel' do
       xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_physicalDescription.txt#L107'
     end


### PR DESCRIPTION
closes #1252

## Why was this change made?
displayLabel should be optional for a form note.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


