### PR TITLE
Fix missing authorityURI for name subject.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -59,12 +59,11 @@ module Cocina
         end
 
         def source_attrs(subject, attrs = {})
+          source = { code: code_for(subject), uri: AuthorityUri.normalize(subject[:authorityURI]), version: edition_for(subject) }.compact
           if subject[:valueURI]
-            source = { code: code_for(subject), uri: AuthorityUri.normalize(subject[:authorityURI]) }.compact
             attrs[:source] = source unless source.empty?
             attrs[:uri] = subject[:valueURI]
           elsif subject[:authority]
-            source = { code: code_for(subject), version: edition_for(subject) }.compact
             attrs[:source] = source unless source.empty?
           end
           attrs.compact

--- a/spec/services/cocina/from_fedora/descriptive/subject_name_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_name_spec.rb
@@ -87,6 +87,31 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     end
   end
 
+  context 'with authority missing valueURI' do
+    let(:xml) do
+      <<~XML
+        <subject authority="lcsh">
+          <name type="corporate" authority="naf" authorityURI="http://id.loc.gov/authorities/names/">
+            <namePart>Biblioteka Polskiej Akademii Nauk w Krakowie</namePart>
+          </name>
+        </subject>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "value": 'Biblioteka Polskiej Akademii Nauk w Krakowie',
+          "type": 'organization',
+          "source": {
+            "code": 'naf',
+            "uri": 'http://id.loc.gov/authorities/names/'
+          }
+        }
+      ]
+    end
+  end
+
   context 'with additional terms' do
     let(:xml) do
       <<~XML


### PR DESCRIPTION
closes #1497

## Why was this change made?
Fix missing authorityURI for name subject.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


