### PR TITLE
Handle empty cartographic form elements.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/form.rb
+++ b/app/services/cocina/from_fedora/descriptive/form.rb
@@ -33,6 +33,8 @@ module Cocina
 
         def add_subject_cartographics(forms)
           cartographic_scale.each do |scale|
+            next if scale.text.blank?
+
             forms << {
               value: scale.text,
               type: 'map scale'
@@ -40,6 +42,8 @@ module Cocina
           end
 
           cartographic_projection.each do |projection|
+            next if projection.text.blank?
+
             forms << {
               value: projection.text,
               type: 'map projection'

--- a/spec/services/cocina/from_fedora/descriptive/form_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/form_spec.rb
@@ -203,6 +203,24 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
       end
     end
 
+    context 'when there is a subject/cartographics node with empty elements' do
+      let(:xml) do
+        <<~XML
+          <subject>
+            <cartographics>
+              <coordinates>E 72°--E 148°/N 13°--N 18°</coordinates>
+              <scale />
+              <projection />
+            </cartographics>
+          </subject>
+        XML
+      end
+
+      it 'ignores empty elements' do
+        expect(build).to eq []
+      end
+    end
+
     context 'when there is a subject/genre node' do
       let(:xml) do
         <<~XML


### PR DESCRIPTION
refs #1372

## Why was this change made?
Handle empty cartographic elements to avoid "" values.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


