### PR TITLE
Fix mapping of life dates on name part subelements of title

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -10,10 +10,16 @@ module Cocina
           'title' => 'main title',
           'subTitle' => 'subtitle',
           'partNumber' => 'part number',
-          'partName' => 'part name'
+          'partName' => 'part name',
+          'date' => 'life dates',
+          'given' => 'forename',
+          'family' => 'surname',
+          'uniform title' => 'title'
         }.freeze
 
         PERSON_TYPE = 'person'
+
+        NAME_TYPES = ['person', 'forename', 'surname', 'life dates'].freeze
 
         # @param [Nokogiri::XML::Document] ng_xml the descriptive metadata XML
         # @return [Hash] a hash that can be mapped to a cocina model

--- a/app/services/cocina/to_fedora/descriptive/title.rb
+++ b/app/services/cocina/to_fedora/descriptive/title.rb
@@ -62,33 +62,73 @@ module Cocina
         end
 
         def write_structured(structured_node, name_title_group:)
-          title_info_attrs = {}
-          title_info_attrs[:usage] = 'primary' if structured_node.status == 'primary'
-          title_info_attrs[:type] = structured_node.type if structured_node.type
+          title_info_attrs = {} # title_attrs(structured_node)
+          # title_info_attrs[:usage] = 'primary' if structured_node.status == 'primary'
+          # title_info_attrs[:type] = structured_node.type if structured_node.type
 
-          names = structured_node.structuredValue.group_by { |component| component.type == FromFedora::Descriptive::Titles::PERSON_TYPE }
+          names = structured_node.structuredValue.group_by { |component| FromFedora::Descriptive::Titles::NAME_TYPES.include? component.type }
+          name_title_group += 1 if names[true].present? && name_title_group < 1
 
+          title_info_attrs[:type] = structured_node.type # 'uniform' if structured_node.structuredValue.find { |component| component.type == 'title' }
+          title_info_attrs[:usage] = structured_node.status if names[false].present?
           title_info_attrs[:nameTitleGroup] = name_title_group if names[true].present?
 
           xml.titleInfo(with_uri_info(structured_node, title_info_attrs)) do
             names[false].each do |title|
-              xml.public_send(TAG_NAME.fetch(title.type), title.value) unless title.note
+              title_type = TAG_NAME.fetch(title.type, nil)
+              if title_type == 'uniform title'
+                title_type = 'title' 
+                title_info_attrs.merge(title)
+              end
+              xml.public_send(title_type, title.value) unless title.note
             end
           end
 
-          Array(names[true]).each do |name|
-            xml.name with_uri_info(name, nameTitleGroup: name_title_group, type: 'personal') do
-              xml.namePart name.value
+          if names[true].present?
+            name_block = { attributes: {}, values: [] }
+            Array(names[true]).each do |name|
+              name_block[:attributes].tap do |attrs|
+                attrs[:type] = 'personal'
+                attrs[:usage] = structured_node.status if structured_node.status
+                attrs[:nameTitleGroup] = name_title_group
+                attrs[:valueURI] = name.uri if name.uri
+                attrs[:authorityURI] = name.source.uri if name.source&.uri
+                attrs[:authority] = name.source.code if name.source&.code
+              end
+              name_block[:values] << { value: name.value, type: name.type }
+              # xml.name with_uri_info(structured_node, type: 'personal', nameTitleGroup: name_title_group) do
+                # name_attrs = {}
+                
+                # name_attrs[:type] = name_type if name_type
+                # xml.namePart name.value # , with_uri_info(name, nameTitleGroup: name_title_group, type: name_type)
+             # end
+            end
+            xml.name name_block[:attributes] do
+              name_block[:values].each do |name|
+                name_type = TAG_NAME.fetch(name[:type], nil)
+                name_attr = {}
+                name_attr[:type] = name_type if name_type
+                xml.namePart name[:value], name_attr
+              end
             end
           end
         end
 
         def with_uri_info(cocina, xml_attrs)
-          xml_attrs[:valueURI] = cocina.uri
-          xml_attrs[:authorityURI] = cocina.source&.uri
-          xml_attrs[:authority] = cocina.source&.code
+          if cocina
+            xml_attrs[:valueURI] = cocina.uri
+            xml_attrs[:authorityURI] = cocina.source&.uri
+            xml_attrs[:authority] = cocina.source&.code
+          end
           xml_attrs.compact
         end
+
+        # def title_attrs(node)
+        #   {}.tap do |attr|
+        #     attr[:usage] = 'primary' if node.status == 'primary'
+        #     # attr[:type] = node.type if node.type
+        #   end
+        # end
       end
     end
   end

--- a/app/services/cocina/to_fedora/descriptive/title.rb
+++ b/app/services/cocina/to_fedora/descriptive/title.rb
@@ -6,6 +6,7 @@ module Cocina
       # Maps titles from cocina to MODS XML
       class Title
         TAG_NAME = FromFedora::Descriptive::Titles::TYPES.invert.freeze
+        NAME_TYPES = ['person', 'forename', 'surname', 'life dates'].freeze
 
         # @params [Nokogiri::XML::Builder] xml
         # @params [Array<Cocina::Models::DescriptiveValueRequired>] titles
@@ -93,16 +94,14 @@ module Cocina
         end
 
         def with_uri_info(cocina, xml_attrs)
-          if cocina
-            xml_attrs[:valueURI] = cocina.uri
-            xml_attrs[:authorityURI] = cocina.source&.uri
-            xml_attrs[:authority] = cocina.source&.code
-          end
+          xml_attrs[:valueURI] = cocina.uri
+          xml_attrs[:authorityURI] = cocina.source&.uri
+          xml_attrs[:authority] = cocina.source&.code
           xml_attrs.compact
         end
 
         def components
-          @components ||= title.structuredValue.group_by { |component| FromFedora::Descriptive::Titles::NAME_TYPES.include? component.type }
+          @components ||= title.structuredValue.group_by { |component| NAME_TYPES.include? component.type }
         end
 
         def names
@@ -112,15 +111,13 @@ module Cocina
         end
 
         def basic_names
-          return unless names[false]
-
           names[false]
         end
 
         def name_with_authority
           return unless names[true]
 
-          names[true].first
+          Array(names[true]).first
         end
 
         def name_attrs
@@ -139,7 +136,7 @@ module Cocina
         end
 
         def name_title_group
-          return nil unless names
+          return unless names
 
           return title_group + 1 if title_group < 1
 

--- a/app/services/cocina/to_fedora/descriptive/title.rb
+++ b/app/services/cocina/to_fedora/descriptive/title.rb
@@ -20,21 +20,23 @@ module Cocina
 
         def write
           titles.each_with_index do |title, count|
+            @title = title
+            @title_group = count
             if title.parallelValue
-              write_parallel(title, alt_rep_group: count)
+              write_parallel(alt_rep_group: count)
             elsif title.structuredValue
-              write_structured(title, name_title_group: count)
+              write_structured
             elsif title.value
-              write_basic(title)
+              write_basic
             end
           end
         end
 
         private
 
-        attr_reader :xml, :titles
+        attr_reader :xml, :titles, :title, :title_group
 
-        def write_basic(title)
+        def write_basic
           title_info_attrs = {}
           title_info_attrs[:usage] = 'primary' if title.status == 'primary'
           title_info_attrs[:type] = title.type if title.type
@@ -44,7 +46,7 @@ module Cocina
           end
         end
 
-        def write_parallel(title, alt_rep_group:)
+        def write_parallel(alt_rep_group:)
           title.parallelValue.each_with_index do |descriptive_value, i|
             title_info_attrs = { altRepGroup: alt_rep_group }
             title_info_attrs[:lang] = descriptive_value.valueLanguage.code if descriptive_value.valueLanguage
@@ -61,57 +63,33 @@ module Cocina
           end
         end
 
-        def write_structured(structured_node, name_title_group:)
-          title_info_attrs = {} # title_attrs(structured_node)
-          # title_info_attrs[:usage] = 'primary' if structured_node.status == 'primary'
-          # title_info_attrs[:type] = structured_node.type if structured_node.type
-
-          names = structured_node.structuredValue.group_by { |component| FromFedora::Descriptive::Titles::NAME_TYPES.include? component.type }
-          name_title_group += 1 if names[true].present? && name_title_group < 1
-
-          title_info_attrs[:type] = structured_node.type # 'uniform' if structured_node.structuredValue.find { |component| component.type == 'title' }
-          title_info_attrs[:usage] = structured_node.status if names[false].present?
-          title_info_attrs[:nameTitleGroup] = name_title_group if names[true].present?
-
-          xml.titleInfo(with_uri_info(structured_node, title_info_attrs)) do
-            names[false].each do |title|
+        def write_structured
+          xml.titleInfo(with_uri_info(title, title_attrs)) do
+            sturctured_titles.each do |title|
               title_type = TAG_NAME.fetch(title.type, nil)
               if title_type == 'uniform title'
-                title_type = 'title' 
-                title_info_attrs.merge(title)
+                title_type = 'title'
+                title_attrs.merge(title)
               end
               xml.public_send(title_type, title.value) unless title.note
             end
           end
 
-          if names[true].present?
-            name_block = { attributes: {}, values: [] }
-            Array(names[true]).each do |name|
-              name_block[:attributes].tap do |attrs|
-                attrs[:type] = 'personal'
-                attrs[:usage] = structured_node.status if structured_node.status
-                attrs[:nameTitleGroup] = name_title_group
-                attrs[:valueURI] = name.uri if name.uri
-                attrs[:authorityURI] = name.source.uri if name.source&.uri
-                attrs[:authority] = name.source.code if name.source&.code
-              end
-              name_block[:values] << { value: name.value, type: name.type }
-              # xml.name with_uri_info(structured_node, type: 'personal', nameTitleGroup: name_title_group) do
-                # name_attrs = {}
-                
-                # name_attrs[:type] = name_type if name_type
-                # xml.namePart name.value # , with_uri_info(name, nameTitleGroup: name_title_group, type: name_type)
-             # end
-            end
-            xml.name name_block[:attributes] do
-              name_block[:values].each do |name|
-                name_type = TAG_NAME.fetch(name[:type], nil)
-                name_attr = {}
-                name_attr[:type] = name_type if name_type
-                xml.namePart name[:value], name_attr
-              end
+          return unless names
+
+          xml.name name_attrs do
+            format_name(name_with_authority) if name_with_authority
+            basic_names&.each do |name|
+              format_name(name)
             end
           end
+        end
+
+        def format_name(name)
+          name_type = TAG_NAME.fetch(name[:type], nil)
+          name_attr = {}
+          name_attr[:type] = name_type if name_type
+          xml.namePart name[:value], name_attr
         end
 
         def with_uri_info(cocina, xml_attrs)
@@ -123,12 +101,58 @@ module Cocina
           xml_attrs.compact
         end
 
-        # def title_attrs(node)
-        #   {}.tap do |attr|
-        #     attr[:usage] = 'primary' if node.status == 'primary'
-        #     # attr[:type] = node.type if node.type
-        #   end
-        # end
+        def components
+          @components ||= title.structuredValue.group_by { |component| FromFedora::Descriptive::Titles::NAME_TYPES.include? component.type }
+        end
+
+        def names
+          return unless components[true]
+
+          @names ||= components[true].group_by { |name| FromFedora::Descriptive::Titles::PERSON_TYPE == name.type }
+        end
+
+        def basic_names
+          return unless names[false]
+
+          names[false]
+        end
+
+        def name_with_authority
+          return unless names[true]
+
+          names[true].first
+        end
+
+        def name_attrs
+          {}.tap do |attrs|
+            attrs[:type] = 'personal'
+            attrs[:usage] = title.status if title.status
+            attrs[:nameTitleGroup] = name_title_group
+            attrs[:valueURI] = name_with_authority.uri if name_with_authority
+            attrs[:authorityURI] = name_with_authority.source.uri if name_with_authority&.source&.uri
+            attrs[:authority] = name_with_authority.source.code if name_with_authority&.source&.code
+          end
+        end
+
+        def sturctured_titles
+          components[false]
+        end
+
+        def name_title_group
+          return nil unless names
+
+          return title_group + 1 if title_group < 1
+
+          title_group
+        end
+
+        def title_attrs
+          {}.tap do |attrs|
+            attrs[:type] = title.type
+            attrs[:usage] = title.status
+            attrs[:nameTitleGroup] = name_title_group if name_title_group
+          end
+        end
       end
     end
   end

--- a/spec/services/cocina/to_fedora/descriptive/title_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/title_spec.rb
@@ -70,6 +70,39 @@ RSpec.describe Cocina::ToFedora::Descriptive::Title do
       end
     end
 
+    context 'when it is a uniform title with multiple namePart subelements' do
+      # xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_titleInfo.txt#L243'
+      let(:titles) do
+        [
+          Cocina::Models::Title.new(
+            { structuredValue: [{ type: 'surname', value: 'Saint-Saëns' },
+                                { type: 'forename', value: 'Camille' },
+                                { type: 'life dates', value: '1835-1921' },
+                                { type: 'title', value: 'Princesse jaune. Vocal score' }],
+              type: 'uniform',
+              status: 'primary' }
+          )
+        ]
+      end
+
+      it 'builds the xml' do
+        expect(xml).to be_equivalent_to <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <titleInfo type="uniform" usage="primary" nameTitleGroup="1">
+              <title>Princesse jaune. Vocal score</title>
+            </titleInfo>
+            <name type="personal" usage="primary" nameTitleGroup="1">
+              <namePart type="family">Saint-Sa&#xEB;ns</namePart>
+              <namePart type="given">Camille</namePart>
+              <namePart type="date">1835-1921</namePart>
+            </name>
+          </mods>
+        XML
+      end
+    end
+
     context 'when it has an alternative' do
       let(:titles) do
         [
@@ -237,19 +270,15 @@ RSpec.describe Cocina::ToFedora::Descriptive::Title do
             <titleInfo usage="primary">
               <title>Hamlet</title>
             </titleInfo>
-            <titleInfo type="uniform" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n80008522" nameTitleGroup="1">
+            <titleInfo type="uniform" nameTitleGroup="1" valueURI="http://id.loc.gov/authorities/names/n80008522" authorityURI="http://id.loc.gov/authorities/names/" authority="naf">
               <title>Hamlet</title>
             </titleInfo>
-            <name type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n78095332" nameTitleGroup="1">
+            <name type="personal" nameTitleGroup="1" valueURI="http://id.loc.gov/authorities/names/n78095332" authorityURI="http://id.loc.gov/authorities/names/" authority="naf">
               <namePart>Shakespeare, William, 1564-1616</namePart>
             </name>
           </mods>
         XML
       end
-    end
-
-    context 'when it is a uniform title with multiple namePart subelements' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_titleInfo.txt#L243'
     end
 
     context 'when it is supplied' do


### PR DESCRIPTION
## Why was this change made?

Fixes #1234 

## How was this change tested?

Adds a unit test for title with name part subelements.

## Which documentation and/or configurations were updated?

N/A

