### PR TITLE
Handles subject classification missing source.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -91,7 +91,7 @@ module Cocina
 
           case subject.type
           when 'classification'
-            subject_attributes[:authority] = subject.source.code
+            subject_attributes[:authority] = subject.source.code if subject.source&.code
             write_classification(subject.value, subject_attributes)
           else
             xml.subject(subject_attributes) do

--- a/spec/services/cocina/to_fedora/descriptive/subject_classification_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_classification_spec.rb
@@ -116,4 +116,28 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
       XML
     end
   end
+
+  context 'when given a classification without authority' do
+    let(:subjects) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          {
+            "type": 'classification',
+            "value": 'G9801.S12 2015 .Z3'
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <classification>G9801.S12 2015 .Z3</classification>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #1383

## Why was this change made?
To not raise when mapping a subject classification without a source.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


