### PR TITLE
name mapping fix for unrecognized type attribute value

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -155,7 +155,12 @@ module Cocina
         end
 
         def type_for(type)
+          unless Contributor::ROLES.keys.include?(type.downcase)
+            Honeybadger.notify("[DATA ERROR] Contributor type unrecognized '#{type}'", { tags: 'data_error' })
+            return
+          end
           Honeybadger.notify('[DATA ERROR] Contributor type incorrectly capitalized', { tags: 'data_error' }) if type.downcase != type
+
           ROLES.fetch(type.downcase)
         end
       end

--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 module Cocina
   module FromFedora
     class Descriptive
@@ -167,3 +168,4 @@ module Cocina
     end
   end
 end
+# rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
## Why was this change made?

To add mapping grease for #1292 (`<name>` has invalid type attribute of 'primary') and #1293 (`<name>` has invalid type attribute of 'naf')

## How was this change tested?

- wrote unit tests for these cases
- with from-fedora-to-cocina validator

    ```
    $ diff results-master-branch.txt results-name-type-unrec-branch.txt 
    1c1
    < 723 of 350000 (0.20657142857142857%)
    ---
    > 719 of 350000 (0.20542857142857143%)
    722,725d721
    < Error: key not found: "primary" (3 errors)
    < druid:rw667tg8009
    < druid:md049mq5771
    < druid:wq793rc8271
    731,732d726
    < Error: key not found: "naf" (1 errors)
    < druid:pw260mt1867
    ```

## Which documentation and/or configurations were updated?



