### PR TITLE
Prefer `Array#uniq` over set operations

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -97,10 +97,7 @@ module Cocina
         end
 
         def all_same_authority?(structured_value)
-          return nil if structured_value.nil?
-          return nil unless Set.new(structured_value.map { |value| authority_for(value) }).size == 1
-
-          authority_for(structured_value.first)
+          Array(structured_value).map { |value| authority_for(value) }.uniq.size == 1
         end
 
         def write_basic(subject)


### PR DESCRIPTION
And make `Cocina::ToFedora::Descriptive::Subject#all_same_authority?` return a boolean since its value is not used otherwise (i.e., as a string)

## Why was this change made?

Because it was suggested in code review, which I didn't notice before merging.

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

