### PR TITLE
Fixes handling of subject authorities.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -85,19 +85,30 @@ module Cocina
 
         def write_basic(subject)
           subject_attributes = {}
-          subject_attributes[:authority] = 'lcsh' if subject.source && subject.type != 'place'
+          authority = authority_for(subject)
+          subject_attributes[:authority] = authority if authority
           subject_attributes[:displayLabel] = subject.displayLabel if subject.displayLabel
           subject_attributes[:edition] = edition(subject.source.version) if subject.source&.version
 
           case subject.type
           when 'classification'
-            subject_attributes[:authority] = subject.source.code if subject.source&.code
             write_classification(subject.value, subject_attributes)
           else
             xml.subject(subject_attributes) do
               write_topic(subject)
             end
           end
+        end
+
+        def authority_for(subject)
+          # Authority for place is on the geographicCode, not the subject.
+          # See "Geographic code subject" example.
+          return nil if subject.type == 'place'
+
+          # Both lcsh and naf map for lcsh for the subject.
+          return 'lcsh' if %w[lcsh naf].include?(subject.source&.code)
+
+          subject.source&.code
         end
 
         def write_classification(value, attrs)

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -241,6 +241,28 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     end
   end
 
+  context 'with a single-term topic subject with non-lcsh authority on the subject' do
+    let(:xml) do
+      <<~XML
+        <subject authority="mesh">
+          <topic>Cats</topic>
+        </subject>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "value": 'Cats',
+          "type": 'topic',
+          "source": {
+            "code": 'mesh'
+          }
+        }
+      ]
+    end
+  end
+
   context 'with invalid subject "#N/A" authority' do
     let(:xml) do
       <<~XML

--- a/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
@@ -116,6 +116,34 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
     end
   end
 
+  context 'when it has a single-term topic subject with non-lcsh authority' do
+    let(:subjects) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          {
+            "value": 'Cats',
+            "type": 'topic',
+            "source": {
+              "code": 'mesh'
+            }
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject authority="mesh">
+            <topic>Cats</topic>
+          </subject>
+        </mods>
+      XML
+    end
+  end
+
   context 'when it has a single-term topic subject with authority but no valueURI' do
     let(:subjects) do
       [


### PR DESCRIPTION
closes #1418

## Why was this change made?
Authorities for subjects were being mistakingly set.


## How was this change tested?
Unit, sdr-deploy.


## Which documentation and/or configurations were updated?
NA


