### PR TITLE
Maps events without dates.

### DIFF
--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -884,28 +884,28 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
   end
 
   context 'with displayLabel' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L1282'
-    # let(:xml) do
-    #   <<~XML
-    #     <originInfo displayLabel="Origin">
-    #       <place>
-    #         <placeTerm type="text">Stanford (Calif.)</placeTerm>
-    #       <place>
-    #     </originInfo>
-    #   XML
-    # end
-    #
-    # it 'builds the cocina data structure' do
-    #   expect(build).to eq [
-    #     {
-    #       "displayLabel": 'Origin',
-    #       "location": [
-    #         {
-    #           "value": 'Stanford (Calif.)'
-    #         }
-    #       ]
-    #     }
-    #   ]
-    # end
+    let(:xml) do
+      <<~XML
+        <originInfo displayLabel="Origin" eventType="production">
+          <place>
+            <placeTerm type="text">Stanford (Calif.)</placeTerm>
+          </place>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'creation',
+          "displayLabel": 'Origin',
+          "location": [
+            {
+              "value": 'Stanford (Calif.)'
+            }
+          ]
+        }
+      ]
+    end
   end
 end

--- a/spec/services/cocina/to_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/event_spec.rb
@@ -1308,4 +1308,36 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       XML
     end
   end
+
+  context 'when it has a displayLabel' do
+    let(:events) do
+      [
+        Cocina::Models::Event.new(
+          {
+            "type": 'creation',
+            "displayLabel": 'Origin',
+            "location": [
+              {
+                "value": 'Stanford (Calif.)'
+              }
+            ]
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <originInfo displayLabel="Origin" eventType="production">
+            <place>
+              <placeTerm type="text">Stanford (Calif.)</placeTerm>
+            </place>
+          </originInfo>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #1551

## Why was this change made?
To map events that don't have dates.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


