### PR TITLE
Maps invalid identifiers.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/identifier.rb
+++ b/app/services/cocina/from_fedora/descriptive/identifier.rb
@@ -20,6 +20,7 @@ module Cocina
           identifiers.map do |id|
             { value: id.text }.tap do |item|
               item[:type] = id['type'].upcase if id['type']
+              item[:status] = 'invalid' if id['invalid'] == 'yes'
               item[:displayLabel] = id['displayLabel'] if id['displayLabel']
             end
           end

--- a/app/services/cocina/to_fedora/descriptive/identifier.rb
+++ b/app/services/cocina/to_fedora/descriptive/identifier.rb
@@ -21,6 +21,7 @@ module Cocina
             attributes = {}
             attributes[:type] = identifier.type.downcase if identifier.type
             attributes[:displayLabel] = identifier.displayLabel if identifier.displayLabel
+            attributes[:invalid] = 'yes' if identifier.status == 'invalid'
             xml.identifier identifier.value, attributes
           end
         end

--- a/spec/services/cocina/from_fedora/descriptive/identifier_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/identifier_spec.rb
@@ -65,4 +65,22 @@ RSpec.describe Cocina::FromFedora::Descriptive::Identifier do
       ]
     end
   end
+
+  context 'with invalid identifier' do
+    let(:xml) do
+      <<~XML
+        <identifier type="isbn" invalid="yes">1234 5678 9203</identifier>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "value": '1234 5678 9203',
+          "status": 'invalid',
+          "type": 'ISBN'
+        }
+      ]
+    end
+  end
 end

--- a/spec/services/cocina/to_fedora/descriptive/identifier_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/identifier_spec.rb
@@ -97,4 +97,26 @@ RSpec.describe Cocina::ToFedora::Descriptive::Identifier do
       XML
     end
   end
+
+  context 'when it is invalid' do
+    let(:identifiers) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          "value": '1234 5678 9203',
+          "status": 'invalid',
+          "type": 'ISBN'
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <identifier type="isbn" invalid="yes">1234 5678 9203</identifier>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #1508

## Why was this change made?
To map invalid identifiers.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


