### PR TITLE
Include RelatedResource in to_fedora descriptive

### DIFF
--- a/app/services/cocina/to_fedora/descriptive.rb
+++ b/app/services/cocina/to_fedora/descriptive.rb
@@ -30,6 +30,7 @@ module Cocina
             Descriptive::Event.write(xml: xml, events: descriptive.event)
             Descriptive::Identifier.write(xml: xml, identifiers: descriptive.identifier)
             Descriptive::AdminMetadata.write(xml: xml, admin_metadata: descriptive.adminMetadata)
+            Descriptive::RelatedResource.write(xml: xml, related_resources: descriptive.relatedResource)
           end
         end
       end


### PR DESCRIPTION
## Why was this change made?

Fixes #1219 

Confirmed on stage for the druid in the ticket:

```
  <relatedItem type="series">
    <titleInfo>
      <title>Biblioteca del pensamiento vivo, 18</title>
    </titleInfo>
  </relatedItem>
```


## How was this change tested?

Unit

## Which documentation and/or configurations were updated?

N/A

