### PR TITLE
Normalizes when relatedItem has otherType and type.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -25,6 +25,7 @@ module Cocina
       normalize_text_role_term
       normalize_role_term_authority
       normalize_purl
+      normalize_related_item_other_type
       ng_xml
     end
 
@@ -136,6 +137,14 @@ module Cocina
         purl_node = url_nodes.find { |url_node| Cocina::FromFedora::Descriptive::Location::PURL_REGEX.match(url_node.text) }
         has_primary_usage = url_nodes.any? { |url_node| url_node[:usage] == 'primary display' }
         purl_node[:usage] = 'primary display' if purl_node && !has_primary_usage
+      end
+    end
+
+    def normalize_related_item_other_type
+      ng_xml.root.xpath('//mods:relatedItem[@type and @otherType]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |related_node|
+        related_node.delete('otherType')
+        related_node.delete('otherTypeURI')
+        related_node.delete('otherTypeAuth')
       end
     end
   end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -326,4 +326,37 @@ RSpec.describe Cocina::ModsNormalizer do
       XML
     end
   end
+
+  context 'when normalizing relatedType with type and otherType' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <relatedItem type="otherFormat" otherType="Online version:" displayLabel="Online version:">
+            <titleInfo>
+              <title>Sitzungsberichte der Kaiserlichen Akademie der Wissenschaften. Mathematisch-Naturwissenschaftliche Classe. Abt. 2, Mathematik, Physik, Chemie, Physiologie, Meteorologie, physische Geographie und Astronomie</title>
+            </titleInfo>
+            <identifier type="local">(OCoLC)606338944</identifier>
+          </relatedItem>
+        </mods>
+      XML
+    end
+
+    it 'does not add otherType' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <relatedItem type="otherFormat" displayLabel="Online version:">
+            <titleInfo>
+              <title>Sitzungsberichte der Kaiserlichen Akademie der Wissenschaften. Mathematisch-Naturwissenschaftliche Classe. Abt. 2, Mathematik, Physik, Chemie, Physiologie, Meteorologie, physische Geographie und Astronomie</title>
+            </titleInfo>
+            <identifier type="local">(OCoLC)606338944</identifier>
+          </relatedItem>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?
To normalize when relatedItem has otherType and type attributes to enhance matching.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


