### PR TITLE
Correctly map download access

### DIFF
--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -121,7 +121,7 @@ module Cocina
             size: node['size'].to_i,
             version: version,
             hasMessageDigests: digests(node),
-            access: { access: node['publish'] == 'yes' ? 'world' : 'dark' },
+            access: access(node),
             administrative: {
               sdrPreserve: node['preserve'] == 'yes',
               shelve: node['shelve'] == 'yes'
@@ -132,6 +132,14 @@ module Cocina
             attrs[:presentation] = { height: height, width: width } if height && width
             attrs[:use] = use if use
           end
+        end
+      end
+
+      def access(node)
+        if node['publish'] == 'yes'
+          { access: 'world', download: 'world' }
+        else
+          { access: 'dark', download: 'none' }
         end
       end
     end

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -61,7 +61,7 @@ module Cocina
       raise
     rescue StandardError => e
       Honeybadger.notify(e)
-      raise UnexpectedBuildError # wrap unexpected StandardError, caller will probably want to look at #cause
+      raise UnexpectedBuildError, e # wrap unexpected StandardError, caller will probably want to look at #cause
     end
 
     private

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -448,7 +448,7 @@ RSpec.describe 'Create object' do
                     filename: '00001.jp2',
                     size: 0, version: 1,
                     hasMimeType: 'image/jp2', hasMessageDigests: [],
-                    access: { access: 'world', download: 'none' },
+                    access: { access: 'world', download: 'world' },
                     administrative: { sdrPreserve: true, shelve: true }
                   }
                 ]
@@ -465,7 +465,7 @@ RSpec.describe 'Create object' do
                     label: '00002.html', filename: '00002.html', size: 0,
                     version: 1, hasMimeType: 'text/html',
                     hasMessageDigests: [],
-                    access: { access: 'world', download: 'none' },
+                    access: { access: 'world', download: 'world' },
                     administrative: { sdrPreserve: true, shelve: false }
                   }, {
                     type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
@@ -475,7 +475,7 @@ RSpec.describe 'Create object' do
                     size: 0, version: 1,
                     hasMimeType: 'image/jp2',
                     hasMessageDigests: [],
-                    access: { access: 'world', download: 'none' },
+                    access: { access: 'world', download: 'world' },
                     administrative: { sdrPreserve: true, shelve: true }
                   }
                 ]

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -665,7 +665,7 @@ RSpec.describe 'Update object' do
                       filename: '00001.jp2',
                       size: 0, version: 1,
                       hasMimeType: 'image/jp2', hasMessageDigests: [],
-                      access: { access: 'world', download: 'none' },
+                      access: { access: 'world', download: 'world' },
                       administrative: { sdrPreserve: true, shelve: true }
                     }
                   ]
@@ -682,7 +682,7 @@ RSpec.describe 'Update object' do
                       label: '00002.html', filename: '00002.html', size: 0,
                       version: 1, hasMimeType: 'text/html',
                       hasMessageDigests: [],
-                      access: { access: 'world', download: 'none' },
+                      access: { access: 'world', download: 'world' },
                       administrative: { sdrPreserve: true, shelve: false }
                     }, {
                       type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
@@ -692,7 +692,7 @@ RSpec.describe 'Update object' do
                       size: 0, version: 1,
                       hasMimeType: 'image/jp2',
                       hasMessageDigests: [],
-                      access: { access: 'world', download: 'none' },
+                      access: { access: 'world', download: 'world' },
                       administrative: { sdrPreserve: true, shelve: true }
                     }
                   ]


### PR DESCRIPTION


## Why was this change made?

Previously it was returning "none" for download access, which was not accurate

## How was this change tested?



## Which documentation and/or configurations were updated?



