### PR TITLE
handle geo extension format and type independently

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/geographic.rb
+++ b/app/services/cocina/from_fedora/descriptive/geographic.rb
@@ -72,9 +72,18 @@ module Cocina
         end
 
         def build_type
-          return { value: type, type: MEDIA_TYPE, source: DCMI_VOCAB } if type == 'Image'
+          type_section =
+            if type == 'Image'
+              { value: type, type: MEDIA_TYPE, source: DCMI_VOCAB }
+            else
+              { value: type, type: TYPE }
+            end
 
-          [{ value: format[:format], type: DATA_FORMAT }, { value: type, type: TYPE }]
+          if format[:format].present?
+            [{ value: format[:format], type: DATA_FORMAT }, type_section]
+          else
+            type_section
+          end
         end
 
         def build_subject

--- a/app/services/cocina/from_fedora/descriptive/geographic.rb
+++ b/app/services/cocina/from_fedora/descriptive/geographic.rb
@@ -180,7 +180,16 @@ module Cocina
         end
 
         def type
-          @type = description.xpath('//dc:type', NAMESPACE).text
+          @type ||= normalize_type_text(description.xpath('//dc:type', NAMESPACE).text)
+        end
+
+        def normalize_type_text(text)
+          if text.downcase == 'image' && text != 'Image'
+            Honeybadger.notify("[DATA ERROR] <dc:type>#{text}</dc:type> normalized to <dc:type>Image</dc:type>", { tags: 'data_error' })
+            'Image'
+          else
+            text
+          end
         end
       end
       # rubocop:enable Metrics/ClassLength

--- a/spec/services/cocina/from_fedora/descriptive/geographic_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/geographic_spec.rb
@@ -79,6 +79,22 @@ RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
       expect(build).to eq([expected_hash])
       build.each { |model| Cocina::Models::DescriptiveGeographicMetadata.new(model) }
     end
+
+    context 'when dc:type does not have the expected capitalization' do
+      let(:dc_type) { 'image' }
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq([expected_hash])
+        build.each { |model| Cocina::Models::DescriptiveGeographicMetadata.new(model) }
+      end
+
+      it 'sends a warning about the data error via Honeybadger' do
+        allow(Honeybadger).to receive(:notify)
+        build
+        err_msg = '[DATA ERROR] <dc:type>image</dc:type> normalized to <dc:type>Image</dc:type>'
+        expect(Honeybadger).to have_received(:notify).with(err_msg, { tags: 'data_error' })
+      end
+    end
   end
 
   context 'with a basic bounding box' do
@@ -152,6 +168,22 @@ RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
     it 'builds the cocina data structure' do
       expect(build).to eq([expected_hash])
       build.each { |model| Cocina::Models::DescriptiveGeographicMetadata.new(model) }
+    end
+
+    context 'when dc:type does not have the expected capitalization' do
+      let(:dc_type) { 'image' }
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq([expected_hash])
+        build.each { |model| Cocina::Models::DescriptiveGeographicMetadata.new(model) }
+      end
+
+      it 'sends a warning about the data error via Honeybadger' do
+        allow(Honeybadger).to receive(:notify)
+        build
+        err_msg = '[DATA ERROR] <dc:type>image</dc:type> normalized to <dc:type>Image</dc:type>'
+        expect(Honeybadger).to have_received(:notify).with(err_msg, { tags: 'data_error' })
+      end
     end
   end
 

--- a/spec/services/cocina/from_fedora/descriptive/geographic_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/geographic_spec.rb
@@ -17,13 +17,14 @@ RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
   end
 
   context 'with point coordinates' do
+    let(:dc_type) { 'Image' }
     let(:xml) do
       <<~XML
         <extension displayLabel="geo">
           <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:gmd="http://www.isotc211.org/2005/gmd">
             <rdf:Description rdf:about="http://www.stanford.edu/kk138ps4721">
               <dc:format>image/jpeg</dc:format>
-              <dc:type>Image</dc:type>
+              <dc:type>#{dc_type}</dc:type>
               <gmd:centerPoint>
                 <gml:Point gml:id="ID">
                   <gml:pos>41.893367 12.483736</gml:pos>
@@ -35,55 +36,60 @@ RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
       XML
     end
 
+    let(:expected_hash) do
+      {
+        "form": [
+          {
+            "value": 'image/jpeg',
+            "type": 'media type',
+            "source": {
+              "value": 'IANA media type terms'
+            }
+          },
+          {
+            "value": 'Image',
+            "type": 'media type',
+            "source": {
+              "value": 'DCMI Type Vocabulary'
+            }
+          }
+        ],
+        "subject": [
+          {
+            "structuredValue": [
+              {
+                "value": '41.893367',
+                "type": 'latitude'
+              },
+              {
+                "value": '12.483736',
+                "type": 'longitude'
+              }
+            ],
+            "type": 'point coordinates',
+            "encoding": {
+              "value": 'decimal'
+            }
+          }
+        ]
+      }
+    end
+
     it 'builds the cocina data structure' do
-      expect(build).to eq([{
-                            "form": [
-                              {
-                                "value": 'image/jpeg',
-                                "type": 'media type',
-                                "source": {
-                                  "value": 'IANA media type terms'
-                                }
-                              },
-                              {
-                                "value": 'Image',
-                                "type": 'media type',
-                                "source": {
-                                  "value": 'DCMI Type Vocabulary'
-                                }
-                              }
-                            ],
-                            "subject": [
-                              {
-                                "structuredValue": [
-                                  {
-                                    "value": '41.893367',
-                                    "type": 'latitude'
-                                  },
-                                  {
-                                    "value": '12.483736',
-                                    "type": 'longitude'
-                                  }
-                                ],
-                                "type": 'point coordinates',
-                                "encoding": {
-                                  "value": 'decimal'
-                                }
-                              }
-                            ]
-                          }])
+      expect(build).to eq([expected_hash])
       build.each { |model| Cocina::Models::DescriptiveGeographicMetadata.new(model) }
     end
   end
 
   context 'with a basic bounding box' do
+    let(:dc_type) { 'Image' }
     let(:xml) do
       <<~XML
         <extension displayLabel="geo">
           <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
             <rdf:Description rdf:about="http://purl.stanford.edu/cw222pt0426">
               <dc:format>image/jpeg</dc:format>
-              <dc:type>Image</dc:type>
+              <dc:type>#{dc_type}</dc:type>
               <gml:boundedBy>
                 <gml:Envelope>
                   <gml:lowerCorner>-122.191292 37.4063388</gml:lowerCorner>
@@ -96,56 +102,55 @@ RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
       XML
     end
 
-    it 'builds the cocina data structure' do
-      expect(build).to eq(
-        [
+    let(:expected_hash) do
+      {
+        form: [
           {
-            form: [
+            value: 'image/jpeg',
+            type: 'media type',
+            source: {
+              value: 'IANA media type terms'
+            }
+          },
+          {
+            value: 'Image',
+            type: 'media type',
+            source: {
+              value: 'DCMI Type Vocabulary'
+            }
+          }
+        ],
+        subject: [
+          {
+            structuredValue: [
               {
-                value: 'image/jpeg',
-                type: 'media type',
-                source: {
-                  value: 'IANA media type terms'
-                }
+                value: '-122.191292',
+                type: 'west'
               },
               {
-                value: 'Image',
-                type: 'media type',
-                source: {
-                  value: 'DCMI Type Vocabulary'
-                }
+                value: '37.4063388',
+                type: 'south'
+              },
+              {
+                value: '-122.149475',
+                type: 'east'
+              },
+              {
+                value: '37.4435369',
+                type: 'north'
               }
             ],
-            subject: [
-              {
-                structuredValue: [
-                  {
-                    value: '-122.191292',
-                    type: 'west'
-                  },
-                  {
-                    value: '37.4063388',
-                    type: 'south'
-                  },
-                  {
-                    value: '-122.149475',
-                    type: 'east'
-                  },
-                  {
-                    value: '37.4435369',
-                    type: 'north'
-                  }
-                ],
-                type: 'bounding box coordinates',
-                encoding: {
-                  value: 'decimal'
-                }
-              }
-            ]
+            type: 'bounding box coordinates',
+            encoding: {
+              value: 'decimal'
+            }
           }
         ]
-      )
+      }
+    end
 
+    it 'builds the cocina data structure' do
+      expect(build).to eq([expected_hash])
       build.each { |model| Cocina::Models::DescriptiveGeographicMetadata.new(model) }
     end
   end


### PR DESCRIPTION
## Why was this change made?

compare to #1465.  also intended to handle the data problem described iin #1464, and in particular attempts to address point 3 in https://github.com/sul-dlss/dor-services-app/issues/1464#issuecomment-732058434 (use presence of format info rather than `dc:type` value).

i _think_ this is an improvement on #1465, but wasn't totally sure, hence the separate PR.  probably only one of the two needs to be merged.



## How was this change tested?

* unit tests
* running the to cocina validation over the cache of fedora data...

```
[deploy@sdr-deploy dor-services-app]$ diff results_to-cocina_2020-11-21T05-06-37Z_master_adbb5dc.txt results_to-cocina_2020-11-21T08-00-19Z_geo-ext-format-independent-of-type_873a31c.txt 
1,2c1,2
< To Cocina error: 349 of 2685579 (0.01299533545652539%)
< Data error: 118268 of 2685579 (4.403817575278925%)
---
> To Cocina error: 42 of 2685579 (0.0015639085649686716%)
> Data error: 118575 of 2685579 (4.415249002170482%)
5c5
< Error:  isn't one of in #/components/schemas/DescriptiveBasicValue/allOf/2/properties/value (349 errors)
---
> Error:  isn't one of in #/components/schemas/DescriptiveBasicValue/allOf/2/properties/value (42 errors)
7,13d6
< druid:yt817fv6262
< druid:px155dc2427
...
< druid:dt358wg6359
< druid:rk239rx7072
355c48
< Data error: [DATA ERROR] Subject has unknown authority code (78729 errors)
---
> Data error: [DATA ERROR] Subject has unknown authority code (78739 errors)
7899a7593
> druid:fn773fm6535
12335a12030
> druid:pq479rm6462
13545a13241
> druid:kn722tx1063
21969a21666
> druid:wm291yb6106
24194a23892
> druid:cw431mx5162
25387a25086
> druid:np961rx0962
33402a33102
> druid:zh370tm1988
56333a56034
> druid:kv426zy6590
58072a57774
> druid:xv258hm5571
60808a60511
> druid:tn672rn4683
118301a118005,118302
> Data error: [DATA ERROR] <dc:type>image</dc:type> normalized to <dc:type>Image</dc:type> (297 errors)
> druid:yt817fv6262
> druid:px155dc2427
...
> druid:dt358wg6359
> druid:rk239rx7072
[deploy@sdr-deploy dor-services-app]$ 
```

compared to #1465, it seems that an additional 10 `To Cocina error`s are turned into `Subject has unknown authority code` data errors.

```
[deploy@sdr-deploy dor-services-app]$ diff results_to-cocina_2020-11-21T06-41-30Z_geo-ext-format_fba24c6.txt results_to-cocina_2020-11-21T08-00-19Z_geo-ext-format-independent-of-type_873a31c.txt
1,2c1,2
< To Cocina error: 52 of 2685579 (0.0019362677471040696%)
< Data error: 118565 of 2685579 (4.414876642988347%)
---
> To Cocina error: 42 of 2685579 (0.0015639085649686716%)
> Data error: 118575 of 2685579 (4.415249002170482%)
5c5
< Error:  isn't one of in #/components/schemas/DescriptiveBasicValue/allOf/2/properties/value (52 errors)
---
> Error:  isn't one of in #/components/schemas/DescriptiveBasicValue/allOf/2/properties/value (42 errors)
10d9
< druid:fn773fm6535
13,14d11
< druid:pq479rm6462
< druid:kn722tx1063
18d14
< druid:wm291yb6106
20,21d15
< druid:cw431mx5162
< druid:np961rx0962
26d19
< druid:zh370tm1988
40,42d32
< druid:kv426zy6590
< druid:xv258hm5571
< druid:tn672rn4683
58c48
< Data error: [DATA ERROR] Subject has unknown authority code (78729 errors)
---
> Data error: [DATA ERROR] Subject has unknown authority code (78739 errors)
7602a7593
> druid:fn773fm6535
12038a12030
> druid:pq479rm6462
13248a13241
> druid:kn722tx1063
21672a21666
> druid:wm291yb6106
23897a23892
> druid:cw431mx5162
25090a25086
> druid:np961rx0962
33105a33102
> druid:zh370tm1988
56036a56034
> druid:kv426zy6590
57775a57774
> druid:xv258hm5571
60511a60511
> druid:tn672rn4683
```


## Which documentation and/or configurations were updated?



