### PR TITLE
contributor.name to_fedora mapping fix for structuredValue

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor.rb
@@ -59,9 +59,9 @@ module Cocina
                 attributes[:type] = 'code'
                 value = role.code
               end
-              attributes[:valueURI] = role.uri
-              attributes[:authority] = role.source&.code
-              attributes[:authorityURI] = role.source&.uri
+              attributes[:valueURI] = role.uri if role.uri
+              attributes[:authority] = role.source&.code if role.source&.code
+              attributes[:authorityURI] = role.source&.uri if role.source&.uri
               xml.roleTerm value, attributes if value
             end
           end

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -404,7 +404,54 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
   end
 
   context 'with multiple names, one primary' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L365'
+    let(:xml) do
+      <<~XML
+        <name type="personal" usage="primary">
+          <namePart>Bulgakov, Mikhail</namePart>
+          <role>
+            <roleTerm type="text">author</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Burgin, Diana Lewis</namePart>
+          <role>
+            <roleTerm type="text">translator</roleTerm>
+          </role>
+        </name>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "name": [
+            {
+              "value": 'Bulgakov, Mikhail'
+            }
+          ],
+          "type": 'person',
+          "status": 'primary',
+          "role": [
+            {
+              "value": 'author'
+            }
+          ]
+        },
+        {
+          "name": [
+            {
+              "value": 'Burgin, Diana Lewis'
+            }
+          ],
+          "type": 'person',
+          "role": [
+            {
+              "value": 'translator'
+            }
+          ]
+        }
+      ]
+    end
   end
 
   context 'with multiple names, no primary' do

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -454,6 +454,55 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     end
   end
 
+  context 'with multiple names, one primary, dates, no roles' do
+    let(:xml) do
+      <<~XML
+        <name type="personal" usage="primary">
+          <namePart>Sarmiento, Domingo Faustino</namePart>
+          <namePart type="date">1811-1888</namePart>
+        </name>
+        <name type="personal">
+          <namePart>Rojas, Ricardo</namePart>
+          <namePart type="date">1882-1957</namePart>
+        </name>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "name": [
+            "structuredValue": [
+              {
+                "value": 'Sarmiento, Domingo Faustino'
+              },
+              {
+                "type": 'life dates',
+                "value": '1811-1888'
+              }
+            ]
+          ],
+          "type": 'person',
+          "status": 'primary'
+        },
+        {
+          "name": [
+            "structuredValue": [
+              {
+                "value": 'Rojas, Ricardo'
+              },
+              {
+                "type": 'life dates',
+                "value": '1882-1957'
+              }
+            ]
+          ],
+          "type": 'person'
+        }
+      ]
+    end
+  end
+
   context 'with multiple names, no primary' do
     xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L410'
   end

--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -453,6 +453,59 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     end
   end
 
+  context 'with multiple names, one primary, dates, no roles' do
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          "name": [
+            "structuredValue": [
+              {
+                "value": 'Sarmiento, Domingo Faustino'
+              },
+              {
+                "type": 'life dates',
+                "value": '1811-1888'
+              }
+            ]
+          ],
+          "type": 'person',
+          "status": 'primary'
+        ),
+        Cocina::Models::Contributor.new(
+          "name": [
+            "structuredValue": [
+              {
+                "value": 'Rojas, Ricardo'
+              },
+              {
+                "type": 'life dates',
+                "value": '1882-1957'
+              }
+            ]
+          ],
+          "type": 'person'
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <name type="personal" usage="primary">
+            <namePart>Sarmiento, Domingo Faustino</namePart>
+            <namePart type="date">1811-1888</namePart>
+          </name>
+          <name type="personal">
+            <namePart>Rojas, Ricardo</namePart>
+            <namePart type="date">1882-1957</namePart>
+          </name>
+        </mods>
+      XML
+    end
+  end
+
   context 'with multiple names, no primary' do
     xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L410'
   end

--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -399,6 +399,58 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
 
   context 'with multiple names, one primary' do
     xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L365'
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          "name": [
+            {
+              "value": 'Bulgakov, Mikhail'
+            }
+          ],
+          "type": 'person',
+          "status": 'primary',
+          "role": [
+            {
+              "value": 'author'
+            }
+          ]
+        ),
+        Cocina::Models::Contributor.new(
+          "name": [
+            {
+              "value": 'Burgin, Diana Lewis'
+            }
+          ],
+          "type": 'person',
+          "role": [
+            {
+              "value": 'translator'
+            }
+          ]
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <name type="personal" usage="primary">
+            <namePart>Bulgakov, Mikhail</namePart>
+            <role>
+              <roleTerm type="text">author</roleTerm>
+            </role>
+          </name>
+          <name type="personal">
+            <namePart>Burgin, Diana Lewis</namePart>
+            <role>
+              <roleTerm type="text">translator</roleTerm>
+            </role>
+          </name>
+        </mods>
+      XML
+    end
   end
 
   context 'with multiple names, no primary' do


### PR DESCRIPTION
## Why was this change made?

Fixes #1218

- corrects to_fedora mapping for contributor.name.namePart when it is a structured value
- bonus:   added to_fedora and from_fedora specs for "multiple names, one primary" - started with this thinking it would trip the problem, but it turned out NOT to trip the problem in #1218, AND it turned out to be already implemented.

## How was this change tested?

functional tests were written with the same data as was in the record in ticket #1218 -- the from_fedora as well as the to_fedora.

## Which documentation and/or configurations were updated?



