### PR TITLE
Handle subjects with empty name parts.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -104,7 +104,10 @@ module Cocina
             else
               Honeybadger.notify('[DATA ERROR] Subject has <name> with no type attribute within <subject>', { tags: 'data_error' })
             end
-            Contributor.name_parts(node, add_default_type: true).first.merge(attrs)
+            name_parts = Contributor.name_parts(node, add_default_type: true).first
+            return nil if name_parts.nil?
+
+            name_parts.merge(attrs)
           when 'titleInfo'
             query = node.xpath('mods:title', mods: DESC_METADATA_NS)
             attrs.merge(value: query.first.text, type: 'title')

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -592,6 +592,27 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
       end
     end
 
+    context 'with an empty namePart' do
+      let(:xml) do
+        <<~XML
+          <subject authority="lcsh">
+            <name type="corporate">
+              <namePart/>
+            </name>
+          </subject>
+        XML
+      end
+
+      before do
+        allow(Honeybadger).to receive(:notify)
+      end
+
+      it 'ignores the subject and Honeybadger notifies' do
+        expect(build).to eq []
+        expect(Honeybadger).to have_received(:notify).with('Data Error: name/namePart missing value', { tags: 'data_error' })
+      end
+    end
+
     context 'with invalid subject-name "#N/A" type' do
       let(:xml) do
         <<~XML


### PR DESCRIPTION
closes #1311

## Why was this change made?
Handle subjects that have empty name parts, e.g.,
```
<subject authority="lcsh">
            <name type="corporate">
              <namePart/>
            </name>
          </subject>
```


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


