### PR TITLE
Normalizes empty attributes.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -17,6 +17,7 @@ module Cocina
     def normalize
       normalize_default_namespace
       normalize_version
+      normalize_empty_attributes
       normalize_topics
       normalize_subject_name
       normalize_authority_uris
@@ -166,6 +167,12 @@ module Cocina
         next unless nodes.size == 1
 
         nodes.first.delete('altRepGroup')
+      end
+    end
+
+    def normalize_empty_attributes
+      ng_xml.root.xpath('//mods:*[@*=""]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+        node.each { |attr_name, attr_value| node.delete(attr_name) if attr_value.blank? }
       end
     end
   end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -451,4 +451,27 @@ RSpec.describe Cocina::ModsNormalizer do
       XML
     end
   end
+
+  context 'when normalizing empty attributes' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <classification authority="">Y 1.1/2:</mods:classification>
+        </mods>
+      XML
+    end
+
+    it 'removes unmatched' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <classification>Y 1.1/2:</mods:classification>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #1485

## Why was this change made?
Remove empty attributes to help with mapping.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


