### PR TITLE
Map structured forms for H2 types and subtypes

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/form.rb
+++ b/app/services/cocina/to_fedora/descriptive/form.rb
@@ -5,6 +5,7 @@ module Cocina
     class Descriptive
       # Maps forms from cocina to MODS XML
       class Form
+        # NOTE: H2 is the first case of structured form values we're implementing
         H2_SOURCE_LABEL = 'Stanford self-deposit resource types'
         PHYSICAL_DESCRIPTION_TAG = {
           'reformatting quality' => :reformattingQuality,

--- a/spec/services/cocina/from_fedora/descriptive/form_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/form_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
             "value": 'text',
             "type": 'resource type',
             "source": {
-              "value": 'MODS resource type'
+              "value": 'MODS resource types'
             }
           }
         ]
@@ -241,6 +241,323 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
           {
             "value": 'Bibliographies',
             "type": 'genre'
+          }
+        ]
+      end
+    end
+  end
+
+  # From https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_form.txt
+  describe 'H2 work types & subtypes' do
+    context 'with text / article' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <genre type="H2 type">Text</genre>
+            <genre type="H2 subtype">Article</genre>
+            <genre valueURI="http://vocab.getty.edu/aat/300048715" authority="aat">articles</genre>
+            <typeOfResource>text</typeOfResource>
+          </mods>
+        XML
+      end
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq [
+          {
+            structuredValue: [
+              {
+                value: 'Text',
+                type: 'type'
+              },
+              {
+                value: 'Article',
+                type: 'subtype'
+              }
+            ],
+            source: {
+              value: 'Stanford self-deposit resource types'
+            },
+            type: 'resource type'
+          },
+          {
+            value: 'articles',
+            type: 'genre',
+            uri: 'http://vocab.getty.edu/aat/300048715',
+            source: {
+              code: 'aat'
+            }
+          },
+          {
+            value: 'text',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          }
+        ]
+      end
+    end
+
+    context 'with text / essay' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <genre type="H2 type">Text</genre>
+            <genre type="H2 subtype">Essay</genre>
+            <genre valueURI="http://id.loc.gov/authorities/genreForms/gf2014026094" authority="lcgft">Essays</genre>
+            <typeOfResource>text</typeOfResource>
+          </mods>
+        XML
+      end
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq [
+          {
+            structuredValue: [
+              {
+                value: 'Text',
+                type: 'type'
+              },
+              {
+                value: 'Essay',
+                type: 'subtype'
+              }
+            ],
+            source: {
+              value: 'Stanford self-deposit resource types'
+            },
+            type: 'resource type'
+          },
+          {
+            value: 'Essays',
+            type: 'genre',
+            uri: 'http://id.loc.gov/authorities/genreForms/gf2014026094',
+            source: {
+              code: 'lcgft'
+            }
+          },
+          {
+            value: 'text',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          }
+        ]
+      end
+    end
+
+    context 'with data / 3d model' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <genre type="H2 type">Data</genre>
+            <genre type="H2 subtype">3D model</genre>
+            <genre>Three dimensional scan</genre>
+            <typeOfResource>three dimensional object</typeOfResource>
+          </mods>
+        XML
+      end
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq [
+          {
+            structuredValue: [
+              {
+                value: 'Data',
+                type: 'type'
+              },
+              {
+                value: '3D model',
+                type: 'subtype'
+              }
+            ],
+            source: {
+              value: 'Stanford self-deposit resource types'
+            },
+            type: 'resource type'
+          },
+          {
+            value: 'Three dimensional scan',
+            type: 'genre'
+          },
+          {
+            value: 'three dimensional object',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          }
+        ]
+      end
+    end
+
+    context 'with data / GIS' do
+      let(:xml) do
+        <<~XML
+          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <genre type="H2 type">Data</genre>
+            <genre type="H2 subtype">GIS</genre>
+            <genre authority="lcgft" valueURI="http://id.loc.gov/authorities/genreForms/gf2011026294">Geographic information systems</genre>
+            <genre>dataset</genre>
+            <typeOfResource>cartographic</typeOfResource>
+            <typeOfResource>software, multimedia</typeOfResource>
+          </mods>
+        XML
+      end
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq [
+          {
+            structuredValue: [
+              {
+                value: 'Data',
+                type: 'type'
+              },
+              {
+                value: 'GIS',
+                type: 'subtype'
+              }
+            ],
+            source: {
+              value: 'Stanford self-deposit resource types'
+            },
+            type: 'resource type'
+          },
+          {
+            value: 'Geographic information systems',
+            type: 'genre',
+            uri: 'http://id.loc.gov/authorities/genreForms/gf2011026294',
+            source: {
+              code: 'lcgft'
+            }
+          },
+          {
+            value: 'dataset',
+            type: 'genre'
+          },
+          {
+            value: 'cartographic',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          },
+          {
+            value: 'software, multimedia',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          }
+        ]
+      end
+    end
+
+    context 'with software / code, documentation' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <genre type="H2 type">Software</genre>
+            <genre type="H2 subtype">Code</genre>
+            <genre type="H2 subtype">Documentation</genre>
+            <genre authority="aat" valueURI="http://vocab.getty.edu/aat/300312188">programs (computer)</genre>
+            <genre authority="aat" valueURI="http://vocab.getty.edu/aat/300026413">technical manuals</genre>
+            <typeOfResource>software, multimedia</typeOfResource>
+            <typeOfResource>text</typeOfResource>
+          </mods>
+        XML
+      end
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq [
+          {
+            structuredValue: [
+              {
+                value: 'Software',
+                type: 'type'
+              },
+              {
+                value: 'Code',
+                type: 'subtype'
+              },
+              {
+                value: 'Documentation',
+                type: 'subtype'
+              }
+
+            ],
+            source: {
+              value: 'Stanford self-deposit resource types'
+            },
+            type: 'resource type'
+          },
+          {
+            value: 'programs (computer)',
+            type: 'genre',
+            uri: 'http://vocab.getty.edu/aat/300312188',
+            source: {
+              code: 'aat'
+            }
+          },
+          {
+            value: 'technical manuals',
+            type: 'genre',
+            uri: 'http://vocab.getty.edu/aat/300026413',
+            source: {
+              code: 'aat'
+            }
+          },
+          {
+            value: 'software, multimedia',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          },
+          {
+            value: 'text',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          }
+        ]
+      end
+    end
+
+    context 'with other / dance notation' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <genre type="H2 type">Other</genre>
+            <genre type="H2 subtype">Dance notation</genre>
+          </mods>
+        XML
+      end
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq [
+          {
+            structuredValue: [
+              {
+                value: 'Other',
+                type: 'type'
+              },
+              {
+                value: 'Dance notation',
+                type: 'subtype'
+              }
+            ],
+            source: {
+              value: 'Stanford self-deposit resource types'
+            },
+            type: 'resource type'
           }
         ]
       end

--- a/spec/services/cocina/from_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Cocina::FromFedora::Descriptive do
         }]
       }]
       expect(descriptive[:form]).to match_array [
-        { source: { value: 'MODS resource type' }, type: 'resource type', value: 'text' },
+        { source: { value: 'MODS resource types' }, type: 'resource type', value: 'text' },
         { source: { code: 'local' }, type: 'genre', value: 'archived website' },
         {
           value: 'electronic',
@@ -347,7 +347,7 @@ RSpec.describe Cocina::FromFedora::Descriptive do
       expect(descriptive[:form]).to match_array [
         { source: { code: 'marcgt' }, type: 'genre', value: 'theses' },
         { source: { code: 'rdacontent' }, type: 'genre', value: 'text' },
-        { source: { value: 'MODS resource type' }, type: 'resource type', value: 'text' },
+        { source: { value: 'MODS resource types' }, type: 'resource type', value: 'text' },
         {
           value: 'electronic resource',
           type: 'form',

--- a/spec/services/cocina/to_fedora/descriptive/form_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/form_spec.rb
@@ -53,30 +53,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Form do
         XML
       end
     end
-
-    context 'with an object with multiple types' do
-      xit 'https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_typeOfResource.txt#L17'
-    end
-
-    context 'with an object with multiple types and one predominant' do
-      xit 'https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_typeOfResource.txt#L39'
-    end
-
-    context 'with a manuscript' do
-      xit 'https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_typeOfResource.txt#L62'
-    end
-
-    context 'with an attribute without a value' do
-      xit 'https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_typeOfResource.txt#L79'
-    end
-
-    context 'with a collection' do
-      xit 'https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_typeOfResource.txt#L89'
-    end
-
-    context 'with display label' do
-      xit 'https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_typeOfResource.txt#L106'
-    end
   end
 
   describe 'genre' do
@@ -174,14 +150,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Form do
       end
     end
 
-    context 'with usage' do
-      xit 'TODO https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_genre.txt#L57'
-    end
-
-    context 'with multilingual' do
-      xit 'TODO https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_genre.txt#L74'
-    end
-
     context 'with displayLabel' do
       let(:forms) do
         [
@@ -199,6 +167,291 @@ RSpec.describe Cocina::ToFedora::Descriptive::Form do
             xmlns="http://www.loc.gov/mods/v3" version="3.6"
             xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
             <genre displayLabel="Style">Art deco</genre>
+          </mods>
+        XML
+      end
+    end
+  end
+
+  # From https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_form.txt
+  describe 'H2 work types & subtypes' do
+    context 'with text / article' do
+      let(:forms) do
+        [
+          Cocina::Models::DescriptiveValue.new(
+            structuredValue: [
+              {
+                value: 'Text',
+                type: 'type'
+              },
+              {
+                value: 'Article',
+                type: 'subtype'
+              }
+            ],
+            source: {
+              value: 'Stanford self-deposit resource types'
+            },
+            type: 'resource type'
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            value: 'articles',
+            type: 'genre',
+            uri: 'http://vocab.getty.edu/aat/300048715',
+            source: {
+              code: 'aat'
+            }
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            value: 'text',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          )
+        ]
+      end
+
+      it 'builds the xml' do
+        expect(xml).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <genre type="H2 type">Text</genre>
+            <genre type="H2 subtype">Article</genre>
+            <genre valueURI="http://vocab.getty.edu/aat/300048715" authority="aat">articles</genre>
+            <typeOfResource>text</typeOfResource>
+          </mods>
+        XML
+      end
+    end
+
+    context 'with text / essay' do
+      let(:forms) do
+        [
+          Cocina::Models::DescriptiveValue.new(
+            structuredValue: [
+              {
+                value: 'Text',
+                type: 'type'
+              },
+              {
+                value: 'Essay',
+                type: 'subtype'
+              }
+            ],
+            source: {
+              value: 'Stanford self-deposit resource types'
+            },
+            type: 'resource type'
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            value: 'Essays',
+            type: 'genre',
+            uri: 'http://id.loc.gov/authorities/genreForms/gf2014026094',
+            source: {
+              code: 'lcgft'
+            }
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            value: 'text',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          )
+        ]
+      end
+
+      it 'builds the xml' do
+        expect(xml).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <genre type="H2 type">Text</genre>
+            <genre type="H2 subtype">Essay</genre>
+            <genre valueURI="http://id.loc.gov/authorities/genreForms/gf2014026094" authority="lcgft">Essays</genre>
+            <typeOfResource>text</typeOfResource>
+          </mods>
+        XML
+      end
+    end
+
+    context 'with data / 3d model' do
+      let(:forms) do
+        [
+          Cocina::Models::DescriptiveValue.new(
+            structuredValue: [
+              {
+                value: 'Data',
+                type: 'type'
+              },
+              {
+                value: '3D model',
+                type: 'subtype'
+              }
+            ],
+            source: {
+              value: 'Stanford self-deposit resource types'
+            },
+            type: 'resource type'
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            value: 'Three dimensional scan',
+            type: 'genre'
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            value: 'three dimensional object',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          )
+        ]
+      end
+
+      it 'builds the xml' do
+        expect(xml).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <genre type="H2 type">Data</genre>
+            <genre type="H2 subtype">3D model</genre>
+            <genre>Three dimensional scan</genre>
+            <typeOfResource>three dimensional object</typeOfResource>
+          </mods>
+        XML
+      end
+    end
+
+    context 'with data / GIS' do
+      let(:forms) do
+        [
+          Cocina::Models::DescriptiveValue.new(
+            structuredValue: [
+              {
+                value: 'Data',
+                type: 'type'
+              },
+              {
+                value: 'GIS',
+                type: 'subtype'
+              }
+            ],
+            source: {
+              value: 'Stanford self-deposit resource types'
+            },
+            type: 'resource type'
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            value: 'Geographic information systems',
+            type: 'genre',
+            uri: 'http://id.loc.gov/authorities/genreForms/gf2011026294',
+            source: {
+              code: 'lcgft'
+            }
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            value: 'dataset',
+            type: 'genre'
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            value: 'cartographic',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            value: 'software, multimedia',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          )
+        ]
+      end
+
+      it 'builds the xml' do
+        expect(xml).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <genre type="H2 type">Data</genre>
+            <genre type="H2 subtype">GIS</genre>
+            <genre authority="lcgft" valueURI="http://id.loc.gov/authorities/genreForms/gf2011026294">Geographic information systems</genre>
+            <genre>dataset</genre>
+            <typeOfResource>cartographic</typeOfResource>
+            <typeOfResource>software, multimedia</typeOfResource>
+          </mods>
+        XML
+      end
+    end
+
+    context 'with software / code, documentation' do
+      let(:forms) do
+        [
+          Cocina::Models::DescriptiveValue.new(
+            structuredValue: [
+              {
+                value: 'Software',
+                type: 'type'
+              },
+              {
+                value: 'Code',
+                type: 'subtype'
+              },
+              {
+                value: 'Documentation',
+                type: 'subtype'
+              }
+
+            ],
+            source: {
+              value: 'Stanford self-deposit resource types'
+            },
+            type: 'resource type'
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            value: 'programs (computer)',
+            type: 'genre',
+            uri: 'http://vocab.getty.edu/aat/300312188',
+            source: {
+              code: 'aat'
+            }
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            value: 'technical manuals',
+            type: 'genre',
+            uri: 'http://vocab.getty.edu/aat/300026413',
+            source: {
+              code: 'aat'
+            }
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            value: 'software, multimedia',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            value: 'text',
+            type: 'resource type',
+            source: {
+              value: 'MODS resource types'
+            }
+          )
+        ]
+      end
+
+      it 'builds the xml' do
+        expect(xml).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <genre type="H2 type">Software</genre>
+            <genre type="H2 subtype">Code</genre>
+            <genre type="H2 subtype">Documentation</genre>
+            <genre authority="aat" valueURI="http://vocab.getty.edu/aat/300312188">programs (computer)</genre>
+            <genre authority="aat" valueURI="http://vocab.getty.edu/aat/300026413">technical manuals</genre>
+            <typeOfResource>software, multimedia</typeOfResource>
+            <typeOfResource>text</typeOfResource>
           </mods>
         XML
       end
@@ -267,10 +520,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Form do
       end
     end
 
-    context 'with multiple descriptions' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_physicalDescription.txt#L52'
-    end
-
     context 'when form has authority' do
       let(:forms) do
         [
@@ -297,10 +546,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Form do
           </mods>
         XML
       end
-    end
-
-    context 'when it has displayLabel' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_physicalDescription.txt#L107'
     end
   end
 end

--- a/spec/services/cocina/to_fedora/descriptive/form_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/form_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Form do
             "value": 'text',
             "type": 'resource type',
             "source": {
-              "value": 'MODS resource type'
+              "value": 'MODS resource types'
             }
           )
         ]
@@ -452,6 +452,39 @@ RSpec.describe Cocina::ToFedora::Descriptive::Form do
             <genre authority="aat" valueURI="http://vocab.getty.edu/aat/300026413">technical manuals</genre>
             <typeOfResource>software, multimedia</typeOfResource>
             <typeOfResource>text</typeOfResource>
+          </mods>
+        XML
+      end
+    end
+
+    context 'with other / dance notation' do
+      let(:forms) do
+        [
+          Cocina::Models::DescriptiveValue.new(
+            structuredValue: [
+              {
+                value: 'Other',
+                type: 'type'
+              },
+              {
+                value: 'Dance notation',
+                type: 'subtype'
+              }
+            ],
+            source: {
+              value: 'Stanford self-deposit resource types'
+            },
+            type: 'resource type'
+          )
+        ]
+      end
+
+      it 'builds the xml' do
+        expect(xml).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <genre type="H2 type">Other</genre>
+            <genre type="H2 subtype">Dance notation</genre>
           </mods>
         XML
       end


### PR DESCRIPTION
Connects to sul-dlss/happy-heron#241

## Why was this change made?

To map H2 types and subtypes from Cocina to Fedora.

Note that I removed a bunch of apparently bogus `xit`s that seemed to be for Fedora to Cocina in a test for Cocina to Fedora.

## How was this change tested?

CI, and also against 500K objects on the sdr-deploy box:

### To Cocina

#### Before my changes

```shell
$ bin/validate-to-cocina -s 500000                                                                                
Error: 57 of 500000 (0.0114%)
Data error: 14818 of 500000 (2.9636%)
```

#### After my changes

```shell
$ bin/validate-to-cocina -s 500000                                                                                
Error: 57 of 500000 (0.0114%)
Data error: 14818 of 500000 (2.9636%)
```

### To Fedora

#### Before my changes

```shell
$ bin/validate-to-fedora -s 500000                                                                                
To Fedora error: 155 of 500000 (0.031%)
To Cocina error: 57 of 500000 (0.0114%)
Data error: 146 of 500000 (0.0292%)
Missing: 2954 of 500000 (0.5908%)
```

#### After my changes

```shell
$ bin/validate-to-fedora -s 500000                                                                                
To Fedora error: 101 of 500000 (0.02%)
To Cocina error: 57 of 500000 (0.0114%)
Data error: 146 of 500000 (0.0292%)
Missing: 2954 of 500000 (0.5908%)
```

The improvements here are not due to my branch, btw. They're because I rebased to pick up geo-related fixes.


## Which documentation and/or configurations were updated?

None

