### PR TITLE
Handles authority for subject that have multiple parts.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -86,11 +86,18 @@ module Cocina
             if subject.source
               attrs[:authority] = authority_for(subject)
               attrs[:authorityURI] = subject.source.uri
-            elsif subject.structuredValue&.first&.source
+            elsif all_same_authority?(subject.structuredValue)
               attrs[:authority] = authority_for(subject.structuredValue.first)
             end
             attrs[:valueURI] = subject.uri
           end.compact
+        end
+
+        def all_same_authority?(structured_value)
+          return nil if structured_value.nil?
+          return nil unless Set.new(structured_value.map { |value| authority_for(value) }).size == 1
+
+          authority_for(structured_value.first)
         end
 
         def write_basic(subject)

--- a/spec/services/cocina/to_fedora/descriptive/subject_name_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_name_spec.rb
@@ -230,6 +230,47 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
     end
   end
 
+  context 'when it has a name subject with additional terms and authority for the name' do
+    let(:subjects) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          {
+            structuredValue: [
+              {
+                "value": 'Shakespeare, William, 1564-1616',
+                "type": 'person',
+                "uri": 'http://id.loc.gov/authorities/names/n78095332',
+                "source": {
+                  "code": 'naf',
+                  "uri": 'http://id.loc.gov/authorities/names/'
+                }
+              },
+              {
+                "value": 'Homes and haunts',
+                "type": 'topic'
+              }
+            ]
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject>
+            <name authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n78095332" type="personal">
+              <namePart>Shakespeare, William, 1564-1616</namePart>
+            </name>
+            <topic>Homes and haunts</topic>
+          </subject>
+        </mods>
+      XML
+    end
+  end
+
   context 'when it has a name subject with multiple namePart elements and inverted full name' do
     let(:subjects) do
       [


### PR DESCRIPTION
closes #1544

## Why was this change made?
Subject authority should only be added when all parts have same authority.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


