### PR TITLE
Handle form-only cartographic subjects.

### DIFF
--- a/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
@@ -532,6 +532,53 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
     end
   end
 
+  context 'when it has a cartographic subject without subjects' do
+    let(:writer) do
+      Nokogiri::XML::Builder.new do |xml|
+        xml.mods('xmlns' => 'http://www.loc.gov/mods/v3',
+                 'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+                 'version' => '3.6',
+                 'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd') do
+          described_class.write(xml: xml, subjects: subjects, forms: forms)
+        end
+      end
+    end
+
+    let(:subjects) { [] }
+
+    let(:forms) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          {
+            "value": '1:22,000,000',
+            "type": 'map scale'
+          }
+        ),
+        Cocina::Models::DescriptiveValue.new(
+          {
+            "value": 'Conic proj',
+            "type": 'map projection'
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject>
+            <cartographics>
+              <scale>1:22,000,000</scale>
+              <projection>Conic proj</projection>
+            </cartographics>
+          </subject>
+        </mods>
+      XML
+    end
+  end
+
   context 'when it has a geographic code subject' do
     let(:subjects) do
       [


### PR DESCRIPTION
closes #1495

## Why was this change made?
Not all cartographic subjects have subjects (but have forms only).


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


