### PR TITLE
Contrib role authority tweak

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -163,7 +163,11 @@ module Cocina
           {}.tap do |role|
             if role_authority&.content.present?
               role[:source] = { code: role_authority.content }
-              role[:source][:uri] = role_authority_uri.content if role_authority_uri&.content.present?
+              if role_authority_uri&.content.present?
+                role[:source][:uri] = role_authority_uri.content
+              elsif role_authority.content == 'marcrelator'
+                role[:source][:uri] = 'http://id.loc.gov/vocabulary/relators/'
+              end
             end
 
             role[:code] = role_code&.content
@@ -175,8 +179,8 @@ module Cocina
               return []
             end
           end.compact
-          # rubocop:enable Metrics/AbcSize
         end
+        # rubocop:enable Metrics/AbcSize
 
         def type_for(type)
           unless Contributor::ROLES.keys.include?(type.downcase)

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -699,11 +699,76 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     end
 
     context 'when role has valueURI as the only authority attribute' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L263'
+      let(:xml) do
+        <<~XML
+          <name type="personal" usage="primary">
+            <namePart>Dunnett, Dorothy</namePart>
+            <role>
+              <roleTerm type="text" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+              <roleTerm type="code" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            </role>
+          </name>
+        XML
+      end
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq [
+          {
+            name: [
+              {
+                value: 'Dunnett, Dorothy'
+              }
+            ],
+            status: 'primary',
+            type: 'person',
+            role: [
+              {
+                value: 'author',
+                code: 'aut',
+                uri: 'http://id.loc.gov/vocabulary/relators/aut'
+              }
+            ]
+          }
+        ]
+      end
     end
 
     context 'when role has authority as the only authority attribute' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L292'
+      let(:xml) do
+        <<~XML
+          <name type="personal" usage="primary">
+            <namePart>Dunnett, Dorothy</namePart>
+            <role>
+              <roleTerm type="text" authority="marcrelator">author</roleTerm>
+              <roleTerm type="code" authority="marcrelator">aut</roleTerm>
+            </role>
+          </name>
+        XML
+      end
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq [
+          {
+            name: [
+              {
+                value: 'Dunnett, Dorothy'
+              }
+            ],
+            status: 'primary',
+            type: 'person',
+            role: [
+              {
+                value: 'author',
+                code: 'aut',
+                source: {
+                  code: 'marcrelator',
+                  uri: 'http://id.loc.gov/vocabulary/relators/'
+                }
+              }
+            ]
+          }
+        ]
+      end
     end
 
     context 'when role without namePart value' do

--- a/spec/services/cocina/from_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive_spec.rb
@@ -305,7 +305,8 @@ RSpec.describe Cocina::FromFedora::Descriptive do
             value: 'degree supervisor',
             code: 'ths',
             source: {
-              code: 'marcrelator'
+              code: 'marcrelator',
+              uri: 'http://id.loc.gov/vocabulary/relators/'
             }
           }]
         },
@@ -318,7 +319,8 @@ RSpec.describe Cocina::FromFedora::Descriptive do
             value: 'degree committee member',
             code: 'ths',
             source: {
-              code: 'marcrelator'
+              code: 'marcrelator',
+              uri: 'http://id.loc.gov/vocabulary/relators/'
             }
           }]
         },
@@ -331,7 +333,8 @@ RSpec.describe Cocina::FromFedora::Descriptive do
             value: 'degree committee member',
             code: 'ths',
             source: {
-              code: 'marcrelator'
+              code: 'marcrelator',
+              uri: 'http://id.loc.gov/vocabulary/relators/'
             }
           }]
         },

--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -336,11 +336,84 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     end
 
     context 'when role has valueURI as the only authority attribute' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L263'
+      let(:contributors) do
+        [
+          Cocina::Models::Contributor.new(
+            name: [
+              {
+                value: 'Dunnett, Dorothy'
+              }
+            ],
+            status: 'primary',
+            type: 'person',
+            role: [
+              {
+                value: 'author',
+                code: 'aut',
+                uri: 'http://id.loc.gov/vocabulary/relators/aut'
+              }
+            ]
+          )
+        ]
+      end
+
+      it 'builds the xml' do
+        expect(xml).to be_equivalent_to <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <name type="personal" usage="primary">
+              <namePart>Dunnett, Dorothy</namePart>
+              <role>
+                <roleTerm type="text" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+                <roleTerm type="code" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+              </role>
+            </name>
+          </mods>
+        XML
+      end
     end
 
     context 'when role has authority as the only authority attribute' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt#L292'
+      let(:contributors) do
+        [
+          Cocina::Models::Contributor.new(
+            name: [
+              {
+                value: 'Dunnett, Dorothy'
+              }
+            ],
+            status: 'primary',
+            type: 'person',
+            role: [
+              {
+                value: 'author',
+                code: 'aut',
+                source: {
+                  code: 'marcrelator',
+                  uri: 'http://id.loc.gov/vocabulary/relators/'
+                }
+              }
+            ]
+          )
+        ]
+      end
+
+      it 'builds the xml' do
+        expect(xml).to be_equivalent_to <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <name type="personal" usage="primary">
+              <namePart>Dunnett, Dorothy</namePart>
+              <role>
+                <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/">author</roleTerm>
+                <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/">aut</roleTerm>
+              </role>
+            </name>
+          </mods>
+        XML
+      end
     end
 
     context 'when role and name elements are empty' do


### PR DESCRIPTION
## Why was this change made?

Fixes #1251 - a couple of wrinkles exposed when working on contributor role mappings a while back

(actually:  "why" is that I saw that these specs weren't written and thought they might "just work" if I implemented the specs ... and it was almost true)

## How was this change tested?

unit tests added

### Validations

Ran 500,000 records through round trip validation and it didn't get worse: bin/validate-cocina-roundtrip -s 500000

my branch:
```
To Cocina error: 57 of 500000 (0.0114%)
Data error: 17606 of 500000 (3.5212%)
Missing: 2954 of 500000 (0.5908%)

Error:  isn't one of in #/components/schemas/DescriptiveBasicValue/allOf/2/properties/value (57 errors)
Data error: [DATA ERROR] Subject has unknown authority code (14566 errors)
Data error: [DATA ERROR] originInfo/dateOther missing eventType (1019 errors)
Data error: [DATA ERROR] Subject contains a <name> element without a type attribute (660 errors)
Data error: [DATA ERROR] Contributor type incorrectly capitalized (473 errors)
Data error: [DATA ERROR] name/role/roleTerm missing value (457 errors)
Data error: Missing title (146 errors)
Data error: [DATA ERROR] Empty title node (90 errors)
Data error: [DATA ERROR] Name not found for title group (74 errors)
Data error: [DATA ERROR] name/namePart missing value (64 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'Corporate' (26 errors)
Data error: [DATA ERROR] Contributor role code is missing authority (14 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute '#N/A' (9 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'Personal' (3 errors)
Data error: [DATA ERROR] Contributor type unrecognized 'pesonal' (3 errors)
Data error: [DATA ERROR] Unexpected node type for subject: 'cartographic' (1 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'naf' (1 errors)
```

master:
```
To Cocina error: 57 of 500000 (0.0114%)
Data error: 17606 of 500000 (3.5212%)
Missing: 2954 of 500000 (0.5908%)

Error:  isn't one of in #/components/schemas/DescriptiveBasicValue/allOf/2/properties/value (57 errors)
Data error: [DATA ERROR] Subject has unknown authority code (14566 errors)
Data error: [DATA ERROR] originInfo/dateOther missing eventType (1019 errors)
Data error: [DATA ERROR] Subject contains a <name> element without a type attribute (660 errors)
Data error: [DATA ERROR] Contributor type incorrectly capitalized (473 errors)
Data error: [DATA ERROR] name/role/roleTerm missing value (457 errors)
Data error: Missing title (146 errors)
Data error: [DATA ERROR] Empty title node (90 errors)
Data error: [DATA ERROR] Name not found for title group (74 errors)
Data error: [DATA ERROR] name/namePart missing value (64 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'Corporate' (26 errors)
Data error: [DATA ERROR] Contributor role code is missing authority (14 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute '#N/A' (9 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'Personal' (3 errors)
Data error: [DATA ERROR] Contributor type unrecognized 'pesonal' (3 errors)
Data error: [DATA ERROR] Unexpected node type for subject: 'cartographic' (1 errors)
Data error: [DATA ERROR] Subject has <name> with an invalid type attribute 'naf' (1 errors)
```


## Which documentation and/or configurations were updated?



