### PR TITLE
ParallelValue for geographic and geographicTerm 

### DIFF
--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -697,7 +697,25 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
   end
 
   context 'with a geographic code and term' do
-    xit 'TODO https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_subject.txt#L652'
+    let(:xml) do
+      <<~XML
+        <subject>
+          <geographic authority="lcsh">United States</geographic>
+        </subject>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "source": {
+            "code": 'lcsh'
+          },
+          "value": 'United States',
+          "type": 'place'
+        }
+      ]
+    end
   end
 
   context 'with a temporal subject with encoding' do

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -696,11 +696,12 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     end
   end
 
-  context 'with a geographic code and term' do
+  context 'with geographic code and term' do
     let(:xml) do
       <<~XML
         <subject>
           <geographic authority="lcsh">United States</geographic>
+          <geographicCode authority="iso3166">us</geographicCode>
         </subject>
       XML
     end
@@ -708,10 +709,20 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     it 'builds the cocina data structure' do
       expect(build).to eq [
         {
-          "source": {
-            "code": 'lcsh'
-          },
-          "value": 'United States',
+          "parallelValue": [
+            {
+              "value": 'United States',
+              "source": {
+                "code": 'lcsh'
+              }
+            },
+            {
+              "code": 'us',
+              "source": {
+                "code": 'iso3166'
+              }
+            }
+          ],
           "type": 'place'
         }
       ]


### PR DESCRIPTION
## Why was this change made?
Adds missing implementation and test for parallelValue `geographic` and `geographicTerm`

See https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/ad622577057b8bd97b048d7bb13c23c14c62b542/mods_cocina_mappings/mods_to_cocina_subject.txt#L679-L704

## How was this change tested?
New test to replace  `xit` TODO at https://github.com/sul-dlss/dor-services-app/blob/c5233af81c21d19784082d4d4f1c915fc6018bac/spec/services/cocina/from_fedora/descriptive/subject_spec.rb#L699


## Which documentation and/or configurations were updated?
n/a


