### PR TITLE
Handles mapping of related resource with incorrect type.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/from_fedora/descriptive/related_resource.rb
@@ -24,7 +24,7 @@ module Cocina
               item[:contributor] = build_contributors(related_item)
               item[:access] = build_access(related_item)
               item[:form] = build_form(related_item)
-              item[:type] = TYPES.fetch(related_item['type']) if related_item['type']
+              item[:type] = type_for(related_item['type']) if related_item['type']
               item[:displayLabel] = related_item['displayLabel']
             end.compact
           end
@@ -69,6 +69,15 @@ module Cocina
 
         def related_items
           ng_xml.xpath('//mods:mods/mods:relatedItem', mods: DESC_METADATA_NS)
+        end
+
+        def type_for(type)
+          # This handles a common data error.
+          if type.downcase == 'other version'
+            Honeybadger.notify('Notice: Invalid related resource type (Other version)')
+            return TYPES['otherVersion']
+          end
+          TYPES.fetch(type)
         end
       end
     end

--- a/spec/services/cocina/from_fedora/descriptive/related_resource_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/related_resource_spec.rb
@@ -62,6 +62,36 @@ RSpec.describe Cocina::FromFedora::Descriptive::RelatedResource do
     end
   end
 
+  context 'with Other version type data error' do
+    let(:xml) do
+      <<~XML
+        <relatedItem type="Other version">
+          <titleInfo>
+            <title>Lymond chronicles</title>
+          </titleInfo>
+        </relatedItem>
+      XML
+    end
+
+    before do
+      allow(Honeybadger).to receive(:notify)
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "title": [
+            {
+              "value": 'Lymond chronicles'
+            }
+          ],
+          "type": 'has version'
+        }
+      ]
+      expect(Honeybadger).to have_received(:notify).with('Notice: Invalid related resource type (Other version)')
+    end
+  end
+
   context 'without type' do
     let(:xml) do
       <<~XML


### PR DESCRIPTION
refs #1260

## Why was this change made?
This handles incorrect data that has a related resource type of "Other version". The data is mapped to the correct value and HB is notified of the data error.


## How was this change tested?
Unit.


## Which documentation and/or configurations were updated?
NA


