### PR TITLE
Handles genre without valueURI.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/form.rb
+++ b/app/services/cocina/from_fedora/descriptive/form.rb
@@ -61,13 +61,10 @@ module Cocina
               value: type.text,
               type: type['type'] || 'genre'
             }.tap do |item|
-              if type[:valueURI]
-                item[:uri] = type[:valueURI]
-                item[:source] = { code: type[:authority], uri: type[:authorityURI] }.compact
-              elsif type[:authority]
-                item[:source] = { code: type[:authority] }
-              end
-            end
+              item[:uri] = type[:valueURI]
+              source = { code: type[:authority], uri: type[:authorityURI] }.compact
+              item[:source] = source if source.present?
+            end.compact
           end
         end
 

--- a/spec/services/cocina/from_fedora/descriptive/form_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/form_spec.rb
@@ -141,6 +141,27 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
       end
     end
 
+    context 'without valueURI' do
+      let(:xml) do
+        <<~XML
+          <genre authority="lcgft" authorityURI="http://id.loc.gov/authorities/genreForms/">Photographs</genre>
+        XML
+      end
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq [
+          {
+            "value": 'Photographs',
+            "type": 'genre',
+            "source": {
+              "code": 'lcgft',
+              "uri": 'http://id.loc.gov/authorities/genreForms/'
+            }
+          }
+        ]
+      end
+    end
+
     context 'with authority missing authorityURI' do
       let(:xml) do
         <<~XML


### PR DESCRIPTION
closes #1421

## Why was this change made?
So handle genres that have authorityURI, but no valueURI.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


