### PR TITLE
Remove extra error reporting characters

### DIFF
--- a/bin/validate-to-cocina
+++ b/bin/validate-to-cocina
@@ -96,8 +96,8 @@ results_by_data_error = results_by(data_error_results)
 aggregated_error_results = aggregated_errors_for(results_by_error)
 aggregated_data_error_results = aggregated_errors_for(results_by_data_error)
 
-puts "\n#{summary_line_for(error_results, 'Error')}%)\n"
-puts "#{summary_line_for(data_error_results, 'Data error')}%)\n"
+puts "\n#{summary_line_for(error_results, 'Error')}\n"
+puts "#{summary_line_for(data_error_results, 'Data error')}\n"
 
 print_results(aggregated_error_results, 'Error')
 print_results(aggregated_data_error_results, 'Data error')


### PR DESCRIPTION
See:

```
Error: 57 of 500000 (0.0114%)%)                                                                                                                       
Data error: 14818 of 500000 (2.9636%)%)   
```
