### PR TITLE
Normalizes text roleTerms to downcase.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -22,6 +22,7 @@ module Cocina
       normalize_authority_uris
       normalize_origin_info_event_types
       normalize_subject_authority
+      normalize_text_role_term
       ng_xml
     end
 
@@ -110,6 +111,12 @@ module Cocina
 
     def add_event_type(value, origin_info_node)
       origin_info_node['eventType'] = value if origin_info_node[:eventType].blank?
+    end
+
+    def normalize_text_role_term
+      ng_xml.root.xpath("//mods:roleTerm[@type='text']", mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |role_term_node|
+        role_term_node.content = role_term_node.content.downcase
+      end
     end
   end
 end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Cocina::ModsNormalizer do
     end
   end
 
-  context 'when normalizing normalized_ng_xml authority' do
+  context 'when normalizing subject authority' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -194,6 +194,39 @@ RSpec.describe Cocina::ModsNormalizer do
           <subject authority="lcsh">
             <topic>Marine biology</topic>
           </subject>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when normalizing roleTerm' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <name>
+            <role>
+              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
+              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pht">Photographer</roleTerm>
+            </role>
+          </name>
+        </mods>
+      XML
+    end
+
+    it 'downcases text' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <name>
+            <role>
+              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
+              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pht">photographer</roleTerm>
+            </role>
+          </name>
         </mods>
       XML
     end


### PR DESCRIPTION
closes #1486

## Why was this change made?
Normalizes text roleTerms to downcase to improve matching of mapped MODS.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


