### PR TITLE
Remove empty notes.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,7 @@ Metrics/ClassLength:
     - 'app/services/cocina/from_fedora/descriptive/admin_metadata.rb'
     - 'app/services/cocina/to_fedora/descriptive/title.rb'
     - 'app/services/cocina/from_fedora/descriptive/titles.rb'
+    - 'app/services/cocina/mods_normalizer.rb'
 
 RSpec/DescribeClass:
   Exclude:

--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -26,6 +26,7 @@ module Cocina
       normalize_role_term_authority
       normalize_purl
       normalize_related_item_other_type
+      normalize_empty_notes
       ng_xml
     end
 
@@ -146,6 +147,10 @@ module Cocina
         related_node.delete('otherTypeURI')
         related_node.delete('otherTypeAuth')
       end
+    end
+
+    def normalize_empty_notes
+      ng_xml.root.xpath('//mods:note[not(text())]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each(&:remove)
     end
   end
 end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -359,4 +359,28 @@ RSpec.describe Cocina::ModsNormalizer do
       XML
     end
   end
+
+  context 'when normalizing empty notes' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <note type="statement of responsibility" altRepGroup="00" script="Latn"/>
+          <note>Includes various issues of some sheets.</note>
+        </mods>
+      XML
+    end
+
+    it 'removes' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <note>Includes various issues of some sheets.</note>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #1479

## Why was this change made?
So that empty nodes match when checking equivalence.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


