### PR TITLE
Handle mapping geo to fedora when no subject.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/geographic.rb
+++ b/app/services/cocina/to_fedora/descriptive/geographic.rb
@@ -29,7 +29,7 @@ module Cocina
             attributes = {}
             attributes[:displayLabel] = 'geo'
             xml.extension attributes do
-              xml['rdf'].RDF(format_namespace(geo.subject.first.type)) do
+              xml['rdf'].RDF(format_namespace(geo)) do
                 # REVIST: Need the druid to include rdf:about
                 # xml['rdf'].Description('rdf:about' => 'http://www.stanford.edu/kk138ps4721') do
                 xml['rdf'].Description do
@@ -46,13 +46,13 @@ module Cocina
 
         attr_reader :xml, :geos
 
-        def format_namespace(type)
+        def format_namespace(geo)
           namespace = {
             'xmlns:gml' => 'http://www.opengis.net/gml/3.2/',
             'xmlns:dc' => 'http://purl.org/dc/elements/1.1/'
           }
 
-          namespace['xmlns:gmd'] = 'http://www.isotc211.org/2005/gmd' if type.include? 'point coordinates'
+          namespace['xmlns:gmd'] = 'http://www.isotc211.org/2005/gmd' if geo.subject&.first&.type&.include? 'point coordinates'
 
           namespace
         end
@@ -82,7 +82,7 @@ module Cocina
         end
 
         def add_content(geo)
-          type = geo.subject.first.type
+          type = geo.subject&.first&.type
           case type
           when 'point coordinates'
             add_centerpoint(geo)

--- a/spec/services/cocina/to_fedora/descriptive/geographic_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/geographic_spec.rb
@@ -342,6 +342,48 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
     end
   end
 
+  context 'when a polygon shapefile without subject' do
+    let(:geo) do
+      Cocina::Models::DescriptiveGeographicMetadata.new(
+        form: [
+          {
+            "value": 'application/x-esri-shapefile',
+            "type": 'media type',
+            "source": {
+              "value": 'IANA media type terms'
+            }
+          },
+          {
+            "value": 'Shapefile',
+            "type": 'data format'
+          },
+          {
+            "value": 'Dataset#Polygon',
+            "type": 'type'
+          }
+        ]
+      )
+    end
+
+    it 'builds the cocina data structure' do
+      # TODO:  rdf:about="http://purl.stanford.edu/xy581jd9710"
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <extension displayLabel="geo">
+            <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+              <rdf:Description>
+                <dc:format>application/x-esri-shapefile; format=Shapefile</dc:format>
+                <dc:type>Dataset#Polygon</dc:type>
+              </rdf:Description>
+            </rdf:RDF>
+          </extension>
+      XML
+    end
+  end
+
   # 4. Bounding box for point shapefile converted from ISO 19139
   context 'with a bounding box from a point shapefile converted from ISO 19139' do
     let(:geo) do


### PR DESCRIPTION
closes #1382

## Why was this change made?
So that mapping to fedora doesn't raise when geo has a form, but not a subject.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


