### PR TITLE
Handles namePart with type but not value.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -52,7 +52,7 @@ module Cocina
                 parts << name_part(name_part, add_default_type: add_default_type)
               end
             else
-              vals = query.map { |name_part| name_part(name_part, add_default_type: add_default_type) }
+              vals = query.map { |name_part| name_part(name_part, add_default_type: add_default_type) }.compact
               parts << { structuredValue: vals }
             end
 

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -579,7 +579,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
       xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L292'
     end
 
-    context 'when role without namepart value' do
+    context 'when role without namePart value' do
       let(:xml) do
         <<~XML
           <name>
@@ -627,6 +627,32 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
         expect(Honeybadger).to have_received(:notify)
           .with('Data Error: name/namePart missing value', tags: 'data_error')
       end
+    end
+  end
+
+  context 'when namePart with type but no value' do
+    let(:xml) do
+      <<~XML
+        <name type="personal">
+          <namePart>Kielmansegg, Erich Ludwig Friedrich Christian</namePart>
+          <namePart type="termsOfAddress">Graf von</namePart>
+          <namePart type="date">1847-1923</namePart>
+          <namePart type="date"/>
+        </name>
+      XML
+    end
+
+    before do
+      allow(Honeybadger).to receive(:notify).once
+    end
+
+    it 'ignores the namePart with no value and Honeybadger notifies' do
+      expect(build).to eq [{ name: [{ structuredValue: [{ value: 'Kielmansegg, Erich Ludwig Friedrich Christian' },
+                                                        { type: 'term of address', value: 'Graf von' },
+                                                        { type: 'life dates', value: '1847-1923' }] }],
+                             type: 'person' }]
+      expect(Honeybadger).to have_received(:notify)
+        .with('Data Error: name/namePart missing value', tags: 'data_error')
     end
   end
 


### PR DESCRIPTION
refs #1312

## Why was this change made?
Handles namePart with type but not value, e.g.,
```
        <name type="personal">
          <namePart>Kielmansegg, Erich Ludwig Friedrich Christian</namePart>
          <namePart type="termsOfAddress">Graf von</namePart>
          <namePart type="date">1847-1923</namePart>
          <namePart type="date"/>
        </name>
```


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


