### PR TITLE
Adds or corrects roleTerm authorityURI.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -177,10 +177,10 @@ module Cocina
           {}.tap do |role|
             if authority&.content.present?
               role[:source] = { code: authority.content }
-              if authority_uri&.content.present?
-                role[:source][:uri] = authority_uri.content
-              elsif authority.content == 'marcrelator'
+              if authority.content == 'marcrelator'
                 role[:source][:uri] = "http://#{MARC_RELATOR_PIECE}/"
+              elsif authority_uri&.content.present?
+                role[:source][:uri] = authority_uri.content
               end
             end
 

--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -23,6 +23,7 @@ module Cocina
       normalize_origin_info_event_types
       normalize_subject_authority
       normalize_text_role_term
+      normalize_role_term_authority
       ng_xml
     end
 
@@ -62,6 +63,9 @@ module Cocina
       end
       ng_xml.root.xpath("//mods:*[@authorityURI='http://id.loc.gov/authorities/subjects']", mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
         node[:authorityURI] = 'http://id.loc.gov/authorities/subjects/'
+      end
+      ng_xml.root.xpath("//mods:*[@authorityURI='http://id.loc.gov/vocabulary/relators']", mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+        node[:authorityURI] = 'http://id.loc.gov/vocabulary/relators/'
       end
     end
 
@@ -116,6 +120,12 @@ module Cocina
     def normalize_text_role_term
       ng_xml.root.xpath("//mods:roleTerm[@type='text']", mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |role_term_node|
         role_term_node.content = role_term_node.content.downcase
+      end
+    end
+
+    def normalize_role_term_authority
+      ng_xml.root.xpath("//mods:roleTerm[@authority='marcrelator']", mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |role_term_node|
+        role_term_node['authorityURI'] = 'http://id.loc.gov/vocabulary/relators/'
       end
     end
   end

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -535,7 +535,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
                 uri: 'http://id.loc.gov/vocabulary/relators/spn',
                 source: {
                   code: 'marcrelator',
-                  uri: 'http://id.loc.gov/vocabulary/relators'
+                  uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
               }
             ]

--- a/spec/services/cocina/from_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Cocina::FromFedora::Descriptive do
           uri: 'http://id.loc.gov/vocabulary/relators/col',
           source: {
             code: 'marcrelator',
-            uri: 'http://id.loc.gov/vocabulary/relators'
+            uri: 'http://id.loc.gov/vocabulary/relators/'
           }
         }]
       }, {

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -108,6 +108,9 @@ RSpec.describe Cocina::ModsNormalizer do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <name authorityURI="http://id.loc.gov/authorities/names">
             <namePart authorityURI="http://id.loc.gov/authorities/subjects">Anning, Mary, 1799-1847</namePart>
+            <role>
+              <roleTerm authority="marcrelator" type="text" authorityURI="http://id.loc.gov/vocabulary/relators">creator</roleTerm>
+            </role>
           </name>
         </mods>
       XML
@@ -121,6 +124,9 @@ RSpec.describe Cocina::ModsNormalizer do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <name authorityURI="http://id.loc.gov/authorities/names/">
             <namePart authorityURI="http://id.loc.gov/authorities/subjects/">Anning, Mary, 1799-1847</namePart>
+            <role>
+              <roleTerm authority="marcrelator" type="text" authorityURI="http://id.loc.gov/vocabulary/relators/">creator</roleTerm>
+            </role>
           </name>
         </mods>
       XML
@@ -199,7 +205,7 @@ RSpec.describe Cocina::ModsNormalizer do
     end
   end
 
-  context 'when normalizing roleTerm' do
+  context 'when normalizing text roleTerm' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -207,8 +213,8 @@ RSpec.describe Cocina::ModsNormalizer do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <name>
             <role>
-              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
-              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pht">Photographer</roleTerm>
+              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
+              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">Photographer</roleTerm>
             </role>
           </name>
         </mods>
@@ -223,8 +229,41 @@ RSpec.describe Cocina::ModsNormalizer do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <name>
             <role>
-              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
-              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pht">photographer</roleTerm>
+              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
+              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">photographer</roleTerm>
+            </role>
+          </name>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when normalizing roleTerm authorityURI' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <name>
+            <role>
+              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
+              <roleTerm type="text" authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pht">Photographer</roleTerm>
+            </role>
+          </name>
+        </mods>
+      XML
+    end
+
+    it 'adds authorityURI' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <name>
+            <role>
+              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
+              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">photographer</roleTerm>
             </role>
           </name>
         </mods>


### PR DESCRIPTION
closes #1502

## Why was this change made?
Adds and/or corrects roleTerm authorityURI to improve matching.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


