### PR TITLE
Handle cartographics missing forms.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -155,8 +155,10 @@ module Cocina
         def cartographics(xml, subject)
           xml.cartographics do
             xml.coordinates subject.value
-            xml.scale forms.find { |form| form.type == 'map scale' }.value
-            xml.projection forms.find { |form| form.type == 'map projection' }.value
+            scale = forms.find { |form| form.type == 'map scale' }
+            xml.scale scale.value if scale
+            projection = forms.find { |form| form.type == 'map projection' }
+            xml.projection projection.value if projection
           end
         end
 

--- a/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
@@ -936,6 +936,45 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
     end
   end
 
+  context 'when it has a cartographic subject without forms' do
+    let(:writer) do
+      Nokogiri::XML::Builder.new do |xml|
+        xml.mods('xmlns' => 'http://www.loc.gov/mods/v3',
+                 'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+                 'version' => '3.6',
+                 'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd') do
+          described_class.write(xml: xml, subjects: subjects, forms: [])
+        end
+      end
+    end
+
+    let(:subjects) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          "value": 'E 72°--E 148°/N 13°--N 18°',
+          "type": 'map coordinates',
+          "encoding": {
+            "value": 'DMS'
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject>
+            <cartographics>
+              <coordinates>E 72°--E 148°/N 13°--N 18°</coordinates>
+            </cartographics>
+          </subject>
+        </mods>
+      XML
+    end
+  end
+
   context 'when it has a geographic code subject' do
     let(:subjects) do
       [


### PR DESCRIPTION
closes #1343

## Why was this change made?
Allow cartographics to be missing forms.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


