### PR TITLE
Only use the root physicalDescription.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/form.rb
+++ b/app/services/cocina/from_fedora/descriptive/form.rb
@@ -8,7 +8,6 @@ module Cocina
       class Form
         # NOTE: H2 is the first case of structured form (genre/typeOfResource) values we're implementing
         H2_GENRE_TYPE_PREFIX = 'H2 '
-        PHYSICAL_DESCRIPTION_XPATH = '//mods:physicalDescription'
 
         # @param [Nokogiri::XML::Document] ng_xml the descriptive metadata XML
         # @return [Hash] a hash that can be mapped to a cocina model
@@ -167,7 +166,7 @@ module Cocina
         end
 
         def physical_descriptions
-          ng_xml.xpath('//mods:physicalDescription', mods: DESC_METADATA_NS)
+          ng_xml.xpath('//mods:mods/mods:physicalDescription', mods: DESC_METADATA_NS)
         end
 
         def source_for(form)

--- a/spec/services/cocina/from_fedora/descriptive/form_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/form_spec.rb
@@ -672,6 +672,31 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
       end
     end
 
+    context 'when physical description elsewhere in record' do
+      let(:xml) do
+        <<~XML
+          <relatedItem type="original">
+              <physicalDescription>
+                 <form authority="marcform">print</form>
+                 <extent>v. ; 24 cm.</extent>
+              </physicalDescription>
+           </relatedItem>        
+          <physicalDescription>
+            <form>mezzotints (prints)</form>
+          </physicalDescription>
+        XML
+      end
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq [
+          {
+            "value": 'mezzotints (prints)',
+            "type": 'form'
+          }
+        ]
+      end
+    end
+
     context 'when it has displayLabel' do
       xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_physicalDescription.txt#L107'
     end


### PR DESCRIPTION
closes #1402

## Why was this change made?
The xpath for selecting the physicalDescription was not specific enough.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


