### PR TITLE
When mapping from fedora, re-use builders to build related items.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive.rb
+++ b/app/services/cocina/from_fedora/descriptive.rb
@@ -6,22 +6,9 @@ module Cocina
     class Descriptive
       DESC_METADATA_NS = Dor::DescMetadataDS::MODS_NS
 
-      BUILDERS = {
-        note: Notes,
-        language: Language,
-        contributor: Contributor,
-        event: Descriptive::Event,
-        subject: Subject,
-        form: Form,
-        identifier: Identifier,
-        adminMetadata: AdminMetadata,
-        relatedResource: RelatedResource,
-        geographic: Geographic
-      }.freeze
-
       # @param [#build] title_builder
       # @param [Nokogiri::XML] mods
-      # @return [Hash] a hash that can be mapped to a cocina administrative model
+      # @return [Hash] a hash that can be mapped to a cocina descriptive model
       # @raises [Cocina::Mapper::InvalidDescMetadata] if some assumption about descMetadata is violated
       def self.props(mods:, title_builder: Titles)
         new(title_builder: title_builder, mods: mods).props
@@ -33,19 +20,7 @@ module Cocina
       end
 
       def props
-        add_descriptive_elements({ title: title_builder.build(ng_xml) })
-      end
-
-      private
-
-      attr_reader :title_builder, :ng_xml
-
-      def add_descriptive_elements(cocina_description)
-        BUILDERS.each do |descriptive_property, builder|
-          result = builder.build(ng_xml)
-          cocina_description.merge!(descriptive_property => result) if result.present?
-        end
-        cocina_description
+        DescriptiveBuilder.build(title_builder: @title_builder, resource_element: @ng_xml.root)
       end
     end
   end

--- a/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
+++ b/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
@@ -5,14 +5,15 @@ module Cocina
     class Descriptive
       # Maps MODS recordInfo to cocina
       class AdminMetadata
-        # @param [Nokogiri::XML::Document] ng_xml the descriptive metadata XML
+        # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
+        # @param [Cocina::FromFedora::Descriptive::DescriptiveBuilder] descriptive_builder
         # @return [Hash] a hash that can be mapped to a cocina model
-        def self.build(ng_xml)
-          new(ng_xml).build
+        def self.build(resource_element:, descriptive_builder: nil)
+          new(resource_element: resource_element).build
         end
 
-        def initialize(ng_xml)
-          @ng_xml = ng_xml
+        def initialize(resource_element:)
+          @resource_element = resource_element
         end
 
         def build
@@ -28,7 +29,7 @@ module Cocina
 
         private
 
-        attr_reader :ng_xml
+        attr_reader :resource_element
 
         def build_events
           events = []
@@ -131,31 +132,31 @@ module Cocina
         end
 
         def language_of_cataloging
-          @language_of_cataloging ||= ng_xml.xpath('//mods:mods/mods:recordInfo/mods:languageOfCataloging', mods: DESC_METADATA_NS).first
+          @language_of_cataloging ||= resource_element.xpath('mods:recordInfo/mods:languageOfCataloging', mods: DESC_METADATA_NS).first
         end
 
         def record_content_source
-          @record_content_source ||= ng_xml.xpath('//mods:mods/mods:recordInfo/mods:recordContentSource', mods: DESC_METADATA_NS).first
+          @record_content_source ||= resource_element.xpath('mods:recordInfo/mods:recordContentSource', mods: DESC_METADATA_NS).first
         end
 
         def description_standard
-          @description_standard ||= ng_xml.xpath('//mods:mods/mods:recordInfo/mods:descriptionStandard', mods: DESC_METADATA_NS).first
+          @description_standard ||= resource_element.xpath('mods:recordInfo/mods:descriptionStandard', mods: DESC_METADATA_NS).first
         end
 
         def record_origin
-          @record_origin ||= ng_xml.xpath('//mods:mods/mods:recordInfo/mods:recordOrigin', mods: DESC_METADATA_NS).first
+          @record_origin ||= resource_element.xpath('mods:recordInfo/mods:recordOrigin', mods: DESC_METADATA_NS).first
         end
 
         def identifier
-          @identifier ||= ng_xml.xpath('//mods:mods/mods:recordInfo/mods:recordIdentifier', mods: DESC_METADATA_NS).first
+          @identifier ||= resource_element.xpath('mods:recordInfo/mods:recordIdentifier', mods: DESC_METADATA_NS).first
         end
 
         def creation_event
-          @creation_event ||= ng_xml.xpath('//mods:mods/mods:recordInfo/mods:recordCreationDate', mods: DESC_METADATA_NS).first
+          @creation_event ||= resource_element.xpath('mods:recordInfo/mods:recordCreationDate', mods: DESC_METADATA_NS).first
         end
 
         def modification_event
-          @modification_event ||= ng_xml.xpath('//mods:mods/mods:recordInfo/mods:recordChangeDate', mods: DESC_METADATA_NS).first
+          @modification_event ||= resource_element.xpath('mods:recordInfo/mods:recordChangeDate', mods: DESC_METADATA_NS).first
         end
       end
     end

--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -20,17 +20,18 @@ module Cocina
           'date' => 'life dates'
         }.freeze
 
-        NAME_XPATH = '/mods:mods/mods:name'
+        NAME_XPATH = 'mods:name'
         NAME_PART_XPATH = './mods:namePart'
 
-        # @param [Nokogiri::XML::Document] ng_xml the descriptive metadata XML
+        # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
+        # @param [Cocina::FromFedora::Descriptive::DescriptiveBuilder] descriptive_builder
         # @return [Hash] a hash that can be mapped to a cocina model
-        def self.build(ng_xml)
-          new(ng_xml).build
+        def self.build(resource_element:, descriptive_builder: nil)
+          new(resource_element: resource_element).build
         end
 
-        def initialize(ng_xml)
-          @ng_xml = ng_xml
+        def initialize(resource_element:)
+          @resource_element = resource_element
         end
 
         def build
@@ -83,7 +84,7 @@ module Cocina
 
         private
 
-        attr_reader :ng_xml
+        attr_reader :resource_element
 
         def build_contributor_hash(name)
           { name: self.class.name_parts(name) }.tap do |contributor_hash|
@@ -138,7 +139,7 @@ module Cocina
         end
 
         def names
-          @names ||= ng_xml.xpath(NAME_XPATH, mods: DESC_METADATA_NS)
+          @names ||= resource_element.xpath(NAME_XPATH, mods: DESC_METADATA_NS)
         end
 
         ROLE_XPATH = './mods:role'

--- a/app/services/cocina/from_fedora/descriptive/descriptive_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/descriptive_builder.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Cocina
+  module FromFedora
+    class Descriptive
+      # Creates Cocina Descriptive objects from MODS resource element.
+      class DescriptiveBuilder
+        BUILDERS = {
+          note: Notes,
+          language: Language,
+          contributor: Contributor,
+          event: Descriptive::Event,
+          subject: Subject,
+          form: Form,
+          identifier: Identifier,
+          adminMetadata: AdminMetadata,
+          relatedResource: RelatedResource,
+          geographic: Geographic
+        }.freeze
+
+        # @param [#build] title_builder
+        # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
+        # @return [Hash] a hash that can be mapped to a cocina descriptive model
+        # @raises [Cocina::Mapper::InvalidDescMetadata] if some assumption about descMetadata is violated
+        def self.build(resource_element:, title_builder: Titles)
+          new(title_builder: title_builder).build(resource_element: resource_element)
+        end
+
+        def initialize(title_builder: Titles)
+          @title_builder = title_builder
+        end
+
+        def build(resource_element:, require_title: true)
+          cocina_description = {}
+          title_result = @title_builder.build(resource_element: resource_element, require_title: require_title)
+          cocina_description[:title] = title_result if title_result.present?
+
+          BUILDERS.each do |descriptive_property, builder|
+            result = builder.build(resource_element: resource_element, descriptive_builder: self)
+            cocina_description.merge!(descriptive_property => result) if result.present?
+          end
+          cocina_description
+        end
+      end
+    end
+  end
+end

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -6,16 +6,17 @@ module Cocina
       # Maps originInfo to cocina events
       # rubocop:disable Metrics/ClassLength
       class Event
-        ORIGININFO_XPATH = '/mods:mods/mods:originInfo'
+        ORIGININFO_XPATH = 'mods:originInfo'
 
-        # @param [Nokogiri::XML::Document] ng_xml the descriptive metadata XML
+        # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
+        # @param [Cocina::FromFedora::Descriptive::DescriptiveBuilder] descriptive_builder
         # @return [Hash] a hash that can be mapped to a cocina model
-        def self.build(ng_xml)
-          new(ng_xml).build
+        def self.build(resource_element:, descriptive_builder: nil)
+          new(resource_element: resource_element).build
         end
 
-        def initialize(ng_xml)
-          @ng_xml = ng_xml
+        def initialize(resource_element:)
+          @resource_element = resource_element
         end
 
         def build
@@ -44,7 +45,7 @@ module Cocina
 
         private
 
-        attr_reader :ng_xml
+        attr_reader :resource_element
 
         def find_or_create_publication_event(events)
           publication_event = events.find { |e| e[:type] == 'publication' }
@@ -191,7 +192,7 @@ module Cocina
         end
 
         def origin_info
-          @origin_info ||= ng_xml.xpath(ORIGININFO_XPATH, mods: DESC_METADATA_NS)
+          @origin_info ||= resource_element.xpath(ORIGININFO_XPATH, mods: DESC_METADATA_NS)
         end
       end
       # rubocop:enable Metrics/ClassLength

--- a/app/services/cocina/from_fedora/descriptive/form.rb
+++ b/app/services/cocina/from_fedora/descriptive/form.rb
@@ -9,14 +9,15 @@ module Cocina
         # NOTE: H2 is the first case of structured form (genre/typeOfResource) values we're implementing
         H2_GENRE_TYPE_PREFIX = 'H2 '
 
-        # @param [Nokogiri::XML::Document] ng_xml the descriptive metadata XML
+        # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
+        # @param [Cocina::FromFedora::Descriptive::DescriptiveBuilder] descriptive_builder
         # @return [Hash] a hash that can be mapped to a cocina model
-        def self.build(ng_xml)
-          new(ng_xml).build
+        def self.build(resource_element:, descriptive_builder: nil)
+          new(resource_element: resource_element).build
         end
 
-        def initialize(ng_xml)
-          @ng_xml = ng_xml
+        def initialize(resource_element:)
+          @resource_element = resource_element
         end
 
         def build
@@ -30,7 +31,7 @@ module Cocina
 
         private
 
-        attr_reader :ng_xml
+        attr_reader :resource_element
 
         def add_subject_cartographics(forms)
           cartographic_scale.each do |scale|
@@ -166,7 +167,7 @@ module Cocina
         end
 
         def physical_descriptions
-          ng_xml.xpath('//mods:mods/mods:physicalDescription', mods: DESC_METADATA_NS)
+          resource_element.xpath('mods:physicalDescription', mods: DESC_METADATA_NS)
         end
 
         def source_for(form)
@@ -174,25 +175,25 @@ module Cocina
         end
 
         def type_of_resource
-          ng_xml.xpath('//mods:typeOfResource', mods: DESC_METADATA_NS)
+          resource_element.xpath('mods:typeOfResource', mods: DESC_METADATA_NS)
         end
 
         # returns genre at the root and inside subjects excluding structured genres
         def basic_genre
-          ng_xml.xpath("//mods:mods/mods:genre[not(@type) or not(starts-with(@type, '#{H2_GENRE_TYPE_PREFIX}'))]", mods: DESC_METADATA_NS)
+          resource_element.xpath("mods:genre[not(@type) or not(starts-with(@type, '#{H2_GENRE_TYPE_PREFIX}'))]", mods: DESC_METADATA_NS)
         end
 
         # returns structured genres at the root and inside subjects, which are combined to form a single, structured Cocina element
         def structured_genre
-          ng_xml.xpath("//mods:mods/mods:genre[@type and starts-with(@type, '#{H2_GENRE_TYPE_PREFIX}')]", mods: DESC_METADATA_NS)
+          resource_element.xpath("mods:genre[@type and starts-with(@type, '#{H2_GENRE_TYPE_PREFIX}')]", mods: DESC_METADATA_NS)
         end
 
         def cartographic_scale
-          ng_xml.xpath('//mods:subject/mods:cartographics/mods:scale', mods: DESC_METADATA_NS)
+          resource_element.xpath('mods:subject/mods:cartographics/mods:scale', mods: DESC_METADATA_NS)
         end
 
         def cartographic_projection
-          ng_xml.xpath('//mods:subject/mods:cartographics/mods:projection', mods: DESC_METADATA_NS)
+          resource_element.xpath('mods:subject/mods:cartographics/mods:projection', mods: DESC_METADATA_NS)
         end
       end
       # rubocop:enable Metrics/ClassLength

--- a/app/services/cocina/from_fedora/descriptive/geographic.rb
+++ b/app/services/cocina/from_fedora/descriptive/geographic.rb
@@ -38,14 +38,15 @@ module Cocina
         POINT_COORDS = 'point coordinates'
         TYPE = 'type'
 
-        # @param [Nokogiri::XML::Document] ng_xml the descriptive metadata XML
+        # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
+        # @param [Cocina::FromFedora::Descriptive::DescriptiveBuilder] descriptive_builder
         # @return [Hash] a hash that can be mapped to a cocina model
-        def self.build(ng_xml)
-          new(ng_xml).build
+        def self.build(resource_element:, descriptive_builder: nil)
+          new(resource_element: resource_element).build
         end
 
-        def initialize(ng_xml)
-          @ng_xml = ng_xml
+        def initialize(resource_element:)
+          @resource_element = resource_element
         end
 
         def build
@@ -59,7 +60,7 @@ module Cocina
 
         private
 
-        attr_reader :ng_xml
+        attr_reader :resource_element
 
         def build_form
           return unless format
@@ -123,7 +124,7 @@ module Cocina
         end
 
         def description
-          @description ||= ng_xml.xpath('//mods:mods/mods:extension/rdf:RDF/rdf:Description', NAMESPACE).first
+          @description ||= resource_element.xpath('mods:extension/rdf:RDF/rdf:Description', NAMESPACE).first
         end
 
         def centerpoint

--- a/app/services/cocina/from_fedora/descriptive/hydrus_default_title_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/hydrus_default_title_builder.rb
@@ -5,10 +5,10 @@ module Cocina
     class Descriptive
       # Maps titles
       class HydrusDefaultTitleBuilder
-        # @param [Nokogiri::XML::Document] _ng_xml the descriptive metadata XML
-        # @return [Array] a hash that can be mapped to a cocina model
-        # @raises [Mapper::MissingTitle]
-        def self.build(_ng_xml)
+        # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
+        # @param [boolean] require_title raise Cocina::Mapper::MissingTitle if true and title is missing.
+        # @return [Hash] a hash that can be mapped to a cocina model
+        def self.build(resource_element:, require_title: nil)
           [{ value: 'Hydrus' }]
         end
       end

--- a/app/services/cocina/from_fedora/descriptive/identifier.rb
+++ b/app/services/cocina/from_fedora/descriptive/identifier.rb
@@ -5,14 +5,15 @@ module Cocina
     class Descriptive
       # Maps MODS identifer to cocina identifier
       class Identifier
-        # @param [Nokogiri::XML::Document] ng_xml the descriptive metadata XML
+        # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
+        # @param [Cocina::FromFedora::Descriptive::DescriptiveBuilder] descriptive_builder
         # @return [Hash] a hash that can be mapped to a cocina model
-        def self.build(ng_xml)
-          new(ng_xml).build
+        def self.build(resource_element:, descriptive_builder: nil)
+          new(resource_element: resource_element).build
         end
 
-        def initialize(ng_xml)
-          @ng_xml = ng_xml
+        def initialize(resource_element:)
+          @resource_element = resource_element
         end
 
         def build
@@ -26,10 +27,10 @@ module Cocina
 
         private
 
-        attr_reader :ng_xml
+        attr_reader :resource_element
 
         def identifiers
-          ng_xml.xpath('//mods:mods/mods:identifier', mods: DESC_METADATA_NS)
+          resource_element.xpath('mods:identifier', mods: DESC_METADATA_NS)
         end
       end
     end

--- a/app/services/cocina/from_fedora/descriptive/language.rb
+++ b/app/services/cocina/from_fedora/descriptive/language.rb
@@ -5,12 +5,12 @@ module Cocina
     class Descriptive
       # Maps languages
       class Language
-        LANG_XPATH = '//mods:language'
+        LANG_XPATH = 'mods:language'
         LANG_STATUS_XPATH = './@status'
         OBJECT_PART_XPATH = './@objectPart'
         DISPLAY_LABEL_XPATH = './@displayLabel'
-        LANGUAGE_TERM_XPATH = "#{LANG_XPATH}/mods:languageTerm"
-        SCRIPT_TERM_XPATH = "#{LANG_XPATH}/mods:scriptTerm"
+        LANGUAGE_TERM_XPATH = 'mods:languageTerm'
+        SCRIPT_TERM_XPATH = 'mods:scriptTerm'
         LANG_TERM_TEXT_XPATH = './mods:languageTerm[@type="text"]/text()'
         LANG_TERM_CODE_XPATH = './mods:languageTerm[@type="code"]/text()'
         LANG_TERM_CODE_AUTHORITY_XPATH = './mods:languageTerm[@type="code"]/@authority'
@@ -18,14 +18,15 @@ module Cocina
         TEXT_AUTHORITY_URI_XPATH = './*[@type="text"]/@authorityURI' # can be for languageTerm or scriptTerm
         TEXT_VALUE_URI_XPATH = './*[@type="text"]/@valueURI' # can be for languageTerm or scriptTerm
 
-        # @param [Nokogiri::XML::Document] ng_xml the descriptive metadata XML
+        # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
+        # @param [Cocina::FromFedora::Descriptive::DescriptiveBuilder] descriptive_builder
         # @return [Hash] a hash that can be mapped to a cocina model
-        def self.build(ng_xml)
-          new(ng_xml).build
+        def self.build(resource_element:, descriptive_builder: nil)
+          new(resource_element: resource_element).build
         end
 
-        def initialize(ng_xml)
-          @ng_xml = ng_xml
+        def initialize(resource_element:)
+          @resource_element = resource_element
         end
 
         def build
@@ -35,7 +36,6 @@ module Cocina
               attribs = lang_term_attributes_for(lang) if language_term?(lang)
               attribs[:status] = language_status_for(lang) if language_status_for(lang).present?
               attribs[:script] = script_term_attributes_for(script_term_nodes(lang)) if script_term?(lang)
-
               langs << attribs
             end
           end
@@ -43,7 +43,7 @@ module Cocina
 
         private
 
-        attr_reader :ng_xml
+        attr_reader :resource_element
 
         def lang_term_attributes_for(lang)
           {
@@ -74,7 +74,7 @@ module Cocina
         end
 
         def languages
-          @languages ||= ng_xml.xpath(LANG_XPATH, mods: DESC_METADATA_NS)
+          @languages ||= resource_element.xpath(LANG_XPATH, mods: DESC_METADATA_NS)
         end
 
         def language_code_for(lang)

--- a/app/services/cocina/from_fedora/descriptive/notes.rb
+++ b/app/services/cocina/from_fedora/descriptive/notes.rb
@@ -5,14 +5,15 @@ module Cocina
     class Descriptive
       # Maps notes
       class Notes
-        # @param [Nokogiri::XML::Document] ng_xml the descriptive metadata XML
+        # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
+        # @param [Cocina::FromFedora::Descriptive::DescriptiveBuilder] descriptive_builder
         # @return [Hash] a hash that can be mapped to a cocina model
-        def self.build(ng_xml)
-          new(ng_xml).build
+        def self.build(resource_element:, descriptive_builder: nil)
+          new(resource_element: resource_element).build
         end
 
-        def initialize(ng_xml)
-          @ng_xml = ng_xml
+        def initialize(resource_element:)
+          @resource_element = resource_element
         end
 
         def build
@@ -21,10 +22,10 @@ module Cocina
 
         private
 
-        attr_reader :ng_xml
+        attr_reader :resource_element
 
         def abstract
-          set = ng_xml.xpath('//mods:abstract', mods: DESC_METADATA_NS)
+          set = resource_element.xpath('mods:abstract', mods: DESC_METADATA_NS)
           set.map do |node|
             { type: 'summary', value: node.content }.tap do |attributes|
               attributes[:displayLabel] = node[:displayLabel] if node[:displayLabel]
@@ -33,7 +34,7 @@ module Cocina
         end
 
         def notes
-          set = ng_xml.xpath('//mods:note', mods: DESC_METADATA_NS).select { |node| node.text.present? }
+          set = resource_element.xpath('mods:note', mods: DESC_METADATA_NS).select { |node| node.text.present? }
           set.map do |node|
             { value: node.text }.tap do |attributes|
               attributes[:type] = node[:type] if node[:type]

--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -15,14 +15,15 @@ module Cocina
           'topic' => 'topic'
         }.freeze
 
-        # @param [Nokogiri::XML::Document] ng_xml the descriptive metadata XML
+        # @param [Nokogiri::XML::Element] resource_element mods or relatedItem element
+        # @param [Cocina::FromFedora::Descriptive::DescriptiveBuilder] descriptive_builder
         # @return [Hash] a hash that can be mapped to a cocina model
-        def self.build(ng_xml)
-          new(ng_xml).build
+        def self.build(resource_element:, descriptive_builder: nil)
+          new(resource_element: resource_element).build
         end
 
-        def initialize(ng_xml)
-          @ng_xml = ng_xml
+        def initialize(resource_element:)
+          @resource_element = resource_element
         end
 
         def build
@@ -43,7 +44,7 @@ module Cocina
 
         private
 
-        attr_reader :ng_xml
+        attr_reader :resource_element
 
         def check_valid_authority(subject)
           return unless subject['authority'] == '#N/A'
@@ -153,7 +154,7 @@ module Cocina
         end
 
         def subjects
-          ng_xml.xpath('//mods:subject', mods: DESC_METADATA_NS) + ng_xml.xpath('//mods:classification', mods: DESC_METADATA_NS)
+          resource_element.xpath('mods:subject', mods: DESC_METADATA_NS) + resource_element.xpath('mods:classification', mods: DESC_METADATA_NS)
         end
 
         def edition_for(subject)

--- a/spec/services/cocina/from_fedora/descriptive/admin_metadata_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/admin_metadata_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::FromFedora::Descriptive::AdminMetadata do
-  subject(:build) { described_class.build(ng_xml) }
+  subject(:build) { described_class.build(resource_element: ng_xml.root) }
 
   let(:ng_xml) do
     Nokogiri::XML <<~XML

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
-  subject(:build) { described_class.build(ng_xml) }
+  subject(:build) { described_class.build(resource_element: ng_xml.root) }
 
   let(:ng_xml) do
     Nokogiri::XML <<~XML

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::FromFedora::Descriptive::Event do
-  subject(:build) { described_class.build(ng_xml) }
+  subject(:build) { described_class.build(resource_element: ng_xml.root) }
 
   let(:ng_xml) do
     Nokogiri::XML <<~XML

--- a/spec/services/cocina/from_fedora/descriptive/form_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/form_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::FromFedora::Descriptive::Form do
-  subject(:build) { described_class.build(ng_xml) }
+  subject(:build) { described_class.build(resource_element: ng_xml.root) }
 
   let(:ng_xml) do
     Nokogiri::XML <<~XML
@@ -247,13 +247,10 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
     context 'with text / article' do
       let(:xml) do
         <<~XML
-          <?xml version="1.0"?>
-          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-            <genre type="H2 type">Text</genre>
-            <genre type="H2 subtype">Article</genre>
-            <genre valueURI="http://vocab.getty.edu/aat/300048715" authority="aat">articles</genre>
-            <typeOfResource>text</typeOfResource>
-          </mods>
+          <genre type="H2 type">Text</genre>
+          <genre type="H2 subtype">Article</genre>
+          <genre valueURI="http://vocab.getty.edu/aat/300048715" authority="aat">articles</genre>
+          <typeOfResource>text</typeOfResource>
         XML
       end
 
@@ -297,13 +294,10 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
     context 'with text / essay' do
       let(:xml) do
         <<~XML
-          <?xml version="1.0"?>
-          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-            <genre type="H2 type">Text</genre>
-            <genre type="H2 subtype">Essay</genre>
-            <genre valueURI="http://id.loc.gov/authorities/genreForms/gf2014026094" authority="lcgft">Essays</genre>
-            <typeOfResource>text</typeOfResource>
-          </mods>
+          <genre type="H2 type">Text</genre>
+          <genre type="H2 subtype">Essay</genre>
+          <genre valueURI="http://id.loc.gov/authorities/genreForms/gf2014026094" authority="lcgft">Essays</genre>
+          <typeOfResource>text</typeOfResource>
         XML
       end
 
@@ -347,13 +341,10 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
     context 'with data / 3d model' do
       let(:xml) do
         <<~XML
-          <?xml version="1.0"?>
-          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-            <genre type="H2 type">Data</genre>
-            <genre type="H2 subtype">3D model</genre>
-            <genre>Three dimensional scan</genre>
-            <typeOfResource>three dimensional object</typeOfResource>
-          </mods>
+          <genre type="H2 type">Data</genre>
+          <genre type="H2 subtype">3D model</genre>
+          <genre>Three dimensional scan</genre>
+          <typeOfResource>three dimensional object</typeOfResource>
         XML
       end
 
@@ -393,14 +384,12 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
     context 'with data / GIS' do
       let(:xml) do
         <<~XML
-          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-            <genre type="H2 type">Data</genre>
-            <genre type="H2 subtype">GIS</genre>
-            <genre authority="lcgft" valueURI="http://id.loc.gov/authorities/genreForms/gf2011026294">Geographic information systems</genre>
-            <genre>dataset</genre>
-            <typeOfResource>cartographic</typeOfResource>
-            <typeOfResource>software, multimedia</typeOfResource>
-          </mods>
+          <genre type="H2 type">Data</genre>
+          <genre type="H2 subtype">GIS</genre>
+          <genre authority="lcgft" valueURI="http://id.loc.gov/authorities/genreForms/gf2011026294">Geographic information systems</genre>
+          <genre>dataset</genre>
+          <typeOfResource>cartographic</typeOfResource>
+          <typeOfResource>software, multimedia</typeOfResource>
         XML
       end
 
@@ -455,16 +444,13 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
     context 'with software / code, documentation' do
       let(:xml) do
         <<~XML
-          <?xml version="1.0"?>
-          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-            <genre type="H2 type">Software</genre>
-            <genre type="H2 subtype">Code</genre>
-            <genre type="H2 subtype">Documentation</genre>
-            <genre authority="aat" valueURI="http://vocab.getty.edu/aat/300312188">programs (computer)</genre>
-            <genre authority="aat" valueURI="http://vocab.getty.edu/aat/300026413">technical manuals</genre>
-            <typeOfResource>software, multimedia</typeOfResource>
-            <typeOfResource>text</typeOfResource>
-          </mods>
+          <genre type="H2 type">Software</genre>
+          <genre type="H2 subtype">Code</genre>
+          <genre type="H2 subtype">Documentation</genre>
+          <genre authority="aat" valueURI="http://vocab.getty.edu/aat/300312188">programs (computer)</genre>
+          <genre authority="aat" valueURI="http://vocab.getty.edu/aat/300026413">technical manuals</genre>
+          <typeOfResource>software, multimedia</typeOfResource>
+          <typeOfResource>text</typeOfResource>
         XML
       end
 
@@ -528,11 +514,8 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
     context 'with other / dance notation' do
       let(:xml) do
         <<~XML
-          <?xml version="1.0"?>
-          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-            <genre type="H2 type">Other</genre>
-            <genre type="H2 subtype">Dance notation</genre>
-          </mods>
+          <genre type="H2 type">Other</genre>
+          <genre type="H2 subtype">Dance notation</genre>
         XML
       end
 

--- a/spec/services/cocina/from_fedora/descriptive/geographic_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/geographic_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
-  subject(:build) { described_class.build(ng_xml) }
+  subject(:build) { described_class.build(resource_element: ng_xml.root) }
 
   let(:ng_xml) do
     Nokogiri::XML <<~XML

--- a/spec/services/cocina/from_fedora/descriptive/identifier_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/identifier_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::FromFedora::Descriptive::Identifier do
-  subject(:build) { described_class.build(ng_xml) }
+  subject(:build) { described_class.build(resource_element: ng_xml.root) }
 
   let(:ng_xml) do
     Nokogiri::XML <<~XML

--- a/spec/services/cocina/from_fedora/descriptive/language_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/language_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::FromFedora::Descriptive::Language do
-  subject(:build) { described_class.build(ng_xml) }
+  subject(:build) { described_class.build(resource_element: ng_xml.root) }
 
   let(:ng_xml) do
     Nokogiri::XML <<~XML

--- a/spec/services/cocina/from_fedora/descriptive/notes_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/notes_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::FromFedora::Descriptive::Notes do
-  subject(:build) { described_class.build(ng_xml) }
+  subject(:build) { described_class.build(resource_element: ng_xml.root) }
 
   let(:ng_xml) do
     Nokogiri::XML <<~XML

--- a/spec/services/cocina/from_fedora/descriptive/related_resource_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/related_resource_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::FromFedora::Descriptive::RelatedResource do
-  subject(:build) { described_class.build(ng_xml) }
+  subject(:build) { described_class.build(resource_element: ng_xml.root, descriptive_builder: descriptive_builder) }
+
+  let(:descriptive_builder) { Cocina::FromFedora::Descriptive::DescriptiveBuilder.new }
 
   let(:ng_xml) do
     Nokogiri::XML <<~XML
@@ -164,18 +166,30 @@ RSpec.describe Cocina::FromFedora::Descriptive::RelatedResource do
       XML
     end
 
-    xit 'TODO: Justin is in discussion with Arcadia about how this should look.'
-    # https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_relatedItem.txt#L52-L66
-    # appears to be incorrect
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "title": [
+            {
+              "value": 'Supplement'
+            }
+          ],
+          "note": [
+            {
+              "value": 'Additional data.',
+              "type": 'summary'
+            }
+          ]
+        }
+      ]
+    end
   end
 
   context 'without title' do
     let(:xml) do
       <<~XML
         <relatedItem>
-          <location>
-            <url>https://www.example.com</url>
-          </location>
+          <abstract>Additional data.</abstract>
         </relatedItem>
       XML
     end
@@ -183,13 +197,12 @@ RSpec.describe Cocina::FromFedora::Descriptive::RelatedResource do
     it 'builds the cocina data structure' do
       expect(build).to eq [
         {
-          "access": {
-            "url": [
-              {
-                "value": 'https://www.example.com'
-              }
-            ]
-          }
+          "note": [
+            {
+              "value": 'Additional data.',
+              "type": 'summary'
+            }
+          ]
         }
       ]
     end

--- a/spec/services/cocina/from_fedora/descriptive/subject_classification_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_classification_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::FromFedora::Descriptive::Subject do
-  subject(:build) { described_class.build(ng_xml) }
+  subject(:build) { described_class.build(resource_element: ng_xml.root) }
 
   let(:ng_xml) do
     Nokogiri::XML <<~XML

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::FromFedora::Descriptive::Subject do
-  subject(:build) { described_class.build(ng_xml) }
+  subject(:build) { described_class.build(resource_element: ng_xml.root) }
 
   let(:ng_xml) do
     Nokogiri::XML <<~XML

--- a/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
@@ -6,13 +6,25 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
   let(:object) { Dor::Item.new }
 
   describe '.build' do
-    subject(:build) { described_class.build(ng_xml) }
+    subject(:build) { described_class.build(resource_element: ng_xml.root, require_title: require_title) }
+
+    let(:require_title) { true }
 
     context 'when the object has no title' do
       let(:ng_xml) { Dor::Item.new.descMetadata.ng_xml }
 
       it 'raises and error' do
         expect { build }.to raise_error Cocina::Mapper::MissingTitle
+      end
+    end
+
+    context 'when the object has no title and not required' do
+      let(:ng_xml) { Dor::Item.new.descMetadata.ng_xml }
+
+      let(:require_title) { false }
+
+      it 'raises and error' do
+        expect(build).to eq([])
       end
     end
 


### PR DESCRIPTION
refs #1403, #1404

## Why was this change made?
`mods:relatedItems` can contain all of the same elements as `mods:mods`. This changes the mapping so that use the same builders for both.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


