### PR TITLE
Add individual location blocks for each URL and avoid blank URLs

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -28,15 +28,16 @@ module Cocina
       normalize_subject_authority_naf
       normalize_text_role_term
       normalize_role_term_authority
-      normalize_purl
       normalize_related_item_other_type
-      normalize_empty_notes
       normalize_unmatched_altrepgroup
       normalize_xml_space
       normalize_language_term_type
       normalize_geo_purl
       normalize_access_condition
       normalize_identifier_type
+      normalize_location_physical_location
+      normalize_purl
+      normalize_empty_notes
       ng_xml
     end
 
@@ -257,6 +258,17 @@ module Cocina
     def normalize_subject_authority_lcnaf
       ng_xml.root.xpath("//mods:*[@authority='lcnaf']", mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
         node[:authority] = 'naf'
+      end
+    end
+
+    def normalize_location_physical_location
+      location_nodes(ng_xml).each do |location_node|
+        location_node.xpath('mods:physicalLocation|mods:url|mods:shelfLocator', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+          new_location = Nokogiri::XML::Node.new('location', Nokogiri::XML(nil))
+          new_location << node
+          ng_xml.root << new_location
+        end
+        location_node.remove
       end
     end
   end

--- a/app/services/cocina/to_fedora/descriptive/location.rb
+++ b/app/services/cocina/to_fedora/descriptive/location.rb
@@ -30,18 +30,9 @@ module Cocina
             end
           end
 
-          if access.physicalLocation
-            xml.location do
-              write_physical_locations
-              write_shelf_locators
-            end
-          end
-
-          return unless access.accessContact
-
-          xml.location do
-            write_access_contact_locations
-          end
+          write_physical_locations
+          write_shelf_locators
+          write_access_contact_locations
         end
 
         private
@@ -50,19 +41,25 @@ module Cocina
 
         def write_physical_locations
           Array(access.physicalLocation).reject { |physical_location| shelf_locator?(physical_location) }.each do |physical_location|
-            xml.physicalLocation physical_location.value || physical_location.code, descriptive_attrs(physical_location)
+            xml.location do
+              xml.physicalLocation physical_location.value || physical_location.code, descriptive_attrs(physical_location)
+            end
           end
         end
 
         def write_access_contact_locations
           Array(access.accessContact).each do |access_contact|
-            xml.physicalLocation access_contact.value, { type: 'repository' }.merge(descriptive_attrs(access_contact))
+            xml.location do
+              xml.physicalLocation access_contact.value, { type: 'repository' }.merge(descriptive_attrs(access_contact))
+            end
           end
         end
 
         def write_shelf_locators
           Array(access.physicalLocation).select { |physical_location| shelf_locator?(physical_location) }.each do |physical_location|
-            xml.shelfLocator physical_location.value
+            xml.location do
+              xml.shelfLocator physical_location.value
+            end
           end
         end
 
@@ -76,7 +73,9 @@ module Cocina
         end
 
         def write_purl
-          xml.url purl, { usage: 'primary display' }
+          xml.location do
+            xml.url purl, { usage: 'primary display' }
+          end
         end
 
         def descriptive_attrs(cocina)

--- a/app/services/cocina/to_fedora/descriptive/location.rb
+++ b/app/services/cocina/to_fedora/descriptive/location.rb
@@ -85,6 +85,7 @@ module Cocina
             attrs[:authority] = cocina.source&.code
             attrs[:script] = cocina.valueLanguage&.valueScript&.code
             attrs[:lang] = cocina.valueLanguage&.code
+            attrs[:type] = cocina.type
           end.compact
         end
 

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -355,6 +355,8 @@ RSpec.describe Cocina::ModsNormalizer do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <location>
             <url>http://purl.stanford.edu/bw502ns3302</url>
+          </location>
+          <location>
             <url usage="primary display">http://www.stanford.edu</url>
           </location>
         </mods>
@@ -835,6 +837,43 @@ RSpec.describe Cocina::ModsNormalizer do
           <subject authority="lcsh">
             <topic authority="naf">Marine biology</topic>
           </subject>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when normalizing physical location purl' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3"
+          version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <location>
+            <url usage="primary display">http://purl.stanford.edu/cy979mw6316</url>
+            <physicalLocation>Stanford University Libraries</physicalLocation>
+            <shelfLocator>Who Wants Shelves</shelfLocator>
+          </location>
+        </mods>
+      XML
+    end
+
+    it 'combines the location blocks' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3"
+          version="3.6"          
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <location>
+            <url usage="primary display">http://purl.stanford.edu/cy979mw6316</url>
+          </location>
+          <location>
+            <physicalLocation>Stanford University Libraries</physicalLocation>
+          </location>
+          <location>
+            <shelfLocator>Who Wants Shelves</shelfLocator>
+          </location>
         </mods>
       XML
     end

--- a/spec/services/cocina/to_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/location_spec.rb
@@ -345,19 +345,14 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
             }
           }
         ],
-        "physicalLocation": [
+        "url": [
           {
-            "value": 'Box: 20, Folder: Engineering laboratories -- exterior -- #1',
-            "type": 'location'
+            "value": 'https://swap.stanford.edu/20171107174354/https://www.le.ac.uk/english/em1060to1220/index.html',
+            "displayLabel": 'Archived website'
           },
           {
-            "value": 'SC1071',
-            "type": 'shelf locator'
-          }
-        ],
-        "digitalRepository": [
-          {
-            "value": 'Stanford Digital Repository'
+            "value": 'https://second.swap.stanford.edu/20171107174354/https://www.le.ac.uk/english/em1060to1220/index.html',
+            "displayLabel": 'Second Archived website'
           }
         ]
       )
@@ -370,13 +365,13 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <location>
-            <physicalLocation>Box: 20, Folder: Engineering laboratories -- exterior -- #1</physicalLocation>
-          </location>
-          <location>
-            <shelfLocator>SC1071</shelfLocator>
-          </location>
-          <location>
             <physicalLocation type="repository" valueURI="http://id.loc.gov/authorities/names/no2014019980" authorityURI="http://id.loc.gov/authorities/names/" authority="naf">Stanford University. Libraries. Department of Special Collections and University Archives</physicalLocation>
+          </location>
+          <location>
+            <url displayLabel="Archived website">https://swap.stanford.edu/20171107174354/https://www.le.ac.uk/english/em1060to1220/index.html</url>
+          </location>
+          <location>
+            <url displayLabel="Second Archived website">https://second.swap.stanford.edu/20171107174354/https://www.le.ac.uk/english/em1060to1220/index.html</url>
           </location>
         </mods>
       XML

--- a/spec/services/cocina/to_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/location_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
               "uri": 'http://id.loc.gov/authorities/names/'
             }
           }
+        ],
+        "digitalRepository": [
+          {
+            "value": 'Stanford Digital Repository'
+          }
         ]
       )
     end
@@ -53,7 +58,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <location>
-            <physicalLocation authority="lcsh" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/nb2006009317">British Broadcasting Corporation. Sound Effects Library</physicalLocation>
+            <physicalLocation authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/nb2006009317" authority="lcsh">British Broadcasting Corporation. Sound Effects Library</physicalLocation>
           </location>
         </mods>
       XML
@@ -69,6 +74,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
             "source": {
               "code": 'marcorg'
             }
+          }
+        ],
+        "digitalRepository": [
+          {
+            "value": 'Stanford Digital Repository'
           }
         ]
       )
@@ -98,6 +108,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
             "source": {
               "code": 'naf'
             }
+          }
+        ],
+        "digitalRepository": [
+          {
+            "value": 'Stanford Digital Repository'
           }
         ]
       )
@@ -165,6 +180,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
             "value": 'https://www.davidrumsey.com/luna/servlet/view/search?q=pub_list_no=%2211728.000',
             "status": 'primary'
           }
+        ],
+        "digitalRepository": [
+          {
+            "value": 'Stanford Digital Repository'
+          }
         ]
       )
     end
@@ -194,6 +214,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
                 "value": 'Online table of contents from PCI available to Stanford-affiliated users:'
               }
             ]
+          }
+        ],
+        "digitalRepository": [
+          {
+            "value": 'Stanford Digital Repository'
           }
         ]
       )
@@ -246,6 +271,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
             "value": 'https://swap.stanford.edu/20171107174354/https://www.le.ac.uk/english/em1060to1220/index.html',
             "displayLabel": 'Archived website'
           }
+        ],
+        "digitalRepository": [
+          {
+            "value": 'Stanford Digital Repository'
+          }
         ]
       )
     end
@@ -279,6 +309,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
             "value": 'SC080',
             "type": 'shelf locator'
           }
+        ],
+        "digitalRepository": [
+          {
+            "value": 'Stanford Digital Repository'
+          }
         ]
       )
     end
@@ -297,24 +332,32 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
   end
 
   context 'when it has multiple URLs' do
-    let(:purl) { 'http://purl.stanford.edu/cy979mw6316' }
     let(:access) do
       Cocina::Models::DescriptiveAccessMetadata.new(
-        "url": [
+        "accessContact": [
           {
-            "value": 'http://infoweb.newsbank.com/?db=SERIAL',
-            "status": 'primary'
-          },
-          {
-            "value": 'http://web.lexis-nexis.com/congcomp/form/cong/s_pubadvanced.html?srcboxes=SSMaps&srcboxes=SerialSet'
-          },
-          {
-            "value": 'http://purl.access.gpo.gov/GPO/LPS839'
+            "value": 'Stanford University. Libraries. Department of Special Collections and University Archives',
+            "type": 'repository',
+            "uri": 'http://id.loc.gov/authorities/names/no2014019980',
+            "source": {
+              "code": 'naf',
+              "uri": 'http://id.loc.gov/authorities/names/'
+            }
           }
         ],
         "physicalLocation": [
           {
-            "code": 'Stanford University Libraries'
+            "value": 'Box: 20, Folder: Engineering laboratories -- exterior -- #1',
+            "type": 'location'
+          },
+          {
+            "value": 'SC1071',
+            "type": 'shelf locator'
+          }
+        ],
+        "digitalRepository": [
+          {
+            "value": 'Stanford Digital Repository'
           }
         ]
       )
@@ -327,19 +370,13 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <location>
-            <physicalLocation>Stanford University Libraries</physicalLocation>
+            <physicalLocation>Box: 20, Folder: Engineering laboratories -- exterior -- #1</physicalLocation>
           </location>
           <location>
-            <url usage="primary display">http://purl.stanford.edu/cy979mw6316</url>
+            <shelfLocator>SC1071</shelfLocator>
           </location>
           <location>
-            <url>http://infoweb.newsbank.com/?db=SERIAL</url>
-          </location>
-          <location>
-            <url>http://web.lexis-nexis.com/congcomp/form/cong/s_pubadvanced.html?srcboxes=SSMaps&amp;srcboxes=SerialSet</url>
-          </location>
-          <location>
-            <url>http://purl.access.gpo.gov/GPO/LPS839</url>
+            <physicalLocation type="repository" valueURI="http://id.loc.gov/authorities/names/no2014019980" authorityURI="http://id.loc.gov/authorities/names/" authority="naf">Stanford University. Libraries. Department of Special Collections and University Archives</physicalLocation>
           </location>
         </mods>
       XML

--- a/spec/services/cocina/to_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/location_spec.rb
@@ -259,7 +259,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <location>
             <physicalLocation type="repository" authority="naf" valueURI="http://id.loc.gov/authorities/names/n81070667">Stanford University. Libraries</physicalLocation>
+          </location>
+          <location>
             <url usage="primary display">http://purl.stanford.edu/hf898mn6942</url>
+          </location>
+          <location>
             <url displayLabel="Archived website">https://swap.stanford.edu/20171107174354/https://www.le.ac.uk/english/em1060to1220/index.html</url>
           </location>
         </mods>
@@ -286,6 +290,56 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <location>
             <shelfLocator>SC080</shelfLocator>
+          </location>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when it has multiple URLs' do
+    let(:purl) { 'http://purl.stanford.edu/cy979mw6316' }
+    let(:access) do
+      Cocina::Models::DescriptiveAccessMetadata.new(
+        "url": [
+          {
+            "value": 'http://infoweb.newsbank.com/?db=SERIAL',
+            "status": 'primary'
+          },
+          {
+            "value": 'http://web.lexis-nexis.com/congcomp/form/cong/s_pubadvanced.html?srcboxes=SSMaps&srcboxes=SerialSet'
+          },
+          {
+            "value": 'http://purl.access.gpo.gov/GPO/LPS839'
+          }
+        ],
+        "physicalLocation": [
+          {
+            "code": 'Stanford University Libraries'
+          }
+        ]
+      )
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <?xml version=\"1.0\"?>
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <location>
+            <physicalLocation>Stanford University Libraries</physicalLocation>
+          </location>
+          <location>
+            <url usage="primary display">http://purl.stanford.edu/cy979mw6316</url>
+          </location>
+          <location>
+            <url>http://infoweb.newsbank.com/?db=SERIAL</url>
+          </location>
+          <location>
+            <url>http://web.lexis-nexis.com/congcomp/form/cong/s_pubadvanced.html?srcboxes=SSMaps&amp;srcboxes=SerialSet</url>
+          </location>
+          <location>
+            <url>http://purl.access.gpo.gov/GPO/LPS839</url>
           </location>
         </mods>
       XML


### PR DESCRIPTION
## Why was this change made?

Fixes #1483 - Alters the logic slightly to allow for multiple location blocks and avoids blank blocks.

## How was this change tested?

Additional spec.

## Which documentation and/or configurations were updated?

N/A

