### PR TITLE
Normalizes originInfo that is child of relatedItem.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -102,7 +102,7 @@ module Cocina
     # change original xml to have the event type that will be output
     def normalize_origin_info_event_types
       # code
-      ng_xml.root.xpath('mods:originInfo', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |origin_info_node|
+      ng_xml.root.xpath('//mods:originInfo', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |origin_info_node|
         date_issued_nodes = origin_info_node.xpath('mods:dateIssued', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS)
         add_event_type('publication', origin_info_node) && next if date_issued_nodes.present?
 

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -177,9 +177,11 @@ RSpec.describe Cocina::ModsNormalizer do
           <originInfo>
             <dateCreated>1932</dateCreated>
           </originInfo>
-          <originInfo>
-            <dateCaptured>1932</dateCaptured>
-          </originInfo>
+          <relatedItem>
+            <originInfo>
+              <dateCaptured>1932</dateCaptured>
+            </originInfo>
+          </relatedItem>
         </mods>
       XML
     end
@@ -199,9 +201,11 @@ RSpec.describe Cocina::ModsNormalizer do
           <originInfo eventType="production">
             <dateCreated>1932</dateCreated>
           </originInfo>
-          <originInfo eventType="capture">
-            <dateCaptured>1932</dateCaptured>
-          </originInfo>
+          <relatedItem>
+            <originInfo eventType="capture">
+              <dateCaptured>1932</dateCaptured>
+            </originInfo>
+          </relatedItem>
         </mods>
       XML
     end


### PR DESCRIPTION
closes #1542

## Why was this change made?
All `<originInfo>` should be normalized.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


