### PR TITLE
Fix MODS Equivalent Service performance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ $ bin/validate-cocina-roundtrip -h
 Usage: bin/validate-cocina-roundtrip [options]
     -s, --sample SAMPLE              Sample size, otherwise all druids.
     -r, --random                     Select random druids.
+    -f, --fast                       Do not write results files.    
     -d, --druids DRUIDS              List of druids (instead of druids.txt).
     -h, --help                       Displays help.
 
@@ -236,9 +237,11 @@ $ bin/validate-cocina-roundtrip -d druid:bh164hd2167
 Errors totals are summarized. For example:
 ```
 Status (n=100):
-  Success:   11 (11.0%)
-  Different: 81 (81.0%)
-  Error:     7 (7.0%)
+  Success:   54 (54.0%)
+  Different: 45 (45.0%)
+  To Cocina error:     0 (0.0%)
+  To Fedora error:     0 (0.0%)
+  Missing:     1 (1.0%)
 ```
 
 In addition, detailed results for each item with a difference are provided in an individual file in `results/`.
@@ -267,19 +270,17 @@ $ echo $FEDORA_CACHE
 /opt/app/deploy/dor-services-app/cache
 ```
 
-If testing a mapping to cocina, test with `bin/validate-to-cocina`. If testing a mapping to fedora, test with `bin/validate-to-fedora`.
-
-In both cases, compare results from master against your branch. The sample size to you is up to you; biggers samples are recommended for more complex changes.
+Test with `bin/validate-cocina-roundtrip`, comparing results from master against your branch. The sample size to you is up to you; biggers samples are recommended for more complex changes.
 
 ```
 $ git checkout master
 $ git pull
-$ bin/validate-to-cocina -s 350000
+$ bin/validate-cocina-roundtrip -s 350000 -f
 $ git checkout YOUR_BRANCH_NAME
-$ bin/validate-to-cocina -s 350000
+$ bin/validate-cocina-roundtrip -s 350000 -f
 ```
 
-When done, you may want to fetch the `results.txt` to your local drive (it is written to the root folder of dor-services-app)
+When running `bin/validate-to-cocina` or `bin/validate-to-feodora`, you may want to fetch the `results.txt` to your local drive (it is written to the root folder of dor-services-app)
 and look for errors.
 
 ```

--- a/app/services/mods_equivalent_service.rb
+++ b/app/services/mods_equivalent_service.rb
@@ -64,8 +64,13 @@ class ModsEquivalentService
     return mods_nodes2_with_same_tag.first if mods_nodes2_with_same_tag.size == 1
 
     distances = {}
-    mods_nodes2_with_same_tag.each { |mods_node2| distances[Text::Levenshtein.distance(mods_node1.to_s, mods_node2.to_s)] = mods_node2 }
+    mods_nodes2_with_same_tag.each { |mods_node2| distances[Text::Levenshtein.distance(content_for(mods_node1), content_for(mods_node2))] = mods_node2 }
 
     distances[distances.keys.min]
+  end
+
+  def content_for(node)
+    # By reducing the text, distance runs faster.
+    node.content.split(' ').sort.join(' ')
   end
 end

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -7,12 +7,13 @@ require 'set'
 require 'optparse'
 require 'diffy'
 
-options = { random: false, druids: [] }
+options = { random: false, druids: [], fast: false }
 parser = OptionParser.new do |option_parser|
   option_parser.banner = 'Usage: bin/validate-cocina-roundtrip [options]'
 
   option_parser.on('-sSAMPLE', '--sample SAMPLE', Integer, 'Sample size, otherwise all druids.')
   option_parser.on('-r', '--random', 'Select random druids.')
+  option_parser.on('-f', '--fast', 'Do not write results files.')
   option_parser.on('-dDRUIDS', '--druids DRUIDS', Array, 'List of druids (instead of druids.txt).')
   option_parser.on('-h', '--help', 'Displays help.') do
     puts option_parser
@@ -65,7 +66,7 @@ def write_error(druid, original_ng_xml, cocina, error)
   end
 end
 
-def validate_druid(druid, cache)
+def validate_druid(druid, cache, fast: false)
   begin
     original_ng_xml = cache.descmd_xml(druid)
     label = cache.label(druid)
@@ -89,6 +90,10 @@ def validate_druid(druid, cache)
     return :to_fedora_error
   end
 
+  if fast
+    return EquivalentXml.equivalent?(norm_original_ng_xml, roundtrip_ng_xml) ? :success : :different
+  end
+
   equiv = ModsEquivalentService.equivalent?(norm_original_ng_xml, roundtrip_ng_xml)
 
   return :success if equiv.success?
@@ -97,8 +102,10 @@ def validate_druid(druid, cache)
   :different
 end
 
-FileUtils.rm_rf('results')
-FileUtils.mkdir_p('results')
+unless options[:fast]
+  FileUtils.rm_rf('results')
+  FileUtils.mkdir_p('results')
+end
 
 if options[:druids].empty?
   druids = File.read('druids.txt').split
@@ -109,7 +116,7 @@ else
 end
 
 results = Parallel.map(druids, progress: 'Testing') do |druid|
-  validate_druid(druid, cache)
+  validate_druid(druid, cache, fast: options[:fast])
 end
 counts = { different: 0, success: 0, to_cocina_error: 0, to_fedora_error: 0, missing: 0 }
 results.each { |result| counts[result] += 1 }


### PR DESCRIPTION
## Why was this change made?
Computing Levenstein distance was significantly slowing down `validate-cocina-roundtrip`.


## How was this change tested?
sdr-deploy, unit


## Which documentation and/or configurations were updated?
README


