### PR TITLE
Fixes missing authority for topic.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -151,13 +151,11 @@ module Cocina
 
         def topic_attributes_for(subject)
           {}.tap do |topic_attributes|
-            if subject.source&.uri
-              topic_attributes[:authority] = subject.source.code
-              topic_attributes[:authorityURI] = subject.source.uri
-            end
-            topic_attributes[:encoding] = subject.encoding.code if subject.encoding
-            topic_attributes[:valueURI] = subject.uri if subject.uri
-          end
+            topic_attributes[:authority] = subject.source&.code if subject.source&.uri || subject.uri
+            topic_attributes[:authorityURI] = subject.source&.uri
+            topic_attributes[:encoding] = subject.encoding&.code
+            topic_attributes[:valueURI] = subject.uri
+          end.compact
         end
 
         def geographic(subject)

--- a/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
@@ -116,6 +116,35 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
     end
   end
 
+  context 'when it has a single-term topic subject with authority but no authorityURI' do
+    let(:subjects) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          {
+            "value": 'Cats',
+            "type": 'topic',
+            "uri": 'http://id.loc.gov/authorities/subjects/sh85021262',
+            "source": {
+              "code": 'lcsh'
+            }
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject authority="lcsh">
+            <topic authority="lcsh" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
+          </subject>
+        </mods>
+      XML
+    end
+  end
+
   context 'when it has a single-term topic subject with non-lcsh authority' do
     let(:subjects) do
       [


### PR DESCRIPTION
closes #1549

## Why was this change made?
Topics should have authority attribute even if subject has authority.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


