### PR TITLE
Handles miscapitalized contributor types.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -36,7 +36,7 @@ module Cocina
           [].tap do |contributors|
             names.each do |name|
               contributors << { name: self.class.name_parts(name) }.tap do |contributor_hash|
-                contributor_hash[:type] = ROLES.fetch(name['type']) if name['type']
+                contributor_hash[:type] = type_for(name['type']) if name['type']
                 contributor_hash[:status] = name['usage'] if name['usage']
                 roles = [roles_for(name)]
                 contributor_hash[:role] = roles unless roles.flatten.empty?
@@ -135,6 +135,11 @@ module Cocina
           # rubocop:enable Metrics/AbcSize
           # rubocop:enable Metrics/CyclomaticComplexity
           # rubocop:enable Metrics/PerceivedComplexity
+        end
+
+        def type_for(type)
+          Honeybadger.notify('Notice: Contributor type incorrectly capitalized') if type.downcase != type
+          ROLES.fetch(type.downcase)
         end
       end
     end

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -111,6 +111,35 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     end
   end
 
+  context 'with miscapitalized type' do
+    let(:xml) do
+      <<~XML
+        <name type="Personal" usage="primary">
+          <namePart>Dunnett, Dorothy</namePart>
+        </name>
+      XML
+    end
+
+    before do
+      allow(Honeybadger).to receive(:notify)
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "name": [
+            {
+              "value": 'Dunnett, Dorothy'
+            }
+          ],
+          "type": 'person',
+          "status": 'primary'
+        }
+      ]
+      expect(Honeybadger).to have_received(:notify).with('Notice: Contributor type incorrectly capitalized')
+    end
+  end
+
   context 'with additional subelements' do
     let(:xml) do
       <<~XML


### PR DESCRIPTION
refs #1273

## Why was this change made?
To handle miscapitalized contributor types. It normalizes to the expected downcase and HB notifies about the bad data.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


