### PR TITLE
Removes xml:space.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/language.rb
+++ b/app/services/cocina/from_fedora/descriptive/language.rb
@@ -17,80 +17,14 @@ module Cocina
         end
 
         def build
-          [].tap do |langs|
-            languages.each do |lang|
-              attribs = lang_term_attributes_for(lang)
-              attribs[:status] = lang['status']
-              attribs[:script] = script_term_attributes_for(lang)
-              langs << attribs.compact
-            end
+          resource_element.xpath('mods:language', mods: DESC_METADATA_NS).map do |lang_node|
+            Cocina::FromFedora::Descriptive::LanguageTerm.build(language_element: lang_node)
           end
         end
 
         private
 
         attr_reader :resource_element
-
-        def lang_term_attributes_for(lang)
-          code_language_term = lang.xpath('./mods:languageTerm[@type="code"]', mods: DESC_METADATA_NS).first
-          text_language_term = lang.xpath('./mods:languageTerm[@type="text"]', mods: DESC_METADATA_NS).first
-          if code_language_term.nil? && text_language_term.nil?
-            Honeybadger.notify('[DATA ERROR] languageTerm missing type', { tags: 'data_error' })
-            code_language_term = lang.xpath('./mods:languageTerm', mods: DESC_METADATA_NS).first
-          end
-
-          {
-            code: code_language_term&.text,
-            value: text_language_term&.text,
-            uri: language_value_uri_for(code_language_term, text_language_term),
-            appliesTo: language_applies_to(lang),
-            displayLabel: lang['displayLabel']
-          }.tap do |attrs|
-            source = language_source_for(code_language_term, text_language_term)
-            attrs[:source] = source if source.present?
-          end
-        end
-
-        def script_term_attributes_for(lang)
-          script_term_nodes = lang.xpath('mods:scriptTerm', mods: DESC_METADATA_NS)
-
-          return if script_term_nodes.blank?
-
-          code, value, authority = nil
-          script_term_nodes.each do |script_term_node|
-            code ||= script_term_node.content if script_term_node['type'] == 'code'
-            value ||= script_term_node.content if script_term_node['type'] == 'text'
-            authority ||= script_term_node['authority']
-          end
-          source = { code: authority } if authority
-          {
-            code: code,
-            value: value,
-            source: source
-          }.compact
-        end
-
-        def languages
-          @languages ||= resource_element.xpath('mods:language', mods: DESC_METADATA_NS)
-        end
-
-        # this can be present for type text and/or code, but we only want one.
-        def language_value_uri_for(code_language_term, text_language_term)
-          code_language_term&.attribute('valueURI')&.to_s || text_language_term&.attribute('valueURI')&.to_s
-        end
-
-        def language_applies_to(lang)
-          value = lang['objectPart']
-          [value: value] if value.present?
-        end
-
-        def language_source_for(code_language_term, text_language_term)
-          {
-            code: code_language_term&.attribute('authority')&.to_s || text_language_term&.attribute('authority')&.to_s,
-            uri: code_language_term&.attribute('authorityURI')&.to_s || text_language_term&.attribute('authorityURI')&.to_s
-
-          }.compact
-        end
       end
     end
   end

--- a/app/services/cocina/from_fedora/descriptive/language_term.rb
+++ b/app/services/cocina/from_fedora/descriptive/language_term.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Cocina
+  module FromFedora
+    class Descriptive
+      # Maps language terms
+      class LanguageTerm
+        # @param [Nokogiri::XML::Element] language_element language or languageOfCataloging element
+        # @return [Hash] a hash that can be mapped to a cocina model
+        def self.build(language_element:, descriptive_builder: nil)
+          new(language_element: language_element).build
+        end
+
+        def initialize(language_element:)
+          @language_element = language_element
+        end
+
+        def build
+          attribs = lang_term_attributes
+          attribs[:status] = status
+          attribs[:script] = script_term_attributes
+          attribs.compact
+        end
+
+        private
+
+        attr_reader :language_element
+
+        def lang_term_attributes
+          code_language_term = language_element.xpath('./mods:languageTerm[@type="code"]', mods: DESC_METADATA_NS).first
+          text_language_term = language_element.xpath('./mods:languageTerm[@type="text"]', mods: DESC_METADATA_NS).first
+          if code_language_term.nil? && text_language_term.nil?
+            Honeybadger.notify('[DATA ERROR] languageTerm missing type', { tags: 'data_error' })
+            code_language_term = language_element.xpath('./mods:languageTerm', mods: DESC_METADATA_NS).first
+          end
+
+          {
+            code: code_language_term&.text,
+            value: text_language_term&.text,
+            uri: language_value_uri_for(code_language_term, text_language_term),
+            appliesTo: language_applies_to,
+            displayLabel: language_element['displayLabel']
+          }.tap do |attrs|
+            source = language_source_for(code_language_term, text_language_term)
+            attrs[:source] = source if source.present?
+          end
+        end
+
+        def script_term_attributes
+          script_term_nodes = language_element.xpath('mods:scriptTerm', mods: DESC_METADATA_NS)
+
+          return if script_term_nodes.blank?
+
+          code, value, authority = nil
+          script_term_nodes.each do |script_term_node|
+            code ||= script_term_node.content if script_term_node['type'] == 'code'
+            value ||= script_term_node.content if script_term_node['type'] == 'text'
+            authority ||= script_term_node['authority']
+          end
+          source = { code: authority } if authority
+          {
+            code: code,
+            value: value,
+            source: source
+          }.compact
+        end
+
+        # this can be present for type text and/or code, but we only want one.
+        def language_value_uri_for(code_language_term, text_language_term)
+          code_language_term&.attribute('valueURI')&.to_s || text_language_term&.attribute('valueURI')&.to_s
+        end
+
+        def language_applies_to
+          value = language_element['objectPart']
+          [value: value] if value.present?
+        end
+
+        def language_source_for(code_language_term, text_language_term)
+          {
+            code: code_language_term&.attribute('authority')&.to_s || text_language_term&.attribute('authority')&.to_s,
+            uri: code_language_term&.attribute('authorityURI')&.to_s || text_language_term&.attribute('authorityURI')&.to_s
+
+          }.compact
+        end
+
+        def status
+          status_value = language_element[:usage] || language_element[:status]
+          return unless status_value
+
+          status_value.downcase.tap do |value|
+            if status_value != value
+              Honeybadger.notify("[DATA ERROR] #{language_element.name} usage attribute is set to \"#{language_element[:usage]}\"",
+                                 { tags: 'data_error' })
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -29,6 +29,7 @@ module Cocina
       normalize_related_item_other_type
       normalize_empty_notes
       normalize_unmatched_altrepgroup
+      normalize_xml_space
       ng_xml
     end
 
@@ -169,6 +170,12 @@ module Cocina
     def normalize_empty_attributes
       ng_xml.root.xpath('//mods:*[@*=""]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
         node.each { |attr_name, attr_value| node.delete(attr_name) if attr_value.blank? }
+      end
+    end
+
+    def normalize_xml_space
+      ng_xml.root.xpath('//mods:*[@xml:space]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+        node.delete('space')
       end
     end
   end

--- a/spec/services/cocina/from_fedora/descriptive/admin_metadata_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/admin_metadata_spec.rb
@@ -399,4 +399,29 @@ RSpec.describe Cocina::FromFedora::Descriptive::AdminMetadata do
       )
     end
   end
+
+  context 'with languageTerm missing type' do
+    let(:xml) do
+      <<~XML
+        <recordInfo>
+          <languageOfCataloging>
+            <languageTerm authority="iso639-2b">eng</languageTerm>
+          </languageOfCataloging>
+        </recordInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq(
+        "language": [
+          {
+            "code": 'eng',
+            "source": {
+              "code": 'iso639-2b'
+            }
+          }
+        ]
+      )
+    end
+  end
 end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -474,4 +474,35 @@ RSpec.describe Cocina::ModsNormalizer do
       XML
     end
   end
+
+  context 'when normalizing xml:space' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <titleInfo>
+            <nonSort xml:space="preserve">The</nonSort>
+            <title>registers of the parish church of Adel, in the county of York, from 1606 to 1812</title>
+            <subTitle>and monumental inscriptions</subTitle>
+          </titleInfo>
+        </mods>
+      XML
+    end
+
+    it 'removes xml:space' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <titleInfo>
+            <nonSort>The</nonSort>
+            <title>registers of the parish church of Adel, in the county of York, from 1606 to 1812</title>
+            <subTitle>and monumental inscriptions</subTitle>
+          </titleInfo>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #1557

## Why was this change made?
`xml:space` isn't mapped, so removing for matching.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


