### PR TITLE
Adds missing event type.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/event.rb
+++ b/app/services/cocina/to_fedora/descriptive/event.rb
@@ -13,6 +13,7 @@ module Cocina
         }.freeze
 
         EVENT_TYPE = {
+          'copyright' => 'copyright notice',
           'creation' => 'production',
           'publication' => 'publication'
         }.freeze


### PR DESCRIPTION
closes #1355

## Why was this change made?
Add missing event type so that mapping to fedora can succeed.


## How was this change tested?
Local


## Which documentation and/or configurations were updated?
NA


