### PR TITLE
Normalize unmatched altRepGroups.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -27,6 +27,7 @@ module Cocina
       normalize_purl
       normalize_related_item_other_type
       normalize_empty_notes
+      normalize_unmatched_altrepgroup
       ng_xml
     end
 
@@ -151,6 +152,21 @@ module Cocina
 
     def normalize_empty_notes
       ng_xml.root.xpath('//mods:note[not(text())]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each(&:remove)
+    end
+
+    def normalize_unmatched_altrepgroup
+      altrepgroups = {}
+      ng_xml.root.xpath('//mods:*[@altRepGroup]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+        altrepgroup = node['altRepGroup']
+        altrepgroups[altrepgroup] = [] unless altrepgroups.include?(altrepgroup)
+        altrepgroups[altrepgroup] << node
+      end
+
+      altrepgroups.each do |_altrepgroup, nodes|
+        next unless nodes.size == 1
+
+        nodes.first.delete('altRepGroup')
+      end
     end
   end
 end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -412,4 +412,43 @@ RSpec.describe Cocina::ModsNormalizer do
       XML
     end
   end
+
+  context 'when normalizing unmatches altRepGroups' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject altRepGroup='1'>
+            <topic>Marine biology</topic>
+          </subject>
+          <subject altRepGroup='1'>
+            <topic>Biología marina</topic>
+          </subject>
+          <subject altRepGroup='2'>
+            <topic>Vulcanology</topic>
+          </subject>
+        </mods>
+      XML
+    end
+
+    it 'removes unmatched' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject altRepGroup='1'>
+            <topic>Marine biology</topic>
+          </subject>
+          <subject altRepGroup='1'>
+            <topic>Biología marina</topic>
+          </subject>
+          <subject>
+            <topic>Vulcanology</topic>
+          </subject>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #1488

## Why was this change made?
To normalize for unmatched altRepGroups.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


