### PR TITLE
Refactor interface of from_fedora mapping

### DIFF
--- a/app/services/cocina/from_fedora/apo.rb
+++ b/app/services/cocina/from_fedora/apo.rb
@@ -22,7 +22,8 @@ module Cocina
           version: item.current_version.to_i,
           administrative: build_apo_administrative
         }.tap do |props|
-          description = FromFedora::Descriptive.props(item)
+          title_builder = FromFedora::Descriptive::TitleBuilderStrategy.find(label: item.label)
+          description = FromFedora::Descriptive.props(title_builder: title_builder, mods: item.descMetadata.ng_xml)
           props[:description] = description unless description.nil?
         end
       end

--- a/app/services/cocina/from_fedora/collection.rb
+++ b/app/services/cocina/from_fedora/collection.rb
@@ -23,7 +23,8 @@ module Cocina
           administrative: FromFedora::Administrative.props(item),
           access: Access.collection_props(item)
         }.tap do |props|
-          description = FromFedora::Descriptive.props(item)
+          title_builder = FromFedora::Descriptive::TitleBuilderStrategy.find(label: item.label)
+          description = FromFedora::Descriptive.props(title_builder: title_builder, mods: item.descMetadata.ng_xml)
           props[:description] = description unless description.nil?
           identification = FromFedora::Identification.props(item)
           identification[:catalogLinks] = [{ catalog: 'symphony', catalogRecordId: item.catkey }] if item.catkey

--- a/app/services/cocina/from_fedora/descriptive.rb
+++ b/app/services/cocina/from_fedora/descriptive.rb
@@ -18,31 +18,26 @@ module Cocina
         relatedResource: RelatedResource
       }.freeze
 
-      # @param [Dor::Item,Dor::Etd] item
+      # @param [#build] title_builder
+      # @param [Nokogiri::XML] mods
       # @return [Hash] a hash that can be mapped to a cocina administrative model
       # @raises [Cocina::Mapper::InvalidDescMetadata] if some assumption about descMetadata is violated
-      def self.props(item)
-        new(item).props
+      def self.props(mods:, title_builder: Titles)
+        new(title_builder: title_builder, mods: mods).props
       end
 
-      def initialize(item)
-        @label = item.label
-        @ng_xml = item.descMetadata.ng_xml
+      def initialize(title_builder:, mods:)
+        @title_builder = title_builder
+        @ng_xml = mods
       end
 
       def props
-        titles = if label == 'Hydrus'
-                   # Some hydrus items don't have titles, so using label. See https://github.com/sul-dlss/hydrus/issues/421
-                   [{ value: 'Hydrus' }]
-                 else
-                   Titles.build(ng_xml)
-                 end
-        add_descriptive_elements(title: titles)
+        add_descriptive_elements({ title: title_builder.build(ng_xml) })
       end
 
       private
 
-      attr_reader :label, :ng_xml
+      attr_reader :title_builder, :ng_xml
 
       def add_descriptive_elements(cocina_description)
         BUILDERS.each do |descriptive_property, builder|

--- a/app/services/cocina/from_fedora/descriptive/hydrus_default_title_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/hydrus_default_title_builder.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Cocina
+  module FromFedora
+    class Descriptive
+      # Maps titles
+      class HydrusDefaultTitleBuilder
+        # @param [Nokogiri::XML::Document] _ng_xml the descriptive metadata XML
+        # @return [Array] a hash that can be mapped to a cocina model
+        # @raises [Mapper::MissingTitle]
+        def self.build(_ng_xml)
+          [{ value: 'Hydrus' }]
+        end
+      end
+    end
+  end
+end

--- a/app/services/cocina/from_fedora/descriptive/title_builder_strategy.rb
+++ b/app/services/cocina/from_fedora/descriptive/title_builder_strategy.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Cocina
+  module FromFedora
+    class Descriptive
+      # Decides how to build a title based on whether this is a registered Hydrus object or not.
+      class TitleBuilderStrategy
+        # @param [String] label
+        # @return [#build] a class that can build a title
+        def self.find(label:)
+          # Some hydrus items don't have titles, so using label. See https://github.com/sul-dlss/hydrus/issues/421
+          label == 'Hydrus' ? HydrusDefaultTitleBuilder : Titles
+        end
+      end
+    end
+  end
+end

--- a/app/services/cocina/from_fedora/dro.rb
+++ b/app/services/cocina/from_fedora/dro.rb
@@ -26,7 +26,8 @@ module Cocina
           access: DROAccess.props(item),
           structural: DroStructural.props(item, type: dro_type)
         }.tap do |props|
-          description = FromFedora::Descriptive.props(item)
+          title_builder = FromFedora::Descriptive::TitleBuilderStrategy.find(label: item.label)
+          description = FromFedora::Descriptive.props(title_builder: title_builder, mods: item.descMetadata.ng_xml)
           props[:description] = description unless description.nil?
 
           identification = FromFedora::Identification.props(item)

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -107,11 +107,12 @@ module Cocina
       validator = Cocina::ApoExistenceValidator.new(obj)
       raise ValidationError, validator.error unless validator.valid?
 
+      title_builder = FromFedora::Descriptive::TitleBuilderStrategy.find(label: item.label)
       # Can't currently roundtrip desc metadata, including title.
       # Note that title is the only desc metadata field handled by the mapper. However, the mapped title is composed from
       # several MODS fields which makes writing back to the MODS problematic.
       raise NotImplemented, 'Updating descriptive metadata not supported' if
-        obj.description.title != FromFedora::Descriptive.props(item).fetch(:title).map { |value| Cocina::Models::Title.new(value) }
+        obj.description.title != FromFedora::Descriptive.props(title_builder: title_builder, mods: item.descMetadata.ng_xml).fetch(:title).map { |value| Cocina::Models::Title.new(value) }
     end
 
     # TODO: duplicate from ObjectCreator

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -4,7 +4,8 @@
 require_relative '../config/environment'
 
 def round_tripped_xml(item)
-  desc_props = Cocina::FromFedora::Descriptive.props(item)
+  title_builder = Cocina::FromFedora::Descriptive::TitleBuilderStrategy.find(label: item.label)
+  desc_props = Cocina::FromFedora::Descriptive.props(title_builder: title_builder, mods: item.descMetadata.ng_xml)
   cocina = Cocina::Models::Description.new(desc_props)
   Nokogiri::XML(Cocina::ToFedora::Descriptive.transform(cocina).to_xml)
 end

--- a/spec/services/cocina/from_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive_spec.rb
@@ -3,15 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::FromFedora::Descriptive do
-  subject(:descriptive) { described_class.props(item) }
-
-  let(:item) do
-    Dor::Item.new
-  end
-
-  before do
-    item.descMetadata.content = desc_metadata
-  end
+  subject(:descriptive) { described_class.props(mods: Nokogiri::XML(desc_metadata)) }
 
   context 'when the item is a was-seed' do
     let(:desc_metadata) do


### PR DESCRIPTION
No functional changes.

## Why was this change made?

1. This simplifies the interface for the mapper by passing values rather than heavyweight objects.  This means we need to cache much less to analyze if the repository can use this mapping without error.

2. This does dependency injection that encompasses the conditional about how to build titles and extracts it from the descriptive metadata builder.



## How was this change tested?



## Which documentation and/or configurations were updated?



