### PR TITLE
Cocina::FromFedora::Descriptive::RelatedResource -- normalize mis-capitalized type isReferencedBy

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/from_fedora/descriptive/related_resource.rb
@@ -72,12 +72,22 @@ module Cocina
         end
 
         def type_for(type)
-          # This handles a common data error.
+          normalized_type = normalized_type_for(type)
+
+          Honeybadger.notify("[DATA ERROR] Invalid related resource type (#{type})", { tags: 'data_error' }) if normalized_type != type
+
+          normalized_type
+        end
+
+        # Normalize type so we can tolerate certain known data errors.
+        def normalized_type_for(type)
           if type.downcase == 'other version'
-            Honeybadger.notify('[DATA ERROR] Invalid related resource type (Other version)', { tags: 'data_error' })
-            return TYPES['otherVersion']
+            TYPES['otherVersion']
+          elsif type.downcase == 'isreferencedby'
+            TYPES['isReferencedBy']
+          else
+            TYPES.fetch(type)
           end
-          TYPES.fetch(type)
         end
       end
     end

--- a/spec/services/cocina/from_fedora/descriptive/related_resource_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/related_resource_spec.rb
@@ -60,6 +60,37 @@ RSpec.describe Cocina::FromFedora::Descriptive::RelatedResource do
         }
       ]
     end
+
+    context 'when type is mis-capitalized isReferencedBy' do
+      let(:xml) do
+        <<~XML
+          <relatedItem displayLabel="Original James Record" type="isReferencedby">
+            <titleInfo>
+              <title>https://stacks.stanford.edu/file/druid:mf281cz1275/MS_296.pdf</title>
+            </titleInfo>
+          </relatedItem>
+        XML
+      end
+
+      before do
+        allow(Honeybadger).to receive(:notify)
+      end
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq [
+          {
+            'displayLabel': 'Original James Record',
+            'title': [
+              {
+                'value': 'https://stacks.stanford.edu/file/druid:mf281cz1275/MS_296.pdf'
+              }
+            ],
+            'type': 'referenced by'
+          }
+        ]
+        expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] Invalid related resource type (isReferencedby)', { tags: 'data_error' })
+      end
+    end
   end
 
   context 'with Other version type data error' do


### PR DESCRIPTION
## Why was this change made?

tolerate (but alert on) bad data as described in #1268 ("normalize capitalization, but continue to alert for error" when `isReferencedBy` is mis-capitalized).

## How was this change tested?

- [x] new unit test
- [x] test branch with mapping fix against the cache of prod fedora objects on sdr-deploy

## Which documentation and/or configurations were updated?

hopefully updated test and slightly refactored code should suffice