### PR TITLE
Add missing valid authority codes

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/subject_authority_codes.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject_authority_codes.rb
@@ -761,11 +761,20 @@ module Cocina
 
         ISO_CODES = %w[
           ISO19115TopicCategory
+          iso639-2b
+          iso639-3
+        ].freeze
+
+        MARC_CODES = %w[
+          marcfrequency
+          marcorg
+          marcrelator
+          marctarget
         ].freeze
 
         SUBJECT_AUTHORITY_CODES = SUBJECT_CODES + CLASSIFICATION_CODES + GENRE_CODES + NAME_TITLE_CODES \
           + CARTOGRAPHIC_CODES + OCCUPATION_CODES + COUNTRY_CODES + GEOGRAPHIC_CODES \
-          + ISO_CODES + ['wikidata', 'marcrelator', 'iso639-2b', 'iso639-3', 'marcfrequency', 'marcorg', 'marctarget', 'EPSG']
+          + ISO_CODES + MARC_CODES + %w[wikidata EPSG]
       end
     end
   end

--- a/app/services/cocina/from_fedora/descriptive/subject_authority_codes.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject_authority_codes.rb
@@ -765,7 +765,7 @@ module Cocina
 
         SUBJECT_AUTHORITY_CODES = SUBJECT_CODES + CLASSIFICATION_CODES + GENRE_CODES + NAME_TITLE_CODES \
           + CARTOGRAPHIC_CODES + OCCUPATION_CODES + COUNTRY_CODES + GEOGRAPHIC_CODES \
-          + ISO_CODES + ['wikidata']
+          + ISO_CODES + ['wikidata', 'marcrelator', 'iso639-2b', 'iso639-3', 'marcfrequency', 'marcorg', 'marctarget', 'EPSG']
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?
Valid authority codes missing from the validation list were causing many false positive errors.


## How was this change tested?
n/a


## Which documentation and/or configurations were updated?
n/a


