### PR TITLE
more H2 contrib mappings

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -6,12 +6,12 @@ module Cocina
     class Descriptive
       # Maps contributors
       class Contributor
+        # key: MODS, value: cocina
         ROLES = {
           'personal' => 'person',
           'corporate' => 'organization',
           'family' => 'family',
-          'conference' => 'conference',
-          'event' => 'event'
+          'conference' => 'conference'
         }.freeze
 
         NAME_PART = {
@@ -171,9 +171,8 @@ module Cocina
           authority = ng_role.xpath(ROLE_AUTHORITY_XPATH, mods: DESC_METADATA_NS).first
           authority_uri = ng_role.xpath(ROLE_AUTHORITY_URI_XPATH, mods: DESC_METADATA_NS).first
           authority_value = ng_role.xpath(ROLE_AUTHORITY_VALUE_XPATH, mods: DESC_METADATA_NS).first
-          marcrelator = marc_relator_role?(authority, authority_uri, authority_value)
 
-          check_code(code, authority)
+          check_role_code(code, authority)
 
           {}.tap do |role|
             if authority&.content.present?
@@ -187,6 +186,7 @@ module Cocina
 
             role[:uri] = authority_value&.content
             role[:code] = code&.content
+            marcrelator = marc_relator_role?(authority, authority_uri, authority_value)
             role[:value] = normalized_role_value(text.content, marcrelator) if text
 
             if role[:code].blank? && role[:value].blank?
@@ -209,7 +209,7 @@ module Cocina
           ROLES.fetch(type.downcase)
         end
 
-        def check_code(role_code, role_authority)
+        def check_role_code(role_code, role_authority)
           return if role_code.nil? || role_authority
 
           if role_code.content.present? && role_code.content.size == 3

--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -217,7 +217,7 @@ module Cocina
             return
           end
 
-          raise Cocina::Mapper::InvalidDescMetadata, "Contributor role code is missing and has unexpected value: #{role_code.content}"
+          raise Cocina::Mapper::InvalidDescMetadata, "Contributor role code has unexpected value: #{role_code.content}"
         end
 
         # ensure value is downcased if it's a marcrelator value

--- a/app/services/cocina/to_fedora/descriptive/form.rb
+++ b/app/services/cocina/to_fedora/descriptive/form.rb
@@ -69,6 +69,7 @@ module Cocina
         end
 
         def write_basic(form)
+          return nil if form.source&.value&.match?(/DataCite/i)
           return note(form) if form.note
 
           attributes = {}

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe 'Get the object' do
 
       let(:expected) do
         {
-          errors: [{ detail: 'Contributor role code is missing and has unexpected value: isbx', status: '422', title: 'Invalid descMetadata' }]
+          errors: [{ detail: 'Contributor role code has unexpected value: isbx', status: '422', title: 'Invalid descMetadata' }]
         }
       end
 

--- a/spec/services/cocina/from_fedora/descriptive/contributor_h2_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_h2_spec.rb
@@ -1,0 +1,558 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
+  # h2 mapping specification examples
+  # from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_contributor.txt
+  subject(:build) { described_class.build(ng_xml) }
+
+  let(:ng_xml) do
+    Nokogiri::XML <<~XML
+      <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.loc.gov/mods/v3" version="3.6"
+        xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        #{xml}
+      </mods>
+    XML
+  end
+  let(:marc_relator_source) do
+    {
+      code: 'marcrelator',
+      uri: 'http://id.loc.gov/vocabulary/relators/'
+    }
+  end
+  let(:author_roles) do
+    [
+      {
+        value: 'author',
+        code: 'aut',
+        uri: 'http://id.loc.gov/vocabulary/relators/aut',
+        source: marc_relator_source
+      }
+    ]
+  end
+  let(:sponsor_roles) do
+    [
+      {
+        value: 'sponsor',
+        code: 'spn',
+        uri: 'http://id.loc.gov/vocabulary/relators/spn',
+        source: marc_relator_source
+      }
+    ]
+  end
+  let(:publisher_roles) do
+    [
+      {
+        value: 'publisher',
+        code: 'pbl',
+        uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+        source: marc_relator_source
+      }
+    ]
+  end
+
+  # example 1 from h2_to_cocina_contributor.txt
+  context 'with person with single role' do
+    let(:xml) do
+      <<~XML
+        <name type="personal" usage="primary">
+          <namePart>Stanford, Jane</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/com">com</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/com">compiler</roleTerm>
+          </role>
+        </name>
+      XML
+    end
+
+    it 'builds the expected cocina data structure' do
+      expect(build).to eq [
+        {
+          name: [{ value: 'Stanford, Jane' }],
+          type: 'person',
+          status: 'primary',
+          role: [
+            {
+              value: 'compiler',
+              code: 'com',
+              uri: 'http://id.loc.gov/vocabulary/relators/com',
+              source: marc_relator_source
+            }
+          ]
+        }
+      ]
+    end
+  end
+
+  # example 2 from h2_to_cocina_contributor.txt
+  context 'with person with multiple roles, one maps to DataCite creator property' do
+    let(:xml) do
+      <<~XML
+        <name type="personal" usage="primary">
+          <namePart>Stanford, Jane</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/rth">rth</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/rth">research team head</roleTerm>
+          </role>
+        </name>
+      XML
+    end
+
+    it 'builds the expected cocina data structure' do
+      expect(build).to eq [
+        {
+          name: [{ value: 'Stanford, Jane' }],
+          type: 'person',
+          status: 'primary',
+          role: [
+            {
+              value: 'author',
+              code: 'aut',
+              uri: 'http://id.loc.gov/vocabulary/relators/aut',
+              source: marc_relator_source
+            },
+            {
+              value: 'research team head',
+              code: 'rth',
+              uri: 'http://id.loc.gov/vocabulary/relators/rth',
+              source: marc_relator_source
+            }
+          ]
+        }
+      ]
+    end
+  end
+
+  # example 3 from h2_to_cocina_contributor.txt
+  context 'with organization with single role' do
+    let(:xml) do
+      <<~XML
+        <name type="corporate" usage="primary">
+          <namePart>Stanford University</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/his">his</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/his">host institution</roleTerm>
+          </role>
+        </name>
+      XML
+    end
+
+    it 'builds the expected cocina data structure' do
+      expect(build).to eq [
+        {
+          name: [{ value: 'Stanford University' }],
+          type: 'organization',
+          status: 'primary',
+          role: [
+            {
+              value: 'host institution',
+              code: 'his',
+              uri: 'http://id.loc.gov/vocabulary/relators/his',
+              source: marc_relator_source
+            }
+          ]
+        }
+      ]
+    end
+  end
+
+  # example 4 from h2_to_cocina_contributor.txt
+  context 'with organization with multiple roles' do
+    let(:xml) do
+      <<~XML
+        <name type="corporate" usage="primary">
+          <namePart>Stanford University</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/spn">spn</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/spn">sponsor</roleTerm>
+          </role>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/isb">isb</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/isb">issuing body</roleTerm>
+          </role>
+        </name>
+      XML
+    end
+
+    it 'builds the expected cocina data structure' do
+      expect(build).to eq [
+        {
+          name: [{ value: 'Stanford University' }],
+          type: 'organization',
+          status: 'primary',
+          role: [
+            {
+              value: 'sponsor',
+              code: 'spn',
+              uri: 'http://id.loc.gov/vocabulary/relators/spn',
+              source: marc_relator_source
+            },
+            {
+              value: 'issuing body',
+              code: 'isb',
+              uri: 'http://id.loc.gov/vocabulary/relators/isb',
+              source: marc_relator_source
+            }
+          ]
+        }
+      ]
+    end
+  end
+
+  # example 5 from h2_to_cocina_contributor.txt
+  context 'with conference as contributor' do
+    let(:xml) do
+      <<~XML
+        <name type="conference" usage="primary">
+          <namePart>LDCX</namePart>
+        </name>
+      XML
+    end
+
+    it 'builds the expected cocina data structure' do
+      expect(build).to eq [
+        {
+          contributors: [
+            {
+              name: [{ value: 'LDCX' }],
+              type: 'conference',
+              status: 'primary'
+            }
+          ],
+          forms: [
+            {
+              value: 'Event',
+              type: 'resource types',
+              source: {
+                value: 'DataCite resource types'
+              }
+            }
+          ]
+        }
+      ]
+    end
+  end
+
+  # example 6 from h2_to_cocina_contributor.txt
+  context 'with event as contributor' do
+    let(:xml) do
+      <<~XML
+        <name type="corporate" usage="primary">
+          <namePart>San Francisco Symphony Concert</namePart>
+        </name>
+      XML
+    end
+
+    it 'builds the expected cocina data structure' do
+      expect(build).to eq [
+        {
+          name: [{ value: 'San Francisco Symphony Concert' }],
+          type: 'event',
+          status: 'primary'
+        }
+      ]
+    end
+  end
+
+  # example 7 from h2_to_cocina_contributor.txt
+  context 'with multiple person contributors' do
+    # TODO: implement order
+    let(:xml) do
+      <<~XML
+        <name type="personal" usage="primary">
+          <namePart>Stanford, Jane</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Stanford, Leland</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+      XML
+    end
+
+    it 'builds the expected cocina data structure' do
+      expect(build).to eq [
+        {
+          name: [{ value: 'Stanford, Jane' }],
+          type: 'person',
+          status: 'primary',
+          # order: 1,
+          role: author_roles
+        },
+        {
+          name: [{ value: 'Stanford, Leland' }],
+          type: 'person',
+          # order: 2,
+          role: author_roles
+        }
+      ]
+    end
+  end
+
+  # example 8 from h2_to_cocina_contributor.txt
+  context 'with multiple contributors - person and organization' do
+    let(:xml) do
+      <<~XML
+        <name type="personal" usage="primary">
+          <namePart>Stanford, Jane</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+        <name type="corporate">
+          <namePart>Stanford University</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/spn">spn</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/spn">sponsor</roleTerm>
+          </role>
+        </name>
+      XML
+    end
+
+    it 'builds the expected cocina data structure' do
+      expect(build).to eq [
+        {
+          name: [{ value: 'Stanford, Jane' }],
+          type: 'person',
+          status: 'primary',
+          role: author_roles
+        },
+        {
+          name: [{ value: 'Stanford University' }],
+          type: 'organization',
+          role: sponsor_roles
+        }
+      ]
+    end
+  end
+
+  # example 9 from h2_to_cocina_contributor.txt
+  context 'with multipe person contributors and organization as author' do
+    # TODO: implement order
+    let(:xml) do
+      <<~XML
+        <name type="personal" usage="primary">
+          <namePart>Stanford, Jane</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+        <name type="corporate">
+          <namePart>Stanford University</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Stanford, Leland</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+      XML
+    end
+
+    it 'builds the expected cocina data structure' do
+      expect(build).to eq [
+        {
+          name: [{ value: 'Stanford, Jane' }],
+          type: 'person',
+          status: 'primary',
+          # order: 1,
+          role: author_roles
+        },
+        {
+          name: [{ value: 'Stanford University' }],
+          type: 'organization',
+          # order: 2,
+          role: author_roles
+        },
+        {
+          name: [{ value: 'Stanford, Leland' }],
+          type: 'person',
+          # order: 3,
+          role: author_roles
+        }
+      ]
+    end
+  end
+
+  # example 10 from h2_to_cocina_contributor.txt
+  context 'with multipe person contributors and organization as non-author' do
+    # TODO: implement order
+    let(:xml) do
+      <<~XML
+        <name type="personal" usage="primary">
+          <namePart>Stanford, Jane</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+        <name type="corporate">
+          <namePart>Stanford University</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/spn">spn</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/spn">sponsor</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Stanford, Leland</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+      XML
+    end
+
+    it 'builds the expected cocina data structure' do
+      expect(build).to eq [
+        {
+          name: [{ value: 'Stanford, Jane' }],
+          type: 'person',
+          status: 'primary',
+          # order: 1,
+          role: author_roles
+        },
+        {
+          name: [{ value: 'Stanford University' }],
+          type: 'organization',
+          # order: 2,
+          role: sponsor_roles
+        },
+        {
+          name: [{ value: 'Stanford, Leland' }],
+          type: 'person',
+          # order: 3,
+          role: author_roles
+        }
+      ]
+    end
+  end
+
+  # example 11 from h2_to_cocina_contributor.txt
+  context 'with organization as funder' do
+    let(:xml) do
+      <<~XML
+        <name type="corporate" usage="primary">
+          <namePart>Stanford University</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/fnd">fnd</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/fnd">funder</roleTerm>
+          </role>
+        </name>
+      XML
+    end
+
+    it 'builds the expected cocina data structure' do
+      expect(build).to eq [
+        {
+          name: [{ value: 'Stanford University' }],
+          type: 'organization',
+          status: 'primary',
+          role: [
+            {
+              value: 'funder',
+              code: 'fnd',
+              uri: 'http://id.loc.gov/vocabulary/relators/fnd',
+              source: marc_relator_source
+            }
+          ]
+        }
+      ]
+    end
+  end
+
+  # example 12 from h2_to_cocina_contributor.txt
+  context 'with publisher and publication date entered by H2 user' do
+    let(:xml) do
+      <<~XML
+        <titleInfo>
+          <title>Foo</title>
+        </titleInfo>
+        <originInfo eventType="publication">
+          <publisher>Stanford University Press</publisher>
+          <dateIssued keyDate="yes" encoding="w3cdtf">2020-02-14</dateIssued>
+        </originInfo>
+      XML
+    end
+    let(:descriptive) { Cocina::FromFedora::Descriptive.props(mods: ng_xml) }
+
+    it 'builds the expected cocina data structure' do
+      # expect(descriptive[:events]).to match_array [
+
+      expect(descriptive).to eq(
+        {
+          title: [{ value: 'Foo' }],
+          event: [
+            {
+              type: 'publication',
+              contributor: [
+                {
+                  name: [{ value: 'Stanford University Press' }],
+                  type: 'organization',
+                  role: publisher_roles
+                }
+              ],
+              date: [{ encoding: { code: 'w3cdtf' }, value: '2020-02-14' }]
+            }
+          ]
+        }
+      )
+    end
+  end
+
+  # example 13 from h2_to_cocina_contributor.txt
+  context 'with publisher entered by user' do
+    let(:xml) do
+      <<~XML
+        <titleInfo>
+          <title>Foo</title>
+        </titleInfo>
+        <originInfo eventType="publication">
+          <publisher>Stanford University Press</publisher>
+        </originInfo>
+      XML
+    end
+    let(:descriptive) { Cocina::FromFedora::Descriptive.props(mods: ng_xml) }
+
+    it 'builds the expected cocina data structure' do
+      # expect(descriptive[:events]).to match_array [
+
+      expect(descriptive).to eq(
+        {
+          title: [{ value: 'Foo' }],
+          event: [
+            {
+              type: 'publication',
+              contributor: [
+                {
+                  name: [{ value: 'Stanford University Press' }],
+                  type: 'organization',
+                  role: publisher_roles
+                }
+              ]
+            }
+          ]
+        }
+      )
+    end
+  end
+end

--- a/spec/services/cocina/from_fedora/descriptive/contributor_h2_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_h2_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
   # h2 mapping specification examples
   # from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_contributor.txt
-  subject(:build) { described_class.build(ng_xml) }
+  subject(:build) { described_class.build(resource_element: ng_xml.root) }
 
   let(:ng_xml) do
     Nokogiri::XML <<~XML
@@ -218,28 +218,15 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     it 'builds the expected cocina data structure' do
       expect(build).to eq [
         {
-          contributors: [
-            {
-              name: [{ value: 'LDCX' }],
-              type: 'conference',
-              status: 'primary'
-            }
-          ],
-          forms: [
-            {
-              value: 'Event',
-              type: 'resource types',
-              source: {
-                value: 'DataCite resource types'
-              }
-            }
-          ]
+          name: [{ value: 'LDCX' }],
+          type: 'conference',
+          status: 'primary'
         }
       ]
     end
   end
 
-  # example 6 from h2_to_cocina_contributor.txt
+  # old example 6 from h2_to_cocina_contributor.txt
   context 'with event as contributor' do
     let(:xml) do
       <<~XML
@@ -253,8 +240,34 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
       expect(build).to eq [
         {
           name: [{ value: 'San Francisco Symphony Concert' }],
-          type: 'event',
+          type: 'organization',
           status: 'primary'
+        }
+      ]
+    end
+  end
+
+  # example 6 from h2_to_cocina_contributor.txt
+  context 'with event as contributor with role' do
+    let(:xml) do
+      <<~XML
+        <name type="corporate" usage="primary">
+          <namePart>San Francisco Symphony Concert</namePart>
+          <role>
+            <roleTerm type="text">Event</roleTerm>
+          </role>
+        </name>
+      XML
+    end
+
+    it 'builds the expected cocina data structure' do
+      # NOTE: from the DSA app, there is not enough context to make the cocina type "event" (?)
+      expect(build).to eq [
+        {
+          name: [{ value: 'San Francisco Symphony Concert' }],
+          type: 'organization',
+          status: 'primary',
+          role: [{ value: 'Event' }]
         }
       ]
     end

--- a/spec/services/cocina/from_fedora/descriptive/contributor_h2_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_h2_spec.rb
@@ -509,6 +509,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     let(:descriptive) { Cocina::FromFedora::Descriptive.props(mods: ng_xml) }
 
     it 'builds the expected cocina data structure' do
+      skip('TODO: changes to originInfo mappings for h2 coming shortly')
       # expect(descriptive[:events]).to match_array [
 
       expect(descriptive).to eq(

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -694,7 +694,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
       end
 
       it 'raises an error' do
-        expect { build }.to raise_error Cocina::Mapper::InvalidDescMetadata, 'Contributor role code is missing and has unexpected value: isbx'
+        expect { build }.to raise_error Cocina::Mapper::InvalidDescMetadata, 'Contributor role code has unexpected value: isbx'
       end
     end
 

--- a/spec/services/cocina/from_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive_spec.rb
@@ -302,42 +302,48 @@ RSpec.describe Cocina::FromFedora::Descriptive do
             value: 'Doe, John Sr.'
           }],
           type: 'person',
-          role: [{
-            value: 'degree supervisor',
-            code: 'ths',
-            source: {
-              code: 'marcrelator',
-              uri: 'http://id.loc.gov/vocabulary/relators/'
+          role: [
+            { value: 'degree supervisor' },
+            {
+              code: 'ths',
+              source: {
+                code: 'marcrelator',
+                uri: 'http://id.loc.gov/vocabulary/relators/'
+              }
             }
-          }]
+          ]
         },
         {
           name: [{
             value: 'Doe, Jane'
           }],
           type: 'person',
-          role: [{
-            value: 'degree committee member',
-            code: 'ths',
-            source: {
-              code: 'marcrelator',
-              uri: 'http://id.loc.gov/vocabulary/relators/'
+          role: [
+            { value: 'degree committee member' },
+            {
+              code: 'ths',
+              source: {
+                code: 'marcrelator',
+                uri: 'http://id.loc.gov/vocabulary/relators/'
+              }
             }
-          }]
+          ]
         },
         {
           name: [{
             value: 'Majors, Brad'
           }],
           type: 'person',
-          role: [{
-            value: 'degree committee member',
-            code: 'ths',
-            source: {
-              code: 'marcrelator',
-              uri: 'http://id.loc.gov/vocabulary/relators/'
+          role: [
+            { value: 'degree committee member' },
+            {
+              code: 'ths',
+              source: {
+                code: 'marcrelator',
+                uri: 'http://id.loc.gov/vocabulary/relators/'
+              }
             }
-          }]
+          ]
         },
         {
           name: [{

--- a/spec/services/cocina/to_fedora/descriptive/contributor_h2_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_h2_spec.rb
@@ -352,13 +352,13 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     let(:descriptive) { Cocina::Models::Description.new({ contributor: contributors, form: forms }, false, false) }
 
     it 'builds the expected xml' do
+      # NOTE: conference does NOT get a role because 'conference' is a MODS name type
       result_xml = Cocina::ToFedora::Descriptive.transform(descriptive, druid).to_xml
       expect(result_xml).to be_equivalent_to <<~XML
         #{mods_element_open}
         <name type="conference" usage="primary">
           <namePart>LDCX</namePart>
         </name>
-        <genre type="resource types">Event</genre>
         #{mods_element_close}
       XML
     end
@@ -396,13 +396,16 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     let(:descriptive) { Cocina::Models::Description.new({ contributor: contributors, form: forms }, false, false) }
 
     it 'builds the expected xml' do
+      # NOTE: event does get a role because 'event' is NOT a MODS name type
       result_xml = Cocina::ToFedora::Descriptive.transform(descriptive, druid).to_xml
       expect(result_xml).to be_equivalent_to <<~XML
         #{mods_element_open}
         <name type="corporate" usage="primary">
           <namePart>San Francisco Symphony Concert</namePart>
+          <role>
+            <roleTerm type="text">Event</roleTerm>
+          </role>
         </name>
-        <genre type="resource types">Event</genre>
         #{mods_element_close}
       XML
     end

--- a/spec/services/cocina/to_fedora/descriptive/contributor_h2_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_h2_spec.rb
@@ -700,6 +700,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     let(:descriptive) { Cocina::Models::Description.new({ event: events }, false, false) }
 
     it 'builds the expected xml' do
+      skip('TODO: changes to originInfo mappings for h2 coming shortly')
       result_xml = Cocina::ToFedora::Descriptive.transform(descriptive, druid).to_xml
       expect(result_xml).to be_equivalent_to <<~XML
         #{mods_element_open}
@@ -732,6 +733,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     let(:descriptive) { Cocina::Models::Description.new({ event: events }, false, false) }
 
     it 'builds the expected xml' do
+      skip('TODO: changes to originInfo mappings for h2 coming shortly')
       result_xml = Cocina::ToFedora::Descriptive.transform(descriptive, druid).to_xml
       expect(result_xml).to be_equivalent_to <<~XML
         #{mods_element_open}

--- a/spec/services/cocina/to_fedora/descriptive/contributor_h2_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_h2_spec.rb
@@ -1,0 +1,742 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
+  # h2 mapping specification examples
+  # from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_contributor.txt
+
+  subject(:xml) { writer.to_xml }
+
+  let(:writer) do
+    Nokogiri::XML::Builder.new do |xml|
+      xml.mods('xmlns' => 'http://www.loc.gov/mods/v3',
+               'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+               'version' => '3.6',
+               'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd') do
+        described_class.write(xml: xml, contributors: contributors)
+      end
+    end
+  end
+
+  let(:mods_element_open) do
+    <<~XML
+      <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.loc.gov/mods/v3" version="3.6"
+        xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+    XML
+  end
+  let(:mods_element_close) { '</mods>' }
+  let(:stanford_self_deposit_source) do
+    {
+      value: 'Stanford self-deposit contributor types'
+    }
+  end
+  let(:marc_relator_source) do
+    {
+      code: 'marcrelator',
+      uri: 'http://id.loc.gov/vocabulary/relators/'
+    }
+  end
+  let(:datacite_properties) do
+    {
+      value: 'DataCite properties'
+    }
+  end
+  let(:datacite_contributor_types) do
+    {
+      value: 'DataCite contributor types'
+    }
+  end
+  let(:datacite_creator_role) do
+    Cocina::Models::DescriptiveValue.new(
+      value: 'Creator',
+      source: { value: 'DataCite properties' }
+    )
+  end
+  let(:author_roles) do
+    [
+      {
+        value: 'Author',
+        source: stanford_self_deposit_source
+      },
+      {
+        value: 'author',
+        code: 'aut',
+        uri: 'http://id.loc.gov/vocabulary/relators/aut',
+        source: marc_relator_source
+      },
+      datacite_creator_role
+    ]
+  end
+  let(:sponsor_roles) do
+    [
+      {
+        value: 'Sponsor',
+        source: stanford_self_deposit_source
+      },
+      Cocina::Models::DescriptiveValue.new(
+        value: 'sponsor',
+        code: 'spn',
+        uri: 'http://id.loc.gov/vocabulary/relators/spn',
+        source: marc_relator_source
+      ),
+      Cocina::Models::DescriptiveValue.new(
+        value: 'Sponsor',
+        source: { value: 'DataCite contributor types' }
+      )
+    ]
+  end
+  let(:publisher_roles) do
+    [
+      {
+        value: 'Publisher',
+        source: stanford_self_deposit_source
+      },
+      {
+        value: 'publisher',
+        code: 'pbl',
+        uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+        source: marc_relator_source
+      }
+    ]
+  end
+
+  # example 1 from h2_to_cocina_contributor.txt
+  context 'with person with single role' do
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          name: [
+            {
+              value: 'Stanford, Jane',
+              type: 'inverted full name'
+            }
+          ],
+          type: 'person',
+          status: 'primary',
+          role: [
+            {
+              value: 'Data collector',
+              source: stanford_self_deposit_source
+            },
+            Cocina::Models::DescriptiveValue.new(
+              value: 'compiler',
+              code: 'com',
+              uri: 'http://id.loc.gov/vocabulary/relators/com',
+              source: marc_relator_source
+            ),
+            Cocina::Models::DescriptiveValue.new(
+              value: 'DataCollector',
+              source: datacite_contributor_types
+            )
+          ]
+        )
+      ]
+    end
+
+    it 'builds the expected xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        #{mods_element_open}
+          <name type="personal" usage="primary">
+            <namePart>Stanford, Jane</namePart>
+            <role>
+              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/com">com</roleTerm>
+              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/com">compiler</roleTerm>
+            </role>
+          </name>
+        #{mods_element_close}
+      XML
+    end
+  end
+
+  # example 2 from h2_to_cocina_contributor.txt
+  context 'with person with multiple roles, one maps to DataCite creator property' do
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          name: [
+            {
+              value: 'Stanford, Jane',
+              type: 'inverted full name'
+            }
+          ],
+          type: 'person',
+          status: 'primary',
+          role: [
+            {
+              value: 'Author',
+              source: stanford_self_deposit_source
+            },
+            {
+              value: 'Principal investigator',
+              source: stanford_self_deposit_source
+            },
+            Cocina::Models::DescriptiveValue.new(
+              value: 'author',
+              code: 'aut',
+              uri: 'http://id.loc.gov/vocabulary/relators/aut',
+              source: marc_relator_source
+            ),
+            Cocina::Models::DescriptiveValue.new(
+              value: 'research team head',
+              code: 'rth',
+              uri: 'http://id.loc.gov/vocabulary/relators/rth',
+              source: marc_relator_source
+            ),
+            Cocina::Models::DescriptiveValue.new(
+              value: 'Creator',
+              source: datacite_properties
+            ),
+            Cocina::Models::DescriptiveValue.new(
+              value: 'ProjectLeader',
+              source: datacite_contributor_types
+            )
+          ]
+        )
+      ]
+    end
+
+    it 'builds the expected xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        #{mods_element_open}
+        <name type="personal" usage="primary">
+          <namePart>Stanford, Jane</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/rth">rth</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/rth">research team head</roleTerm>
+          </role>
+        </name>
+        #{mods_element_close}
+      XML
+    end
+  end
+
+  # example 3 from h2_to_cocina_contributor.txt
+  context 'with organization with single role' do
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          name: [{ value: 'Stanford University' }],
+          type: 'organization',
+          status: 'primary',
+          role: [
+            {
+              value: 'Host institution',
+              source: stanford_self_deposit_source
+            },
+            Cocina::Models::DescriptiveValue.new(
+              value: 'host institution',
+              code: 'his',
+              uri: 'http://id.loc.gov/vocabulary/relators/his',
+              source: marc_relator_source
+            ),
+            Cocina::Models::DescriptiveValue.new(
+              value: 'HostingInstitution',
+              source: datacite_contributor_types
+            )
+          ]
+        )
+      ]
+    end
+
+    it 'builds the expected xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        #{mods_element_open}
+          <name type="corporate" usage="primary">
+            <namePart>Stanford University</namePart>
+            <role>
+              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/his">his</roleTerm>
+              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/his">host institution</roleTerm>
+            </role>
+          </name>
+        #{mods_element_close}
+      XML
+    end
+  end
+
+  # example 4 from h2_to_cocina_contributor.txt
+  context 'with organization with multiple roles' do
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          name: [{ value: 'Stanford University' }],
+          type: 'organization',
+          status: 'primary',
+          role: [
+            {
+              value: 'Sponsor',
+              source: stanford_self_deposit_source
+            },
+            Cocina::Models::DescriptiveValue.new(
+              value: 'sponsor',
+              code: 'spn',
+              uri: 'http://id.loc.gov/vocabulary/relators/spn',
+              source: marc_relator_source
+            ),
+            Cocina::Models::DescriptiveValue.new(
+              value: 'Sponsor',
+              source: datacite_contributor_types
+            ),
+            {
+              value: 'Issuing body',
+              source: stanford_self_deposit_source
+            },
+            Cocina::Models::DescriptiveValue.new(
+              value: 'issuing body',
+              code: 'isb',
+              uri: 'http://id.loc.gov/vocabulary/relators/isb',
+              source: marc_relator_source
+            ),
+            Cocina::Models::DescriptiveValue.new(
+              value: 'Distributor',
+              source: datacite_contributor_types
+            )
+          ]
+        )
+      ]
+    end
+
+    it 'builds the expected xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        #{mods_element_open}
+        <name type="corporate" usage="primary">
+          <namePart>Stanford University</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/spn">spn</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/spn">sponsor</roleTerm>
+          </role>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/isb">isb</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/isb">issuing body</roleTerm>
+          </role>
+        </name>
+        #{mods_element_close}
+      XML
+    end
+  end
+
+  # example 5 from h2_to_cocina_contributor.txt
+  context 'with conference as contributor' do
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          name: [{ value: 'LDCX' }],
+          type: 'conference',
+          status: 'primary',
+          role: [
+            {
+              value: 'Conference',
+              source: stanford_self_deposit_source
+            }
+          ]
+        )
+      ]
+    end
+    let(:forms) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          value: 'Event',
+          type: 'resource types',
+          source: {
+            value: 'DataCite resource types'
+          }
+        )
+      ]
+    end
+    let(:druid) { 'druid:oo111oo2222' }
+    let(:descriptive) { Cocina::Models::Description.new({ contributor: contributors, form: forms }, false, false) }
+
+    it 'builds the expected xml' do
+      result_xml = Cocina::ToFedora::Descriptive.transform(descriptive, druid).to_xml
+      expect(result_xml).to be_equivalent_to <<~XML
+        #{mods_element_open}
+        <name type="conference" usage="primary">
+          <namePart>LDCX</namePart>
+        </name>
+        <genre type="resource types">Event</genre>
+        #{mods_element_close}
+      XML
+    end
+  end
+
+  # example 6 from h2_to_cocina_contributor.txt
+  context 'with event as contributor' do
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          name: [{ value: 'San Francisco Symphony Concert' }],
+          type: 'event',
+          status: 'primary',
+          role: [
+            {
+              value: 'Event',
+              source: stanford_self_deposit_source
+            }
+          ]
+        )
+      ]
+    end
+    let(:forms) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          value: 'Event',
+          type: 'resource types',
+          source: {
+            value: 'DataCite resource types'
+          }
+        )
+      ]
+    end
+    let(:druid) { 'druid:oo111oo2222' }
+    let(:descriptive) { Cocina::Models::Description.new({ contributor: contributors, form: forms }, false, false) }
+
+    it 'builds the expected xml' do
+      result_xml = Cocina::ToFedora::Descriptive.transform(descriptive, druid).to_xml
+      expect(result_xml).to be_equivalent_to <<~XML
+        #{mods_element_open}
+        <name type="corporate" usage="primary">
+          <namePart>San Francisco Symphony Concert</namePart>
+        </name>
+        <genre type="resource types">Event</genre>
+        #{mods_element_close}
+      XML
+    end
+  end
+
+  # example 7 from h2_to_cocina_contributor.txt
+  context 'with multiple person contributors' do
+    # TODO: implement order
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          name: [
+            {
+              value: 'Stanford, Jane',
+              type: 'inverted full name'
+            }
+          ],
+          type: 'person',
+          status: 'primary',
+          # order: 1,
+          role: author_roles
+        ),
+        Cocina::Models::Contributor.new(
+          name: [
+            {
+              value: 'Stanford, Leland',
+              type: 'inverted full name'
+            }
+          ],
+          type: 'person',
+          # order: 2,
+          role: author_roles
+        )
+      ]
+    end
+
+    it 'builds the expected xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        #{mods_element_open}
+        <name type="personal" usage="primary">
+          <namePart>Stanford, Jane</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Stanford, Leland</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+        #{mods_element_close}
+      XML
+    end
+  end
+
+  # example 8 from h2_to_cocina_contributor.txt
+  context 'with multiple contributors - person and organization' do
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          name: [
+            {
+              value: 'Stanford, Jane',
+              type: 'inverted full name'
+            }
+          ],
+          type: 'person',
+          status: 'primary',
+          role: author_roles
+        ),
+        Cocina::Models::Contributor.new(
+          name: [{ value: 'Stanford University' }],
+          type: 'organization',
+          role: sponsor_roles
+        )
+      ]
+    end
+
+    it 'builds the expected xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        #{mods_element_open}
+        <name type="personal" usage="primary">
+          <namePart>Stanford, Jane</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+        <name type="corporate">
+          <namePart>Stanford University</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/spn">spn</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/spn">sponsor</roleTerm>
+          </role>
+        </name>
+        #{mods_element_close}
+      XML
+    end
+  end
+
+  # example 9 from h2_to_cocina_contributor.txt
+  context 'with multipe person contributors and organization as author' do
+    # TODO: implement order
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          name: [
+            {
+              value: 'Stanford, Jane',
+              type: 'inverted full name'
+            }
+          ],
+          type: 'person',
+          status: 'primary',
+          # order: 1,
+          role: author_roles
+        ),
+        Cocina::Models::Contributor.new(
+          name: [{ value: 'Stanford University' }],
+          type: 'organization',
+          # order: 2,
+          role: author_roles
+        ),
+        Cocina::Models::Contributor.new(
+          name: [
+            {
+              value: 'Stanford, Leland',
+              type: 'inverted full name'
+            }
+          ],
+          type: 'person',
+          # order: 3,
+          role: author_roles
+        )
+      ]
+    end
+
+    it 'builds the expected xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        #{mods_element_open}
+        <name type="personal" usage="primary">
+          <namePart>Stanford, Jane</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+        <name type="corporate">
+          <namePart>Stanford University</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Stanford, Leland</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+        #{mods_element_close}
+      XML
+    end
+  end
+
+  # example 10 from h2_to_cocina_contributor.txt
+  context 'with multipe person contributors and organization as non-author' do
+    # TODO: implement order
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          name: [
+            {
+              value: 'Stanford, Jane',
+              type: 'inverted full name'
+            }
+          ],
+          type: 'person',
+          status: 'primary',
+          # order: 1,
+          role: author_roles
+        ),
+        Cocina::Models::Contributor.new(
+          name: [{ value: 'Stanford University' }],
+          type: 'organization',
+          role: sponsor_roles
+        ),
+        Cocina::Models::Contributor.new(
+          name: [
+            {
+              value: 'Stanford, Leland',
+              type: 'inverted full name'
+            }
+          ],
+          type: 'person',
+          # order: 2,
+          role: author_roles
+        )
+      ]
+    end
+
+    it 'builds the expected xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        #{mods_element_open}
+        <name type="personal" usage="primary">
+          <namePart>Stanford, Jane</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+        <name type="corporate">
+          <namePart>Stanford University</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/spn">spn</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/spn">sponsor</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart>Stanford, Leland</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+        #{mods_element_close}
+      XML
+    end
+  end
+
+  # example 11 from h2_to_cocina_contributor.txt
+  context 'with organization as funder' do
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          name: [{ value: 'Stanford University' }],
+          type: 'organization',
+          status: 'primary',
+          role: [
+            {
+              value: 'Funder',
+              source: stanford_self_deposit_source
+            },
+            {
+              value: 'funder',
+              code: 'fnd',
+              uri: 'http://id.loc.gov/vocabulary/relators/fnd',
+              source: marc_relator_source
+            }
+          ]
+        )
+      ]
+    end
+
+    it 'builds the expected xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        #{mods_element_open}
+        <name type="corporate" usage="primary">
+          <namePart>Stanford University</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/fnd">fnd</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/fnd">funder</roleTerm>
+          </role>
+        </name>
+        #{mods_element_close}
+      XML
+    end
+  end
+
+  # example 12 from h2_to_cocina_contributor.txt
+  context 'with publisher and publication date entered by H2 user' do
+    let(:events) do
+      [
+        Cocina::Models::Event.new(
+          type: 'publication',
+          contributor: [
+            {
+              name: [{ value: 'Stanford University Press' }],
+              type: 'organization',
+              role: publisher_roles
+            }
+          ],
+          date: [{ encoding: { code: 'edtf' }, value: '2020-02-14' }]
+        )
+      ]
+    end
+    let(:druid) { 'druid:oo111oo2222' }
+    let(:descriptive) { Cocina::Models::Description.new({ event: events }, false, false) }
+
+    it 'builds the expected xml' do
+      result_xml = Cocina::ToFedora::Descriptive.transform(descriptive, druid).to_xml
+      expect(result_xml).to be_equivalent_to <<~XML
+        #{mods_element_open}
+        <originInfo eventType="publication">
+          <publisher>Stanford University Press</publisher>
+          <dateIssued keyDate="yes" encoding="w3cdtf">2020-02-14</dateIssued>
+        </originInfo>
+        #{mods_element_close}
+      XML
+    end
+  end
+
+  # example 13 from h2_to_cocina_contributor.txt
+  context 'with publisher entered by user' do
+    let(:events) do
+      [
+        Cocina::Models::Event.new(
+          type: 'publication',
+          contributor: [
+            {
+              name: [{ value: 'Stanford University Press' }],
+              type: 'organization',
+              role: publisher_roles
+            }
+          ]
+        )
+      ]
+    end
+    let(:druid) { 'druid:oo111oo2222' }
+    let(:descriptive) { Cocina::Models::Description.new({ event: events }, false, false) }
+
+    it 'builds the expected xml' do
+      result_xml = Cocina::ToFedora::Descriptive.transform(descriptive, druid).to_xml
+      expect(result_xml).to be_equivalent_to <<~XML
+        #{mods_element_open}
+        <originInfo eventType="publication">
+          <publisher>Stanford University Press</publisher>
+        </originInfo>
+        #{mods_element_close}
+      XML
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Part of #1375 - ensuring that all the mappings needed for contributors by h2 are coded here.

Mapping changes in this PR 
- Cocina contributor type `event` added but it is mapped to `corporate` in MODS, which already has a mapping to Cocina `organization` (in other words, it's not a reciprocal mapping)
- accommodates a cocina contributor having multiple roles.
- DataCite event data should not become a cocina `form`

There are 3 failing specs but I want to put those in a separate PR to avoid potential merging problems, as there is an open PR on `originInfo` mappings, which are implicated in these failing specs.

## How was this change tested?

I used https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/h2_cocina_mappings/h2_to_cocina_contributor.txt as my source for the two new spec files added;  I was glad for all the existing specs so I knew whether my changes were messing up anything else.

## Which documentation and/or configurations were updated?



