### PR TITLE
subject mapping fixes for topic - two separate causes

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -36,7 +36,7 @@ module Cocina
         def build
           [].tap do |contributors|
             names.each do |name|
-              Honeybadger.notify('Data Error: name type attribute is set to ""', { tags: 'data_error' }) if name['type'] == ''
+              Honeybadger.notify('[DATA ERROR] name type attribute is set to ""', { tags: 'data_error' }) if name['type'] == ''
 
               contributors << build_contributor_hash(name).reject { |_k, v| v.blank? } # name: can be an empty array, so can't use .compact
             end
@@ -63,12 +63,12 @@ module Cocina
 
         def self.name_part(name_part_node, add_default_type:)
           if name_part_node.content.blank?
-            Honeybadger.notify('Data Error: name/namePart missing value', { tags: 'data_error' })
+            Honeybadger.notify('[DATA ERROR] name/namePart missing value', { tags: 'data_error' })
             return
           end
 
           { value: name_part_node.content }.tap do |name_part|
-            Honeybadger.notify('Data Error: name/namePart type attribute set to ""', { tags: 'data_error' }) if name_part_node['type'] == ''
+            Honeybadger.notify('[DATA ERROR] name/namePart type attribute set to ""', { tags: 'data_error' }) if name_part_node['type'] == ''
 
             type = if add_default_type
                      NAME_PART.fetch(name_part_node['type'], 'name')
@@ -146,7 +146,7 @@ module Cocina
             role[:value] = role_text.content if role_text&.content.present?
             role[:uri] = role_authority_value.content if role_authority_value&.content.present?
             if !role[:code] && !role[:value]
-              Honeybadger.notify('Data Error: name/role/roleTerm missing value', { tags: 'data_error' })
+              Honeybadger.notify('[DATA ERROR] name/role/roleTerm missing value', { tags: 'data_error' })
               return []
             end
           end

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -159,7 +159,7 @@ module Cocina
           { date: dates }.tap do |event|
             event[:displayLabel] = display_label if display_label
             event[:type] = type if type
-            Honeybadger.notify('Data Error: originInfo/dateOther missing eventType', { tags: 'data_error' }) unless event[:type]
+            Honeybadger.notify('[DATA ERROR] originInfo/dateOther missing eventType', { tags: 'data_error' }) unless event[:type]
           end
         end
 

--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -107,7 +107,7 @@ module Cocina
 
             attrs.merge(value: coords.text, type: 'map coordinates', encoding: { value: 'DMS' })
           when 'Topic'
-            Honeybadger.notify('Data error: <subject> has <Topic>; normalized to "topic"', tags: 'data_error')
+            Honeybadger.notify('[DATA ERROR] <subject> has <Topic>; normalized to "topic"', tags: 'data_error')
             attrs.merge(value: node.text, type: 'topic')
           else
             attrs.merge(value: node.text, type: NODE_TYPE.fetch(node.name))

--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -118,6 +118,9 @@ module Cocina
             return nil if coords.nil?
 
             attrs.merge(value: coords.text, type: 'map coordinates', encoding: { value: 'DMS' })
+          when 'Topic'
+            Honeybadger.notify('Data error: <subject> has <Topic>; normalized to "topic"', tags: 'data_error')
+            attrs.merge(value: node.text, type: 'topic')
           else
             attrs.merge(value: node.text, type: NODE_TYPE.fetch(node.name))
           end

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -190,9 +190,9 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     it 'notifies Honeybadger' do
       allow(Honeybadger).to receive(:notify).exactly(3).times
       build
-      expect(Honeybadger).to have_received(:notify).with('Data Error: name type attribute is set to ""', { tags: 'data_error' })
-      expect(Honeybadger).to have_received(:notify).with('Data Error: name/role/roleTerm missing value', { tags: 'data_error' })
-      expect(Honeybadger).to have_received(:notify).with('Data Error: name/namePart missing value', { tags: 'data_error' })
+      expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] name type attribute is set to ""', { tags: 'data_error' })
+      expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] name/role/roleTerm missing value', { tags: 'data_error' })
+      expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] name/namePart missing value', { tags: 'data_error' })
     end
   end
 
@@ -222,7 +222,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
       it 'notifies Honeybadger' do
         allow(Honeybadger).to receive(:notify).once
         build
-        expect(Honeybadger).to have_received(:notify).with('Data Error: name/namePart type attribute set to ""', { tags: 'data_error' })
+        expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] name/namePart type attribute set to ""', { tags: 'data_error' })
       end
     end
 
@@ -254,8 +254,8 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
       it 'notifies Honeybadger' do
         allow(Honeybadger).to receive(:notify).twice
         build
-        expect(Honeybadger).to have_received(:notify).with('Data Error: name/namePart type attribute set to ""', { tags: 'data_error' })
-        expect(Honeybadger).to have_received(:notify).with('Data Error: name/role/roleTerm missing value', { tags: 'data_error' })
+        expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] name/namePart type attribute set to ""', { tags: 'data_error' })
+        expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] name/role/roleTerm missing value', { tags: 'data_error' })
       end
     end
   end
@@ -599,7 +599,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
         allow(Honeybadger).to receive(:notify).once
         build
         expect(Honeybadger).to have_received(:notify)
-          .with('Data Error: name/namePart missing value', tags: 'data_error')
+          .with('[DATA ERROR] name/namePart missing value', tags: 'data_error')
       end
     end
 
@@ -623,9 +623,9 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
         allow(Honeybadger).to receive(:notify).twice
         build
         expect(Honeybadger).to have_received(:notify)
-          .with('Data Error: name/role/roleTerm missing value', tags: 'data_error')
+          .with('[DATA ERROR] name/role/roleTerm missing value', tags: 'data_error')
         expect(Honeybadger).to have_received(:notify)
-          .with('Data Error: name/namePart missing value', tags: 'data_error')
+          .with('[DATA ERROR] name/namePart missing value', tags: 'data_error')
       end
     end
   end
@@ -652,7 +652,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
                                                         { type: 'life dates', value: '1847-1923' }] }],
                              type: 'person' }]
       expect(Honeybadger).to have_received(:notify)
-        .with('Data Error: name/namePart missing value', tags: 'data_error')
+        .with('[DATA ERROR] name/namePart missing value', tags: 'data_error')
     end
   end
 

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
         allow(Honeybadger).to receive(:notify)
         build
         expect(Honeybadger).to have_received(:notify)
-          .with('Data Error: originInfo/dateOther missing eventType', tags: 'data_error')
+          .with('[DATA ERROR] originInfo/dateOther missing eventType', tags: 'data_error')
       end
     end
 
@@ -180,7 +180,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
         allow(Honeybadger).to receive(:notify)
         build
         expect(Honeybadger).to have_received(:notify)
-          .with('Data Error: originInfo/dateOther missing eventType', tags: 'data_error')
+          .with('[DATA ERROR] originInfo/dateOther missing eventType', tags: 'data_error')
       end
     end
   end

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     it 'notifies Honeybadger' do
       allow(Honeybadger).to receive(:notify).once
       build
-      expect(Honeybadger).to have_received(:notify).with('Data error: <subject> has <Topic>; normalized to "topic"', tags: 'data_error')
+      expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] <subject> has <Topic>; normalized to "topic"', tags: 'data_error')
     end
   end
 
@@ -639,7 +639,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
 
       it 'ignores the subject and Honeybadger notifies' do
         expect(build).to eq []
-        expect(Honeybadger).to have_received(:notify).with('Data Error: name/namePart missing value', { tags: 'data_error' })
+        expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] name/namePart missing value', { tags: 'data_error' })
       end
     end
 

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -15,6 +15,36 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     XML
   end
 
+  context 'with invalid subelement <Topic>' do
+    let(:xml) do
+      <<~XML
+        <subject authority="topic" authorityURI="http://id.loc.gov/authorities/subjects" valueURI="http://id.loc.gov/authorities/subjects/sh85028356">
+          <Topic>College students</Topic>
+        </subject>
+      XML
+    end
+
+    it 'builds the cocina data structure (as if it was <topic> lowercase)' do
+      expect(build).to eq [
+        {
+          "value": 'College students',
+          "type": 'topic',
+          "uri": 'http://id.loc.gov/authorities/subjects/sh85028356',
+          "source": {
+            "code": 'topic',
+            "uri": 'http://id.loc.gov/authorities/subjects'
+          }
+        }
+      ]
+    end
+
+    it 'notifies Honeybadger' do
+      allow(Honeybadger).to receive(:notify).once
+      build
+      expect(Honeybadger).to have_received(:notify).with('Data error: <subject> has <Topic>; normalized to "topic"', tags: 'data_error')
+    end
+  end
+
   context 'with a single-term topic subject' do
     let(:xml) do
       <<~XML

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -618,7 +618,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
 
       it 'notifies honeybadger' do
         build
-        expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] Subject has <name> with no type attribute within <subject>', { tags: 'data_error' })
+        expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] Subject contains a <name> element without a type attribute', { tags: 'data_error' })
       end
     end
 
@@ -662,7 +662,39 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
             uri: '#N/A',
             value: 'Hoveyda, Fereydoun' }
         ]
-        expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] Subject has <name> with an invalid type attribute "#N/A"', tags: 'data_error')
+        expect(Honeybadger).to have_received(:notify).with("[DATA ERROR] Subject has <name> with an invalid type attribute '#N/A'", tags: 'data_error')
+      end
+    end
+
+    context 'with invalid subject-name "topic" type' do
+      let(:xml) do
+        <<~XML
+          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85129276">
+            <name type="topic">
+              <namePart>Student movements</namePart>
+            </name>
+          </subject>
+        XML
+      end
+
+      it 'builds the cocina data structure as if subject topic' do
+        expect(build).to eq [
+          {
+            "value": 'Student movements',
+            "type": 'topic',
+            "uri": 'http://id.loc.gov/authorities/subjects/sh85129276',
+            "source": {
+              "code": 'lcsh',
+              "uri": 'http://id.loc.gov/authorities/subjects/'
+            }
+          }
+        ]
+      end
+
+      it 'notifies Honeybadger' do
+        allow(Honeybadger).to receive(:notify).once
+        build
+        expect(Honeybadger).to have_received(:notify).with("[DATA ERROR] Subject has <name> with an invalid type attribute 'topic'", tags: 'data_error')
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

To add mapping grease for
- #1291 (`<Topic>` element uppercase)  and 
- #1306 (`<subject><name>` has invalid type attribute of "topic")

## How was this change tested?

- wrote unit tests for these cases
- with from-fedora-to-cocina validator

    ```
    $ diff results-master-branch.txt results-topic-branch.txt 
    698,721d641
    < Error: key not found: "Topic" (11 errors)
    < druid:xv661kx4223
    < druid:qr684zq1130
    < druid:xy743kk5793
    < druid:yw448qd5583
    < druid:ky082np9069
    < druid:gf424bq2099
    < druid:rd235fv8920
    < druid:fz099qm8777
    < druid:bq782pp3515
    < druid:jx066kr2212
    < druid:qt282gh9166
    729,730d648
    < Error: key not found: "topic" (1 errors)
    < druid:kd333yz5798
    ```

## Which documentation and/or configurations were updated?



