### PR TITLE
Handle missing hierarchical geographic and adds continent.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -164,8 +164,12 @@ module Cocina
 
         def hierarchical_geographic(xml, subject)
           xml.hierarchicalGeographic do
-            xml.country subject.structuredValue.find { |geo| geo.type == 'country' }.value
-            xml.city subject.structuredValue.find { |geo| geo.type == 'city' }.value
+            continent = subject.structuredValue.find { |geo| geo.type == 'continent' }&.value
+            xml.continent continent if continent
+            country = subject.structuredValue.find { |geo| geo.type == 'country' }&.value
+            xml.country country if country
+            city = subject.structuredValue.find { |geo| geo.type == 'city' }&.value
+            xml.city city if city
           end
         end
 

--- a/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
@@ -849,6 +849,10 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
         Cocina::Models::DescriptiveValue.new(
           "structuredValue": [
             {
+              "value": 'North America',
+              "type": 'continent'
+            },
+            {
               "value": 'Canada',
               "type": 'country'
             },
@@ -869,8 +873,39 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <subject>
             <hierarchicalGeographic>
+              <continent>North America</continent>
               <country>Canada</country>
-              <city>Vancouver</city>
+              <city>Vancouver</city>              
+            </hierarchicalGeographic>
+          </subject>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when it has a hierarchical geographic subject missing some hierarchies' do
+    let(:subjects) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          "structuredValue": [
+            {
+              "value": 'Africa',
+              "type": 'continent'
+            }
+          ],
+          "type": 'place'
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject>
+            <hierarchicalGeographic>
+              <continent>Africa</continent>
             </hierarchicalGeographic>
           </subject>
         </mods>


### PR DESCRIPTION
closes #1367

## Why was this change made?
Allow levels of a hierarchical geographic subject to be skipped.
Add continent as a level.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


