### PR TITLE
Handle name not found for title group.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -90,11 +90,15 @@ module Cocina
         end
 
         def structured_name(node:, name_title_group:, title:)
-          # Derefernce the name in a nameTitleGroup to create the value
+          # Dereference the name in a nameTitleGroup to create the value
           parts = node.xpath("//mods:name[@nameTitleGroup='#{name_title_group}']/mods:namePart", mods: DESC_METADATA_NS)
-          raise "name not found for #{name_title_group}" if parts.blank?
 
-          vals = parts.map { |part| { value: part.text, type: Contributor::NAME_PART.fetch(part['type'], PERSON_TYPE) } }
+          vals = if parts.blank?
+                   Honeybadger.notify('[DATA ERROR] Name not found for title group', { tags: 'data_error' })
+                   []
+                 else
+                   parts.map { |part| { value: part.text, type: Contributor::NAME_PART.fetch(part['type'], PERSON_TYPE) } }
+                 end
 
           with_attributes({ structuredValue: vals + [{ value: title, type: 'title' }] },
                           node,


### PR DESCRIPTION
refs #1271

## Why was this change made?
Provide a HB alert, but not raise, when name not found for a title group.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


