### PR TITLE
Adds data_error tags to appropriate HB notifications.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -138,7 +138,7 @@ module Cocina
         end
 
         def type_for(type)
-          Honeybadger.notify('Notice: Contributor type incorrectly capitalized') if type.downcase != type
+          Honeybadger.notify('[DATA ERROR] Contributor type incorrectly capitalized', { tags: 'data_error' }) if type.downcase != type
           ROLES.fetch(type.downcase)
         end
       end

--- a/app/services/cocina/from_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/from_fedora/descriptive/related_resource.rb
@@ -74,7 +74,7 @@ module Cocina
         def type_for(type)
           # This handles a common data error.
           if type.downcase == 'other version'
-            Honeybadger.notify('Notice: Invalid related resource type (Other version)')
+            Honeybadger.notify('[DATA ERROR] Invalid related resource type (Other version)', { tags: 'data_error' })
             return TYPES['otherVersion']
           end
           TYPES.fetch(type)

--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -88,7 +88,7 @@ module Cocina
             if node[:type]
               attrs[:type] = Contributor::ROLES.fetch(node[:type])
             else
-              Honeybadger.notify('Notice: Subject has <name> with no type attribute within <subject>')
+              Honeybadger.notify('[DATA ERROR] Subject has <name> with no type attribute within <subject>', { tags: 'data_error' })
             end
             Contributor.name_parts(node, add_default_type: true).first.merge(attrs)
           when 'titleInfo'

--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -65,7 +65,7 @@ module Cocina
           # Find all the child nodes that have text
           children = title_info.xpath('./*[child::node()[self::text()]]')
           if children.empty?
-            Honeybadger.notify('Notice: Missing title')
+            Honeybadger.notify('[DATA ERROR] Missing title', { tags: 'data_error' })
             return nil
           end
 

--- a/app/services/cocina/to_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor.rb
@@ -90,7 +90,7 @@ module Cocina
             when 'description'
               xml.description note.value
             else
-              Honeybadger.notify('Notice: Unknown contributor note type')
+              Honeybadger.notify('[DATA ERROR] Unknown contributor note type', { tags: 'data_error' })
             end
           end
         end

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
           "status": 'primary'
         }
       ]
-      expect(Honeybadger).to have_received(:notify).with('Notice: Contributor type incorrectly capitalized')
+      expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] Contributor type incorrectly capitalized', { tags: 'data_error' })
     end
   end
 

--- a/spec/services/cocina/from_fedora/descriptive/related_resource_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/related_resource_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::RelatedResource do
           "type": 'has version'
         }
       ]
-      expect(Honeybadger).to have_received(:notify).with('Notice: Invalid related resource type (Other version)')
+      expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] Invalid related resource type (Other version)', { tags: 'data_error' })
     end
   end
 

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -532,7 +532,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
 
     context 'without name type' do
       before do
-        allow(Honeybadger).to receive(:notify).with('Notice: Subject has <name> with no type attribute within <subject>')
+        allow(Honeybadger).to receive(:notify)
       end
 
       let(:xml) do
@@ -562,7 +562,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
 
       it 'notifies honeybadger' do
         build
-        expect(Honeybadger).to have_received(:notify).with('Notice: Subject has <name> with no type attribute within <subject>')
+        expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] Subject has <name> with no type attribute within <subject>', { tags: 'data_error' })
       end
     end
   end

--- a/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
         expect(build).to eq [
           { status: 'primary', value: 'Five red herrings' }
         ]
-        expect(Honeybadger).to have_received(:notify).at_least(:once).with('Notice: Missing title')
+        expect(Honeybadger).to have_received(:notify).at_least(:once).with('[DATA ERROR] Missing title', { tags: 'data_error' })
       end
     end
 


### PR DESCRIPTION
## Why was this change made?
To make it clearer which notifications are for data errors.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


