### PR TITLE
Fix rubocop build failure on master

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/to_fedora/descriptive/related_resource.rb
@@ -16,8 +16,7 @@ module Cocina
           'has part' => 'constituent',
           'part of' => 'host',
           'referenced by' => 'isReferencedBy',
-          'has other format' => 'otherFormat',
-          'has version' => 'otherVersion'
+          'has other format' => 'otherFormat'
         }.freeze
         # @params [Nokogiri::XML::Builder] xml
         # @params [Array<Cocina::Models::DescriptiveValue>] related_resources


### PR DESCRIPTION
## Why was this change made?

Fixes the rubocop build failure on master

## How was this change tested?



## Which documentation and/or configurations were updated?



