### PR TITLE
Maps lang and script for physicalLocation.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/language_script.rb
+++ b/app/services/cocina/from_fedora/descriptive/language_script.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Cocina
+  module FromFedora
+    class Descriptive
+      # Maps lang and script attributes
+      class LanguageScript
+        # @param [Nokogiri::XML::Element] element that may have lang or script attributes
+        # @param [Cocina::FromFedora::Descriptive::DescriptiveBuilder] descriptive_builder
+        # @return [Hash] a hash that can be mapped to a cocina model for a valueLanguage
+        def self.build(node:)
+          return nil unless node['lang'].present? || node['script'].present?
+
+          {}.tap do |value_language|
+            if node['lang'].present?
+              value_language[:code] = node['lang']
+              value_language[:source] = { code: 'iso639-2b' }
+            end
+            value_language[:valueScript] = { code: node['script'], source: { code: 'iso15924' } } if node['script'].present?
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/cocina/from_fedora/descriptive/location.rb
+++ b/app/services/cocina/from_fedora/descriptive/location.rb
@@ -72,6 +72,8 @@ module Cocina
               source = { code: node[:authority], uri: AuthorityUri.normalize(node[:authorityURI]) }.compact
               attrs[:source] = source unless source.empty?
               attrs[:type] = node[:type]
+              value_language = LanguageScript.build(node: node)
+              attrs[:valueLanguage] = value_language if value_language
             end.compact
           end
         end

--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -129,7 +129,6 @@ module Cocina
         # @param [Hash<Symbol,String>] value
         # @param [Nokogiri::XML::Element] title_info the titleInfo node
         # @param [Bool] display_types this is set to false in the case that it's a parallelValue and all are translations
-        # rubocop:disable Metrics/CyclomaticComplexity
         def with_attributes(value, title_info, display_types: true)
           value.tap do |result|
             result[:status] = 'primary' if title_info['usage'] == 'primary'
@@ -140,20 +139,10 @@ module Cocina
             result[:source] = { code: title_info[:authority] } if title_info['type'] == 'abbreviated' && title_info[:authority]
             result[:uri] = title_info[:valueURI] if title_info['valueURI']
 
-            result[:valueLanguage] = language(title_info) if title_info['lang'].present? || title_info['script'].present?
+            value_language = LanguageScript.build(node: title_info)
+            result[:valueLanguage] = value_language if value_language
             result[:standard] = { value: title_info['transliteration'] } if title_info['transliteration']
             result[:displayLabel] = title_info['displayLabel'] if title_info['displayLabel']
-          end
-        end
-        # rubocop:enable Metrics/CyclomaticComplexity
-
-        def language(title_info)
-          {}.tap do |value_language|
-            if title_info['lang'].present?
-              value_language[:code] = title_info['lang']
-              value_language[:source] = { code: 'iso639-2b' }
-            end
-            value_language[:valueScript] = { code: title_info['script'], source: { code: 'iso15924' } } if title_info['script'].present?
           end
         end
 

--- a/app/services/cocina/to_fedora/descriptive/location.rb
+++ b/app/services/cocina/to_fedora/descriptive/location.rb
@@ -37,11 +37,11 @@ module Cocina
 
         def write_physical_locations
           Array(access.physicalLocation).reject { |physical_location| shelf_locator?(physical_location) }.each do |physical_location|
-            xml.physicalLocation physical_location.value || physical_location.code, with_uri_info(physical_location, {})
+            xml.physicalLocation physical_location.value || physical_location.code, descriptive_attrs(physical_location)
           end
 
           Array(access.accessContact).each do |access_contact|
-            xml.physicalLocation access_contact.value, with_uri_info(access_contact, { type: 'repository' })
+            xml.physicalLocation access_contact.value, { type: 'repository' }.merge(descriptive_attrs(access_contact))
           end
         end
 
@@ -65,11 +65,14 @@ module Cocina
           xml.url purl, { usage: 'primary display' }
         end
 
-        def with_uri_info(cocina, xml_attrs)
-          xml_attrs[:valueURI] = cocina.uri
-          xml_attrs[:authorityURI] = cocina.source&.uri
-          xml_attrs[:authority] = cocina.source&.code
-          xml_attrs.compact
+        def descriptive_attrs(cocina)
+          {}.tap do |attrs|
+            attrs[:valueURI] = cocina.uri
+            attrs[:authorityURI] = cocina.source&.uri
+            attrs[:authority] = cocina.source&.code
+            attrs[:script] = cocina.valueLanguage&.valueScript&.code
+            attrs[:lang] = cocina.valueLanguage&.code
+          end.compact
         end
 
         def shelf_locator?(physical_location)

--- a/spec/services/cocina/from_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/location_spec.rb
@@ -92,6 +92,43 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     end
   end
 
+  context 'with a physical repository with language and script' do
+    let(:xml) do
+      <<~XML
+        <location>
+          <physicalLocation type="repository" authority="naf" valueURI="http://id.loc.gov/authorities/names/no2014019980" lang="eng" script="Latn">Stanford University. Libraries. Department of Special Collections and University Archives</physicalLocation>
+        </location>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq(
+        "accessContact": [
+          {
+            "value": 'Stanford University. Libraries. Department of Special Collections and University Archives',
+            "valueLanguage": {
+              "code": 'eng',
+              "source": {
+                "code": 'iso639-2b'
+              },
+              "valueScript": {
+                "code": 'Latn',
+                "source": {
+                  "code": 'iso15924'
+                }
+              }
+            },
+            "uri": 'http://id.loc.gov/authorities/names/no2014019980',
+            "type": 'repository',
+            "source": {
+              "code": 'naf'
+            }
+          }
+        ]
+      )
+    end
+  end
+
   context 'with a URL (with usage)' do
     let(:xml) do
       <<~XML

--- a/spec/services/cocina/to_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/location_spec.rb
@@ -116,6 +116,47 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
     end
   end
 
+  context 'when it is a physical repository with language and script' do
+    let(:access) do
+      Cocina::Models::DescriptiveAccessMetadata.new(
+        "accessContact": [
+          {
+            "value": 'Stanford University. Libraries. Department of Special Collections and University Archives',
+            "valueLanguage": {
+              "code": 'eng',
+              "source": {
+                "code": 'iso639-2b'
+              },
+              "valueScript": {
+                "code": 'Latn',
+                "source": {
+                  "code": 'iso15924'
+                }
+              }
+            },
+            "type": 'repository',
+            "uri": 'http://id.loc.gov/authorities/names/no2014019980',
+            "source": {
+              "code": 'naf'
+            }
+          }
+        ]
+      )
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <location>
+            <physicalLocation type="repository" authority="naf" valueURI="http://id.loc.gov/authorities/names/no2014019980" lang="eng" script="Latn">Stanford University. Libraries. Department of Special Collections and University Archives</physicalLocation>
+          </location>
+        </mods>
+      XML
+    end
+  end
+
   context 'when it is a URL (with usage)' do
     let(:access) do
       Cocina::Models::DescriptiveAccessMetadata.new(


### PR DESCRIPTION
closes #1510

## Why was this change made?
To map lang and script attributes for `<physicalLocation>`.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


