### PR TITLE
do not alert hb if we actually do the mapping correctly

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/from_fedora/descriptive/related_resource.rb
@@ -74,7 +74,7 @@ module Cocina
         def type_for(type)
           normalized_type = normalized_type_for(type)
 
-          Honeybadger.notify("[DATA ERROR] Invalid related resource type (#{type})", { tags: 'data_error' }) if normalized_type != type
+          Honeybadger.notify("[DATA ERROR] Invalid related resource type (#{type})", { tags: 'data_error' }) if normalized_type.blank?
 
           normalized_type
         end
@@ -85,7 +85,7 @@ module Cocina
             TYPES['otherVersion']
           elsif type.downcase == 'isreferencedby'
             TYPES['isReferencedBy']
-          else
+          elsif TYPES.key?(type)
             TYPES.fetch(type)
           end
         end

--- a/spec/services/cocina/from_fedora/descriptive/related_resource_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/related_resource_spec.rb
@@ -72,10 +72,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::RelatedResource do
         XML
       end
 
-      before do
-        allow(Honeybadger).to receive(:notify)
-      end
-
       it 'builds the cocina data structure' do
         expect(build).to eq [
           {
@@ -88,7 +84,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::RelatedResource do
             'type': 'referenced by'
           }
         ]
-        expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] Invalid related resource type (isReferencedby)', { tags: 'data_error' })
       end
     end
   end
@@ -104,10 +99,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::RelatedResource do
       XML
     end
 
-    before do
-      allow(Honeybadger).to receive(:notify)
-    end
-
     it 'builds the cocina data structure' do
       expect(build).to eq [
         {
@@ -119,7 +110,35 @@ RSpec.describe Cocina::FromFedora::Descriptive::RelatedResource do
           "type": 'has version'
         }
       ]
-      expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] Invalid related resource type (Other version)', { tags: 'data_error' })
+    end
+  end
+
+  context 'with a totally unknown relatedItem type' do
+    let(:xml) do
+      <<~XML
+        <relatedItem type="Really bogus">
+          <titleInfo>
+            <title>Lymond chronicles</title>
+          </titleInfo>
+        </relatedItem>
+      XML
+    end
+
+    before do
+      allow(Honeybadger).to receive(:notify)
+    end
+
+    it 'leaves off the type and notifies honeybadger' do
+      expect(build).to eq [
+        {
+          "title": [
+            {
+              "value": 'Lymond chronicles'
+            }
+          ]
+        }
+      ]
+      expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] Invalid related resource type (Really bogus)', { tags: 'data_error' })
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #1325 

- do not alert HB if the resource type is mapped correctly
- DO alert HB if it cannot be mapped (and ignore the type in the mapping)

## How was this change tested?

Modified existing tests and added a new unit test


## Which documentation and/or configurations were updated?



