### PR TITLE
validate-to-cocina: turn newlines in error messages into spaces

### DIFF
--- a/bin/validate-to-cocina
+++ b/bin/validate-to-cocina
@@ -24,11 +24,11 @@ results = Parallel.map(druids.take(sample_size), in_processes: 4, progress: 'Tes
   nil
 rescue StandardError => e
   if ignore_errors.include?(e.message)
-    puts " ignoring. #{e.message}\n\n"
+    puts " ignoring. #{e.message.gsub('\n', ' ')}\n\n"
     nil
   else
-    puts " error. #{e.message}\n\n"
-    [e.message, druid]
+    puts " error. #{e.message.gsub('\n', ' ')}\n\n"
+    [e.message.gsub('\n', ' '), druid]
   end
 end.compact
 


### PR DESCRIPTION
## Why was this change made?

Because I hate

```
error. key not found: "isReferencedby"=====================================================    
Did you mean?  "isReferencedBy"
```

## How was this change tested?



## Which documentation and/or configurations were updated?



