### PR TITLE
Handle unexpected node type.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -110,8 +110,14 @@ module Cocina
             Honeybadger.notify('[DATA ERROR] <subject> has <Topic>; normalized to "topic"', tags: 'data_error')
             attrs.merge(value: node.text, type: 'topic')
           else
-            attrs.merge(value: node.text, type: NODE_TYPE.fetch(node.name))
+            attrs.merge(value: node.text, type: node_type_for(node))
           end
+        end
+
+        def node_type_for(node)
+          return NODE_TYPE.fetch(node.name) if NODE_TYPE.keys.include?(node.name)
+
+          raise Cocina::Mapper::InvalidDescMetadata, 'Unexpected node type for subject'
         end
 
         def name_type_for_subject(name_type)

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -45,6 +45,20 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     end
   end
 
+  context 'with invalid subelement <corporate>' do
+    let(:xml) do
+      <<~XML
+        <subject authority="lcsh">
+          <corporate authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/no89003525">Mooseheart (School)</corporate>
+        </subject>
+      XML
+    end
+
+    it 'raises InvalidDescMetadata' do
+      expect { build }.to raise_error(Cocina::Mapper::InvalidDescMetadata, 'Unexpected node type for subject')
+    end
+  end
+
   context 'with a single-term topic subject' do
     let(:xml) do
       <<~XML


### PR DESCRIPTION
closes #1313

## Why was this change made?
To handle unexpected subject node types, e.g.,
```
  <subject authority="lcsh">
    <corporate authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/no89003525">Mooseheart (School)</corporate>
  </subject>
```


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


