### PR TITLE
ObjectsController#show: handle all Cocina::Mapper.build exceptions as 422

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -2330,6 +2330,10 @@ components:
           type: string
           description: a human-readable explanation specific to this occurrence of the problem.
           example: Title must contain at least three characters.
+        meta:
+          type: object
+          description: used to include non-standard meta-information
+          example: { backtrace: ['where things went wrong'] }
         source:
           type: object
           properties:


### PR DESCRIPTION
## Why was this change made?

Handle unexpected errors from `Cocina::Mapper.build` so that an informative 422 is returned (with a ~~backtrace filtered to dor-services-app code~~full backtrace because my first attempt at filtering was hacky and this seemed useful as-is).  This will hopefully help future `Cocina::Mapper` debugging.

closes #1284

* supported by a bit more hierarchy for `Cocina::Mapper` exceptions
* `ObjectsController#json_api_error`: param for optional meta field in JSON-API error
  * `#show`: use meta field for returning backtrace
* test the new functionality
* update openapi spec for new json api error field

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

hopefully code comments and new test suffice