### PR TITLE
Moves nonsorting note to sibling of structuredValue.

### DIFF
--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -169,12 +169,16 @@ RSpec.describe 'Update object' do
     let(:description) do
       {
         title: [
-          { structuredValue: [
-            { value: 'The', "type": 'nonsorting characters' },
-            { value: 'romantic Bach', "type": 'main title' },
-            { value: "a celebration of Bach's most romantic music", "type": 'subtitle' },
-            { note: [{ "value": '4', "type": 'nonsorting character count' }] }
-          ] }
+          {
+            structuredValue: [
+              { value: 'The', "type": 'nonsorting characters' },
+              { value: 'romantic Bach', "type": 'main title' },
+              { value: "a celebration of Bach's most romantic music", "type": 'subtitle' }
+            ],
+            note: [
+              { "value": '4', "type": 'nonsorting character count' }
+            ]
+          }
         ]
       }
     end

--- a/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
@@ -50,11 +50,17 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
 
       it 'is a structured value' do
         expect(build).to eq [
-          { structuredValue: [{ type: 'nonsorting characters', value: 'The' },
-                              { type: 'main title', value: 'journal of stuff' },
-                              { type: 'part number', value: 'volume 5' },
-                              { type: 'part name', value: 'special issue' },
-                              { note: [{ type: 'nonsorting character count', value: '4' }] }] }
+          {
+            structuredValue: [
+              { type: 'nonsorting characters', value: 'The' },
+              { type: 'main title', value: 'journal of stuff' },
+              { type: 'part number', value: 'volume 5' },
+              { type: 'part name', value: 'special issue' }
+            ],
+            note: [
+              { type: 'nonsorting character count', value: '4' }
+            ]
+          }
         ]
       end
     end
@@ -160,14 +166,12 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
                   {
                     "value": 'misérables',
                     "type": 'main title'
-                  },
+                  }
+                ],
+                "note": [
                   {
-                    "note": [
-                      {
-                        "value": '4',
-                        "type": 'nonsorting character count'
-                      }
-                    ]
+                    "value": '4',
+                    "type": 'nonsorting character count'
                   }
                 ],
                 "status": 'primary',
@@ -187,14 +191,12 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
                   {
                     "value": 'wretched',
                     "type": 'main title'
-                  },
+                  }
+                ],
+                "note": [
                   {
-                    "note": [
-                      {
-                        "value": '4',
-                        "type": 'nonsorting character count'
-                      }
-                    ]
+                    "value": '4',
+                    "type": 'nonsorting character count'
                   }
                 ],
                 "type": 'translated',

--- a/spec/services/cocina/to_fedora/descriptive/title_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/title_spec.rb
@@ -43,12 +43,18 @@ RSpec.describe Cocina::ToFedora::Descriptive::Title do
       let(:titles) do
         [
           Cocina::Models::Title.new(
-            { structuredValue: [{ type: 'nonsorting characters', value: 'The' },
-                                { type: 'main title', value: 'journal of stuff' },
-                                { type: 'subtitle', value: 'a journal' },
-                                { type: 'part number', value: 'volume 5' },
-                                { type: 'part name', value: 'special issue' },
-                                { note: [{ type: 'nonsorting character count', value: '4' }] }] }
+            {
+              structuredValue: [
+                { type: 'nonsorting characters', value: 'The' },
+                { type: 'main title', value: 'journal of stuff' },
+                { type: 'subtitle', value: 'a journal' },
+                { type: 'part number', value: 'volume 5' },
+                { type: 'part name', value: 'special issue' }
+              ],
+              note: [
+                { type: 'nonsorting character count', value: '4' }
+              ]
+            }
           )
         ]
       end
@@ -242,14 +248,12 @@ RSpec.describe Cocina::ToFedora::Descriptive::Title do
                       {
                         value: 'misérables',
                         type: 'main title'
-                      },
+                      }
+                    ],
+                    note: [
                       {
-                        note: [
-                          {
-                            value: '4',
-                            type: 'nonsorting character count'
-                          }
-                        ]
+                        value: '4',
+                        type: 'nonsorting character count'
                       }
                     ],
                     status: 'primary',
@@ -271,14 +275,12 @@ RSpec.describe Cocina::ToFedora::Descriptive::Title do
                       {
                         value: 'wretched',
                         type: 'main title'
-                      },
+                      }
+                    ],
+                    note: [
                       {
-                        note: [
-                          {
-                            value: '4',
-                            type: 'nonsorting character count'
-                          }
-                        ]
+                        value: '4',
+                        type: 'nonsorting character count'
                       }
                     ],
                     type: 'translated',


### PR DESCRIPTION
closes #1451

## Why was this change made?
To adjust the modeling of nonsorting note per @arcadiafalcone.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


