### PR TITLE
Fixes determining code/value for physicalLocation.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/location.rb
+++ b/app/services/cocina/from_fedora/descriptive/location.rb
@@ -64,12 +64,12 @@ module Cocina
         def descriptive_value_for(nodes)
           nodes.map do |node|
             {}.tap do |attrs|
-              if node[:valueURI]
-                attrs[:value] = node.text
-                attrs[:uri] = node[:valueURI]
-              else
+              if node[:authority] && !node[:valueURI]
                 attrs[:code] = node.text
+              else
+                attrs[:value] = node.text
               end
+              attrs[:uri] = node[:valueURI]
               source = { code: node[:authority], uri: AuthorityUri.normalize(node[:authorityURI]) }.compact
               attrs[:source] = source unless source.empty?
               attrs[:type] = node[:type]

--- a/spec/services/cocina/from_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/location_spec.rb
@@ -92,6 +92,27 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     end
   end
 
+  context 'with a physical repository without authority and valueURI' do
+    let(:xml) do
+      <<~XML
+        <location>
+          <physicalLocation type="repository">Stanford University. Libraries. Department of Special Collections and University Archives</physicalLocation>
+        </location>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq(
+        "accessContact": [
+          {
+            "value": 'Stanford University. Libraries. Department of Special Collections and University Archives',
+            "type": 'repository'
+          }
+        ]
+      )
+    end
+  end
+
   context 'with a physical repository with language and script' do
     let(:xml) do
       <<~XML


### PR DESCRIPTION
closes #1489

## Why was this change made?
The logic for determining code/value for `<physicalLocation>` was incorrect.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


