### PR TITLE
Handles events that are missing source. Fixes attributes mistaking pu…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,10 @@ Metrics/BlockLength:
     - 'config/routes.rb'
     - 'config/initializers/dor_config.rb'
 
+Metrics/ClassLength:
+  Exclude:
+    - 'app/services/cocina/to_fedora/descriptive/event.rb'
+
 RSpec/DescribeClass:
   Exclude:
     - 'spec/requests/**/*'

--- a/app/services/cocina/to_fedora/descriptive/event.rb
+++ b/app/services/cocina/to_fedora/descriptive/event.rb
@@ -70,7 +70,7 @@ module Cocina
 
         def note(note)
           attributes = {}
-          attributes[:authority] = note.source.code if note.source&.code
+          attributes[:authority] = note.source.code if note&.source&.code
           xml.send(note.type, note.value, attributes)
         end
 
@@ -87,29 +87,38 @@ module Cocina
 
         def location(location)
           if location.code
-            xml.place do
-              xml.placeTerm location.value, type: 'text', authority: location.source.code, authorityURI: location.source.uri, valueURI: location.uri if location.value
-              attributes = { type: 'code', authority: location.source.code }
-              if location.uri
-                attributes[:valueURI] = location.uri
-                attributes[:authorityURI] = location.source.uri
-              end
-              xml.placeTerm location.code, attributes
-            end
+            location_code(location)
           elsif location.value
             location_text_value(location)
           end
         end
 
+        def location_code(location)
+          xml.place do
+            placeterm_attrs = { type: 'text' }
+            placeterm_attrs[:authority] = location.source.code if location.source&.code
+            placeterm_attrs[:authorityURI] = location.source.uri if location.source&.uri
+            placeterm_attrs[:valueURI] = location.uri if location.uri
+            xml.placeTerm location.value, placeterm_attrs if location.value
+            attributes = { type: 'code' }
+            attributes[:authority] = location.source.code if location.source&.code
+            if location.uri
+              attributes[:valueURI] = location.uri
+              attributes[:authorityURI] = location.source.uri if location.source&.uri
+            end
+            xml.placeTerm location.code, attributes
+          end
+        end
+
         def location_text_value(location)
-          attributes = {}
+          attributes = { type: 'text' }
           if location.uri
-            attributes[:authority] = location.source.code
-            attributes[:authorityURI] = location.source.uri
+            attributes[:authority] = location.source.code if location.source&.code
+            attributes[:authorityURI] = location.source.uri if location.source&.uri
             attributes[:valueURI] = location.uri
           end
-          xml.place attributes do
-            xml.placeTerm location.value, type: 'text'
+          xml.place do
+            xml.placeTerm location.value, attributes
           end
         end
 

--- a/spec/services/cocina/to_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/event_spec.rb
@@ -527,8 +527,8 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <originInfo>
-            <place authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">
-              <placeTerm type="text">Stanford (Calif.)</placeTerm>
+            <place>
+              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
             </place>
           </originInfo>
         </mods>
@@ -1183,6 +1183,92 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
               <placeTerm type="text">京都市</placeTerm>
             </place>
             <publisher>臨川書店</publisher>
+          </originInfo>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when event location missing source' do
+    let(:events) do
+      [
+        Cocina::Models::Event.new(
+          "location": [
+            {
+              "code": 'xxu'
+            }
+          ]
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <originInfo>
+            <place>
+              <placeTerm type="code">xxu</placeTerm>
+            </place>
+          </originInfo>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when event location with code missing source' do
+    let(:events) do
+      [
+        Cocina::Models::Event.new(
+          "location": [
+            {
+              "code": 'cau',
+              "uri": 'http://id.loc.gov/vocabulary/countries/cau'
+            }
+          ]
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <originInfo>
+            <place>
+              <placeTerm type="code" valueURI="http://id.loc.gov/vocabulary/countries/cau">cau</placeTerm>
+            </place>
+          </originInfo>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when event location with value missing source' do
+    let(:events) do
+      [
+        Cocina::Models::Event.new(
+          "location": [
+            {
+              "value": 'California',
+              "uri": 'http://id.loc.gov/vocabulary/countries/cau'
+            }
+          ]
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <originInfo>
+            <place>
+              <placeTerm type="text" valueURI="http://id.loc.gov/vocabulary/countries/cau">California</placeTerm>
+            </place>
           </originInfo>
         </mods>
       XML


### PR DESCRIPTION
…t on place element.

closes #1364

## Why was this change made?
* Handle missing source when mapping events to fedora.
* Fix an error in which attributes were added to place element instead of placeterm.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


