### PR TITLE
validate-to-cocina, validate-to-fedora: provide option to automatically give result files unique descriptive names

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ druid:bh164hd2167 (1)
 $ bin/validate-to-cocina -h
 Usage: bin/validate-to-cocina [options]
     -s, --sample SAMPLE              Sample size, otherwise all druids.
+    -u, --unique-filename            Result file named for branch and runtime
     -h, --help                       Displays help.
     
 $ bin/validate-to-cocina -s 10
@@ -200,6 +201,7 @@ Note that the location of the cache can be set with `FEDORA_CACHE` environment v
 $ bin/validate-to-fedora -h
 Usage: bin/validate-to-fedora [options]
     -s, --sample SAMPLE              Sample size, otherwise all druids.
+    -u, --unique-filename            Result file named for branch and runtime
     -h, --help                       Displays help.
     
 $ bin/validate-to-fedora

--- a/bin/validate-to-cocina
+++ b/bin/validate-to-cocina
@@ -5,11 +5,12 @@ require_relative '../config/environment'
 require_relative '../lib/fedora_cache'
 require 'optparse'
 
-options = { overwrite: false, random: false }
+options = { overwrite: false, random: false, unique_filename: false }
 parser = OptionParser.new do |option_parser|
   option_parser.banner = 'Usage: bin/validate-to-cocina [options]'
 
   option_parser.on('-sSAMPLE', '--sample SAMPLE', Integer, 'Sample size, otherwise all druids.')
+  option_parser.on('-u', '--unique-filename', 'Result file named for branch and runtime') { options[:unique_filename] = true }
   option_parser.on('-h', '--help', 'Displays help.') do
     puts option_parser
     exit
@@ -50,6 +51,24 @@ end
 
 def summary_line_for(label, count)
   "#{label}: #{count} of #{@sample_size} (#{100 * count.to_f / @sample_size}%)\n"
+end
+
+def branch_name
+  `git rev-parse --abbrev-ref HEAD`.strip
+end
+
+def short_commit_hash
+  `git rev-parse --short HEAD`.strip
+end
+
+def now_str
+  DateTime.now.utc.iso8601.to_s.gsub(':', '-')
+end
+
+def results_file_name(use_unique_filename)
+  return 'results.txt' unless use_unique_filename
+
+  "results_to-cocina_#{now_str}_#{branch_name}_#{short_commit_hash}.txt"
 end
 
 druids = File.read('druids.txt').split
@@ -107,7 +126,7 @@ aggregated_data_error_results = aggregated_errors_for(results_by_data_error)
 print_results(aggregated_error_results, 'Error')
 print_results(aggregated_data_error_results, 'Data error')
 
-File.open('results.txt', 'w') do |file|
+File.open(results_file_name(options[:unique_filename]), 'w') do |file|
   file.write(summary_line_for('To Cocina error', counts[:to_cocina_error]))
   file.write(summary_line_for('Data error', counts[:data_error]))
   file.write(summary_line_for('Missing', counts[:missing]))

--- a/bin/validate-to-fedora
+++ b/bin/validate-to-fedora
@@ -5,11 +5,12 @@ require_relative '../config/environment'
 require_relative '../lib/fedora_cache'
 require 'optparse'
 
-options = { overwrite: false, random: false }
+options = { overwrite: false, random: false, unique_filename: false }
 parser = OptionParser.new do |option_parser|
   option_parser.banner = 'Usage: bin/validate-to-fedora [options]'
 
   option_parser.on('-sSAMPLE', '--sample SAMPLE', Integer, 'Sample size, otherwise all druids.')
+  option_parser.on('-u', '--unique-filename', 'Result file named for branch and runtime') { options[:unique_filename] = true }
   option_parser.on('-h', '--help', 'Displays help.') do
     puts option_parser
     exit
@@ -74,6 +75,24 @@ def validate_druid(druid, cache)
   nil
 end
 
+def branch_name
+  `git rev-parse --abbrev-ref HEAD`.strip
+end
+
+def short_commit_hash
+  `git rev-parse --short HEAD`.strip
+end
+
+def now_str
+  DateTime.now.utc.iso8601.to_s.gsub(':', '-')
+end
+
+def results_file_name(use_unique_filename)
+  return 'results.txt' unless use_unique_filename
+
+  "results_to-fedora_#{now_str}_#{branch_name}_#{short_commit_hash}.txt"
+end
+
 druids = File.read('druids.txt').split
 druids = druids.take(options[:sample]) if options[:sample]
 @sample_size = druids.size
@@ -99,7 +118,7 @@ aggregated_error_results = aggregated_errors_for(results_by_error)
 
 print_results(aggregated_error_results, 'To Fedora error')
 
-File.open('results.txt', 'w') do |file|
+File.open(results_file_name(options[:unique_filename]), 'w') do |file|
   file.write(summary_line_for('To Fedora error', counts[:to_fedora_error]))
   file.write(summary_line_for('To Cocina error', counts[:to_cocina_error]))
   file.write(summary_line_for('Data error', counts[:data_error]))


### PR DESCRIPTION
## Why was this change made?

When running tests or reports that produce output files, I find it nice when output is easy to associate with the input that produced it, so I added an option to do that for the cocina validation results, since I was running against a number of branches in a row Friday evening.  Figured others might find it useful, and it was quick to write so I thought it'd save me time in the long run.  Old behavior is still the default.

## How was this change tested?

used the new `-u` flag on friday while running validations.

<img width="894" alt="Screen Shot 2020-11-20 at 7 28 42 PM" src="https://user-images.githubusercontent.com/7741604/99951987-ce244e80-2d33-11eb-8529-8914557fdfc5.png">



## Which documentation and/or configurations were updated?

`validate-to-cocina` and `validate-to-fedora` help messages

