### PR TITLE
from_fedora mapping contributor: normalize marcrelator value to lowercase

### DIFF
--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -501,6 +501,53 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
       end
     end
 
+    context 'when roleTerm for type text is incorrectly capitalized' do
+      let(:xml) do
+        <<~XML
+          <name type="corporate" usage="primary">
+            <namePart>Stanford University. School of Engineering</namePart>
+            <role>
+              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/spn">spn</roleTerm>
+              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/spn">Sponsor</roleTerm>
+            </role>
+          </name>
+        XML
+      end
+
+      before do
+        allow(Honeybadger).to receive(:notify)
+      end
+
+      it 'builds the cocina data structure with downcased role' do
+        expect(build).to eq [
+          {
+            name: [
+              {
+                value: 'Stanford University. School of Engineering'
+              }
+            ],
+            status: 'primary',
+            type: 'organization',
+            role: [
+              {
+                value: 'sponsor',
+                code: 'spn',
+                uri: 'http://id.loc.gov/vocabulary/relators/spn',
+                source: {
+                  code: 'marcrelator',
+                  uri: 'http://id.loc.gov/vocabulary/relators'
+                }
+              }
+            ]
+          }
+        ]
+      end
+
+      it 'does not notify Honeybadger' do
+        expect(Honeybadger).not_to have_received(:notify)
+      end
+    end
+
     context 'when roleTerm is type code' do
       let(:xml) do
         <<~XML


### PR DESCRIPTION
## Why was this change made?

Closes #1405

to_fedora contributor mapping copes with role when mods has marcrelator role value that is incorrectly capitalized

## How was this change tested?

added unit test;

### Validations

1.  running single druid  cz548fn3478 roundtrip `bin/validate-cocina-roundtrip -d druid\:cz548fn3478`

This from diffing between master branch results and this branch's results shows the value is downcased in the cocina model:

```
<           "value": "Sponsor",
---
>           "value": "sponsor",
183c181
<           "value": "Photographer",
---
>           "value": "photographer",
453,454c451
```

2. ran 500,000 records through to-cocina validation `bin/validate-to-cocina -s 500000`

master branch
```
To Cocina error: 57 of 500000 (0.0114%)
Data error: 17606 of 500000 (3.5212%)
Missing: 2954 of 500000 (0.5908%)

Error:  isn't one of in #/components/schemas/DescriptiveBasicValue/allOf/2/properties/value (57 errors)
Examples: ...
Data error: [DATA ERROR] Subject has unknown authority code (14566 errors)
Examples: ...
Data error: [DATA ERROR] originInfo/dateOther missing eventType (1019 errors)
Examples: ...
Data error: [DATA ERROR] Subject contains a <name> element without a type attribute (660 errors)
Examples: ...
Data error: [DATA ERROR] Contributor type incorrectly capitalized (473 errors)
Examples: ...
Data error: [DATA ERROR] name/role/roleTerm missing value (457 errors)
Examples: ...
Data error: Missing title (146 errors)
Examples: ...
Data error: [DATA ERROR] Empty title node (90 errors)
Examples: ...
Data error: [DATA ERROR] Name not found for title group (74 errors)
Examples: ...
Data error: [DATA ERROR] name/namePart missing value (64 errors)
Examples: ...
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'Corporate' (26 errors)
Examples: ...
Data error: [DATA ERROR] Contributor role code is missing authority (14 errors)
Examples: ...
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute '#N/A' (9 errors)
Examples: ...
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'Personal' (3 errors)
Examples: ...
Data error: [DATA ERROR] Contributor type unrecognized 'pesonal' (3 errors)
Examples: ...
Data error: [DATA ERROR] Unexpected node type for subject: 'cartographic' (1 errors)
Examples: ...
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'naf' (1 errors)
Examples: ...
```

this branch
```
To Cocina error: 57 of 500000 (0.0114%)
Data error: 17606 of 500000 (3.5212%)
Missing: 2954 of 500000 (0.5908%)

Error:  isn't one of in #/components/schemas/DescriptiveBasicValue/allOf/2/properties/value (57 errors)
Examples: ...
Data error: [DATA ERROR] Subject has unknown authority code (14566 errors)
Examples: ...
Data error: [DATA ERROR] originInfo/dateOther missing eventType (1019 errors)
Examples: ...
Data error: [DATA ERROR] Subject contains a <name> element without a type attribute (660 errors)
Examples: ...
Data error: [DATA ERROR] Contributor type incorrectly capitalized (473 errors)
Examples: ...
Data error: [DATA ERROR] name/role/roleTerm missing value (457 errors)
Examples: ...
Data error: Missing title (146 errors)
Examples: ...
Data error: [DATA ERROR] Empty title node (90 errors)
Examples: ...
Data error: [DATA ERROR] Name not found for title group (74 errors)
Examples: ...
Data error: [DATA ERROR] name/namePart missing value (64 errors)
Examples: ...
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'Corporate' (26 errors)
Examples: ...
Data error: [DATA ERROR] Contributor role code is missing authority (14 errors)
Examples: ...
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute '#N/A' (9 errors)
Examples: ...
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'Personal' (3 errors)
Examples: ...
Data error: [DATA ERROR] Contributor type unrecognized 'pesonal' (3 errors)
Examples: ...
Data error: [DATA ERROR] Unexpected node type for subject: 'cartographic' (1 errors)
Examples: ...
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'naf' (1 errors)
Examples: ...
```

3  ran 500,000 records through round trip validation and it didn't get worse: `bin/validate-cocina-roundtrip -s 500000`


## Which documentation and/or configurations were updated?



