### PR TITLE
Add capture as event type for event mapping.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/event.rb
+++ b/app/services/cocina/to_fedora/descriptive/event.rb
@@ -13,6 +13,7 @@ module Cocina
         }.freeze
 
         EVENT_TYPE = {
+          'capture' => 'capture',
           'copyright' => 'copyright notice',
           'creation' => 'production',
           'publication' => 'publication'


### PR DESCRIPTION
closes #1361

## Why was this change made?
The `capture` event type was missing.


## How was this change tested?
Locally


## Which documentation and/or configurations were updated?
NA

