### PR TITLE
Normalizes usage for PURL.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -24,6 +24,7 @@ module Cocina
       normalize_subject_authority
       normalize_text_role_term
       normalize_role_term_authority
+      normalize_purl
       ng_xml
     end
 
@@ -126,6 +127,15 @@ module Cocina
     def normalize_role_term_authority
       ng_xml.root.xpath("//mods:roleTerm[@authority='marcrelator']", mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |role_term_node|
         role_term_node['authorityURI'] = 'http://id.loc.gov/vocabulary/relators/'
+      end
+    end
+
+    def normalize_purl
+      ng_xml.root.xpath('//mods:location', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |location_node|
+        url_nodes = location_node.xpath('mods:url', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS)
+        purl_node = url_nodes.find { |url_node| Cocina::FromFedora::Descriptive::Location::PURL_REGEX.match(url_node.text) }
+        has_primary_usage = url_nodes.any? { |url_node| url_node[:usage] == 'primary display' }
+        purl_node[:usage] = 'primary display' unless has_primary_usage
       end
     end
   end

--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -135,7 +135,7 @@ module Cocina
         url_nodes = location_node.xpath('mods:url', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS)
         purl_node = url_nodes.find { |url_node| Cocina::FromFedora::Descriptive::Location::PURL_REGEX.match(url_node.text) }
         has_primary_usage = url_nodes.any? { |url_node| url_node[:usage] == 'primary display' }
-        purl_node[:usage] = 'primary display' unless has_primary_usage
+        purl_node[:usage] = 'primary display' if purl_node && !has_primary_usage
       end
     end
   end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -270,4 +270,60 @@ RSpec.describe Cocina::ModsNormalizer do
       XML
     end
   end
+
+  context 'when normalizing PURL' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <location>
+            <url>http://purl.stanford.edu/bw502ns3302</url>
+          </location>
+        </mods>
+      XML
+    end
+
+    it 'adds usage' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <location>
+            <url usage="primary display">http://purl.stanford.edu/bw502ns3302</url>
+          </location>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when normalizing PURL but existing primary display' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <location>
+            <url>http://purl.stanford.edu/bw502ns3302</url>
+            <url usage="primary display">http://www.stanford.edu</url>
+          </location>
+        </mods>
+      XML
+    end
+
+    it 'does not add usage' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <location>
+            <url>http://purl.stanford.edu/bw502ns3302</url>
+            <url usage="primary display">http://www.stanford.edu</url>
+          </location>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #1500

## Why was this change made?
Normalizes usage for PURL to improve matching.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


