### PR TITLE
Adds from fedora mapping for languageOfCataloging usage attribute.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
+++ b/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
@@ -128,6 +128,8 @@ module Cocina
             script_term_source = { code: script_code_term['authority'] } if script_code_term['authority']
             language[:script] = { value: script_text_term.text, code: script_code_term.text, source: script_term_source }.compact
           end
+          language[:status] = language_of_cataloging[:usage]
+
           [language.compact]
         end
 

--- a/spec/services/cocina/from_fedora/descriptive/admin_metadata_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/admin_metadata_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::AdminMetadata do
         "language": [
           {
             "value": 'English',
+            "status": 'primary',
             "code": 'eng',
             "uri": 'http://id.loc.gov/vocabulary/iso639-2/eng',
             "source": {
@@ -93,7 +94,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::AdminMetadata do
     let(:xml) do
       <<~XML
         <recordInfo>
-          <languageOfCataloging usage="primary">
+          <languageOfCataloging>
             <languageTerm type="text" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/eng">English</languageTerm>
             <languageTerm type="code" authority="iso639-2b" authorityURI="http://id.loc.gov/vocabulary/iso639-2/" valueURI="http://id.loc.gov/vocabulary/iso639-2/eng">eng</languageTerm>
             <scriptTerm type="text">Latin</scriptTerm>


### PR DESCRIPTION
closes #1448

## Why was this change made?
Adds from fedora mapping for languageOfCataloging usage attribute.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


