### PR TITLE
contributor mapping fixes for key not found: ""

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -35,6 +35,7 @@ module Cocina
         def build
           [].tap do |contributors|
             names.each do |name|
+              # rubocop:disable Style/MultilineBlockChain
               contributors << { name: self.class.name_parts(name) }.tap do |contributor_hash|
                 contributor_hash[:type] = type_for(name['type']) if name['type']
                 contributor_hash[:status] = name['usage'] if name['usage']
@@ -43,6 +44,7 @@ module Cocina
                 contributor_hash[:note] = notes_for(name)
                 contributor_hash[:identifier] = identifier_for(name)
               end.reject { |_k, v| v.blank? } # it can be an empty array, so can't use .compact
+              # rubocop:enable Style/MultilineBlockChain
             end
           end
         end

--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -39,7 +39,7 @@ module Cocina
                 contributor_hash[:type] = type_for(name['type']) if name['type']
                 contributor_hash[:status] = name['usage'] if name['usage']
                 roles = [roles_for(name)]
-                contributor_hash[:role] = roles unless roles.flatten.empty?
+                contributor_hash[:role] = roles unless roles.flatten.empty? || contributor_hash[:name].blank?
                 contributor_hash[:note] = notes_for(name)
                 contributor_hash[:identifier] = identifier_for(name)
               end.reject { |_k, v| v.blank? } # it can be an empty array, so can't use .compact

--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -35,9 +35,11 @@ module Cocina
         def build
           [].tap do |contributors|
             names.each do |name|
+              Honeybadger.notify('Data Error: name type attribute is set to ""', { tags: 'data_error' }) if name['type'] == ''
+
               # rubocop:disable Style/MultilineBlockChain
               contributors << { name: self.class.name_parts(name) }.tap do |contributor_hash|
-                contributor_hash[:type] = type_for(name['type']) if name['type']
+                contributor_hash[:type] = type_for(name['type']) if name['type'].present?
                 contributor_hash[:status] = name['usage'] if name['usage']
                 roles = [roles_for(name)]
                 contributor_hash[:role] = roles unless roles.flatten.empty? || contributor_hash[:name].blank?

--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -72,9 +72,11 @@ module Cocina
           end
 
           { value: name_part_node.content }.tap do |name_part|
+            Honeybadger.notify('Data Error: name/namePart type attribute set to ""', { tags: 'data_error' }) if name_part_node['type'] == ''
+
             type = if add_default_type
                      NAME_PART.fetch(name_part_node['type'], 'name')
-                   elsif name_part_node['type']
+                   elsif name_part_node['type'].present?
                      NAME_PART.fetch(name_part_node['type'])
                    end
             name_part[:type] = type if type

--- a/app/services/cocina/to_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor.rb
@@ -21,6 +21,7 @@ module Cocina
 
         def write
           Array(contributors).each_with_index do |contributor, _alt_rep_group|
+            next unless contributor.name
             xml.name name_attributes(contributor) do
               contributor.name.each do |name|
                 write_structured(name) if name&.structuredValue

--- a/app/services/cocina/to_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor.rb
@@ -22,6 +22,7 @@ module Cocina
         def write
           Array(contributors).each_with_index do |contributor, _alt_rep_group|
             next unless contributor.name
+
             xml.name name_attributes(contributor) do
               contributor.name.each do |name|
                 write_structured(name) if name&.structuredValue

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -140,6 +140,31 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     end
   end
 
+  context 'with empty type attribute and other empty goodness' do
+    let(:xml) do
+      <<~XML
+        <name type="">
+            <namePart/>
+            <role>
+              <roleTerm authority="marcrelator" type="code" valueURI=""/>
+            <role>
+        </name>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [{}]
+    end
+
+    it 'notifies Honeybadger' do
+      allow(Honeybadger).to receive(:notify).exactly(3).times
+      build
+      expect(Honeybadger).to have_received(:notify).with('Data Error: name type attribute is set to ""', { tags: 'data_error' })
+      expect(Honeybadger).to have_received(:notify).with('Data Error: name/role/roleTerm missing value', { tags: 'data_error' })
+      expect(Honeybadger).to have_received(:notify).with('Data Error: name/namePart missing value', { tags: 'data_error' })
+    end
+  end
+
   context 'with namePart with empty type attribute' do
     context 'without role' do
       let(:xml) do

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -540,7 +540,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
       end
 
       it 'notifies Honeybadger namePart is empty' do
-        allow(Honeybadger).to receive(:notify).exactly(1).times
+        allow(Honeybadger).to receive(:notify).once
         build
         expect(Honeybadger).to have_received(:notify)
           .with('Data Error: name/namePart missing value', tags: 'data_error')
@@ -701,26 +701,26 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
         {
           "name": [
             {
-              "value": "Gaiman, Neil"
+              "value": 'Gaiman, Neil'
             }
           ],
-          "type": "person",
+          "type": 'person',
           "role": [
             {
-              "value": "author"
+              "value": 'author'
             }
           ]
         },
         {
           "name": [
             {
-              "value": "Pratchett, Terry"
+              "value": 'Pratchett, Terry'
             }
           ],
-          "type": "person",
+          "type": 'person',
           "role": [
             {
-              "value": "author"
+              "value": 'author'
             }
           ]
         }

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -524,28 +524,27 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     end
 
     context 'when role without namepart value' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L324'
-      # let(:xml) do
-      #   <<~XML
-      #     <name>
-      #       <namePart/>
-      #       <role>
-      #         <roleTerm authority="marcrelator" type="text">author</roleTerm>
-      #       </role>
-      #     </name>
-      #   XML
-      # end
-      #
-      # it 'builds empty cocina data structure and does not raise error' do
-      #   expect(build).to eq [{}]
-      # end
-      #
-      # it 'notifies Honeybadger namePart is empty' do
-      #   allow(Honeybadger).to receive(:notify).exactly(1).times
-      #   build
-      #   expect(Honeybadger).to have_received(:notify)
-      #     .with('Data Error: name/namePart missing value', tags: 'data_error')
-      # end
+      let(:xml) do
+        <<~XML
+          <name>
+            <namePart/>
+            <role>
+              <roleTerm authority="marcrelator" type="text">author</roleTerm>
+            </role>
+          </name>
+        XML
+      end
+
+      it 'builds empty cocina data structure and does not raise error' do
+        expect(build).to eq [{}]
+      end
+
+      it 'notifies Honeybadger namePart is empty' do
+        allow(Honeybadger).to receive(:notify).exactly(1).times
+        build
+        expect(Honeybadger).to have_received(:notify)
+          .with('Data Error: name/namePart missing value', tags: 'data_error')
+      end
     end
 
     context 'when roleTerm with no value and no namepart' do
@@ -680,7 +679,53 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
   end
 
   context 'with multiple names, no primary' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L410'
+    let(:xml) do
+      <<~XML
+        <name type="personal">
+          <namePart>Gaiman, Neil</namePart>
+          <role>
+            <roleTerm type="text">author</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Pratchett, Terry</namePart>
+          <role>
+            <roleTerm type="text">author</roleTerm>
+          </role>
+        </name>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "name": [
+            {
+              "value": "Gaiman, Neil"
+            }
+          ],
+          "type": "person",
+          "role": [
+            {
+              "value": "author"
+            }
+          ]
+        },
+        {
+          "name": [
+            {
+              "value": "Pratchett, Terry"
+            }
+          ],
+          "type": "person",
+          "role": [
+            {
+              "value": "author"
+            }
+          ]
+        }
+      ]
+    end
   end
 
   context 'with single name, no primary (pseudonym)' do

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -459,45 +459,54 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
       xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L292'
     end
 
-    context 'when role but no namepart' do
+    context 'when role without namepart value' do
       xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L324'
+      # let(:xml) do
+      #   <<~XML
+      #     <name>
+      #       <namePart/>
+      #       <role>
+      #         <roleTerm authority="marcrelator" type="text">author</roleTerm>
+      #       </role>
+      #     </name>
+      #   XML
+      # end
+      #
+      # it 'builds empty cocina data structure and does not raise error' do
+      #   expect(build).to eq [{}]
+      # end
+      #
+      # it 'notifies Honeybadger namePart is empty' do
+      #   allow(Honeybadger).to receive(:notify).exactly(1).times
+      #   build
+      #   expect(Honeybadger).to have_received(:notify)
+      #     .with('Data Error: name/namePart missing value', tags: 'data_error')
+      # end
     end
 
     context 'when roleTerm with no value and no namepart' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L333'
-    end
-
-    context 'when roleTerm element is present but namePart is blank' do
-      # FIXME:  this should not have a cocina model at all, per https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L324
       let(:xml) do
         <<~XML
           <name>
             <namePart/>
             <role>
-              <roleTerm authority="marcreleator" type="text"/>
+              <roleTerm authority="marcrelator" type="text"/>
             </role>
           </name>
         XML
       end
 
-      it 'builds the (valueless) cocina data structure' do
-        expect(build).to eq [
-          {
-            "name": [
-              {
-                "value": ''
-              }
-            ],
-            "role": [
-              {
-                "source":
-                  {
-                    "code": 'marcreleator'
-                  }
-              }
-            ]
-          }
-        ]
+      it 'builds empty cocina data structure and does not raise error' do
+        expect(build).to eq [{}]
+      end
+
+      it 'notifies Honeybadger namePart and roleTerm are empty' do
+        allow(Honeybadger).to receive(:notify).twice
+        build
+        expect(Honeybadger).to have_received(:notify)
+          .with('Data Error: name/role/roleTerm missing value', tags: 'data_error')
+        expect(Honeybadger).to have_received(:notify)
+          .with('Data Error: name/namePart missing value', tags: 'data_error')
       end
     end
   end

--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -261,8 +261,19 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       end
     end
 
+    context 'when role has valueURI as the only authority attribute' do
+      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L263'
+    end
+
+    context 'when role has authority as the only authority attribute' do
+      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L292'
+    end
+
+    context 'when role but no namepart' do
+      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L324'
+    end
+
     context 'when role and name elements are empty' do
-      # FIXME: there should be no model in this case!
       let(:contributors) do
         [
           Cocina::Models::Contributor.new(
@@ -283,7 +294,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
         ]
       end
 
-      it 'builds the (empty) xml' do
+      it 'builds the (empty) name elements in the xml' do
         expect(xml).to be_equivalent_to <<~XML
           <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns="http://www.loc.gov/mods/v3" version="3.6"
@@ -297,20 +308,21 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       end
     end
 
-    context 'when role has valueURI as the only authority attribute' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L263'
-    end
+    context 'when contributor model is empty' do
+      let(:contributors) do
+        [
+          Cocina::Models::Contributor.new()
+        ]
+      end
 
-    context 'when role has authority as the only authority attribute' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L292'
-    end
-
-    context 'when role but no namepart' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L324'
-    end
-
-    context 'when roleTerm with no value and no namepart' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L333'
+      it 'builds the (empty) xml' do
+        expect(xml).to be_equivalent_to <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          </mods>
+        XML
+      end
     end
   end
 

--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
 
       let(:contributors) do
         [
-          Cocina::Models::Contributor.new()
+          Cocina::Models::Contributor.new
         ]
       end
 
@@ -603,28 +603,28 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
         Cocina::Models::Contributor.new(
           "name": [
             {
-              "value": "Gaiman, Neil"
+              "value": 'Gaiman, Neil'
             }
           ],
-          "type": "person",
+          "type": 'person',
           "role": [
             {
-              "value": "author"
+              "value": 'author'
             }
           ]
         ),
         Cocina::Models::Contributor.new(
           "name": [
-             {
-               "value": "Pratchett, Terry"
-             }
-           ],
-           "type": "person",
-           "role": [
-             {
-               "value": "author"
-             }
-           ]
+            {
+              "value": 'Pratchett, Terry'
+            }
+          ],
+          "type": 'person',
+          "role": [
+            {
+              "value": 'author'
+            }
+          ]
         )
       ]
     end

--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -269,10 +269,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L292'
     end
 
-    context 'when role but no namepart' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L324'
-    end
-
     context 'when role and name elements are empty' do
       let(:contributors) do
         [
@@ -309,6 +305,9 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     end
 
     context 'when contributor model is empty' do
+      # NOTE for https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L324'
+      #   from_fedora builds a null structure ... so we're not going to get roleTerm back
+
       let(:contributors) do
         [
           Cocina::Models::Contributor.new()
@@ -491,7 +490,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
   end
 
   context 'with multiple names, one primary' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L365'
     let(:contributors) do
       [
         Cocina::Models::Contributor.new(
@@ -600,7 +598,57 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
   end
 
   context 'with multiple names, no primary' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L410'
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          "name": [
+            {
+              "value": "Gaiman, Neil"
+            }
+          ],
+          "type": "person",
+          "role": [
+            {
+              "value": "author"
+            }
+          ]
+        ),
+        Cocina::Models::Contributor.new(
+          "name": [
+             {
+               "value": "Pratchett, Terry"
+             }
+           ],
+           "type": "person",
+           "role": [
+             {
+               "value": "author"
+             }
+           ]
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <name type="personal">
+            <namePart>Gaiman, Neil</namePart>
+            <role>
+              <roleTerm type="text">author</roleTerm>
+            </role>
+          </name>
+          <name type="personal">
+            <namePart>Pratchett, Terry</namePart>
+            <role>
+              <roleTerm type="text">author</roleTerm>
+            </role>
+          </name>
+        </mods>
+      XML
+    end
   end
 
   context 'with single name, no primary (pseudonym)' do


### PR DESCRIPTION
## Why was this change made?

To add mappings indicated for #1276  (a variety of empty name and subelement attributes and values)

bonus content:
- addressed nil `name/namePart` values 
- added fleshed out some TODO specs where code was already implemented.

Before merging:
- [x] ~~Run this change through from-fedora-to-cocina validator on sdr-deploy to ensure it doesn't add mapping errors~~ see https://github.com/sul-dlss/dor-services-app/pull/1305#issuecomment-720766758


## How was this change tested?

- wrote unit tests per Arcadia's specs.
-  from-fedora-to-cocina validator 

## Which documentation and/or configurations were updated?



