### PR TITLE
Normalizes subject authority.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -23,6 +23,7 @@ module Cocina
       normalize_authority_uris
       normalize_origin_info_event_types
       normalize_subject_authority
+      normalize_subject_authority_naf
       normalize_text_role_term
       normalize_role_term_authority
       normalize_purl
@@ -92,7 +93,7 @@ module Cocina
       subject_node.delete('valueURI')
     end
 
-    def normalize_subject_authority
+    def normalize_subject_authority_naf
       ng_xml.root.xpath("//mods:subject[@authority='naf']", mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |subject_node|
         subject_node[:authority] = 'lcsh'
       end
@@ -183,6 +184,13 @@ module Cocina
     def normalize_language_term_type
       ng_xml.root.xpath('//mods:languageTerm[not(@type)]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
         node['type'] = 'code'
+      end
+    end
+
+    def normalize_subject_authority
+      ng_xml.root.xpath('//mods:subject[not(@authority) and count(mods:*) = 1 and not(mods:geographicCode)]/mods:*[@authority]',
+                        mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+        node.parent['authority'] = node['authority']
       end
     end
   end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -536,4 +536,93 @@ RSpec.describe Cocina::ModsNormalizer do
       XML
     end
   end
+
+  context 'when normalizing subject authority' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject>
+            <name type="personal" authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/270223">
+              <namePart>Anning, Mary, 1799-1847</namePart>
+            </name>
+          </subject>
+        </mods>
+      XML
+    end
+
+    it 'adds authority' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject authority="fast">
+            <name type="personal" authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/270223">
+              <namePart>Anning, Mary, 1799-1847</namePart>
+            </name>
+          </subject>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when normalizing subject authority when child authority is naf' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject>
+            <name type="corporate" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n80034013">
+              <namePart>Institute for the Future</namePart>
+            </name>
+          </subject>
+        </mods>
+      XML
+    end
+
+    it 'adds lcsh authority' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject authority="lcsh">
+            <name type="corporate" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n80034013">
+              <namePart>Institute for the Future</namePart>
+            </name>
+          </subject>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when normalizing subject authority with geographicCode child' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject>
+            <geographicCode authority="marcgac">n-us-md</geographicCode>
+          </subject>
+        </mods>
+      XML
+    end
+
+    it 'does not add authority' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject>
+            <geographicCode authority="marcgac">n-us-md</geographicCode>
+          </subject>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #1539

## Why was this change made?
Subject authorities are really challenging.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


