### PR TITLE
Allow updates to contain cocina descriptive metadata

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,7 @@
 # Feature flippers
 enabled_features:
   registration: true
+  update_descriptive: false
 
 content:
   base_dir: '/dor/workspace'


### PR DESCRIPTION
This feature is behind a feature flag which is off by default

## Why was this change made?
This will enable a way to update metadata using the cocina api and not needing to send MODS.

Fixes #1398



## How was this change tested?



## Which documentation and/or configurations were updated?



