### PR TITLE
Handle identifier without a source when mapping to fedora.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/admin_metadata.rb
+++ b/app/services/cocina/to_fedora/descriptive/admin_metadata.rb
@@ -64,7 +64,9 @@ module Cocina
 
         def build_identifier
           Array(admin_metadata.identifier).each do |identifier|
-            xml.recordIdentifier identifier.value, source: identifier.source.value
+            attrs = {}
+            attrs[:source] = identifier.source.value if identifier.source
+            xml.recordIdentifier identifier.value, attrs
           end
         end
 

--- a/spec/services/cocina/to_fedora/descriptive/admin_metadata_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/admin_metadata_spec.rb
@@ -258,4 +258,30 @@ RSpec.describe Cocina::ToFedora::Descriptive::AdminMetadata do
       XML
     end
   end
+
+  context 'when identifier is missing source' do
+    let(:admin_metadata) do
+      Cocina::Models::DescriptiveAdminMetadata.new(
+        {
+          identifier: [
+            {
+              value: '36105033329140'
+            }
+          ]
+        }
+      )
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <recordInfo>
+            <recordIdentifier>36105033329140</recordIdentifier>
+          </recordInfo>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #1350

## Why was this change made?
To allow mapping of an identifier when source is missing.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


