### PR TITLE
implement contributor name authority mappings

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor.rb
@@ -46,6 +46,13 @@ module Cocina
 
           { type: NAME_TYPE.fetch(contributor.type) }.tap do |attributes|
             attributes[:usage] = 'primary' if contributor.status == 'primary'
+            value_uri = contributor.name.first&.uri
+            if value_uri
+              attributes[:valueURI] = value_uri
+              source = contributor.name.first&.source
+              attributes[:authority] = source.code if source&.code
+              attributes[:authorityURI] = source.uri if source&.uri
+            end
           end
         end
 

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -656,7 +656,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     context 'when the role code is missing the authority and length is 3' do
       let(:xml) do
         <<~XML
-          <name valueURI="corporate">
+          <name>
             <namePart>Selective Service System</namePart>
             <role>
               <roleTerm type="code">isb</roleTerm>
@@ -784,7 +784,32 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
   end
 
   context 'with authority' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L342'
+    let(:xml) do
+      <<~XML
+        <name type="personal" usage="primary" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79046044">
+          <namePart>Sayers, Dorothy L. (Dorothy Leigh), 1893-1957</namePart>
+        </name>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          name: [
+            {
+              value: 'Sayers, Dorothy L. (Dorothy Leigh), 1893-1957',
+              uri: 'http://id.loc.gov/authorities/names/n79046044',
+              source: {
+                code: 'naf',
+                uri: 'http://id.loc.gov/authorities/names/'
+              }
+            }
+          ],
+          status: 'primary',
+          type: 'person'
+        }
+      ]
+    end
   end
 
   context 'with multiple names, one primary' do

--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -560,7 +560,36 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
   end
 
   context 'with authority' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L342'
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          name: [
+            {
+              value: 'Sayers, Dorothy L. (Dorothy Leigh), 1893-1957',
+              uri: 'http://id.loc.gov/authorities/names/n79046044',
+              source: {
+                code: 'naf',
+                uri: 'http://id.loc.gov/authorities/names/'
+              }
+            }
+          ],
+          status: 'primary',
+          type: 'person'
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <name type="personal" usage="primary" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79046044">
+            <namePart>Sayers, Dorothy L. (Dorothy Leigh), 1893-1957</namePart>
+          </name>
+        </mods>
+      XML
+    end
   end
 
   context 'with multiple names, one primary' do


### PR DESCRIPTION
## Why was this change made?

Fixes #1406 - maps MODS name authority attributes to cocina and back again

## How was this change tested?

unit test added

### Validations

1. For the record called out in #1406, cz548fn3478, I did a roundtrip validation for master branch and my branch.  Here is the diff:

```
$ diff cz548fn3478.master.txt cz548fn3478.mybranch.txt 
84c84
<   <name type="corporate" usage="primary">
---
>   <name type="corporate" usage="primary" valueURI="http://id.loc.gov/authorities/names/n82220006" authority="naf" authorityURI="http://id.loc.gov/authorities/names">
157c157,162
<           "value": "Stanford University. School of Engineering"
---
>           "value": "Stanford University. School of Engineering",
>           "uri": "http://id.loc.gov/authorities/names/n82220006",
>           "source": {
>             "code": "naf",
>             "uri": "http://id.loc.gov/authorities/names"
>           }
450c455
<   <name type="corporate" usage="primary">
---
>   <name type="corporate" usage="primary" valueURI="http://id.loc.gov/authorities/names/n82220006" authority="naf" authorityURI="http://id.loc.gov/authorities/names">
521c526
< <name type="corporate" usage="primary">
---
> <name type="corporate" usage="primary" valueURI="http://id.loc.gov/authorities/names/n82220006" authority="naf" authorityURI="http://id.loc.gov/authorities/names">
545c550
< <name type="corporate" usage="primary">
---
> <name type="corporate" usage="primary" valueURI="http://id.loc.gov/authorities/names/n82220006" authority="naf" authorityURI="http://id.loc.gov/authorities/names">
629c634
< <name type="corporate" usage="primary">
---
> <name type="corporate" usage="primary" valueURI="http://id.loc.gov/authorities/names/n82220006" authority="naf" authorityURI="http://id.loc.gov/authorities/names">
```

2.ran 500,000 records through round trip validation and it didn't get worse: `bin/validate-cocina-roundtrip -s 500000`

my branch:
```
To Cocina error: 57 of 500000 (0.0114%)
Data error: 17606 of 500000 (3.5212%)
Missing: 2954 of 500000 (0.5908%)

Error:  isn't one of in #/components/schemas/DescriptiveBasicValue/allOf/2/properties/value (57 errors)
Data error: [DATA ERROR] Subject has unknown authority code (14566 errors)
Data error: [DATA ERROR] originInfo/dateOther missing eventType (1019 errors)
Data error: [DATA ERROR] Subject contains a <name> element without a type attribute (660 errors)
Data error: [DATA ERROR] Contributor type incorrectly capitalized (473 errors)
Data error: [DATA ERROR] name/role/roleTerm missing value (457 errors)
Data error: Missing title (146 errors)
Data error: [DATA ERROR] Empty title node (90 errors)
Data error: [DATA ERROR] Name not found for title group (74 errors)
Data error: [DATA ERROR] name/namePart missing value (64 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'Corporate' (26 errors)
Data error: [DATA ERROR] Contributor role code is missing authority (14 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute '#N/A' (9 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'Personal' (3 errors)
Data error: [DATA ERROR] Contributor type unrecognized 'pesonal' (3 errors)
Data error: [DATA ERROR] Unexpected node type for subject: 'cartographic' (1 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'naf' (1 errors)
```

master branch:
```
To Cocina error: 57 of 500000 (0.0114%)
Data error: 17606 of 500000 (3.5212%)
Missing: 2954 of 500000 (0.5908%)

Error:  isn't one of in #/components/schemas/DescriptiveBasicValue/allOf/2/properties/value (57 errors)
Data error: [DATA ERROR] Subject has unknown authority code (14566 errors)
Data error: [DATA ERROR] originInfo/dateOther missing eventType (1019 errors)
Data error: [DATA ERROR] Subject contains a <name> element without a type attribute (660 errors)
Data error: [DATA ERROR] Contributor type incorrectly capitalized (473 errors)
Data error: [DATA ERROR] name/role/roleTerm missing value (457 errors)
Data error: Missing title (146 errors)
Data error: [DATA ERROR] Empty title node (90 errors)
Data error: [DATA ERROR] Name not found for title group (74 errors)
Data error: [DATA ERROR] name/namePart missing value (64 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'Corporate' (26 errors)
Data error: [DATA ERROR] Contributor role code is missing authority (14 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute '#N/A' (9 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'Personal' (3 errors)
Data error: [DATA ERROR] Contributor type unrecognized 'pesonal' (3 errors)
Data error: [DATA ERROR] Unexpected node type for subject: 'cartographic' (1 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'naf' (1 errors)
```

## Which documentation and/or configurations were updated?



