### PR TITLE
add a new to fedora mapping

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/event.rb
+++ b/app/services/cocina/to_fedora/descriptive/event.rb
@@ -16,7 +16,8 @@ module Cocina
           'capture' => 'capture',
           'copyright' => 'copyright notice',
           'creation' => 'production',
-          'publication' => 'publication'
+          'publication' => 'publication',
+          'acquisition' => 'acquisition'
         }.freeze
         # @params [Nokogiri::XML::Builder] xml
         # @params [Array<Cocina::Models::Event>] events

--- a/spec/services/cocina/to_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/event_spec.rb
@@ -185,6 +185,40 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       end
     end
 
+    describe 'with eventType="acquisition"' do
+      let(:events) do
+        [
+          Cocina::Models::Event.new(
+            {
+              type: 'acquisition',
+              date: [
+                {
+                  value: '1970-11-23',
+                  status: 'primary',
+                  encoding:
+                    {
+                      code: 'w3cdtf'
+                    }
+                }
+              ]
+            }
+          )
+        ]
+      end
+
+      it 'builds the xml' do
+        expect(xml).to be_equivalent_to <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <originInfo eventType="acquisition">
+              <dateOther keyDate="yes" encoding="w3cdtf">1970-11-23</dateOther>
+            </originInfo>
+          </mods>
+        XML
+      end
+    end
+
     describe 'without note, with displayLabel' do
       let(:events) do
         [


### PR DESCRIPTION
## Why was this change made?

Fixes #1379 -- add a new to_fedora mapping based on (5c) described here: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/pull/110/files

A couple comments:

* The from_fedora mapping described in (5c) already exists, as shown in various tests like this https://github.com/sul-dlss/dor-services-app/blob/master/spec/services/cocina/from_fedora/descriptive/event_spec.rb#L153-L177
* I believe (5b) in PR above is covered in the from_fedora mapping, as shown in this test:  https://github.com/sul-dlss/dor-services-app/blob/master/spec/services/cocina/from_fedora/descriptive/event_spec.rb#L117-L151
This shows an HB alert if any element is missing the 'eventType', so more generalized than described in (5b) (and also not a fatal error, which I'm not sure what would mean).


## How was this change tested?

Unit tests

## Which documentation and/or configurations were updated?



