### PR TITLE
Fixes related resource contributor without type.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/to_fedora/descriptive/related_resource.rb
@@ -65,7 +65,9 @@ module Cocina
 
         def add_contributors(contributors)
           contributors.each do |contributor|
-            xml.name type: Contributor::NAME_TYPE.fetch(contributor.type) do
+            attributes = {}
+            attributes[:type] = Contributor::NAME_TYPE.fetch(contributor.type) if contributor.type
+            xml.name attributes do
               contributor.name.each do |name|
                 xml.namePart name.value
               end

--- a/spec/services/cocina/to_fedora/descriptive/related_resource_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/related_resource_spec.rb
@@ -215,4 +215,46 @@ RSpec.describe Cocina::ToFedora::Descriptive::RelatedResource do
       XML
     end
   end
+
+  context 'when it has a related item with a contributor without a type' do
+    let(:resources) do
+      [
+        Cocina::Models::RelatedResource.new(
+          {
+            "title": [
+              {
+                "value": 'Lymond chronicles'
+              }
+            ],
+            "contributor": [
+              {
+                "name": [
+                  {
+                    "value": 'Dunnett, Dorothy'
+                  }
+                ]
+              }
+            ]
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <relatedItem>
+            <titleInfo>
+              <title>Lymond chronicles</title>
+            </titleInfo>
+            <name>
+              <namePart>Dunnett, Dorothy</namePart>
+            </name>
+          </relatedItem>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #1344

## Why was this change made?
Fix mapping to Fedora for related resource contributor that does not have a type.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


