### PR TITLE
Add rdf:about to the geo Description block

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -122,7 +122,7 @@ module Cocina
         item.label = truncate_label(label)
         item.objectLabel = label
       elsif obj.description
-        item.descMetadata.content = Cocina::ToFedora::Descriptive.transform(obj.description).to_xml
+        item.descMetadata.content = Cocina::ToFedora::Descriptive.transform(obj.description, item.pid).to_xml
         item.descMetadata.content_will_change!
       else
         item.descMetadata.mods_title = obj.label

--- a/app/services/cocina/to_fedora/descriptive.rb
+++ b/app/services/cocina/to_fedora/descriptive.rb
@@ -7,12 +7,13 @@ module Cocina
     class Descriptive
       # @param [Cocina::Models::Description] descriptive
       # @return [Nokogiri::XML::Document]
-      def self.transform(descriptive)
-        new(descriptive).transform
+      def self.transform(descriptive, druid)
+        new(descriptive, druid).transform
       end
 
-      def initialize(descriptive)
+      def initialize(descriptive, druid)
         @descriptive = descriptive
+        @druid = druid
       end
 
       # rubocop:disable Metrics/AbcSize
@@ -29,7 +30,7 @@ module Cocina
             Descriptive::Identifier.write(xml: xml, identifiers: descriptive.identifier)
             Descriptive::AdminMetadata.write(xml: xml, admin_metadata: descriptive.adminMetadata)
             Descriptive::RelatedResource.write(xml: xml, related_resources: descriptive.relatedResource)
-            Descriptive::Geographic.write(xml: xml, geos: descriptive.geographic)
+            Descriptive::Geographic.write(xml: xml, geos: descriptive.geographic, druid: druid)
           end
         end
       end
@@ -37,7 +38,7 @@ module Cocina
 
       private
 
-      attr_reader :descriptive
+      attr_reader :descriptive, :druid
 
       def mods_version
         @mods_version ||= begin

--- a/app/services/cocina/to_fedora/descriptive/geographic.rb
+++ b/app/services/cocina/to_fedora/descriptive/geographic.rb
@@ -75,8 +75,7 @@ module Cocina
         end
 
         def about(druid)
-          id = druid.sub(/^druid:/, '')
-          "#{ABOUT_URI_PREFIX}#{id}"
+          "#{ABOUT_URI_PREFIX}#{druid.delete_prefix('druid:')}"
         end
 
         def add_format(data)

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -33,8 +33,8 @@ def normalize_xml(ng_xml)
   ng_xml
 end
 
-def round_tripped_xml(cocina)
-  Nokogiri::XML(Cocina::ToFedora::Descriptive.transform(cocina).to_xml)
+def round_tripped_xml(cocina, druid)
+  Nokogiri::XML(Cocina::ToFedora::Descriptive.transform(cocina, druid).to_xml)
 end
 
 def cocina_model(xml, label)
@@ -161,7 +161,7 @@ def validate_druid(druid, cache)
   normalize_xml(original_xml)
 
   begin
-    result_xml = round_tripped_xml(cocina)
+    result_xml = round_tripped_xml(cocina, druid)
   rescue StandardError => e
     write_error(druid, original_xml, cocina, e)
     return :to_fedora_error

--- a/bin/validate-to-fedora
+++ b/bin/validate-to-fedora
@@ -66,7 +66,7 @@ def validate_druid(druid, cache)
   end
 
   begin
-    Cocina::ToFedora::Descriptive.transform(cocina)
+    Cocina::ToFedora::Descriptive.transform(cocina, druid)
   rescue StandardError => e
     return Result.new(druid, e.message.gsub('\n', ' '), :to_fedora_error)
   end

--- a/spec/services/cocina/to_fedora/descriptive/geographic_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/geographic_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
   subject(:xml) { writer.to_xml }
 
   let(:geos) { [geo] }
+  let(:druid) { 'druid:aa666bb1234' }
 
   let(:writer) do
     Nokogiri::XML::Builder.new do |xml|
@@ -14,7 +15,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
                'version' => '3.6',
                'xmlns:rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
                'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd') do
-        described_class.write(xml: xml, geos: geos)
+        described_class.write(xml: xml, geos: geos, druid: druid)
       end
     end
   end
@@ -82,7 +83,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <extension displayLabel="geo">
             <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:gmd="http://www.isotc211.org/2005/gmd">
-              <rdf:Description>
+              <rdf:Description rdf:about="http://purl.stanford.edu/aa666bb1234">
                 <dc:format>image/jpeg</dc:format>
                 <dc:type>Image</dc:type>
                 <gmd:centerPoint>
@@ -155,7 +156,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <extension displayLabel="geo">
             <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
-              <rdf:Description>
+              <rdf:Description rdf:about="http://purl.stanford.edu/aa666bb1234">
                 <dc:format>image/jpeg</dc:format>
                 <dc:type>Image</dc:type>
                 <gml:boundedBy>
@@ -242,7 +243,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <extension displayLabel="geo">
             <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
-              <rdf:Description>
+              <rdf:Description rdf:about="http://purl.stanford.edu/aa666bb1234">
                 <dc:format>application/x-esri-shapefile; format=Shapefile</dc:format>
                 <dc:type>Dataset#Polygon</dc:type>
                 <gml:boundedBy>
@@ -325,7 +326,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <extension displayLabel="geo">
             <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
-              <rdf:Description>
+              <rdf:Description rdf:about="http://purl.stanford.edu/aa666bb1234">
                 <dc:format>application/x-esri-shapefile; format=Shapefile</dc:format>
                 <dc:type>Dataset#Polygon</dc:type>
                 <gml:boundedBy>
@@ -374,7 +375,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <extension displayLabel="geo">
             <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
-              <rdf:Description>
+              <rdf:Description rdf:about="http://purl.stanford.edu/aa666bb1234">
                 <dc:format>application/x-esri-shapefile; format=Shapefile</dc:format>
                 <dc:type>Dataset#Polygon</dc:type>
               </rdf:Description>
@@ -446,7 +447,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <extension displayLabel="geo">
             <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
-              <rdf:Description>
+              <rdf:Description rdf:about="http://purl.stanford.edu/aa666bb1234">
                 <dc:format>application/x-esri-shapefile; format=Shapefile</dc:format>
                 <dc:type>Dataset#Point</dc:type>
                 <gml:boundedBy>
@@ -524,7 +525,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <extension displayLabel="geo">
             <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
-              <rdf:Description>
+              <rdf:Description rdf:about="http://purl.stanford.edu/aa666bb1234">
                 <dc:format>application/x-esri-shapefile; format=Shapefile</dc:format>
                 <dc:type>Dataset#LineString</dc:type>
                 <gml:boundedBy>
@@ -602,7 +603,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <extension displayLabel="geo">
             <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
-              <rdf:Description>
+              <rdf:Description rdf:about="http://purl.stanford.edu/aa666bb1234">
                 <dc:format>image/tiff; format=GeoTIFF</dc:format>
                 <dc:type>Dataset#Raster</dc:type>
                 <gml:boundedBy>
@@ -702,7 +703,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <extension displayLabel="geo">
             <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
-              <rdf:Description>
+              <rdf:Description rdf:about="http://purl.stanford.edu/aa666bb1234">
                 <dc:format>application/x-esri-shapefile; format=Shapefile</dc:format>
                 <dc:type>Dataset#Polygon</dc:type>
                 <gml:boundedBy>

--- a/spec/services/cocina/to_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe Cocina::ToFedora::Descriptive do
   end
 
   context 'with a MODS version specified in note' do
+    let(:druid) { 'druid:aa666bb1234' }
     let(:descriptive) do
       Cocina::Models::Description.new(
         title: [

--- a/spec/services/cocina/to_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive_spec.rb
@@ -3,9 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::ToFedora::Descriptive do
-  subject(:xml) { described_class.transform(descriptive).to_xml }
+  subject(:xml) { described_class.transform(descriptive, druid).to_xml }
 
   context 'with a minimal description' do
+    let(:druid) { 'druid:aa666bb1234' }
     let(:descriptive) do
       Cocina::Models::Description.new(
         title: [
@@ -28,6 +29,7 @@ RSpec.describe Cocina::ToFedora::Descriptive do
   end
 
   context 'when it has an abstract' do
+    let(:druid) { 'druid:aa666bb1234' }
     let(:descriptive) do
       Cocina::Models::Description.new(
         title: [


### PR DESCRIPTION
## Why was this change made?

Fixes #1371 so that the druid is available in `to_fedora` for the `rdf:about` attribute on the geographic Description block.

Before:

```
    <rdf:Description>
      <dc:format>image/jpeg</dc:format>
      <dc:type>Image</dc:type>
      <gmd:centerPoint>
        <gml:Point gml:id="ID">
          <gml:pos>41.893367 12.483736</gml:pos>
        </gml:Point>
      </gmd:centerPoint>
    </rdf:Description>
  </rdf:RDF>
```

After:

```
    <rdf:Description rdf:about="http://www.stanford.edu/kk138ps4721">
      <dc:format>image/jpeg</dc:format>
      <dc:type>Image</dc:type>
      <gmd:centerPoint>
        <gml:Point gml:id="ID">
          <gml:pos>41.893367 12.483736</gml:pos>
        </gml:Point>
      </gmd:centerPoint>
    </rdf:Description>
  </rdf:RDF>
```

## How was this change tested?

Unit

## Which documentation and/or configurations were updated?

N/A

