### PR TITLE
geo extension format and type handling

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/geographic.rb
+++ b/app/services/cocina/from_fedora/descriptive/geographic.rb
@@ -180,7 +180,16 @@ module Cocina
         end
 
         def type
-          @type = description.xpath('//dc:type', NAMESPACE).text
+          @type ||= normalize_type_text(description.xpath('//dc:type', NAMESPACE).text)
+        end
+
+        def normalize_type_text(text)
+          if text.downcase == 'image' && text != 'Image'
+            Honeybadger.notify("[DATA ERROR] <dc:type>#{text}</dc:type> normalized to <dc:type>Image</dc:type>", { tags: 'data_error' })
+            'Image'
+          else
+            text
+          end
         end
       end
       # rubocop:enable Metrics/ClassLength

--- a/spec/services/cocina/from_fedora/descriptive/geographic_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/geographic_spec.rb
@@ -79,6 +79,22 @@ RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
       expect(build).to eq([expected_hash])
       build.each { |model| Cocina::Models::DescriptiveGeographicMetadata.new(model) }
     end
+
+    context 'when dc:type does not have the expected capitalization' do
+      let(:dc_type) { 'image' }
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq([expected_hash])
+        build.each { |model| Cocina::Models::DescriptiveGeographicMetadata.new(model) }
+      end
+
+      it 'sends a warning about the data error via Honeybadger' do
+        allow(Honeybadger).to receive(:notify)
+        build
+        err_msg = '[DATA ERROR] <dc:type>image</dc:type> normalized to <dc:type>Image</dc:type>'
+        expect(Honeybadger).to have_received(:notify).with(err_msg, { tags: 'data_error' })
+      end
+    end
   end
 
   context 'with a basic bounding box' do
@@ -152,6 +168,22 @@ RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
     it 'builds the cocina data structure' do
       expect(build).to eq([expected_hash])
       build.each { |model| Cocina::Models::DescriptiveGeographicMetadata.new(model) }
+    end
+
+    context 'when dc:type does not have the expected capitalization' do
+      let(:dc_type) { 'image' }
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq([expected_hash])
+        build.each { |model| Cocina::Models::DescriptiveGeographicMetadata.new(model) }
+      end
+
+      it 'sends a warning about the data error via Honeybadger' do
+        allow(Honeybadger).to receive(:notify)
+        build
+        err_msg = '[DATA ERROR] <dc:type>image</dc:type> normalized to <dc:type>Image</dc:type>'
+        expect(Honeybadger).to have_received(:notify).with(err_msg, { tags: 'data_error' })
+      end
     end
   end
 

--- a/spec/services/cocina/from_fedora/descriptive/geographic_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/geographic_spec.rb
@@ -17,13 +17,14 @@ RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
   end
 
   context 'with point coordinates' do
+    let(:dc_type) { 'Image' }
     let(:xml) do
       <<~XML
         <extension displayLabel="geo">
           <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:gmd="http://www.isotc211.org/2005/gmd">
             <rdf:Description rdf:about="http://www.stanford.edu/kk138ps4721">
               <dc:format>image/jpeg</dc:format>
-              <dc:type>Image</dc:type>
+              <dc:type>#{dc_type}</dc:type>
               <gmd:centerPoint>
                 <gml:Point gml:id="ID">
                   <gml:pos>41.893367 12.483736</gml:pos>
@@ -35,55 +36,60 @@ RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
       XML
     end
 
+    let(:expected_hash) do
+      {
+        "form": [
+          {
+            "value": 'image/jpeg',
+            "type": 'media type',
+            "source": {
+              "value": 'IANA media type terms'
+            }
+          },
+          {
+            "value": 'Image',
+            "type": 'media type',
+            "source": {
+              "value": 'DCMI Type Vocabulary'
+            }
+          }
+        ],
+        "subject": [
+          {
+            "structuredValue": [
+              {
+                "value": '41.893367',
+                "type": 'latitude'
+              },
+              {
+                "value": '12.483736',
+                "type": 'longitude'
+              }
+            ],
+            "type": 'point coordinates',
+            "encoding": {
+              "value": 'decimal'
+            }
+          }
+        ]
+      }
+    end
+
     it 'builds the cocina data structure' do
-      expect(build).to eq([{
-                            "form": [
-                              {
-                                "value": 'image/jpeg',
-                                "type": 'media type',
-                                "source": {
-                                  "value": 'IANA media type terms'
-                                }
-                              },
-                              {
-                                "value": 'Image',
-                                "type": 'media type',
-                                "source": {
-                                  "value": 'DCMI Type Vocabulary'
-                                }
-                              }
-                            ],
-                            "subject": [
-                              {
-                                "structuredValue": [
-                                  {
-                                    "value": '41.893367',
-                                    "type": 'latitude'
-                                  },
-                                  {
-                                    "value": '12.483736',
-                                    "type": 'longitude'
-                                  }
-                                ],
-                                "type": 'point coordinates',
-                                "encoding": {
-                                  "value": 'decimal'
-                                }
-                              }
-                            ]
-                          }])
+      expect(build).to eq([expected_hash])
       build.each { |model| Cocina::Models::DescriptiveGeographicMetadata.new(model) }
     end
   end
 
   context 'with a basic bounding box' do
+    let(:dc_type) { 'Image' }
     let(:xml) do
       <<~XML
         <extension displayLabel="geo">
           <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
             <rdf:Description rdf:about="http://purl.stanford.edu/cw222pt0426">
               <dc:format>image/jpeg</dc:format>
-              <dc:type>Image</dc:type>
+              <dc:type>#{dc_type}</dc:type>
               <gml:boundedBy>
                 <gml:Envelope>
                   <gml:lowerCorner>-122.191292 37.4063388</gml:lowerCorner>
@@ -96,56 +102,55 @@ RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
       XML
     end
 
-    it 'builds the cocina data structure' do
-      expect(build).to eq(
-        [
+    let(:expected_hash) do
+      {
+        form: [
           {
-            form: [
+            value: 'image/jpeg',
+            type: 'media type',
+            source: {
+              value: 'IANA media type terms'
+            }
+          },
+          {
+            value: 'Image',
+            type: 'media type',
+            source: {
+              value: 'DCMI Type Vocabulary'
+            }
+          }
+        ],
+        subject: [
+          {
+            structuredValue: [
               {
-                value: 'image/jpeg',
-                type: 'media type',
-                source: {
-                  value: 'IANA media type terms'
-                }
+                value: '-122.191292',
+                type: 'west'
               },
               {
-                value: 'Image',
-                type: 'media type',
-                source: {
-                  value: 'DCMI Type Vocabulary'
-                }
+                value: '37.4063388',
+                type: 'south'
+              },
+              {
+                value: '-122.149475',
+                type: 'east'
+              },
+              {
+                value: '37.4435369',
+                type: 'north'
               }
             ],
-            subject: [
-              {
-                structuredValue: [
-                  {
-                    value: '-122.191292',
-                    type: 'west'
-                  },
-                  {
-                    value: '37.4063388',
-                    type: 'south'
-                  },
-                  {
-                    value: '-122.149475',
-                    type: 'east'
-                  },
-                  {
-                    value: '37.4435369',
-                    type: 'north'
-                  }
-                ],
-                type: 'bounding box coordinates',
-                encoding: {
-                  value: 'decimal'
-                }
-              }
-            ]
+            type: 'bounding box coordinates',
+            encoding: {
+              value: 'decimal'
+            }
           }
         ]
-      )
+      }
+    end
 
+    it 'builds the cocina data structure' do
+      expect(build).to eq([expected_hash])
       build.each { |model| Cocina::Models::DescriptiveGeographicMetadata.new(model) }
     end
   end


### PR DESCRIPTION
## Why was this change made?

Improve mapping when `dc:type` for geo metadata is specified with unexpected capitalization.

see #1464.

## How was this change tested?

* unit tests
* running the to cocina validation over the cache of fedora data...

```
[deploy@sdr-deploy dor-services-app]$ diff results_to-cocina_2020-11-21T05-06-37Z_master_adbb5dc.txt results_to-cocina_2020-11-21T06-41-30Z_geo-ext-format_fba24c6.txt 
1,2c1,2
< To Cocina error: 349 of 2685579 (0.01299533545652539%)
< Data error: 118268 of 2685579 (4.403817575278925%)
---
> To Cocina error: 52 of 2685579 (0.0019362677471040696%)
> Data error: 118565 of 2685579 (4.414876642988347%)
5c5
< Error:  isn't one of in #/components/schemas/DescriptiveBasicValue/allOf/2/properties/value (349 errors)
---
> Error:  isn't one of in #/components/schemas/DescriptiveBasicValue/allOf/2/properties/value (52 errors)
7,13d6
< druid:yt817fv6262
< druid:px155dc2427
...
< druid:dt358wg6359
< druid:rk239rx7072
118301a118005,118302
> Data error: [DATA ERROR] <dc:type>image</dc:type> normalized to <dc:type>Image</dc:type> (297 errors)
> druid:yt817fv6262
> druid:px155dc2427
...
> druid:dt358wg6359
> druid:rk239rx7072
[deploy@sdr-deploy dor-services-app]$ 
```

turns 297 `To Cocina error` into normalizable bad data warnings.

## Which documentation and/or configurations were updated?



