### PR TITLE
Select event for issuance, etc. based on precedence rule.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -33,11 +33,11 @@ module Cocina
             edition = origin.xpath('mods:edition', mods: DESC_METADATA_NS)
             publisher = origin.xpath('mods:publisher', mods: DESC_METADATA_NS)
             if issuance.present? || frequency.present? || edition.present? || publisher.present?
-              publication_event = find_or_create_publication_event(events)
-              add_issuance_info(publication_event, issuance)
-              add_frequency_info(publication_event, frequency)
-              add_edition_info(publication_event, edition)
-              add_publisher_info(publication_event, publisher)
+              event = find_or_create_event_by_precedence(events)
+              add_issuance_info(event, issuance)
+              add_frequency_info(event, frequency)
+              add_edition_info(event, edition)
+              add_publisher_info(event, publisher)
             end
             events.reject(&:blank?)
           end
@@ -47,9 +47,8 @@ module Cocina
 
         attr_reader :resource_element
 
-        def find_or_create_publication_event(events)
-          publication_event = events.find { |e| e[:type] == 'publication' }
-          return publication_event if publication_event
+        def find_or_create_event_by_precedence(events)
+          %w[publication distribution production creation manufacture].each { |event_type| events.each { |event| return event if event[:type] == event_type } }
 
           { type: 'publication' }.tap do |event|
             events << event

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -829,6 +829,43 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  context 'with issuance for a creation event' do
+    let(:xml) do
+      <<~XML
+        <originInfo eventType="production">
+          <dateCreated encoding="w3cdtf" keyDate="yes">1988-08-03</dateCreated>
+          <issuance>monographic</issuance>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'creation',
+          "date": [
+            {
+              "value": '1988-08-03',
+              "status": 'primary',
+              "encoding": {
+                "code": 'w3cdtf'
+              }
+            }
+          ],
+          "note": [
+            {
+              "value": 'monographic',
+              "type": 'issuance',
+              "source": {
+                "value": 'MODS issuance terms'
+              }
+            }
+          ]
+        }
+      ]
+    end
+  end
+
   context 'with multiple originInfo elements for different events' do
     let(:xml) do
       <<~XML


### PR DESCRIPTION
closes #1548

## Why was this change made?
Issuance, etc. should be placed on events based on precedence rule (described in ticket).


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


