### PR TITLE
Maps url note.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/location.rb
+++ b/app/services/cocina/from_fedora/descriptive/location.rb
@@ -56,6 +56,7 @@ module Cocina
             { value: url_value }.tap do |attrs|
               attrs[:status] = 'primary' if url_elem[:usage] == 'primary display'
               attrs[:displayLabel] = url_elem[:displayLabel] if url_elem[:displayLabel]
+              attrs[:note] = [{ value: url_elem[:note] }] if url_elem[:note]
             end
           end.compact
         end

--- a/app/services/cocina/to_fedora/descriptive/location.rb
+++ b/app/services/cocina/to_fedora/descriptive/location.rb
@@ -56,6 +56,7 @@ module Cocina
             url_attrs = {}.tap do |attrs|
               attrs[:usage] = 'primary display' if url.status == 'primary'
               attrs[:displayLabel] = url.displayLabel
+              attrs[:note] = url.note.first.value unless url.note.nil?
             end.compact
             xml.url url.value, url_attrs
           end

--- a/spec/services/cocina/from_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/location_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     let(:xml) do
       <<~XML
         <location>
-          <physicalLocation authority="lcsh" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/nb2006009317">British Broadcasting Corporation. Sound Effects Library</physicalLocation>
+          <physicalLocation authority="lcsh" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/nb2006009317">British Broadcasting Corporation. Sound Effects Library</physicalLocation>
         </location>
       XML
     end
@@ -144,6 +144,32 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
 
     it 'ignores' do
       expect(build).to eq({})
+    end
+  end
+
+  context 'with a URL with note' do
+    let(:xml) do
+      <<~XML
+        <location>
+          <url displayLabel="Coverage: V. 1 (Jan. 1922)-" note="Online table of contents from PCI available to Stanford-affiliated users:">https://stanford.idm.oclc.org/login</url>
+        </location>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq(
+        "url": [
+          {
+            "value": 'https://stanford.idm.oclc.org/login',
+            "displayLabel": 'Coverage: V. 1 (Jan. 1922)-',
+            "note": [
+              {
+                "value": 'Online table of contents from PCI available to Stanford-affiliated users:'
+              }
+            ]
+          }
+        ]
+      )
     end
   end
 

--- a/spec/services/cocina/to_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/location_spec.rb
@@ -141,6 +141,36 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
     end
   end
 
+  context 'when it is a URL with note' do
+    let(:access) do
+      Cocina::Models::DescriptiveAccessMetadata.new(
+        "url": [
+          {
+            "value": 'https://stanford.idm.oclc.org/login',
+            "displayLabel": 'Coverage: V. 1 (Jan. 1922)-',
+            "note": [
+              {
+                "value": 'Online table of contents from PCI available to Stanford-affiliated users:'
+              }
+            ]
+          }
+        ]
+      )
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <location>
+            <url displayLabel="Coverage: V. 1 (Jan. 1922)-" note="Online table of contents from PCI available to Stanford-affiliated users:">https://stanford.idm.oclc.org/login</url>
+          </location>
+        </mods>
+      XML
+    end
+  end
+
   context 'when it is a PURL' do
     let(:purl) { 'http://purl.stanford.edu/ys701qw6956' }
 


### PR DESCRIPTION
closes #1509

## Why was this change made?
To map url note.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


