### PR TITLE
Add a filter that sets the purl in the description on create

### DIFF
--- a/app/services/cocina/add_purl_to_description.rb
+++ b/app/services/cocina/add_purl_to_description.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Cocina
+  # This replaces the :link: placeholder in the citation with the purl, which we are now able to derive.
+  # This is specifically for H2, but could be utilized by any client that provides preferred citation.
+  # This action has to happen regardless of how we persist the data.
+  class AddPurlToDescription
+    def self.call(description, pid)
+      return description unless description.note
+
+      notes = description.note.map do |note|
+        if note.type == 'preferred citation'
+          note.new(value: note.value.gsub(/:link:/, purl_link(pid)))
+        else
+          note
+        end
+      end
+      description.new(note: notes)
+    end
+
+    def self.purl_link(pid)
+      "#{Settings.release.purl_base_url}/#{pid.delete_prefix('druid:')}"
+    end
+    private_class_method :purl_link
+  end
+end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -122,7 +122,8 @@ module Cocina
         item.label = truncate_label(label)
         item.objectLabel = label
       elsif obj.description
-        item.descMetadata.content = Cocina::ToFedora::Descriptive.transform(obj.description, item.pid).to_xml
+        description = AddPurlToDescription.call(obj.description, item.pid)
+        item.descMetadata.content = Cocina::ToFedora::Descriptive.transform(description, item.pid).to_xml
         item.descMetadata.content_will_change!
       else
         item.descMetadata.mods_title = obj.label

--- a/spec/services/cocina/object_creator_spec.rb
+++ b/spec/services/cocina/object_creator_spec.rb
@@ -89,6 +89,10 @@ RSpec.describe Cocina::ObjectCreator do
                 "type": 'contact',
                 "value": 'marypoppins@umbrellas.org',
                 "displayLabel": 'Contact'
+              },
+              {
+                "type": 'preferred citation',
+                "value": 'Zappa, F. (2013) :link:'
               }
             ],
             "title": [
@@ -147,21 +151,26 @@ RSpec.describe Cocina::ObjectCreator do
         expect(result.description.contributor.last.role.first.value).to eq 'Funder'
       end
 
-      it 'subjets are set' do
+      it 'subjects are set' do
         expect(result.description.subject.first.type).to eq 'topic'
         expect(result.description.subject.first.value).to eq 'I am a keyword'
       end
 
       it 'abstract (note of type summary) is set' do
-        summary_note = result.description.note.select { |note| note.type == 'summary' }.first
+        summary_note = result.description.note.find { |note| note.type == 'summary' }
         expect(summary_note.value).to eq 'I am an abstract'
       end
 
       it 'contact (note of type contact) is set' do
-        contact_note = result.description.note.select { |note| note.type == 'contact' }.first
+        contact_note = result.description.note.find { |note| note.type == 'contact' }
         expect(contact_note.value).to eq 'marypoppins@umbrellas.org'
         skip 'TODO: need ToFedora map of displayLabel for note'
         # expect(contact_note.displayLabel).to eq 'Contact'
+      end
+
+      it 'preferred citation is set with the link placeholder replaced' do
+        contact_note = result.description.note.find { |note| note.type == 'preferred citation' }
+        expect(contact_note.value).to eq 'Zappa, F. (2013) http://purl.stanford.edu/mb046vj7485'
       end
     end
 


### PR DESCRIPTION
This prevents having to do two sequential writes as the purl requires knowing the druid

## Why was this change made?
Ref https://github.com/sul-dlss/happy-heron/pull/230


## How was this change tested?



## Which documentation and/or configurations were updated?



