### PR TITLE
Maps multiple identifiers to cocina.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
+++ b/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
@@ -56,13 +56,15 @@ module Cocina
         end
 
         def build_identifier
-          return unless identifier
+          return if identifiers.empty?
 
-          [{
-            value: identifier.text
-          }.tap do |model|
-            model[:source] = { value: identifier['source'] } if identifier['source']
-          end]
+          identifiers.map do |identifier|
+            {
+              value: identifier.text
+            }.tap do |model|
+              model[:source] = { value: identifier['source'] } if identifier['source']
+            end
+          end
         end
 
         def build_note
@@ -160,8 +162,8 @@ module Cocina
           @record_origin ||= resource_element.xpath('mods:recordInfo/mods:recordOrigin', mods: DESC_METADATA_NS).first
         end
 
-        def identifier
-          @identifier ||= resource_element.xpath('mods:recordInfo/mods:recordIdentifier', mods: DESC_METADATA_NS).first
+        def identifiers
+          @identifiers ||= resource_element.xpath('mods:recordInfo/mods:recordIdentifier', mods: DESC_METADATA_NS)
         end
 
         def creation_event

--- a/spec/services/cocina/from_fedora/descriptive/admin_metadata_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/admin_metadata_spec.rb
@@ -338,6 +338,41 @@ RSpec.describe Cocina::FromFedora::Descriptive::AdminMetadata do
     end
   end
 
+  # <mods:recordIdentifier source="SUL catalog key">6766105</mods:recordIdentifier>
+  #        <mods:recordIdentifier source="oclc">3888071</mods:recordIdentifier>
+
+  context 'when there are multiple recordIdentifiers' do
+    let(:xml) do
+      <<~XML
+        <recordInfo>
+          <recordIdentifier source="SUL catalog key">6766105</recordIdentifier>
+          <recordIdentifier source="oclc">3888071</recordIdentifier>
+        </recordInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq(
+        {
+          identifier: [
+            {
+              source: {
+                value: 'SUL catalog key'
+              },
+              value: '6766105'
+            },
+            {
+              source: {
+                value: 'oclc'
+              },
+              value: '3888071'
+            }
+          ]
+        }
+      )
+    end
+  end
+
   context 'when there is no encoding for the recordCreationDate' do
     let(:xml) do
       <<~XML


### PR DESCRIPTION
closes #1481

## Why was this change made?
Only a single identifier was being mapped to cocina.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


