### PR TITLE
Normalize topic for roundtrip.

### DIFF
--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -24,13 +24,32 @@ cache = FedoraCache.new
 
 # Changes to the original XML to help with matching.
 def normalize_xml(ng_xml)
+  normalize_version(ng_xml)
+  normalize_topics(ng_xml)
+  ng_xml
+end
+
+def normalize_version(ng_xml)
   # Only normalize version when version isn't mapped.
   unless /MODS version (\d\.\d)/.match(ng_xml.root.at('//mods:recordInfo/mods:recordOrigin',
                                                       mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS)&.content)
     ng_xml.root['version'] = '3.6'
     ng_xml.root['xsi:schemaLocation'] = 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd'
   end
-  ng_xml
+end
+
+def normalize_topics(ng_xml)
+  ng_xml.root.xpath('mods:subject[count(mods:topic) = 1]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |subject_node|
+    topic_node = subject_node.xpath('mods:topic', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).first
+    # If subject has authority and topic doesn't, copy to topic.
+    topic_node[:authority] = subject_node[:authority] if subject_node[:authority] && !topic_node[:authority]
+    # If subject has authorityURI and topic doesn't, move to topic.
+    topic_node[:authorityURI] = subject_node[:authorityURI] if subject_node[:authorityURI] && !topic_node[:authorityURI]
+    subject_node.delete('authorityURI')
+    # If subject has valueURI and topic doesn't, move to topic.
+    topic_node[:valueURI] = subject_node[:valueURI] if subject_node[:valueURI] && !topic_node[:valueURI]
+    subject_node.delete('valueURI')
+  end
 end
 
 def round_tripped_xml(cocina, druid)

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -313,6 +313,30 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     end
   end
 
+  context 'with a single-term topic subject with authority on the subject and topic' do
+    let(:xml) do
+      <<~XML
+        <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">
+          <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
+        </subject>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "value": 'Cats',
+          "type": 'topic',
+          "uri": 'http://id.loc.gov/authorities/subjects/sh85021262',
+          "source": {
+            "code": 'lcsh',
+            "uri": 'http://id.loc.gov/authorities/subjects/'
+          }
+        }
+      ]
+    end
+  end
+
   context 'with a multi-term topic subject with authority for set' do
     let(:xml) do
       <<~XML


### PR DESCRIPTION
closes #1411

## Why was this change made?
There are a variety of equivalent variations for single topics. This normalizes them when checking equivalence.


## How was this change tested?
Locally


## Which documentation and/or configurations were updated?
NA


