### PR TITLE
Remove double sidekiq config block

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,7 +3,3 @@
 Sidekiq.configure_server do |config|
   config.redis = { url: Settings.redis_url }
 end
-
-Sidekiq.configure_client do |config|
-  config.redis = { url: Settings.redis_url }
-end


### PR DESCRIPTION
While doing some sidekiq sleuthing I say this.

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



