### PR TITLE
to cocina mapping:  originInfo eventType, dateOther

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -72,7 +72,7 @@ module Cocina
             events << build_event('capture', date_captured, display_label) if date_captured.present?
 
             date_other = origin.xpath('mods:dateOther', mods: DESC_METADATA_NS)
-            events << build_event(origin.attr('eventType'), date_other, display_label) if date_other.present?
+            events << build_event(date_other_event_type(origin), date_other, display_label) if date_other.present?
           end
         end
 
@@ -191,9 +191,22 @@ module Cocina
             date[:qualifier] = node[:qualifier] if node[:qualifier]
             date[:encoding] = { code: node['encoding'] } if node['encoding']
             date[:status] = 'primary' if node['keyDate']
-            date[:note] = [{ value: node['type'], type: 'date type' }] if !event_type && node['type']
+            if (!event_type || event_type == 'creation') && (node['type'] || node['calendar'])
+              date[:note] = [
+                {
+                  value: (node['type'] || node['calendar']),
+                  type: node['type'] ? 'date type' : 'calendar'
+                }
+              ]
+            end
             date[:type] = node['point'] if node['point']
           end
+        end
+
+        def date_other_event_type(origin)
+          return 'creation' if origin['eventType'] == 'production'
+
+          origin['eventType']
         end
 
         def origin_info

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -72,7 +72,7 @@ module Cocina
             events << build_event('capture', date_captured, display_label) if date_captured.present?
 
             date_other = origin.xpath('mods:dateOther', mods: DESC_METADATA_NS)
-            events << build_event(nil, date_other, display_label) if date_other.present?
+            events << build_event(origin.attr('eventType'), date_other, display_label) if date_other.present?
           end
         end
 

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
   end
 
   context 'with a single dateOther' do
-    describe 'with type attribute' do
+    describe 'with type attribute on the dateOther element' do
       let(:xml) do
         <<~XML
           <originInfo>
@@ -150,7 +150,40 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
       end
     end
 
-    describe 'without type attribute, with displayLabel' do
+    describe 'with eventType attribute at the originInfo level' do
+      let(:xml) do
+        <<~XML
+          <originInfo eventType="acquisition" displayLabel="Acquisition date">
+            <dateOther encoding="w3cdtf">1992</dateOther>
+          </originInfo>
+        XML
+      end
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq [
+          {
+            "type": 'acquisition',
+            "displayLabel": 'Acquisition date',
+            "date": [
+              {
+                "value": '1992',
+                "encoding": {
+                  "code": 'w3cdtf'
+                }
+              }
+            ]
+          }
+        ]
+      end
+
+      it 'does not notify Honeybadger' do
+        allow(Honeybadger).to receive(:notify)
+        build
+        expect(Honeybadger).not_to have_received(:notify)
+      end
+    end
+
+    describe 'without any type attribute, with displayLabel' do
       let(:xml) do
         <<~XML
           <originInfo displayLabel="Acquisition date">

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -181,6 +181,76 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
         build
         expect(Honeybadger).not_to have_received(:notify)
       end
+
+      describe 'with eventType="production" dateOther type="Julian" (MODS 3.6 and before)' do
+        let(:xml) do
+          <<~XML
+            <originInfo eventType="production">
+              <dateOther type="Julian">1544-02-02</dateOther>
+            </originInfo>
+          XML
+        end
+
+        it 'builds the cocina data structure' do
+          expect(build).to eq [
+            {
+              "type": 'creation',
+              "date": [
+                {
+                  "value": '1544-02-02',
+                  "note": [
+                    {
+                      "value": 'Julian',
+                      "type": 'date type'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        end
+
+        it 'does not notify Honeybadger' do
+          allow(Honeybadger).to receive(:notify)
+          build
+          expect(Honeybadger).not_to have_received(:notify)
+        end
+      end
+
+      describe 'with eventType="production" dateCreated calendar="Julian" (MODS 3.7)' do
+        let(:xml) do
+          <<~XML
+            <originInfo eventType="production">
+              <dateCreated calendar="Julian">1544-02-02</dateCreated>
+            </originInfo>
+          XML
+        end
+
+        it 'builds the cocina data structure' do
+          expect(build).to eq [
+            {
+              "type": 'creation',
+              "date": [
+                {
+                  "value": '1544-02-02',
+                  "note": [
+                    {
+                      "value": 'Julian',
+                      "type": 'calendar'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        end
+
+        it 'does not notify Honeybadger' do
+          allow(Honeybadger).to receive(:notify)
+          build
+          expect(Honeybadger).not_to have_received(:notify)
+        end
+      end
     end
 
     describe 'without any type attribute, with displayLabel' do


### PR DESCRIPTION
## Why was this change made?

to address the problem described in #1426 (though based on validation against the fedora cache, this may also introduce a regression in the mapping, i'm not quite sure, so leaving in draft for pairing/discussion)

## How was this change tested?

* unit tests
* validation against the fedora cache

it seems like the change in this PR fixed most but not all of the `missing eventType` error (5417 down to 1341):
```
[deploy@sdr-deploy dor-services-app]$ 
[deploy@sdr-deploy dor-services-app]$ diff results-master-all_2020-11-13.txt results-dateOther-event-type-all_2020-11-13.txt
2c2
< Data error: 95317 of 2685579 (3.549216016359973%)
---
> Data error: 91316 of 2685579 (3.4002351075876005%)
79324,84741d79323
< Data error: [DATA ERROR] originInfo/dateOther missing eventType (5417 errors)
< druid:xv158sd4671
...snip 5414 druids...
< druid:zc893yf2565
< druid:ds794zt2803
88276c82858
< Data error: [DATA ERROR] Contributor type incorrectly capitalized (2667 errors)
---
> Data error: [DATA ERROR] Contributor type incorrectly capitalized (2742 errors)
88283a82866
> druid:mh797tm0200
...snip 73 druids...
> druid:qh821qx7318
93293a87951,89292
> Data error: [DATA ERROR] originInfo/dateOther missing eventType (1341 errors)
> druid:qy796rh6653
...snip 1339 druids...
> druid:zn454yx7014
[deploy@sdr-deploy dor-services-app]$ 
```

However, it also seemed to introduce 75 instances of `Contributor type incorrectly capitalized`?  i know contributor mappings have been under active development, so maybe this is drift between `master` (as of Fri evening when I ran the validations) and this PR's base branch?  I will rebase and re-run the validation on this branch.

## Which documentation and/or configurations were updated?

worked off of this updated example:  https://github.com/sul-dlss-labs/cocina-descriptive-metadata/pull/127/files