### PR TITLE
to_fedora cocina mapping copes with missing admin_metadata.note

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/admin_metadata.rb
+++ b/app/services/cocina/to_fedora/descriptive/admin_metadata.rb
@@ -34,7 +34,7 @@ module Cocina
         attr_reader :xml, :admin_metadata
 
         def build_record_origin
-          xml.recordOrigin admin_metadata.note.find { |note| note.type == 'record origin' }.value
+          xml.recordOrigin admin_metadata.note&.find { |note| note.type == 'record origin' }&.value if admin_metadata.note.present?
         end
 
         def build_content_source

--- a/spec/services/cocina/from_fedora/descriptive/admin_metadata_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/admin_metadata_spec.rb
@@ -195,4 +195,60 @@ RSpec.describe Cocina::FromFedora::Descriptive::AdminMetadata do
       )
     end
   end
+
+  context 'when there is no recordOrigin element (e.g. jv711gt9148)' do
+    let(:xml) do
+      <<~XML
+        <recordInfo>
+          <recordContentSource>DOR_MARC2MODS3-3.xsl Revision 1.1</recordContentSource>
+          <recordCreationDate encoding="iso8601">2011-02-08T20:00:27.321-08:00</recordCreationDate>
+          <recordIdentifier source="Data Provider Digital Object Identifier">36105033329140</recordIdentifier>
+        </recordInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq(
+        {
+          contributor: [
+            {
+              name: [
+                {
+                  code: 'DOR_MARC2MODS3-3.xsl Revision 1.1',
+                  source: {}
+                }
+              ],
+              role: [
+                {
+                  value: 'original cataloging agency'
+                }
+              ],
+              type: 'organization'
+            }
+          ],
+          event: [
+            {
+              date: [
+                {
+                  encoding: {
+                    code: 'iso8601'
+                  },
+                  value: '2011-02-08T20:00:27.321-08:00'
+                }
+              ],
+              type: 'creation'
+            }
+          ],
+          identifier: [
+            {
+              source: {
+                value: 'Data Provider Digital Object Identifier'
+              },
+              value: '36105033329140'
+            }
+          ]
+        }
+      )
+    end
+  end
 end

--- a/spec/services/cocina/to_fedora/descriptive/admin_metadata_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/admin_metadata_spec.rb
@@ -198,4 +198,64 @@ RSpec.describe Cocina::ToFedora::Descriptive::AdminMetadata do
   context 'when it is converted from ISO 19139' do
     xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_recordInfo.txt#L146'
   end
+
+  context 'when there is no "note" (e.g. jv711gt9148)' do
+    let(:admin_metadata) do
+      Cocina::Models::DescriptiveAdminMetadata.new(
+        {
+          contributor: [
+            {
+              name: [
+                {
+                  code: 'DOR_MARC2MODS3-3.xsl Revision 1.1',
+                  source: {}
+                }
+              ],
+              role: [
+                {
+                  value: 'original cataloging agency'
+                }
+              ],
+              type: 'organization'
+            }
+          ],
+          event: [
+            {
+              date: [
+                {
+                  encoding: {
+                    code: 'iso8601'
+                  },
+                  value: '2011-02-08T20:00:27.321-08:00'
+                }
+              ],
+              type: 'creation'
+            }
+          ],
+          identifier: [
+            {
+              source: {
+                value: 'Data Provider Digital Object Identifier'
+              },
+              value: '36105033329140'
+            }
+          ]
+        }
+      )
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <recordInfo>
+            <recordContentSource>DOR_MARC2MODS3-3.xsl Revision 1.1</recordContentSource>
+            <recordCreationDate encoding="iso8601">2011-02-08T20:00:27.321-08:00</recordCreationDate>
+            <recordIdentifier source="Data Provider Digital Object Identifier">36105033329140</recordIdentifier>
+          </recordInfo>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #1255.

`jv711gt9148` has no `<recordOrigin>` element, which "from_fedora" mappings dealt with fine, but the "to_fedora" mappings needed to allow for missing admin_metadata.note field.

## How was this change tested?

functional tests.  (I got the same line to fail with the new functional tests before the fix as was indicated in #1255):

This was the failure while it was a WIP:
```
1) Cocina::ToFedora::Descriptive::AdminMetadata for jv711gt9148 ... builds the xml
     Failure/Error: xml.recordOrigin admin_metadata.note&.find { |note| note.type == 'record origin' }.value
     
     NoMethodError:
       undefined method `value' for nil:NilClass
     # ./app/services/cocina/to_fedora/descriptive/admin_metadata.rb:37:in `build_record_origin'
     # ./app/services/cocina/to_fedora/descriptive/admin_metadata.rb:26:in `block in write'
     # ./app/services/cocina/to_fedora/descriptive/admin_metadata.rb:22:in `write'
     # ./app/services/cocina/to_fedora/descriptive/admin_metadata.rb:11:in `write'
```

## Which documentation and/or configurations were updated?



