### PR TITLE
Adds HB alerts for build/mapping errors.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -69,9 +69,11 @@ module Cocina
         # @param [Nokogiri::XML::Element] title_info the titleInfo node
         def title_info_to_simple_or_structured(title_info, display_types:)
           # Find all the child nodes that have text
+          return nil if title_info.children.empty?
+
           children = title_info.xpath('./*[child::node()[self::text()]]')
           if children.empty?
-            Honeybadger.notify('[DATA ERROR] Missing title', { tags: 'data_error' })
+            Honeybadger.notify('[DATA ERROR] Empty title node', { tags: 'data_error' })
             return nil
           end
 

--- a/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
         expect(build).to eq [
           { status: 'primary', value: 'Five red herrings' }
         ]
-        expect(Honeybadger).to have_received(:notify).at_least(:once).with('[DATA ERROR] Missing title', { tags: 'data_error' })
+        expect(Honeybadger).to have_received(:notify).at_least(:once).with('[DATA ERROR] Empty title node', { tags: 'data_error' })
       end
     end
 


### PR DESCRIPTION
## Why was this change made?
So that we get HB alerts when there is a mapping/build error.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


