### PR TITLE
to_fedora contrib mapping copes with role text AND code

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor.rb
@@ -53,17 +53,17 @@ module Cocina
           Array(contributor.role).each do |role|
             xml.role do
               attributes = {}
-              if role.value.present?
-                attributes[:type] = 'text'
-                value = role.value
-              elsif role.code.present?
-                attributes[:type] = 'code'
-                value = role.code
-              end
               attributes[:valueURI] = role.uri if role.uri
               attributes[:authority] = role.source.code if role.source&.code
               attributes[:authorityURI] = role.source.uri if role.source&.uri
-              xml.roleTerm value, attributes if value
+              if role.value.present?
+                attributes[:type] = 'text'
+                xml.roleTerm role.value, attributes
+              end
+              if role.code.present?
+                attributes[:type] = 'code'
+                xml.roleTerm role.code, attributes
+              end
             end
           end
         end

--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -176,7 +176,46 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
 
   context 'with role' do
     context 'when both code and value' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L168'
+      let(:contributors) do
+        [
+          Cocina::Models::Contributor.new(
+            name: [
+              {
+                value: 'Dunnett, Dorothy'
+              }
+            ],
+            status: 'primary',
+            type: 'person',
+            role: [
+              {
+                value: 'author',
+                code: 'aut',
+                uri: 'http://id.loc.gov/vocabulary/relators/aut',
+                source: {
+                  code: 'marcrelator',
+                  uri: 'http://id.loc.gov/vocabulary/relators/'
+                }
+              }
+            ]
+          )
+        ]
+      end
+
+      it 'builds the xml' do
+        expect(xml).to be_equivalent_to <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <name type="personal" usage="primary">
+              <namePart>Dunnett, Dorothy</namePart>
+              <role>
+                <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+                <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+              </role>
+            </name>
+          </mods>
+        XML
+      end
     end
 
     context 'when role has code but not value' do


### PR DESCRIPTION
## Why was this change made?

Part of #1405

to_fedora contributor mapping copes with role when both text and code for role are present.


## How was this change tested?

unit test, also

### Validations

1.  For the record called out in #1405, cz548fn3478, I did a roundtrip validation for master branch and my branch.

here's the diff:
```
87c87,88
<       <roleTerm type="text" valueURI="http://id.loc.gov/vocabulary/relators/spn" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators">Sponsor</roleTerm>
---
>       <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/spn" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" type="text">Sponsor</roleTerm>
>       <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/spn" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" type="code">spn</roleTerm>
93c94,95
<       <roleTerm type="text" valueURI="http://id.loc.gov/vocabulary/relators/pht" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators">Photographer</roleTerm>
---
>       <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/pht" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" type="text">Photographer</roleTerm>
>       <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/pht" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" type="code">pht</roleTerm>
451c453,454
<       <roleTerm type="text" valueURI="http://id.loc.gov/vocabulary/relators/spn" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators">Sponsor</roleTerm>
---
>       <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/spn" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" type="text">Sponsor</roleTerm>
>       <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/spn" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" type="code">spn</roleTerm>
457c460,461
<       <roleTerm type="text" valueURI="http://id.loc.gov/vocabulary/relators/pht" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators">Photographer</roleTerm>
---
>       <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/pht" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" type="text">Photographer</roleTerm>
>       <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/pht" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" type="code">pht</roleTerm>
520c524,525
<       <roleTerm type="text" valueURI="http://id.loc.gov/vocabulary/relators/spn" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators">Sponsor</roleTerm>
---
>       <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/spn" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" type="text">Sponsor</roleTerm>
>       <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/spn" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" type="code">spn</roleTerm>
526,548c531,532
<       <roleTerm type="text" valueURI="http://id.loc.gov/vocabulary/relators/pht" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators">Photographer</roleTerm>
<     </role>
<   </name>
``` 



2.  ran 100,000 records through *to-fedora* validation `bin/validate-to-fedora -s 100000`

(also ran 500,000 through master branch and got same 2 errors and no more)

master branch:
```
To Fedora error: 15 of 100000 (0.015%)
To Cocina error: 10 of 100000 (0.01%)
Data error: 31 of 100000 (0.031%)
Missing: 610 of 100000 (0.61%)

To Fedora error: key not found: "person" (14 errors)
Examples: ...
To Fedora error: undefined method `code' for nil:NilClass (1 errors)
Examples: ...
```

this branch:
```
To Fedora error: 15 of 100000 (0.015%)
To Cocina error: 10 of 100000 (0.01%)
Data error: 31 of 100000 (0.031%)
Missing: 610 of 100000 (0.61%)

To Fedora error: key not found: "person" (14 errors)
Examples: ...
To Fedora error: undefined method `code' for nil:NilClass (1 errors)
Examples: ...
```

3.  ran 100,000 records through round trip validation and it didn't get worse: `bin/validate-cocina-roundtrip -s 100000`

Master branch:
```
Status (n=100000):
  Success:   36612 (36.612%)
  Different: 62722 (62.722%)
  To Cocina error:     41 (0.041%)
  To Fedora error:     15 (0.015%)
  Missing:     610 (0.61%)
```

This branch:
```
Status (n=100000):
  Success:   36612 (36.612%)
  Different: 62722 (62.722%)
  To Cocina error:     41 (0.041%)
  To Fedora error:     15 (0.015%)
  Missing:     610 (0.61%)
```

## Which documentation and/or configurations were updated?



