### PR TITLE
[Refactor] .each is fine when you aren't using the index

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor.rb
@@ -20,7 +20,7 @@ module Cocina
         end
 
         def write
-          Array(contributors).each_with_index do |contributor, _alt_rep_group|
+          Array(contributors).each do |contributor|
             next unless contributor.name
 
             xml.name name_attributes(contributor) do

--- a/app/services/cocina/to_fedora/descriptive/language.rb
+++ b/app/services/cocina/to_fedora/descriptive/language.rb
@@ -17,7 +17,7 @@ module Cocina
         end
 
         def write
-          Array(languages).each_with_index do |language, _alt_rep_group|
+          Array(languages).each do |language|
             write_basic(language)
           end
         end

--- a/app/services/cocina/to_fedora/descriptive/note.rb
+++ b/app/services/cocina/to_fedora/descriptive/note.rb
@@ -8,9 +8,9 @@ module Cocina
         # @params [Nokogiri::XML::Builder] xml
         # @params [Array<Cocina::Models::DescriptiveValue>] notes
         def self.write(xml:, notes:)
-          Array(notes).each_with_index do |note, alt_rep_group|
+          Array(notes).each_with_index do |note, index|
             if note.parallelValue
-              write_parallel(xml, note, alt_rep_group: alt_rep_group)
+              write_parallel(xml, note, alt_rep_group: index)
             else
               write_basic(xml, note)
             end

--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -26,11 +26,11 @@ module Cocina
         end
 
         def write
-          subjects.each_with_index do |subject, alt_rep_group|
+          subjects.each_with_index do |subject, index|
             if subject.structuredValue
               write_structured(subject)
             elsif subject.parallelValue
-              write_parallel(subject, alt_rep_group: alt_rep_group)
+              write_parallel(subject, alt_rep_group: index)
             else
               write_basic(subject)
             end


### PR DESCRIPTION
## Why was this change made?

I noticed this on the way to doing something else.  I think I'm the guiltiest party, too.

## How was this change tested?



## Which documentation and/or configurations were updated?



