### PR TITLE
Fix status for language of cataloging.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/admin_metadata.rb
+++ b/app/services/cocina/to_fedora/descriptive/admin_metadata.rb
@@ -77,7 +77,9 @@ module Cocina
 
         def build_language
           Array(admin_metadata.language).each do |language|
-            xml.languageOfCataloging usage: 'primary' do
+            language_of_cataloging_attrs = {}
+            language_of_cataloging_attrs[:usage] = language.status if language.status
+            xml.languageOfCataloging language_of_cataloging_attrs do
               language_attrs = with_uri_info(language, {})
               xml.languageTerm language.value, language_attrs.merge(type: 'text') if language.value
               xml.languageTerm language.code, language_attrs.merge(type: 'code')

--- a/spec/services/cocina/to_fedora/descriptive/admin_metadata_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/admin_metadata_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe Cocina::ToFedora::Descriptive::AdminMetadata do
               "source": {
                 "code": 'iso15924'
               }
-            }
+            },
+            "status": 'primary'
           }
         ],
         "contributor": [
@@ -186,7 +187,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::AdminMetadata do
     end
 
     it 'builds the xml' do
-      # TODO: XML may need adjustment when https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/75 is resolved
       expect(xml).to be_equivalent_to <<~XML
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
@@ -198,7 +198,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::AdminMetadata do
             <recordChangeDate encoding='iso8601'>20200718050001.0</recordChangeDate>
             <recordIdentifier source="SIRSI">a12374669</recordIdentifier>
             <recordOrigin>Converted from MARCXML to MODS version 3.6 using MARC21slim2MODS3-6_SDR.xsl (SUL version 1 2018/06/13; LC Revision 1.118 2018/01/31)</recordOrigin>
-            <languageOfCataloging usage="primary">
+            <languageOfCataloging>
               <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
             </languageOfCataloging>
           </recordInfo>


### PR DESCRIPTION
closes #1413

## Why was this change made?
To set languageOfCataloging usage attribute based on Cocina status, rather than hardcoding to "primary".


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


