### PR TITLE
Normalizes authorityURI with trailing slash.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/authority_uri.rb
+++ b/app/services/cocina/from_fedora/descriptive/authority_uri.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Cocina
+  module FromFedora
+    class Descriptive
+      # Normalizes AuthorityURIs
+      class AuthorityUri
+        NORMALIZE_AUTHORITY_URIS = [
+          'http://id.loc.gov/authorities/names',
+          'http://id.loc.gov/authorities/subjects',
+          'http://id.loc.gov/vocabulary/relators',
+          'http://id.loc.gov/vocabulary/countries',
+          'http://id.loc.gov/authorities/genreForms'
+        ].freeze
+
+        def self.normalize(authority_uri)
+          return "#{authority_uri}/" if NORMALIZE_AUTHORITY_URIS.include?(authority_uri)
+
+          authority_uri
+        end
+      end
+    end
+  end
+end

--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -105,7 +105,7 @@ module Cocina
             name_hash = contributor_hash[:name].first
             name_hash[:uri] = value_uri.content
             code = name_el.xpath('@authority', mods: DESC_METADATA_NS)&.first&.content
-            source_uri = name_el.xpath('@authorityURI', mods: DESC_METADATA_NS)&.first&.content
+            source_uri = AuthorityUri.normalize(name_el.xpath('@authorityURI', mods: DESC_METADATA_NS)&.first&.content)
             name_hash[:source] = name_authority_source(code, source_uri) if code || source_uri
           end
           contributor_hash
@@ -180,7 +180,7 @@ module Cocina
               if authority.content == 'marcrelator'
                 role[:source][:uri] = "http://#{MARC_RELATOR_PIECE}/"
               elsif authority_uri&.content.present?
-                role[:source][:uri] = authority_uri.content
+                role[:source][:uri] = AuthorityUri.normalize(authority_uri.content)
               end
             end
 

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -97,7 +97,7 @@ module Cocina
           if xml_node['authority']
             cocina[:source] = {
               code: xml_node['authority'],
-              uri: xml_node['authorityURI']
+              uri: AuthorityUri.normalize(xml_node['authorityURI'])
             }.compact
           end
           cocina

--- a/app/services/cocina/from_fedora/descriptive/form.rb
+++ b/app/services/cocina/from_fedora/descriptive/form.rb
@@ -62,7 +62,7 @@ module Cocina
               type: type['type'] || 'genre'
             }.tap do |item|
               item[:uri] = type[:valueURI]
-              source = { code: type[:authority], uri: type[:authorityURI] }.compact
+              source = { code: type[:authority], uri: AuthorityUri.normalize(type[:authorityURI]) }.compact
               item[:source] = source if source.present?
             end.compact
           end
@@ -168,7 +168,7 @@ module Cocina
         end
 
         def source_for(form)
-          { code: form['authority'], uri: form['authorityURI'] }.compact
+          { code: form['authority'], uri: AuthorityUri.normalize(form['authorityURI']) }.compact
         end
 
         def type_of_resource

--- a/app/services/cocina/from_fedora/descriptive/location.rb
+++ b/app/services/cocina/from_fedora/descriptive/location.rb
@@ -69,7 +69,7 @@ module Cocina
               else
                 attrs[:code] = node.text
               end
-              source = { code: node[:authority], uri: node[:authorityURI] }.compact
+              source = { code: node[:authority], uri: AuthorityUri.normalize(node[:authorityURI]) }.compact
               attrs[:source] = source unless source.empty?
               attrs[:type] = node[:type]
             end.compact

--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -60,7 +60,7 @@ module Cocina
 
         def source_attrs(subject, attrs = {})
           if subject[:valueURI]
-            source = { code: code_for(subject), uri: uri_for(subject[:authorityURI]) }.compact
+            source = { code: code_for(subject), uri: AuthorityUri.normalize(subject[:authorityURI]) }.compact
             attrs[:source] = source unless source.empty?
             attrs[:uri] = subject[:valueURI]
           elsif subject[:authority]
@@ -68,12 +68,6 @@ module Cocina
             attrs[:source] = source unless source.empty?
           end
           attrs.compact
-        end
-
-        def uri_for(authority_uri)
-          return "#{authority_uri}/" if ['http://id.loc.gov/authorities/names', 'http://id.loc.gov/authorities/subjects'].include?(authority_uri)
-
-          authority_uri
         end
 
         def code_for(subject)

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -851,7 +851,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
   context 'with authority' do
     let(:xml) do
       <<~XML
-        <name type="personal" usage="primary" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79046044">
+        <name type="personal" usage="primary" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n79046044">
           <namePart>Sayers, Dorothy L. (Dorothy Leigh), 1893-1957</namePart>
         </name>
       XML

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -564,7 +564,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
       <<~XML
         <originInfo>
         <place>
-          <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+          <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
         </place>
         </originInfo>
       XML
@@ -593,7 +593,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
       <<~XML
         <originInfo>
           <place>
-            <placeTerm type="code" authority="marccountry" authorityURI="http://id.loc.gov/vocabulary/countries/" valueURI="http://id.loc.gov/vocabulary/countries/cau">cau</placeTerm>
+            <placeTerm type="code" authority="marccountry" authorityURI="http://id.loc.gov/vocabulary/countries" valueURI="http://id.loc.gov/vocabulary/countries/cau">cau</placeTerm>
           <place>
         </originInfo>
       XML

--- a/spec/services/cocina/from_fedora/descriptive/form_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/form_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
     context 'with authority' do
       let(:xml) do
         <<~XML
-          <genre authority="lcgft" authorityURI="http://id.loc.gov/authorities/genreForms/"
+          <genre authority="lcgft" authorityURI="http://id.loc.gov/authorities/genreForms"
             valueURI="http://id.loc.gov/authorities/genreForms/gf2017027249">Photographs</genre>
         XML
       end
@@ -245,7 +245,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
     context 'when there is a subject/genre node' do
       let(:xml) do
         <<~XML
-          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85120809">
+          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects" valueURI="http://id.loc.gov/authorities/subjects/sh85120809">
             <name type="personal">
               <namePart>Shakespeare, William, 1564-1616</namePart>
             </name>

--- a/spec/services/cocina/from_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/location_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     let(:xml) do
       <<~XML
         <location>
-          <physicalLocation authority="lcsh" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/nb2006009317">British Broadcasting Corporation. Sound Effects Library</physicalLocation>
+          <physicalLocation authority="lcsh" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/nb2006009317">British Broadcasting Corporation. Sound Effects Library</physicalLocation>
         </location>
       XML
     end


### PR DESCRIPTION
closes #1484
closes #1490

## Why was this change made?
Normalizes authorityURI with trailing slash.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


