### PR TITLE
Map related-to null type for H2 related works and links

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/to_fedora/descriptive/related_resource.rb
@@ -14,6 +14,7 @@ module Cocina
           'in series' => 'series',
           'part of' => 'host',
           'preceded by' => 'preceding',
+          'related to' => nil, # 'related to' is a null type by design
           'reviewed by' => 'reviewOf',
           'referenced by' => 'isReferencedBy',
           'references' => 'references',
@@ -35,7 +36,7 @@ module Cocina
             attributes = {}
             attributes[:type] = TYPES.fetch(related.type) if related.type
             attributes[:displayLabel] = related.displayLabel if related.displayLabel
-            xml.relatedItem attributes do
+            xml.relatedItem attributes.compact do
               add_titles(Array(related.title))
               add_location(related.access)
               add_contributors(Array(related.contributor))

--- a/spec/services/cocina/to_fedora/descriptive/related_resource_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/related_resource_spec.rb
@@ -117,6 +117,71 @@ RSpec.describe Cocina::ToFedora::Descriptive::RelatedResource do
     end
   end
 
+  context 'when it has a related item with the generic "related to" type (related link from H2)' do
+    let(:resources) do
+      [
+        Cocina::Models::RelatedResource.new(
+          "title": [
+            {
+              "value": 'Supplement'
+            }
+          ],
+          "access": {
+            "url": [
+              "value": 'https://example.com/paper.html'
+            ]
+          },
+          "type": 'related to'
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <relatedItem>
+            <titleInfo>
+              <title>Supplement</title>
+            </titleInfo>
+            <location>
+              <url>https://example.com/paper.html</url>
+            </location>
+          </relatedItem>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when it has a related item with the generic "related to" type (related work from H2)' do
+    let(:resources) do
+      [
+        Cocina::Models::RelatedResource.new(
+          "note": [
+            {
+              "value": 'Stanford University (Stanford, CA.). (2020)',
+              "type": 'preferred citation'
+            }
+          ],
+          "type": 'related to'
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <relatedItem>
+            <note type="preferred citation">Stanford University (Stanford, CA.). (2020)</note>
+          </relatedItem>
+        </mods>
+      XML
+    end
+  end
+
   context 'when it has a related item without title' do
     let(:resources) do
       [


### PR DESCRIPTION

## Why was this change made?

Connects to https://app.honeybadger.io/projects/50568/faults/69893421 which is causing all deposits to fail in stage.


## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

