### PR TITLE
add contributor mapping to_fedora test to match current h2 use case

### DIFF
--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -261,6 +261,41 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       end
     end
 
+    context 'when role has value but not code and no authority' do
+      let(:contributors) do
+        [
+          Cocina::Models::Contributor.new(
+            "name": [
+              {
+                "value": 'Dunnett, Dorothy'
+              }
+            ],
+            "type": 'person',
+            "role": [
+              {
+                "value": 'Author'
+              }
+            ]
+          )
+        ]
+      end
+
+      it 'builds the xml' do
+        expect(xml).to be_equivalent_to <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <name type="personal">
+              <namePart>Dunnett, Dorothy</namePart>
+              <role>
+                <roleTerm type="text">Author</roleTerm>
+              </role>
+            </name>
+          </mods>
+        XML
+      end
+    end
+
     context 'when role has valueURI as the only authority attribute' do
       xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L263'
     end


### PR DESCRIPTION
## Why was this change made?

I originally thought some missing descriptive metadata for h2 deposits was caused by a missing to_fedora mapping.  This test proved the mapping was already correct.   But it's still a good test (and mirrors a from_fedora test that already exists).

## How was this change tested?

the change is the addition of a test.

## Which documentation and/or configurations were updated?



