### PR TITLE
Omit some builders not allowed for related resources.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/descriptive_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/descriptive_builder.rb
@@ -30,12 +30,16 @@ module Cocina
           @title_builder = title_builder
         end
 
-        def build(resource_element:, require_title: true)
+        def build(resource_element:, require_title: true, omit_builders: [])
           cocina_description = {}
           title_result = @title_builder.build(resource_element: resource_element, require_title: require_title)
           cocina_description[:title] = title_result if title_result.present?
 
           BUILDERS.each do |descriptive_property, builder|
+            # This is a temporary fix pending https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/138
+            # and https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/162
+            next if omit_builders.include?(descriptive_property)
+
             result = builder.build(resource_element: resource_element, descriptive_builder: self)
             cocina_description.merge!(descriptive_property => result) if result.present?
           end

--- a/app/services/cocina/from_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/from_fedora/descriptive/related_resource.rb
@@ -21,7 +21,7 @@ module Cocina
 
         def build
           related_items.map do |related_item|
-            descriptive_builder.build(resource_element: related_item, require_title: false).tap do |item|
+            descriptive_builder.build(resource_element: related_item, require_title: false, omit_builders: [:adminMetadata, :relatedResource]).tap do |item|
               item[:type] = normalized_type_for(related_item['type']) if related_item['type']
               item[:displayLabel] = related_item['displayLabel']
             end.compact


### PR DESCRIPTION
## Why was this change made?
Some attributes are not allowed for related resources (adminMetadata and relatedResource). However, some MODS has data that should map to those attributes, which was causing errors.

This omits building those attributes until the appropriate mapping can be determined / changes made to cocina.


## How was this change tested?
Locally


## Which documentation and/or configurations were updated?
NA


