### PR TITLE
Object registration/deposit wired up to use ToFedora mappings

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -108,6 +108,8 @@ module Cocina
       obj.identification&.catalogLinks&.find { |l| l.catalog == 'symphony' }&.catalogRecordId
     end
 
+    # @param [Dor::[Item|Collection|APO]] item
+    # @param [Cocina:Models::Request[DOR|Collection|xxx]] obj
     # @raises SymphonyReader::ResponseError if symphony connection failed
     def add_description(item, obj)
       # Hydrus doesn't set description. See https://github.com/sul-dlss/hydrus/issues/421
@@ -120,13 +122,11 @@ module Cocina
         item.label = truncate_label(label)
         item.objectLabel = label
       elsif obj.description
-        item.descMetadata.mods_title = obj.description.title.first.value
+        item.descMetadata.content = Cocina::ToFedora::Descriptive.transform(obj.description).to_xml
+        item.descMetadata.content_will_change!
       else
         item.descMetadata.mods_title = obj.label
       end
-
-      # collections registered via Argo have abstracts, which appear here as note of type summary
-      item.descMetadata.abstract = obj.description.note.first.value if obj.description&.note&.first&.type == 'summary'
     end
 
     def add_dro_tags(pid, obj)

--- a/spec/services/cocina/object_creator_spec.rb
+++ b/spec/services/cocina/object_creator_spec.rb
@@ -20,13 +20,159 @@ RSpec.describe Cocina::ObjectCreator do
   end
 
   context 'when Cocina::Models::RequestDRO is received' do
+    context 'when no description is supplied but there is a identification.catalogLink' do
+      let(:params) do
+        {
+          'type' => 'http://cocina.sul.stanford.edu/models/media.jsonld',
+          'label' => ':auto',
+          'access' => { 'access' => 'world' },
+          'version' => 1,
+          'structural' => {},
+          'administrative' => {
+            'hasAdminPolicy' => apo
+          },
+          'identification' => {
+            'sourceId' => 'sul:8.559351',
+            'catalogLinks' => [{ 'catalog' => 'symphony', 'catalogRecordId' => '10121797' }]
+          }
+        }
+      end
+
+      it 'title is set to result of RefreshMetadataAction when there is a catalogLink' do
+        expect(result.description.title.first.value).to eq 'foo'
+      end
+    end
+
+    context 'when no description is supplied (no title, but label)' do
+      let(:params) do
+        {
+          'type' => 'http://cocina.sul.stanford.edu/models/object.jsonld',
+          'label' => 'label value',
+          'access' => { 'access' => 'world' },
+          'version' => 1,
+          'structural' => {},
+          'administrative' => {
+            'hasAdminPolicy' => apo
+          },
+          'identification' => {
+            'sourceId' => 'donot:care'
+          }
+        }
+      end
+
+      it 'title is set to label' do
+        expect(result.description.title.first.value).to eq 'label value'
+      end
+    end
+
+    context 'when description is supplied' do
+      let(:params) do
+        {
+          'type' => 'http://cocina.sul.stanford.edu/models/object.jsonld',
+          'label' => 'contributor mapping test',
+          'access' => { 'access' => 'world' },
+          'version' => 1,
+          'structural' => {},
+          'administrative' => {
+            'hasAdminPolicy' => apo
+          },
+          'identification' => {
+            'sourceId' => 'donot:care'
+          },
+          "description": {
+            "note": [
+              {
+                "type": 'summary',
+                "value": 'I am an abstract'
+              },
+              {
+                "type": 'contact',
+                "value": 'marypoppins@umbrellas.org',
+                "displayLabel": 'Contact'
+              }
+            ],
+            "title": [
+              {
+                "value": 'more desc mappings'
+              }
+            ],
+            "subject": [
+              {
+                "type": 'topic',
+                "value": 'I am a keyword'
+              }
+            ],
+            "contributor": [
+              {
+                "name": [
+                  {
+                    "value": 'Miss Piggy'
+                  }
+                ],
+                "role": [
+                  {
+                    "value": 'Creator'
+                  }
+                ],
+                "type": 'person'
+              },
+              {
+                "name": [
+                  {
+                    "value": 'funder.example.org'
+                  }
+                ],
+                "role": [
+                  {
+                    "value": 'Funder'
+                  }
+                ],
+                "type": 'organization'
+              }
+            ]
+          }
+        }
+      end
+
+      it 'title is set to value passed in' do
+        expect(result.description.title.first.value).to eq 'more desc mappings'
+      end
+
+      it 'contributors are set' do
+        expect(result.description.contributor.first.type).to eq 'person'
+        expect(result.description.contributor.first.name.first.value).to eq 'Miss Piggy'
+        expect(result.description.contributor.first.role.first.value).to eq 'Creator'
+        expect(result.description.contributor.last.type).to eq 'organization'
+        expect(result.description.contributor.last.name.first.value).to eq 'funder.example.org'
+        expect(result.description.contributor.last.role.first.value).to eq 'Funder'
+      end
+
+      it 'subjets are set' do
+        expect(result.description.subject.first.type).to eq 'topic'
+        expect(result.description.subject.first.value).to eq 'I am a keyword'
+      end
+
+      it 'abstract (note of type summary) is set' do
+        summary_note = result.description.note.select { |note| note.type == 'summary' }.first
+        expect(summary_note.value).to eq 'I am an abstract'
+      end
+
+      it 'contact (note of type contact) is set' do
+        contact_note = result.description.note.select { |note| note.type == 'contact' }.first
+        expect(contact_note.value).to eq 'marypoppins@umbrellas.org'
+        skip 'TODO: need ToFedora map of displayLabel for note'
+        # expect(contact_note.displayLabel).to eq 'Contact'
+      end
+    end
+
     context 'when the access is dark' do
       let(:params) do
         {
           'type' => 'http://cocina.sul.stanford.edu/models/media.jsonld',
           'label' => ':auto',
           'access' => { 'access' => 'dark', 'download' => 'none' },
-          'version' => 1, 'structural' => {},
+          'version' => 1,
+          'structural' => {},
           'administrative' => {
             'partOfProject' => 'Naxos : 2009',
             'hasAdminPolicy' => apo
@@ -40,10 +186,6 @@ RSpec.describe Cocina::ObjectCreator do
 
       it 'creates dark access' do
         expect(result.access.access).to eq 'dark'
-      end
-
-      it 'title is set to result of RefreshMetadataAction' do
-        expect(result.description.title.first.value).to eq 'foo'
       end
     end
 
@@ -81,7 +223,6 @@ RSpec.describe Cocina::ObjectCreator do
     let(:request) { Cocina::Models.build_request(params) }
 
     context 'when there is a note of type summary' do
-      # NOTE:  Argo registers collections with an abstract, modelled in cocina as a note of type summary
       let(:params) do
         {
           'type' => 'http://cocina.sul.stanford.edu/models/collection.jsonld',
@@ -106,7 +247,7 @@ RSpec.describe Cocina::ObjectCreator do
               {
                 'value' => 'I am not an abstract',
                 'type' => 'other'
-              },
+              }
             ]
           }
         }


### PR DESCRIPTION
part of sul-dlss/happy-heron/issues/240

## Why was this change made?

As part of H2 work -- we want h2 data with cocina descriptive metadata to be mapped into Fedora.

## How was this change tested?

I wrote missing tests for code before I made changes (e.g. item vs collection object, different ways title was getting set, the way we set the abstract for collection records coming from Argo), and I made sure those tests passed along with tests showing that incoming descriptive metadata was being mapped.

Also deployed to qa to test.


## Which documentation and/or configurations were updated?



