### PR TITLE
Implement language mappings to_ and from_fedora per Arcadia's examples

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/language.rb
+++ b/app/services/cocina/from_fedora/descriptive/language.rb
@@ -6,11 +6,17 @@ module Cocina
       # Maps languages
       class Language
         LANG_XPATH = '//mods:language'
-        LANG_TEXT_XPATH = './mods:languageTerm[@type="text"]/text()'
-        LANG_TEXT_AUTHORITY_URI_XPATH = './mods:languageTerm[@type="text"]/@authorityURI'
-        LANG_TEXT_VALUE_URI_XPATH = './mods:languageTerm[@type="text"]/@valueURI'
-        LANG_CODE_XPATH = './mods:languageTerm[@type="code"]/text()'
-        LANG_CODE_AUTHORITY_XPATH = './mods:languageTerm[@type="code"]/@authority'
+        LANG_STATUS_XPATH = './@status'
+        OBJECT_PART_XPATH = './@objectPart'
+        DISPLAY_LABEL_XPATH = './@displayLabel'
+        LANGUAGE_TERM_XPATH = "#{LANG_XPATH}/mods:languageTerm"
+        SCRIPT_TERM_XPATH = "#{LANG_XPATH}/mods:scriptTerm"
+        LANG_TERM_TEXT_XPATH = './mods:languageTerm[@type="text"]/text()'
+        LANG_TERM_CODE_XPATH = './mods:languageTerm[@type="code"]/text()'
+        LANG_TERM_CODE_AUTHORITY_XPATH = './mods:languageTerm[@type="code"]/@authority'
+        LANG_TERM_TEXT_AUTHORITY_XPATH = './mods:languageTerm[@type="text"]/@authority'
+        TEXT_AUTHORITY_URI_XPATH = './*[@type="text"]/@authorityURI' # can be for languageTerm or scriptTerm
+        TEXT_VALUE_URI_XPATH = './*[@type="text"]/@valueURI' # can be for languageTerm or scriptTerm
 
         # @param [Nokogiri::XML::Document] ng_xml the descriptive metadata XML
         # @return [Hash] a hash that can be mapped to a cocina model
@@ -25,10 +31,12 @@ module Cocina
         def build
           [].tap do |langs|
             languages.each do |lang|
-              langs << { code: language_code_for(lang),
-                         value: language_text_for(lang),
-                         uri: language_uri_for(lang),
-                         source: language_source_for(lang) }.reject { |_k, v| v.blank? }
+              attribs = {}
+              attribs = lang_term_attributes_for(lang) if language_term?(lang)
+              attribs[:status] = language_status_for(lang) if language_status_for(lang).present?
+              attribs[:script] = script_term_attributes_for(script_term_nodes(lang)) if script_term?(lang)
+
+              langs << attribs
             end
           end
         end
@@ -37,27 +45,89 @@ module Cocina
 
         attr_reader :ng_xml
 
+        def lang_term_attributes_for(lang)
+          {
+            code: language_code_for(lang),
+            value: language_text_for(lang),
+            uri: language_value_uri_for(lang),
+            appliesTo: language_applies_to(lang),
+            displayLabel: language_display_label(lang),
+            source: language_source_for(lang)
+          }.reject { |_k, v| v.blank? }
+        end
+
+        def script_term_attributes_for(script_term_nodes)
+          return if script_term_nodes.blank?
+
+          code, value, authority = nil
+          script_term_nodes.each do |script_term_node|
+            code ||= script_term_node.content if script_term_node['type'] == 'code'
+            value ||= script_term_node.content if script_term_node['type'] == 'text'
+            authority ||= script_term_node['authority']
+          end
+          source = { code: authority } if authority
+          {
+            code: code,
+            value: value,
+            source: source
+          }.compact
+        end
+
         def languages
           @languages ||= ng_xml.xpath(LANG_XPATH, mods: DESC_METADATA_NS)
         end
 
         def language_code_for(lang)
-          lang.xpath(LANG_CODE_XPATH, mods: DESC_METADATA_NS).to_s
+          lang.xpath(LANG_TERM_CODE_XPATH, mods: DESC_METADATA_NS).to_s if language_term?(lang)
         end
 
         def language_text_for(lang)
-          lang.xpath(LANG_TEXT_XPATH, mods: DESC_METADATA_NS).to_s
+          lang.xpath(LANG_TERM_TEXT_XPATH, mods: DESC_METADATA_NS).to_s if language_term?(lang)
         end
 
-        def language_uri_for(lang)
-          lang.xpath(LANG_TEXT_VALUE_URI_XPATH, mods: DESC_METADATA_NS).to_s
+        # this can be present for type text and/or code, but we only want one.
+        def language_value_uri_for(lang)
+          result = lang.xpath(TEXT_VALUE_URI_XPATH, mods: DESC_METADATA_NS).to_s
+          result = lang.xpath('./*/@valueURI', mods: DESC_METADATA_NS).to_s if result.blank?
+          result
+        end
+
+        def language_applies_to(lang)
+          value = lang.xpath(OBJECT_PART_XPATH, mods: DESC_METADATA_NS).to_s
+          [value: value] if value.present?
+        end
+
+        def language_display_label(lang)
+          lang.xpath(DISPLAY_LABEL_XPATH, mods: DESC_METADATA_NS).to_s
+        end
+
+        def language_status_for(lang)
+          lang.xpath(LANG_STATUS_XPATH, mods: DESC_METADATA_NS).to_s
         end
 
         def language_source_for(lang)
+          code = lang.xpath(LANG_TERM_CODE_AUTHORITY_XPATH, mods: DESC_METADATA_NS).to_s if language_term?(lang)
+          # in case there is only a text node
+          code = lang.xpath(LANG_TERM_TEXT_AUTHORITY_XPATH, mods: DESC_METADATA_NS).to_s if code.blank? && language_term?(lang)
+          # this can be present for type text and/or code, but we only want one.
+          uri = lang.xpath(TEXT_AUTHORITY_URI_XPATH, mods: DESC_METADATA_NS).to_s
+          uri = lang.xpath('./*/@authorityURI', mods: DESC_METADATA_NS).to_s if uri.blank?
           {
-            code: lang.xpath(LANG_CODE_AUTHORITY_XPATH, mods: DESC_METADATA_NS).to_s,
-            uri: lang.xpath(LANG_TEXT_AUTHORITY_URI_XPATH, mods: DESC_METADATA_NS).to_s
+            code: code,
+            uri: uri
           }.reject { |_k, v| v.blank? }
+        end
+
+        def language_term?(lang)
+          lang.xpath(LANGUAGE_TERM_XPATH, mods: DESC_METADATA_NS).to_s.present?
+        end
+
+        def script_term?(lang)
+          script_term_nodes(lang).to_s.present?
+        end
+
+        def script_term_nodes(lang)
+          lang.xpath(SCRIPT_TERM_XPATH, mods: DESC_METADATA_NS)
         end
       end
     end

--- a/app/services/cocina/to_fedora/descriptive/language.rb
+++ b/app/services/cocina/to_fedora/descriptive/language.rb
@@ -26,16 +26,53 @@ module Cocina
 
         attr_reader :xml, :languages
 
+        # rubocop:disable Metrics/AbcSize
         def write_basic(language)
-          xml.language do
+          top_attributes = {}
+          top_attributes[:displayLabel] = language.displayLabel if language.displayLabel
+          applies_to = applies_to_first_value(language.appliesTo)
+          top_attributes[:objectPart] = applies_to if applies_to
+          top_attributes[:status] = language.status if language.status
+          xml.language top_attributes do
+            attributes = {}
+            attributes[:valueURI] = language.uri if language.uri
+            attributes[:authorityURI] = language.source.uri if language.source&.uri
+            attributes[:authority] = language.source.code if language.source&.code
+
             if language.value
-              xml.languageTerm language.value, type: 'text'
-            else
-              attributes = { type: 'code' }
-              attributes[:authority] = language.source.code
+              attributes[:type] = 'text'
+              xml.languageTerm language.value, attributes
+            end
+
+            if language.code
+              attributes[:type] = 'code'
               xml.languageTerm language.code, attributes
             end
+
+            write_script(language.script) if language.script
           end
+        end
+        # rubocop:enable Metrics/AbcSize
+
+        def write_script(script)
+          attributes = {}
+          attributes[:authority] = script.source.code if script.source&.code
+
+          if script.value
+            attributes[:type] = 'text'
+            xml.scriptTerm script.value, attributes
+          end
+
+          return unless script.code
+
+          attributes[:type] = 'code'
+          xml.scriptTerm script.code, attributes
+        end
+
+        # NOTE: appliesTo is an array in cocina model, but it is an xml attribute (thus single value) in MODS ...
+        # get value from DescriptiveBasicValue
+        def applies_to_first_value(applies_to)
+          applies_to&.first&.value
         end
       end
     end

--- a/spec/services/cocina/from_fedora/descriptive/language_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/language_spec.rb
@@ -1,0 +1,278 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::FromFedora::Descriptive::Language do
+  subject(:build) { described_class.build(ng_xml) }
+
+  let(:ng_xml) do
+    Nokogiri::XML <<~XML
+      <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.loc.gov/mods/v3" version="3.6"
+        xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        #{xml}
+      </mods>
+    XML
+  end
+
+  context 'when single language with term, code, and authority uris' do
+    let(:xml) do
+      <<~XML
+        <language>
+          <languageTerm authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2" valueURI="http://id.loc.gov/vocabulary/iso639-2/ara" type="code">ara</languageTerm>
+          <languageTerm authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2" valueURI="http://id.loc.gov/vocabulary/iso639-2/ara" type="text">Arabic</languageTerm>
+        </language>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "code": 'ara',
+          "value": 'Arabic',
+          "uri": 'http://id.loc.gov/vocabulary/iso639-2/ara',
+          "source": {
+            "code": 'iso639-2b',
+            "uri": 'http://id.loc.gov/vocabulary/iso639-2'
+          }
+        }
+      ]
+    end
+  end
+
+  context 'with language term only' do
+    let(:xml) do
+      <<~XML
+        <language>
+          <languageTerm type="text">English</languageTerm>
+        </language>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "value": 'English'
+        }
+      ]
+    end
+  end
+
+  context 'with language code only' do
+    let(:xml) do
+      <<~XML
+        <language>
+          <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+        </language>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "code": 'eng',
+          "source": {
+            "code": 'iso639-2b'
+          }
+        }
+      ]
+    end
+  end
+
+  context 'with multiple languages' do
+    let(:xml) do
+      <<~XML
+        <language status="primary">
+          <languageTerm type="text" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/eng">English</languageTerm>
+          <languageTerm type="code" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/eng">eng</languageTerm>
+        </language>
+        <language>
+          <languageTerm type="text" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/fre">French</languageTerm>
+          <languageTerm type="code" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/fre">fre</languageTerm>
+        </language>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "value": 'English',
+          "code": 'eng',
+          "uri": 'http://id.loc.gov/vocabulary/iso639-2/eng',
+          "source": {
+            "code": 'iso639-2b',
+            "uri": 'http://id.loc.gov/vocabulary/iso639-2/'
+          },
+          "status": 'primary'
+        },
+        {
+          "value": 'French',
+          "code": 'fre',
+          "uri": 'http://id.loc.gov/vocabulary/iso639-2/fre',
+          "source": {
+            "code": 'iso639-2b',
+            "uri": 'http://id.loc.gov/vocabulary/iso639-2/'
+          }
+        }
+      ]
+    end
+  end
+
+  context 'with script and authority' do
+    let(:xml) do
+      <<~XML
+        <language>
+          <languageTerm type="text" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/rus">Russian</languageTerm>
+          <languageTerm type="code" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/rus">rus</languageTerm>
+          <scriptTerm type="text" authority="iso15924">Cyrillic</scriptTerm>
+          <scriptTerm type="code" authority="iso15924">Cyrl</scriptTerm>
+        </language>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "value": 'Russian',
+          "code": 'rus',
+          "uri": 'http://id.loc.gov/vocabulary/iso639-2/rus',
+          "source": {
+            "code": 'iso639-2b',
+            "uri": 'http://id.loc.gov/vocabulary/iso639-2/'
+          },
+          "script": {
+            "value": 'Cyrillic',
+            "code": 'Cyrl',
+            "source": {
+              "code": 'iso15924'
+            }
+          }
+        }
+      ]
+    end
+  end
+
+  context 'with script only' do
+    let(:xml) do
+      <<~XML
+        <language>
+          <scriptTerm type="text" authority="iso15924">Latin</scriptTerm>
+          <scriptTerm type="code" authority="iso15924">Latn</scriptTerm>
+        </language>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "script": {
+            "value": 'Latin',
+            "code": 'Latn',
+            "source": {
+              "code": 'iso15924'
+            }
+          }
+        }
+      ]
+    end
+  end
+
+  context 'with objectPart' do
+    let(:xml) do
+      <<~XML
+        <language objectPart="liner notes">
+          <languageTerm type="text">English</languageTerm>
+        </language>
+        <language objectPart="libretto">
+          <languageTerm type="text">German</languageTerm>
+        </language>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "value": 'English',
+          "appliesTo": [
+            {
+              "value": 'liner notes'
+            }
+          ]
+        },
+        {
+          "value": 'German',
+          "appliesTo": [
+            {
+              "value": 'libretto'
+            }
+          ]
+        }
+      ]
+    end
+  end
+
+  context 'with displayLabel' do
+    let(:xml) do
+      <<~XML
+        <language displayLabel="Translated to">
+          <languageTerm type="text">English</languageTerm>
+        </language>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "value": 'English',
+          "displayLabel": 'Translated to'
+        }
+      ]
+    end
+  end
+
+  context 'with authorityURI and valueURI for code' do
+    let(:xml) do
+      <<~XML
+        <language>
+          <languageTerm type="code" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2" valueURI="http://id.loc.gov/vocabulary/iso639-2/ara">ara</languageTerm>
+        </language>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "code": 'ara',
+          "uri": 'http://id.loc.gov/vocabulary/iso639-2/ara',
+          "source": {
+            "code": 'iso639-2b',
+            "uri": 'http://id.loc.gov/vocabulary/iso639-2'
+          }
+        }
+      ]
+    end
+  end
+
+  context 'with authorityURI and valueURI for text' do
+    let(:xml) do
+      <<~XML
+        <language>
+          <languageTerm type="text" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2" valueURI="http://id.loc.gov/vocabulary/iso639-2/ara">Arabic</languageTerm>
+        </language>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "value": 'Arabic',
+          "uri": 'http://id.loc.gov/vocabulary/iso639-2/ara',
+          "source": {
+            "code": 'iso639-2b',
+            "uri": 'http://id.loc.gov/vocabulary/iso639-2'
+          }
+        }
+      ]
+    end
+  end
+end

--- a/spec/services/cocina/to_fedora/descriptive/language_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/language_spec.rb
@@ -29,7 +29,36 @@ RSpec.describe Cocina::ToFedora::Descriptive::Language do
     end
   end
 
-  context 'when it has a single language term' do
+  context 'when single language with term, code, and authority uris' do
+    let(:languages) do
+      [
+        Cocina::Models::Language.new(
+          "code": 'ara',
+          "value": 'Arabic',
+          "uri": 'http://id.loc.gov/vocabulary/iso639-2/ara',
+          "source": {
+            "code": 'iso639-2b',
+            "uri": 'http://id.loc.gov/vocabulary/iso639-2'
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <language>
+            <languageTerm authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2" valueURI="http://id.loc.gov/vocabulary/iso639-2/ara" type="code">ara</languageTerm>
+            <languageTerm authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2" valueURI="http://id.loc.gov/vocabulary/iso639-2/ara" type="text">Arabic</languageTerm>
+          </language>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when it has a single language term only' do
     let(:languages) do
       [
         Cocina::Models::Language.new(
@@ -51,7 +80,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Language do
     end
   end
 
-  context 'when it has a single language code' do
+  context 'when it has a single language code only' do
     let(:languages) do
       [
         Cocina::Models::Language.new(
@@ -70,6 +99,235 @@ RSpec.describe Cocina::ToFedora::Descriptive::Language do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <language>
             <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
+          </language>
+        </mods>
+      XML
+    end
+  end
+
+  context 'with multiple languages' do
+    let(:languages) do
+      [
+        Cocina::Models::Language.new(
+          "value": 'English',
+          "code": 'eng',
+          "uri": 'http://id.loc.gov/vocabulary/iso639-2/eng',
+          "source": {
+            "code": 'iso639-2b',
+            "uri": 'http://id.loc.gov/vocabulary/iso639-2/'
+          },
+          "status": 'primary'
+        ),
+        Cocina::Models::Language.new(
+          "value": 'French',
+          "code": 'fre',
+          "uri": 'http://id.loc.gov/vocabulary/iso639-2/fre',
+          "source": {
+            "code": 'iso639-2b',
+            "uri": 'http://id.loc.gov/vocabulary/iso639-2/'
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <language status="primary">
+            <languageTerm type="text" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/eng">English</languageTerm>
+            <languageTerm type="code" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/eng">eng</languageTerm>
+          </language>
+          <language>
+            <languageTerm type="text" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/fre">French</languageTerm>
+            <languageTerm type="code" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/fre">fre</languageTerm>
+          </language>
+        </mods>
+      XML
+    end
+  end
+
+  context 'with script and authority' do
+    let(:languages) do
+      [
+        Cocina::Models::Language.new(
+          "value": 'Russian',
+          "code": 'rus',
+          "uri": 'http://id.loc.gov/vocabulary/iso639-2/rus',
+          "source": {
+            "code": 'iso639-2b',
+            "uri": 'http://id.loc.gov/vocabulary/iso639-2/'
+          },
+          "script": {
+            "value": 'Cyrillic',
+            "code": 'Cyrl',
+            "source": {
+              "code": 'iso15924'
+            }
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <language>
+            <languageTerm type="text" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/rus">Russian</languageTerm>
+            <languageTerm type="code" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/rus">rus</languageTerm>
+            <scriptTerm type="text" authority="iso15924">Cyrillic</scriptTerm>
+            <scriptTerm type="code" authority="iso15924">Cyrl</scriptTerm>
+          </language>
+        </mods>
+      XML
+    end
+  end
+
+  context 'with script only' do
+    let(:languages) do
+      [
+        Cocina::Models::Language.new(
+          "script": {
+            "value": 'Latin',
+            "code": 'Latn',
+            "source": {
+              "code": 'iso15924'
+            }
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <language>
+            <scriptTerm type="text" authority="iso15924">Latin</scriptTerm>
+            <scriptTerm type="code" authority="iso15924">Latn</scriptTerm>
+          </language>
+        </mods>
+      XML
+    end
+  end
+
+  context 'with objectPart' do
+    let(:languages) do
+      [
+        Cocina::Models::Language.new(
+          {
+            "value": 'English',
+            "appliesTo": [
+              {
+                "value": 'liner notes'
+              }
+            ]
+          }
+        ),
+        Cocina::Models::Language.new(
+          {
+            "value": 'German',
+            "appliesTo": [
+              {
+                "value": 'libretto'
+              }
+            ]
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <language objectPart="liner notes">
+            <languageTerm type="text">English</languageTerm>
+          </language>
+          <language objectPart="libretto">
+            <languageTerm type="text">German</languageTerm>
+          </language>
+        </mods>
+      XML
+    end
+  end
+
+  context 'with displayLabel' do
+    let(:languages) do
+      [
+        Cocina::Models::Language.new(
+          "value": 'English',
+          "displayLabel": 'Translated to'
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <language displayLabel="Translated to">
+            <languageTerm type="text">English</languageTerm>
+          </language>
+        </mods>
+      XML
+    end
+  end
+
+  context 'with authorityURI and valueURI for code' do
+    let(:languages) do
+      [
+        Cocina::Models::Language.new(
+          "code": 'ara',
+          "uri": 'http://id.loc.gov/vocabulary/iso639-2/ara',
+          "source": {
+            "code": 'iso639-2b',
+            "uri": 'http://id.loc.gov/vocabulary/iso639-2'
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <language>
+            <languageTerm type="code" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2" valueURI="http://id.loc.gov/vocabulary/iso639-2/ara">ara</languageTerm>
+          </language>
+        </mods>
+      XML
+    end
+  end
+
+  context 'with authorityURI and valueURI for text' do
+    let(:languages) do
+      [
+        Cocina::Models::Language.new(
+          "value": 'Arabic',
+          "uri": 'http://id.loc.gov/vocabulary/iso639-2/ara',
+          "source": {
+            "code": 'iso639-2b',
+            "uri": 'http://id.loc.gov/vocabulary/iso639-2'
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <language>
+            <languageTerm type="text" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2" valueURI="http://id.loc.gov/vocabulary/iso639-2/ara">Arabic</languageTerm>
           </language>
         </mods>
       XML


### PR DESCRIPTION
**NOTE:  we have a partial mapping for language;  this may actually reduce the number of errors ... not sure if this should be held as a "new mapping" or not.**

## Why was this change made?

Fixes #1216 -- what to do with the language element `objectPart` attribute
Fixes #1090 -- mapping the language element.   (@jcoyne had this ticket. I believe he did PR #1130, which was a beginning, and this PR does the rest)

This PR implements all of Arcadia's examples* in https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_language.txt for both "from_fedora" and "to_fedora" .

Note that the known examples that were failing in prod are covered by the specs:

#1248 - from gf100ky7916 (quick fix with PR #1249), which has

```xml
<language>
    <languageTerm type="text">Latin</languageTerm>
    <languageTerm type="code" authority="iso639-2b">lat</languageTerm>
  </language>
```

specs have langTerm of type text analogous to above, and langTerm type code analogous to above, and "text" and "code" langTerms occurring together and apart.

#1240 - from md951vt4966 (quick fix with PR #1246), which has 

```xml
<language>
    <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
  </language>
```
specs now cover this case.

bb012xz4244, from honeybadger which has 

```xml
  <language>
    <languageTerm authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2" valueURI="http://id.loc.gov/vocabulary/iso639-2/eng" type="code">eng</languageTerm>
    <languageTerm authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2" valueURI="http://id.loc.gov/vocabulary/iso639-2/eng" type="text">English</languageTerm>
  </language>
```
specs now cover this case.


* Arcadia still needs to do a PR to address the problem I encountered https://github.com/sul-dlss/dor-services-app/issues/1090#issuecomment-715532802 -- my specs reflect her answer https://github.com/sul-dlss/dor-services-app/issues/1090#issuecomment-716613678.

![image](https://user-images.githubusercontent.com/96775/97366783-26ffe480-1865-11eb-843b-c1eadbe03ef7.png)


## How was this change tested?

Wrote functional specs directly off Arcadia's examples in https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_language.txt


## Which documentation and/or configurations were updated?



