### PR TITLE
Maps name without type to fedora.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor.rb
@@ -43,9 +43,7 @@ module Cocina
         attr_reader :xml, :contributors
 
         def name_attributes(contributor)
-          return {} if contributor.type.nil?
-
-          { type: NAME_TYPE.fetch(contributor.type) }.tap do |attributes|
+          { type: NAME_TYPE[contributor.type] }.tap do |attributes|
             attributes[:usage] = 'primary' if contributor.status == 'primary'
             value_uri = contributor.name.first&.uri
             if value_uri
@@ -54,7 +52,7 @@ module Cocina
               attributes[:authority] = source.code if source&.code
               attributes[:authorityURI] = source.uri if source&.uri
             end
-          end
+          end.compact
         end
 
         # return marcrelator roles only if any are present, otherwise return other roles

--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -174,6 +174,33 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     end
   end
 
+  context 'without type' do
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          "name": [
+            {
+              "value": 'Dunnett, Dorothy'
+            }
+          ],
+          "status": 'primary'
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <name usage="primary">
+            <namePart>Dunnett, Dorothy</namePart>
+          </name>
+        </mods>
+      XML
+    end
+  end
+
   context 'with role' do
     context 'when both code and value' do
       let(:contributors) do


### PR DESCRIPTION
closes #1494

## Why was this change made?
Handle names without types.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


