### PR TITLE
Nornalize type attribute for languageTerm

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -30,6 +30,7 @@ module Cocina
       normalize_empty_notes
       normalize_unmatched_altrepgroup
       normalize_xml_space
+      normalize_language_term_type
       ng_xml
     end
 
@@ -176,6 +177,12 @@ module Cocina
     def normalize_xml_space
       ng_xml.root.xpath('//mods:*[@xml:space]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
         node.delete('space')
+      end
+    end
+
+    def normalize_language_term_type
+      ng_xml.root.xpath('//mods:languageTerm[not(@type)]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+        node['type'] = 'code'
       end
     end
   end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -505,4 +505,35 @@ RSpec.describe Cocina::ModsNormalizer do
       XML
     end
   end
+
+  context 'when normalizing languageTerm types' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <recordInfo>
+            <languageOfCataloging>
+              <languageTerm authority="iso639-2b">eng</languageTerm>
+            </languageOfCataloging>
+          </recordInfo>
+        </mods>
+      XML
+    end
+
+    it 'removes unmatched' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <recordInfo>
+            <languageOfCataloging>
+              <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+            </languageOfCataloging>
+          </recordInfo>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?
To add a missing type attribute for languageTerm.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


