### PR TITLE
For validate-to-cocina, use default Parallel options.

### DIFF
--- a/bin/validate-to-cocina
+++ b/bin/validate-to-cocina
@@ -58,7 +58,7 @@ druids = druids.take(options[:sample]) if options[:sample]
 
 Result = Struct.new(:druid, :msg, :is_data_error)
 
-results = Parallel.map(druids, in_processes: 4, progress: 'Testing') do |druid|
+results = Parallel.map(druids, progress: 'Testing') do |druid|
   hb_result = nil
   # Doing this here instead of globally due to process isolation.
   Honeybadger.configure do |config|


### PR DESCRIPTION
## Why was this change made?
To use the defaults, which is in processes where the number of processes is the number of CPUs.


## How was this change tested?
NA


## Which documentation and/or configurations were updated?
NA


