### PR TITLE
H2 contrib publisher mappings

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/event.rb
+++ b/app/services/cocina/to_fedora/descriptive/event.rb
@@ -32,9 +32,9 @@ module Cocina
         def write
           Array(events).each_with_index do |event, count|
             attributes = {}
-            attributes[:eventType] = EVENT_TYPE.fetch(event.type) if events.size > 1 && event.type
+            attributes[:eventType] = EVENT_TYPE.fetch(event.type) if event.type
             if translated?(event)
-              TranslatedEvent.write(xml: xml, event: event, count: count)
+              TranslatedEvent.write(xml: xml, event: event, count: count, event_type: event.type)
             else
               write_basic(event, attributes)
             end

--- a/app/services/cocina/to_fedora/descriptive/event.rb
+++ b/app/services/cocina/to_fedora/descriptive/event.rb
@@ -74,7 +74,10 @@ module Cocina
           xml.send(note.type, note.value, attributes)
         end
 
+        # the only contributors legal for MODS are ones with role publisher
         def contributor(contributor)
+          return unless contributor_role_publisher?(contributor)
+
           attributes = {}
           name = contributor.name.first
           if name.valueLanguage
@@ -82,7 +85,8 @@ module Cocina
             attributes[:script] = name.valueLanguage.valueScript.code
             attributes[:transliteration] = name.standard.value if name.standard
           end
-          xml.send(contributor.role.first.value, name.value, attributes)
+
+          xml.publisher(name.value, attributes)
         end
 
         def location(location)
@@ -123,6 +127,21 @@ module Cocina
           dates.each do |date|
             date_tag(date, event_type, point: date.type)
           end
+        end
+
+        MARC_RELATOR_PIECE = 'id.loc.gov/vocabulary/relators'
+
+        # prefer marcrelator publisher role
+        def contributor_role_publisher?(contributor)
+          return true if contributor.role.any? { |role| role.value.match?(/publisher/i) && role_is_marcrelator?(role) }
+
+          contributor.role.any? { |role| role.value&.match?(/publisher/i) }
+        end
+
+        def role_is_marcrelator?(role)
+          role.source&.code == 'marcrelator' ||
+            role.source&.uri&.include?(MARC_RELATOR_PIECE) ||
+            role.uri&.include?(MARC_RELATOR_PIECE)
         end
       end
     end

--- a/app/services/cocina/to_fedora/descriptive/translated_event.rb
+++ b/app/services/cocina/to_fedora/descriptive/translated_event.rb
@@ -8,14 +8,16 @@ module Cocina
         # @params [Nokogiri::XML::Builder] xml
         # @params [Cocina::Models::Event] event
         # @params [Integer] count
-        def self.write(xml:, event:, count:)
-          new(xml: xml, event: event, count: count).write
+        # @params [String] event_type - see Cocina::ToFedora::Descriptive::Event::EVENT_TYPE
+        def self.write(xml:, event:, count:, event_type:)
+          new(xml: xml, event: event, count: count, event_type: event_type).write
         end
 
-        def initialize(xml:, event:, count:)
+        def initialize(xml:, event:, count:, event_type:)
           @xml = xml
           @event = event
           @count = count
+          @event_type = event_type
           @groups = {}
         end
 
@@ -24,7 +26,12 @@ module Cocina
           group_contributors
 
           groups.each do |script, origin|
-            xml.originInfo script: script, altRepGroup: count do
+            attributes = {
+              script: script,
+              altRepGroup: count,
+              eventType: event_type
+            }
+            xml.originInfo attributes do
               origin[:place].each do |place|
                 xml.place do
                   if place[:text]
@@ -43,7 +50,7 @@ module Cocina
 
         private
 
-        attr_reader :xml, :event, :count, :groups
+        attr_reader :xml, :event, :count, :event_type, :groups
 
         def initialize_translation(key)
           groups[key] ||= { place: [], publisher: [] }

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -29,6 +29,7 @@ def normalize_original(ng_xml)
   normalize_subject_name(ng_xml)
   normalize_authority_uris(ng_xml)
   normalize_subject_authority(ng_xml)
+  normalize_origin_info_event_types(ng_xml)
   ng_xml
 end
 
@@ -81,6 +82,28 @@ def normalize_subject_authority(ng_xml)
   ng_xml.root.xpath("mods:subject[@authority='naf']", mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |subject_node|
     subject_node[:authority] = 'lcsh'
   end
+end
+
+# change original xml to have the event type that will be output
+def normalize_origin_info_event_types(ng_xml)
+  # code
+  ng_xml.root.xpath('mods:originInfo', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |origin_info_node|
+    date_issued_nodes = origin_info_node.xpath('mods:dateIssued', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS)
+    add_event_type('publication', origin_info_node) && break if date_issued_nodes.present?
+
+    copyright_date_nodes = origin_info_node.xpath('mods:copyrightDate', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS)
+    add_event_type('copyright notice', origin_info_node) && break if copyright_date_nodes.present?
+
+    date_created_nodes = origin_info_node.xpath('mods:dateCreated', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS)
+    add_event_type('production', origin_info_node) && break if date_created_nodes.present?
+
+    date_captured_nodes = origin_info_node.xpath('mods:dateCaptured', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS)
+    add_event_type('capture', origin_info_node) && break if date_captured_nodes.present?
+  end
+end
+
+def add_event_type(value, origin_info_node)
+  origin_info_node['eventType'] = value if origin_info_node[:eventType].blank?
 end
 
 def round_tripped_ng_xml(cocina, druid)

--- a/spec/services/cocina/from_fedora/descriptive/contributor_h2_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_h2_spec.rb
@@ -509,9 +509,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     let(:descriptive) { Cocina::FromFedora::Descriptive.props(mods: ng_xml) }
 
     it 'builds the expected cocina data structure' do
-      skip('TODO: changes to originInfo mappings for h2 coming shortly')
-      # expect(descriptive[:events]).to match_array [
-
       expect(descriptive).to eq(
         {
           title: [{ value: 'Foo' }],
@@ -525,7 +522,13 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
                   role: publisher_roles
                 }
               ],
-              date: [{ encoding: { code: 'w3cdtf' }, value: '2020-02-14' }]
+              date: [
+                {
+                  encoding: { code: 'w3cdtf' },
+                  value: '2020-02-14',
+                  status: 'primary'
+                }
+              ]
             }
           ]
         }

--- a/spec/services/cocina/to_fedora/descriptive/contributor_h2_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_h2_spec.rb
@@ -692,7 +692,13 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
               role: publisher_roles
             }
           ],
-          date: [{ encoding: { code: 'edtf' }, value: '2020-02-14' }]
+          date: [
+            {
+              encoding: { code: 'w3cdtf' },
+              value: '2020-02-14',
+              status: 'primary'
+            }
+          ]
         )
       ]
     end
@@ -700,7 +706,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     let(:descriptive) { Cocina::Models::Description.new({ event: events }, false, false) }
 
     it 'builds the expected xml' do
-      skip('TODO: changes to originInfo mappings for h2 coming shortly')
       result_xml = Cocina::ToFedora::Descriptive.transform(descriptive, druid).to_xml
       expect(result_xml).to be_equivalent_to <<~XML
         #{mods_element_open}
@@ -733,7 +738,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     let(:descriptive) { Cocina::Models::Description.new({ event: events }, false, false) }
 
     it 'builds the expected xml' do
-      skip('TODO: changes to originInfo mappings for h2 coming shortly')
       result_xml = Cocina::ToFedora::Descriptive.transform(descriptive, druid).to_xml
       expect(result_xml).to be_equivalent_to <<~XML
         #{mods_element_open}

--- a/spec/services/cocina/to_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/event_spec.rb
@@ -690,6 +690,40 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  context 'when it has a publisher that is not marcrelator' do
+    let(:events) do
+      [
+        Cocina::Models::Event.new(
+          type: 'publication',
+          contributor: [
+            {
+              name: [{ value: 'Stanford University Press' }],
+              type: 'organization',
+              role: [
+                {
+                  value: 'Publisher',
+                  source: { value: 'Stanford self-deposit contributor types' }
+                }
+              ]
+            }
+          ]
+        )
+      ]
+    end
+
+    it 'builds the expected xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <originInfo eventType="publication">
+            <publisher>Stanford University Press</publisher>
+          </originInfo>
+        </mods>
+      XML
+    end
+  end
+
   context 'when it has a publisher that is transliterated' do
     let(:events) do
       [

--- a/spec/services/cocina/to_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/event_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="production">
             <dateCreated>1980</dateCreated>
           </originInfo>
         </mods>
@@ -80,7 +80,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="publication">
             <dateIssued encoding="w3cdtf">1928</dateIssued>
           </originInfo>
         </mods>
@@ -109,7 +109,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="copyright notice">
             <copyrightDate>1930</copyrightDate>
           </originInfo>
         </mods>
@@ -142,7 +142,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="capture">
             <dateCaptured keyDate="yes" encoding="iso8601">20131012231249</dateCaptured>
           </originInfo>
         </mods>
@@ -250,7 +250,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="production">
             <dateCreated keyDate="yes" point="start">1920</dateCreated>
             <dateCreated point="end">1925</dateCreated>
           </originInfo>
@@ -281,7 +281,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="production">
             <dateCreated qualifier="approximate">1940</dateCreated>
           </originInfo>
         </mods>
@@ -322,9 +322,9 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
-          <dateCreated keyDate="yes" point="start" qualifier="approximate">1940</dateCreated>
-          <dateCreated point="end" qualifier="approximate">1945</dateCreated>
+          <originInfo eventType="production">
+            <dateCreated keyDate="yes" point="start" qualifier="approximate">1940</dateCreated>
+            <dateCreated point="end" qualifier="approximate">1945</dateCreated>
           </originInfo>
         </mods>
       XML
@@ -353,7 +353,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="production">
             <dateCreated qualifier="inferred">1940</dateCreated>
           </originInfo>
         </mods>
@@ -383,7 +383,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="production">
             <dateCreated qualifier="questionable">1940</dateCreated>
           </originInfo>
         </mods>
@@ -425,7 +425,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="publication">
             <dateIssued keyDate="yes" point="start">1940</dateIssued>
             <dateIssued point="end">1945</dateIssued>
             <dateIssued>1948</dateIssued>
@@ -460,7 +460,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="publication">
             <dateIssued keyDate="yes">1940</dateIssued>
             <dateIssued>1942</dateIssued>
           </originInfo>
@@ -493,7 +493,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="production">
             <dateCreated encoding="edtf">-0499</dateCreated>
           </originInfo>
         </mods>
@@ -682,7 +682,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="publication">
             <publisher>Virago</publisher>
           </originInfo>
         </mods>
@@ -741,7 +741,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="publication">
             <publisher lang="rus" script="Latn" transliteration="ALA-LC Romanization Tables">Institut russkoĭ literatury (Pushkinskiĭ Dom)</publisher>
           </originInfo>
         </mods>
@@ -796,7 +796,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="publication">
             <publisher lang="rus" script="Cyrl">СФУ</publisher>
           </originInfo>
         </mods>
@@ -858,7 +858,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="publication">
             <publisher>Ardis</publisher>
             <publisher>Commonplace Books</publisher>
           </originInfo>
@@ -887,7 +887,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="publication">
             <edition>1st ed.</edition>
           </originInfo>
         </mods>
@@ -922,7 +922,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="publication">
             <issuance>serial</issuance>
             <frequency>every full moon</frequency>
           </originInfo>
@@ -961,7 +961,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
+          <originInfo eventType="publication">
             <issuance>multipart monograph</issuance>
             <frequency authority="marcfrequency">Annual</frequency>
           </originInfo>
@@ -1169,7 +1169,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo script="Latn" altRepGroup="0">
+          <originInfo eventType="publication" script="Latn" altRepGroup="0">
             <place>
               <placeTerm type="code" authority="marccountry">ja</placeTerm>
             </place>
@@ -1178,7 +1178,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
             </place>
             <publisher>Rinsen Shoten</publisher>
           </originInfo>
-          <originInfo script="Hani" altRepGroup="0">
+          <originInfo eventType="publication" script="Hani" altRepGroup="0">
             <place>
               <placeTerm type="text">京都市</placeTerm>
             </place>

--- a/spec/services/cocina/to_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Cocina::ToFedora::Descriptive do
               <projection>Conic proj</projection>
             </cartographics>
           </subject>
-          <originInfo>
+          <originInfo eventType="production">
             <dateCreated>1980</dateCreated>
           </originInfo>
         </mods>


### PR DESCRIPTION
## Why was this change made?

Closes #1375 - changes to DSA needed for h2 publisher contributors (but of benefit to all our MODS data - cough cough)

## How was this change tested?

- unit tests
    - any tweaks to existing tests were confirmed as correct by Arcadia
    - got H2 contributor publication mapping tests to pass

- validation results of mapping change on prod data are in a comment below https://github.com/sul-dlss/dor-services-app/pull/1456#issuecomment-731394857 -- IMPROVEMENT!!!

## Which documentation and/or configurations were updated?



