### PR TITLE
Support multiple classifications.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -153,14 +153,7 @@ module Cocina
         end
 
         def subjects
-          subject_node = ng_xml.xpath('//mods:subject', mods: DESC_METADATA_NS)
-          return subject_node unless classification
-
-          subject_node << classification
-        end
-
-        def classification
-          ng_xml.xpath('//mods:classification', mods: DESC_METADATA_NS).first
+          ng_xml.xpath('//mods:subject', mods: DESC_METADATA_NS) + ng_xml.xpath('//mods:classification', mods: DESC_METADATA_NS)
         end
 
         def edition_for(subject)

--- a/spec/services/cocina/from_fedora/descriptive/subject_classification_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_classification_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
   end
 
   # 2. Classification with edition
-  context 'when given a classification with authority' do
+  context 'when given a classification with edition' do
     let(:xml) { '<classification authority="ddc" edition="11">683</classification>' }
 
     it 'builds the cocina data structure' do
@@ -64,6 +64,37 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
             "code": 'lcc'
           }
         }
+      ]
+    end
+  end
+
+  context 'when given multiple classifications' do
+    let(:xml) do
+      <<~XML
+        <classification authority="ddc" edition="11">683</classification>
+        <classification authority="ddc" edition="12">684</classification>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'classification',
+          "value": '683',
+          "source": {
+            "code": 'ddc',
+            "version": '11th edition'
+          }
+        },
+        {
+          "type": 'classification',
+          "value": '684',
+          "source": {
+            "code": 'ddc',
+            "version": '12th edition'
+          }
+        }
+
       ]
     end
   end


### PR DESCRIPTION
closes #1396

## Why was this change made?
Because an item can have multiple classifications.


## How was this change tested?
Locally, sdr-deploy


## Which documentation and/or configurations were updated?
NA


