### PR TITLE
Adds mapping of note displayLabel attr to cocina. Ignore blank notes …

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/notes.rb
+++ b/app/services/cocina/from_fedora/descriptive/notes.rb
@@ -31,10 +31,11 @@ module Cocina
         end
 
         def notes
-          set = ng_xml.xpath('//mods:note', mods: DESC_METADATA_NS)
+          set = ng_xml.xpath('//mods:note', mods: DESC_METADATA_NS).select { |node| node.text.present? }
           set.map do |node|
             { value: node.text }.tap do |attributes|
               attributes[:type] = node[:type] if node[:type]
+              attributes[:displayLabel] = node[:displayLabel] if node[:displayLabel]
             end
           end
         end

--- a/spec/services/cocina/from_fedora/descriptive/notes_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/notes_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::FromFedora::Descriptive::Notes do
+  subject(:build) { described_class.build(ng_xml) }
+
+  let(:ng_xml) do
+    Nokogiri::XML <<~XML
+      <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.loc.gov/mods/v3" version="3.6"
+        xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        #{xml}
+      </mods>
+    XML
+  end
+
+  context 'with a simple note' do
+    let(:xml) do
+      <<~XML
+        <note>This is a note.</note>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+
+        {
+          "value": 'This is a note.'
+        }
+
+      ]
+    end
+  end
+
+  context 'with a note with a type' do
+    let(:xml) do
+      <<~XML
+        <note type="preferred citation">This is the preferred citation.</note>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+
+        {
+          "value": 'This is the preferred citation.',
+          "type": 'preferred citation'
+        }
+
+      ]
+    end
+  end
+
+  context 'with a note with a display label' do
+    let(:xml) do
+      <<~XML
+        <note displayLabel="Conservation note">This is a conservation note.</note>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+
+        {
+          "value": 'This is a conservation note.',
+          "displayLabel": 'Conservation note'
+        }
+
+      ]
+    end
+  end
+
+  context 'with an empty note' do
+    let(:xml) do
+      <<~XML
+        <note />
+      XML
+    end
+
+    it 'omits the note' do
+      expect(build).to eq []
+    end
+  end
+end

--- a/spec/services/cocina/from_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive_spec.rb
@@ -82,7 +82,8 @@ RSpec.describe Cocina::FromFedora::Descriptive do
       expect(descriptive[:note]).to match_array [
         {
           value: 'http://ennejah.info/',
-          type: 'system details'
+          type: 'system details',
+          displayLabel: 'Original site'
         },
         {
           type: 'summary',
@@ -100,7 +101,8 @@ RSpec.describe Cocina::FromFedora::Descriptive do
           value: 'Archived by Stanford University Libraries, Humanities and Area Studies Resource Group'
         },
         {
-          value: 'California Digital Library Web Archiving Service'
+          value: 'California Digital Library Web Archiving Service',
+          displayLabel: 'Web archiving service'
         }
       ]
       expect(descriptive[:language]).to match_array [


### PR DESCRIPTION
…when mapping to cocina.

refs #1367

## Why was this change made?
Improve mapping of notes to cocina.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


