### PR TITLE
add multilingual support for origin_info / event mappings

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -40,8 +40,10 @@ module Cocina
             events = build_ungrouped_origin_infos([node_set_array.first])
             first_attribs = node_set_array.first&.attributes
             first_script = first_attribs['script']&.value
+            first_lang_code = first_attribs['lang']&.value
+            event_type = first_attribs['eventType']&.value || 'publication'
             el_names_in_common = child_element_names_in_common(node_set_array)
-            build_parallel_values(events, node_set_array.drop(1), el_names_in_common, first_script)
+            build_parallel_values(events, node_set_array.drop(1), el_names_in_common, first_script, first_lang_code, event_type)
             events.reject(&:blank?)
           end.flatten
         end
@@ -55,14 +57,16 @@ module Cocina
           candidates
         end
 
-        def build_parallel_values(events, node_set_array, el_names_in_common, first_script)
-          node_set_array.each do |origin_node_set|
-            parallel_attribs = origin_node_set&.attributes
+        # rubocop:disable Metrics/ParameterLists
+        def build_parallel_values(events, node_set_array, el_names_in_common, first_script, first_lang_code, event_type)
+          node_set_array.each do |origin_info_node_set|
+            parallel_attribs = origin_info_node_set&.attributes
             parallel_script = parallel_attribs['script']&.value
-            origin_node_set.element_children.each do |child_el|
+            parallel_lang_code = parallel_attribs['lang']&.value
+            origin_info_node_set.element_children.each do |child_el|
               child_el_name = child_el.name
               if el_names_in_common.include?(child_el_name)
-                build_parallel_value(events, child_el, first_script, parallel_script)
+                build_parallel_value(events, child_el, first_script, parallel_script, first_lang_code, parallel_lang_code, event_type)
               else
                 errmsg = "problem building event parallel values due to unmatched originInfo element #{child_el_name}"
                 Honeybadger.notify(errmsg)
@@ -71,24 +75,30 @@ module Cocina
             end
           end
         end
+        # rubocop:enable Metrics/ParameterLists
 
-        def build_parallel_value(events, child_el, first_script, parallel_script)
+        # rubocop:disable Metrics/ParameterLists
+        def build_parallel_value(events, child_el, orig_script, parallel_script, orig_lang_code, parallel_lang_code, event_type)
           child_el_name = child_el.name
           case child_el_name
           when 'dateIssued'
-            add_parallel_publication_date(events, child_el, first_script, parallel_script)
+            add_parallel_publication_date(events, child_el, orig_script, parallel_script)
           when /date/i
             errmsg = "originInfo date flavor #{child_el_name} has unanticipated parallelValue - needs code"
             Honeybadger.notify(errmsg)
             logger.error(errmsg)
           when 'place'
-            # FIXME:  will not always be publication ... depends on event type ...
-            add_parallel_publication_location(events, child_el, first_script, parallel_script)
+            parallel_place_term = child_el.xpath("mods:placeTerm[not(@type='code')]", mods: DESC_METADATA_NS).first
+            parallel_place_value = parallel_place_term&.content
+            return if parallel_place_value.blank?
+
+            event = events.find { |e| e[:type] == Cocina::ToFedora::Descriptive::Event::EVENT_TYPE.key(event_type) }
+            add_parallel_location(event, parallel_place_value, orig_script, parallel_script, orig_lang_code, parallel_lang_code)
           when 'publisher'
-            add_parallel_contributor(events, child_el, first_script, parallel_script)
+            add_parallel_contributor(events, child_el, orig_script, parallel_script)
           when 'edition'
             puts 'TODO: implement parallelValues for edition'
-            # add_parallel_edition_shit(events, child_el, first_script, parallel_script)
+            # add_parallel_edition_shit(events, child_el, orig_script, parallel_script)
           when 'issuance', 'frequency'
             errmsg = "originInfo #{child_el_name} has unanticipated parallelValue - needs code"
             Honeybadger.notify(errmsg)
@@ -99,20 +109,21 @@ module Cocina
             logger.error("DATA ERROR: #{errmsg}")
           end
         end
+        # rubocop:enable Metrics/ParameterLists
 
         def build_ungrouped_origin_infos(origin_infos)
-          origin_infos.flat_map do |origin|
-            events = build_events_for_origin_info(origin, origin[:displayLabel])
+          origin_infos.flat_map do |origin_info|
+            events = build_events_for_origin_info(origin_info, origin_info[:displayLabel])
 
             events = [{}] if events.empty?
 
-            place = origin.xpath('mods:place', mods: DESC_METADATA_NS)
+            place = origin_info.xpath('mods:place', mods: DESC_METADATA_NS)
             add_place_info(events.last, place) if place.present?
 
-            issuance = origin.xpath('mods:issuance', mods: DESC_METADATA_NS)
-            frequency = origin.xpath('mods:frequency', mods: DESC_METADATA_NS)
-            edition = origin.xpath('mods:edition', mods: DESC_METADATA_NS)
-            publisher = origin.xpath('mods:publisher', mods: DESC_METADATA_NS)
+            issuance = origin_info.xpath('mods:issuance', mods: DESC_METADATA_NS)
+            frequency = origin_info.xpath('mods:frequency', mods: DESC_METADATA_NS)
+            edition = origin_info.xpath('mods:edition', mods: DESC_METADATA_NS)
+            publisher = origin_info.xpath('mods:publisher', mods: DESC_METADATA_NS)
             if issuance.present? || frequency.present? || edition.present? || publisher.present?
               event = find_or_create_event_by_precedence(events)
               add_issuance_info(event, issuance)
@@ -132,31 +143,31 @@ module Cocina
           end
         end
 
-        def build_events_for_origin_info(origin, display_label)
+        def build_events_for_origin_info(origin_info, display_label)
           [].tap do |events|
-            date_created = origin.xpath('mods:dateCreated', mods: DESC_METADATA_NS)
+            date_created = origin_info.xpath('mods:dateCreated', mods: DESC_METADATA_NS)
             events << build_event('creation', date_created, display_label) if date_created.present?
 
-            date_issued = origin.xpath('mods:dateIssued', mods: DESC_METADATA_NS)
+            date_issued = origin_info.xpath('mods:dateIssued', mods: DESC_METADATA_NS)
             events << build_event('publication', date_issued, display_label) if date_issued.present?
 
-            copyright_date = origin.xpath('mods:copyrightDate', mods: DESC_METADATA_NS)
+            copyright_date = origin_info.xpath('mods:copyrightDate', mods: DESC_METADATA_NS)
             events << build_event('copyright', copyright_date, display_label) if copyright_date.present?
 
-            date_captured = origin.xpath('mods:dateCaptured', mods: DESC_METADATA_NS)
+            date_captured = origin_info.xpath('mods:dateCaptured', mods: DESC_METADATA_NS)
             events << build_event('capture', date_captured, display_label) if date_captured.present?
 
-            date_other = origin.xpath('mods:dateOther', mods: DESC_METADATA_NS)
-            events << build_event(date_other_event_type(origin), date_other, display_label) if date_other.present?
+            date_other = origin_info.xpath('mods:dateOther', mods: DESC_METADATA_NS)
+            events << build_event(date_other_event_type(origin_info), date_other, display_label) if date_other.present?
 
             has_date = [date_created, date_issued, copyright_date, date_captured, date_other].flatten.present?
-            events << build_event('creation', [], display_label) if origin[:eventType] == 'production' && !has_date
+            events << build_event('creation', [], display_label) if origin_info[:eventType] == 'production' && !has_date
           end
         end
 
         def add_place_info(event, place_set)
           event[:location] = place_set.map do |place|
-            text_place_term = place.xpath("mods:placeTerm[@type='text']", mods: DESC_METADATA_NS).first
+            text_place_term = place.xpath("mods:placeTerm[not(@type='code')]", mods: DESC_METADATA_NS).first
             code_place_term = place.xpath("mods:placeTerm[@type='code']", mods: DESC_METADATA_NS).first
 
             return nil unless text_place_term || code_place_term
@@ -165,19 +176,13 @@ module Cocina
 
             location[:code] = code_place_term.text if code_place_term
             location[:value] = text_place_term.text if text_place_term
-
             location
           end.compact
         end
 
-        def add_parallel_publication_location(events, parallel_xml_node, orig_script, parallel_script)
-          parallel_place_term = parallel_xml_node.xpath("mods:placeTerm[@type='text']", mods: DESC_METADATA_NS).first
-          parallel_place_value = parallel_place_term&.content
-          return nil unless parallel_place_value
-
-          publication_event = events.find { |event| event[:type] == 'publication' }
-
-          orig_locations = publication_event[:location]
+        # rubocop:disable Metrics/ParameterLists
+        def add_parallel_location(event, parallel_place_value, orig_script, parallel_script, orig_lang_code, parallel_lang_code)
+          orig_locations = event[:location]
           orig_location_value = first_value(orig_locations)
           return nil unless orig_location_value
 
@@ -186,15 +191,35 @@ module Cocina
             additional_values = orig_locations.select { |location| location[:value].present? && location[:value] != orig_location_value }
             parallel_value = add_to_parallel_value(parallel_value, additional_values) if additional_values.present?
           end
-          publication_event[:location] = [parallel_value]
+          orig_w_value = first_with_value(orig_locations)
+          add_parallel_location_lang_info(parallel_value, orig_w_value, orig_lang_code, parallel_lang_code)
+          event[:location] = [parallel_value]
 
           addl_locations = orig_locations.reject { |location| location[:value].present? }
-          addl_locations.each { |location_val| publication_event[:location] << location_val }
+          addl_locations.each { |location_val| event[:location] << location_val }
+        end
+        # rubocop:enable Metrics/ParameterLists
+
+        def add_parallel_location_lang_info(parallel_value, orig_w_value, orig_lang_code, parallel_lang_code)
+          parallel_value[:parallelValue].first[:uri] = orig_w_value[:uri] if orig_w_value[:uri]
+          parallel_value[:parallelValue].first[:source] = orig_w_value[:source] if orig_w_value[:source]
+          if orig_lang_code
+            parallel_value[:parallelValue].first[:valueLanguage][:code] = orig_lang_code
+            parallel_value[:parallelValue].first[:valueLanguage][:source] = { code: 'iso639-2b' }
+          end
+
+          return if parallel_lang_code.blank?
+
+          parallel_value[:parallelValue].second[:valueLanguage][:code] = parallel_lang_code
+          parallel_value[:parallelValue].second[:valueLanguage][:source] = { code: 'iso639-2b' }
+        end
+
+        def first_with_value(desc_value_array)
+          desc_value_array&.find { |desc_value| desc_value[:value].present? }
         end
 
         def first_value(desc_value_array)
-          first_value = desc_value_array&.find { |desc_value| desc_value[:value].present? }
-          first_value[:value]
+          first_with_value(desc_value_array)[:value]
         end
 
         def with_uri_info(cocina, xml_node)
@@ -203,6 +228,11 @@ module Cocina
             cocina[:source] = {
               code: Authority.normalize_code(xml_node['authority']),
               uri: Authority.normalize_uri(xml_node['authorityURI'])
+            }.compact
+          elsif xml_node['authorityURI'] # used for originInfo placeTermn
+            cocina[:source] = {
+              # code: xml_node['authorityURI'],
+              uri: AuthorityUri.normalize(xml_node['authorityURI'])
             }.compact
           end
           cocina

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -20,7 +20,88 @@ module Cocina
         end
 
         def build
-          origin_info.flat_map do |origin|
+          events = []
+          with_groups = resource_element.xpath('mods:originInfo[@altRepGroup]', mods: DESC_METADATA_NS)
+          grouped = with_groups.group_by { |node| node['altRepGroup'] }
+
+          events += build_grouped_origin_infos(grouped)
+
+          without_groups = resource_element.xpath('mods:originInfo[not(@altRepGroup)]', mods: DESC_METADATA_NS)
+          events + build_ungrouped_origin_infos(without_groups)
+        end
+
+        private
+
+        attr_reader :resource_element
+
+        # @param [Hash[String, Array[Nokogiri::XML::NodeSet]]] grouped_origin_infos hash of key altRepGroup, value Array of NodeSets for originInfo elements in the grouping
+        def build_grouped_origin_infos(grouped_origin_infos)
+          grouped_origin_infos.map do |_k, node_set_array|
+            events = build_ungrouped_origin_infos([node_set_array.first])
+            first_attribs = node_set_array.first&.attributes
+            first_script = first_attribs['script']&.value
+            el_names_in_common = child_element_names_in_common(node_set_array)
+            build_parallel_values(events, node_set_array.drop(1), el_names_in_common, first_script)
+            events.reject(&:blank?)
+          end.flatten
+        end
+
+        def child_element_names_in_common(node_set_array)
+          candidates = node_set_array.first.element_children.map(&:name).uniq
+          node_set_array.each do |node_set|
+            # set intersection to the rescue!
+            candidates &= node_set.element_children.map(&:name).uniq
+          end
+          candidates
+        end
+
+        def build_parallel_values(events, node_set_array, el_names_in_common, first_script)
+          node_set_array.each do |origin_node_set|
+            parallel_attribs = origin_node_set&.attributes
+            parallel_script = parallel_attribs['script']&.value
+            origin_node_set.element_children.each do |child_el|
+              child_el_name = child_el.name
+              if el_names_in_common.include?(child_el_name)
+                build_parallel_value(events, child_el, first_script, parallel_script)
+              else
+                errmsg = "problem building event parallel values due to unmatched originInfo element #{child_el_name}"
+                Honeybadger.notify(errmsg)
+                logger.error(errmsg)
+              end
+            end
+          end
+        end
+
+        def build_parallel_value(events, child_el, first_script, parallel_script)
+          child_el_name = child_el.name
+          case child_el_name
+          when 'dateIssued'
+            add_parallel_publication_date(events, child_el, first_script, parallel_script)
+          when /date/i
+            errmsg = "originInfo date flavor #{child_el_name} has unanticipated parallelValue - needs code"
+            Honeybadger.notify(errmsg)
+            logger.error(errmsg)
+          when 'place'
+            # FIXME:  will not always be publication ... depends on event type ...
+            add_parallel_publication_location(events, child_el, first_script, parallel_script)
+          when 'publisher'
+            add_parallel_contributor(events, child_el, first_script, parallel_script)
+          when 'edition'
+            puts 'TODO: implement parallelValues for edition'
+            # add_parallel_edition_shit(events, child_el, first_script, parallel_script)
+          when 'issuance', 'frequency'
+            errmsg = "originInfo #{child_el_name} has unanticipated parallelValue - needs code"
+            Honeybadger.notify(errmsg)
+            logger.error(errmsg)
+          else
+            errmsg = "originInfo has unexpected child node #{child_el_name}"
+            Honeybadger.notify("[DATA ERROR] #{errmsg}", { tags: 'data_error' })
+            logger.error("DATA ERROR: #{errmsg}")
+          end
+        end
+
+        def build_ungrouped_origin_infos(origin_infos)
+          origin_infos.flat_map do |origin|
             events = build_events_for_origin_info(origin, origin[:displayLabel])
 
             events = [{}] if events.empty?
@@ -42,10 +123,6 @@ module Cocina
             events.reject(&:blank?)
           end
         end
-
-        private
-
-        attr_reader :resource_element
 
         def find_or_create_event_by_precedence(events)
           %w[publication distribution production creation manufacture].each { |event_type| events.each { |event| return event if event[:type] == event_type } }
@@ -91,6 +168,33 @@ module Cocina
 
             location
           end.compact
+        end
+
+        def add_parallel_publication_location(events, parallel_xml_node, orig_script, parallel_script)
+          parallel_place_term = parallel_xml_node.xpath("mods:placeTerm[@type='text']", mods: DESC_METADATA_NS).first
+          parallel_place_value = parallel_place_term&.content
+          return nil unless parallel_place_value
+
+          publication_event = events.find { |event| event[:type] == 'publication' }
+
+          orig_locations = publication_event[:location]
+          orig_location_value = first_value(orig_locations)
+          return nil unless orig_location_value
+
+          parallel_value = parallel_value(orig_location_value, parallel_place_value, orig_script, parallel_script)
+          if orig_locations.size > 1
+            additional_values = orig_locations.select { |location| location[:value].present? && location[:value] != orig_location_value }
+            parallel_value = add_to_parallel_value(parallel_value, additional_values) if additional_values.present?
+          end
+          publication_event[:location] = [parallel_value]
+
+          addl_locations = orig_locations.reject { |location| location[:value].present? }
+          addl_locations.each { |location_val| publication_event[:location] << location_val }
+        end
+
+        def first_value(desc_value_array)
+          first_value = desc_value_array&.find { |desc_value| desc_value[:value].present? }
+          first_value[:value]
         end
 
         def with_uri_info(cocina, xml_node)
@@ -165,6 +269,37 @@ module Cocina
           end
         end
 
+        def add_parallel_contributor(events, parallel_xml_node, orig_script, parallel_script)
+          parallel_contrib_value = parallel_xml_node&.content
+          return nil unless parallel_contrib_value
+
+          publication_event = events.find { |event| event[:type] == 'publication' }
+
+          orig_contributors = publication_event[:contributor]
+          orig_contrib_name_value = first_contrib_name_value(orig_contributors)
+          return nil unless orig_contrib_name_value
+
+          parallel_value = parallel_value(orig_contrib_name_value, parallel_contrib_value, orig_script, parallel_script)
+          if orig_contributors.size > 1
+            additional_values = orig_contributors.select do |contrib|
+              contrib[:name].first[:value].present? && contrib[:name].first[:value] != orig_contrib_name_value
+            end
+            parallel_value = add_to_parallel_value(parallel_value, additional_values) if additional_values.present?
+          end
+          publication_event[:contributor].first[:name] = [parallel_value]
+
+          addl_contributors = orig_contributors.reject { |contrib| contrib[:name].present? }
+          addl_contributors.each { |contrib_val| publication_event[:contributor] << contrib_val }
+        end
+
+        def first_contrib_name_value(orig_contributors)
+          orig_contrib_name_w_value = orig_contributors&.find do |contrib|
+            first_contrib_name = contrib[:name]&.first
+            first_contrib_name[:value].present?
+          end
+          orig_contrib_name_w_value[:name].first[:value] if orig_contrib_name_w_value
+        end
+
         def build_event(type, node_set, display_label = nil)
           points = node_set.select { |node| node['point'] }
           dates = points.size == 1 ? [build_date(type, points.first)] : build_structured_date(type, points)
@@ -185,6 +320,25 @@ module Cocina
 
           dates = node_set.map { |node| build_date(type, node) }
           [{ structuredValue: dates }]
+        end
+
+        def add_parallel_publication_date(events, parallel_xml_node, orig_script, parallel_script)
+          parallel_date_value = parallel_xml_node&.content
+          return nil unless parallel_date_value
+
+          publication_event = events.find { |event| event[:type] == 'publication' }
+
+          orig_pub_dates = publication_event[:date]
+          orig_pub_date_value = first_value(orig_pub_dates)
+          return nil unless orig_pub_date_value
+
+          parallel_value = parallel_value(orig_pub_date_value, parallel_date_value, orig_script, parallel_script)
+          additional_values = orig_pub_dates.reject { |date| date[:value] == orig_pub_date_value } if orig_pub_dates.size > 1
+          parallel_value = add_to_parallel_value(parallel_value, additional_values) if additional_values.present?
+          publication_event[:date] = [parallel_value]
+
+          other_pub_dates = orig_pub_dates.reject { |date| date[:value].present? }
+          other_pub_dates.each { |pub_date| publication_event[:date] << pub_date }
         end
 
         def build_date(event_type, node)
@@ -213,6 +367,37 @@ module Cocina
 
         def origin_info
           @origin_info ||= resource_element.xpath(ORIGININFO_XPATH, mods: DESC_METADATA_NS)
+        end
+
+        def parallel_value(first_value, second_value, first_script, second_script)
+          {
+            parallelValue: [
+              {
+                value: first_value,
+                valueLanguage: {
+                  valueScript: {
+                    code: first_script,
+                    source: { code: 'iso15924' }
+                  }
+                }
+              },
+              {
+                value: second_value,
+                valueLanguage: {
+                  valueScript: {
+                    code: second_script,
+                    source: { code: 'iso15924' }
+                  }
+                }
+              }
+            ]
+          }
+        end
+
+        def add_to_parallel_value(parallel_value_struct, additional_values)
+          {
+            parallelValue: parallel_value_struct[:parallelValue] + additional_values
+          }
         end
       end
       # rubocop:enable Metrics/ClassLength

--- a/app/services/cocina/to_fedora/descriptive/event.rb
+++ b/app/services/cocina/to_fedora/descriptive/event.rb
@@ -35,8 +35,10 @@ module Cocina
 
         def write
           Array(events).each do |event|
+            event_type = EVENT_TYPE.fetch(event.type) if event.type
             attributes = {}
-            attributes[:eventType] = EVENT_TYPE.fetch(event.type) if event.type
+            attributes[:eventType] = event_type if event_type
+
             if translated?(event)
               TranslatedEvent.write(xml: xml, event: event, alt_rep_group: id_generator.next_altrepgroup, event_type: event.type)
             else
@@ -51,7 +53,8 @@ module Cocina
 
         def translated?(event)
           Array(event.location).any?(&:parallelValue) &&
-            Array(event.contributor).flat_map(&:name).all?(&:parallelValue)
+            Array(event.contributor).flat_map(&:name).all?(&:parallelValue) ||
+            Array(event.note).any?(&:parallelValue)
         end
 
         def write_basic(event, attributes)

--- a/app/services/cocina/to_fedora/descriptive/event.rb
+++ b/app/services/cocina/to_fedora/descriptive/event.rb
@@ -40,7 +40,7 @@ module Cocina
             attributes[:eventType] = event_type if event_type
 
             if translated?(event)
-              TranslatedEvent.write(xml: xml, event: event, alt_rep_group: id_generator.next_altrepgroup, event_type: event.type)
+              TranslatedEvent.write(xml: xml, event: event, alt_rep_group: id_generator.next_altrepgroup, event_type: event_type)
             else
               write_basic(event, attributes)
             end

--- a/app/services/cocina/to_fedora/descriptive/translated_event.rb
+++ b/app/services/cocina/to_fedora/descriptive/translated_event.rb
@@ -29,6 +29,7 @@ module Cocina
           group_contributors
           group_dates
           group_edition_notes
+          normalize_groups
 
           groups.each do |script, origin|
             attributes = {
@@ -75,6 +76,25 @@ module Cocina
         def initialize_translation(key)
           groups[key] ||= { place: [], publisher: [], dateIssued: [], dateCreated: [], edition: [], lang_code: [] }
         end
+
+        # to be called after the group keys and values have been set up
+        #  if there is a key of '', those values should be merged to Latn script or eng language
+        # see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#1202
+        # rubocop:disable Metrics/AbcSize
+        def normalize_groups
+          # we must have '' and Latn groups to do anything useful
+          #  unless we want to look through all the groups for lang_code 'eng' and muck about
+          return if !groups.key?('') || !groups.key?('Latn')
+
+          groups['Latn'][:place] += groups[''][:place]
+          groups['Latn'][:publisher] += groups[''][:publisher]
+          groups['Latn'][:dateIssued] += groups[''][:dateIssued]
+          groups['Latn'][:dateCreated] += groups[''][:dateCreated]
+          groups['Latn'][:edition] += groups[''][:edition]
+          groups['Latn'][:lang_code] ||= groups[''][:lang_code]
+          groups.delete('')
+        end
+        # rubocop:enable Metrics/AbcSize
 
         # rubocop:disable Metrics/AbcSize
         def group_locations

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -966,7 +966,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
   end
 
   # example 39 from mods_to_cocina_originInfo.txt
-  context 'with multilingual' do
+  context 'with multilingual publication location, publisher, dateIssued' do
     let(:xml) do
       <<~XML
         <originInfo script="Latn" altRepGroup="1">

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -1148,79 +1148,78 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
 
   # example 41 from mods_to_cocina_originInfo.txt
   context 'with multiscript originInfo with eventType production' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L1351'
-    # let(:xml) do
-    #   <<~XML
-    #     <originInfo eventType="production" lang="eng" script="Latn" altRepGroup="1">
-    #       <dateCreated keyDate="yes" encoding="w3cdtf">1999-09-09</dateCreated>
-    #       <place>
-    #         <placeTerm authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79076156">Moscow</placeTerm>
-    #       </place>
-    #     </originInfo>
-    #     <originInfo eventType="production" lang="rus" script="Cyrl" altRepGroup="1">
-    #     <place>
-    #       <placeTerm>Москва</placeTerm>
-    #     </place>
-    #     </originInfo>
-    #   XML
-    # end
-    #
-    # it 'builds the expected cocina data structure' do
-    #   expect(build).to eq [
-    #     {
-    #       "type": "creation",
-    #       "date": [
-    #         {
-    #           "value": "1999-09-09",
-    #           "status": "primary",
-    #           "encoding": {
-    #             "code": "w3cdtf"
-    #           }
-    #         }
-    #       ],
-    #       "location": [
-    #         {
-    #           "parallelValue": [
-    #             {
-    #               "value": "Moscow",
-    #               "uri": "http://id.loc.gov/authorities/names/n79076156",
-    #               "source": {
-    #                 "uri": "http://id.loc.gov/authorities/names/"
-    #               },
-    #               "valueLanguage": {
-    #                 "code": "eng",
-    #                 "source": {
-    #                   "code": "iso639-2b"
-    #                 },
-    #                 "valueScript": {
-    #                   "code": "Latn",
-    #                   "source": {
-    #                     "code": "iso15924"
-    #                   }
-    #                 }
-    #               }
-    #             },
-    #             {
-    #               "value": "Москва",
-    #               "valueLanguage": {
-    #                 "code": "rus",
-    #                 "source": {
-    #                   "code": "iso639-2b"
-    #                 },
-    #                 "valueScript": {
-    #                   "code": "Cyrl",
-    #                   "source": {
-    #                     "code": "iso15924"
-    #                   }
-    #                 }
-    #               }
-    #             }
-    #           ]
-    #         }
-    #       ]
-    #     }
-    #   ]
-    # end
+    let(:xml) do
+      <<~XML
+        <originInfo eventType="production" lang="eng" script="Latn" altRepGroup="1">
+          <dateCreated keyDate="yes" encoding="w3cdtf">1999-09-09</dateCreated>
+          <place>
+            <placeTerm authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79076156">Moscow</placeTerm>
+          </place>
+        </originInfo>
+        <originInfo eventType="production" lang="rus" script="Cyrl" altRepGroup="1">
+        <place>
+          <placeTerm>Москва</placeTerm>
+        </place>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the expected cocina data structure' do
+      expect(build).to eq [
+        {
+          type: 'creation',
+          date: [
+            {
+              value: '1999-09-09',
+              status: 'primary',
+              encoding: {
+                code: 'w3cdtf'
+              }
+            }
+          ],
+          location: [
+            {
+              parallelValue: [
+                {
+                  value: 'Moscow',
+                  uri: 'http://id.loc.gov/authorities/names/n79076156',
+                  source: {
+                    uri: 'http://id.loc.gov/authorities/names/'
+                  },
+                  valueLanguage: {
+                    code: 'eng',
+                    source: {
+                      code: 'iso639-2b'
+                    },
+                    valueScript: {
+                      code: 'Latn',
+                      source: {
+                        code: 'iso15924'
+                      }
+                    }
+                  }
+                },
+                {
+                  value: 'Москва',
+                  valueLanguage: {
+                    code: 'rus',
+                    source: {
+                      code: 'iso639-2b'
+                    },
+                    valueScript: {
+                      code: 'Cyrl',
+                      source: {
+                        code: 'iso15924'
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    end
   end
 
   # example 42 from mods_to_cocina_originInfo.txt
@@ -1240,37 +1239,37 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     # it 'builds the expected cocina data structure' do
     #   expect(build).to eq [
     #     {
-    #       "type": "publication",
-    #       "note": [
+    #       "type: "publication",
+    #       "note: [
     #         {
-    #           "type": "edition",
-    #           "parallelValue": [
+    #           "type: "edition",
+    #           "parallelValue: [
     #             {
-    #               "value": "First edition",
-    #               "valueLanguage": {
-    #                 "code": "eng",
-    #                 "source": {
-    #                   "code": "iso639-2b"
+    #               "value: "First edition",
+    #               "valueLanguage: {
+    #                 "code: "eng",
+    #                 "source: {
+    #                   "code: "iso639-2b"
     #                 },
-    #                 "valueScript": {
-    #                   "code": "Latn",
-    #                   "source": {
-    #                     "code": "iso15924"
+    #                 "valueScript: {
+    #                   "code: "Latn",
+    #                   "source: {
+    #                     "code: "iso15924"
     #                   }
     #                 }
     #               }
     #             },
     #             {
-    #               "value": "Первое издание",
-    #               "valueLanguage": {
-    #                 "code": "rus",
-    #                 "source": {
-    #                   "code": "iso639-2b"
+    #               "value: "Первое издание",
+    #               "valueLanguage: {
+    #                 "code: "rus",
+    #                 "source: {
+    #                   "code: "iso639-2b"
     #                 },
-    #                 "valueScript": {
-    #                   "code": "Cyrl",
-    #                   "source": {
-    #                     "code": "iso15924"
+    #                 "valueScript: {
+    #                   "code: "Cyrl",
+    #                   "source: {
+    #                     "code: "iso15924"
     #                   }
     #                 }
     #               }

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     XML
   end
 
+  # example 1 from mods_to_cocina_originInfo.txt
   context 'with a simple dateCreated' do
     let(:xml) do
       <<~XML
@@ -38,6 +39,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 2 from mods_to_cocina_originInfo.txt
   context 'with a simple dateIssued (with encoding)' do
     let(:xml) do
       <<~XML
@@ -64,6 +66,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 3 from mods_to_cocina_originInfo.txt
   context 'with a single copyrightDate' do
     let(:xml) do
       <<~XML
@@ -87,6 +90,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 4 from mods_to_cocina_originInfo.txt
   context 'with a single dateCaptured (ISO 8601 encoding, keyDate)' do
     let(:xml) do
       <<~XML
@@ -114,6 +118,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 5 from mods_to_cocina_originInfo.txt
   context 'with a single dateOther' do
     describe 'with type attribute on the dateOther element' do
       let(:xml) do
@@ -288,6 +293,12 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 5b from mods_to_cocina_originInfo.txt
+  context 'with single dateOther in Gergorian calendar' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L101'
+  end
+
+  # example 6 from mods_to_cocina_originInfo.txt
   context 'with a date range' do
     let(:xml) do
       <<~XML
@@ -322,6 +333,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 7 from mods_to_cocina_originInfo.txt
   context 'with an approximate date' do
     let(:xml) do
       <<~XML
@@ -346,26 +358,32 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 8 from mods_to_cocina_originInfo.txt
   context 'with approximate date range' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L147'
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L169'
   end
 
+  # example 9 from mods_to_cocina_originInfo.txt
   context 'with date range, approximate start date only' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L177'
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L199'
   end
 
+  # example 10 from mods_to_cocina_originInfo.txt
   context 'with date range, approximate end date only' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L206'
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L228'
   end
 
+  # example 11 from mods_to_cocina_originInfo.txt
   context 'with inferred date' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L235'
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L257'
   end
 
+  # example 12 from mods_to_cocina_originInfo.txt
   context 'with questionable date' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L253'
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L275'
   end
 
+  # example 13 from mods_to_cocina_originInfo.txt
   context 'with a range plus single date' do
     let(:xml) do
       <<~XML
@@ -404,6 +422,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 14 from mods_to_cocina_originInfo.txt
   context 'with multiple single dates' do
     let(:xml) do
       <<~XML
@@ -432,6 +451,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 15 from mods_to_cocina_originInfo.txt
   context 'with BCE date (edtf encoding)' do
     let(:xml) do
       <<~XML
@@ -458,18 +478,22 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 16 from mods_to_cocina_originInfo.txt
   context 'with BCE date range (edtf encoding)' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L345'
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L367'
   end
 
+  # example 17 ? from mods_to_cocina_originInfo.txt
   context 'with CE date (edtf encoding)' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L378'
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L400'
   end
 
+  # example 18 from mods_to_cocina_originInfo.txt
   context 'with CE date range (edtf encoing)' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L398'
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L420'
   end
 
+  # example 19 from mods_to_cocina_originInfo.txt
   context 'with multiple date types' do
     let(:xml) do
       <<~XML
@@ -507,10 +531,17 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
-  context 'with Julian calendar' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L457'
+  # example 20 from mods_to_cocina_originInfo.txt
+  context 'with Julian calendar (MODS 3.6 and before)' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L485'
   end
 
+  # example 20 from mods_to_cocina_originInfo.txt
+  context 'with Julian calendar (MODS 3.7 and beyond)' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L508'
+  end
+
+  # example 21 from mods_to_cocina_originInfo.txt
   context 'with date range, no start point' do
     let(:xml) do
       <<~XML
@@ -535,30 +566,37 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 22 from mods_to_cocina_originInfo.txt
   context 'with date range, no end point' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L520'
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L549'
   end
 
+  # example 23 from mods_to_cocina_originInfo.txt
   context 'with MARC-encoded uncertain date' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L538'
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L567'
   end
 
+  # example 24 from mods_to_cocina_originInfo.txt
   context 'with Unencoded date string' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L558'
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L587'
   end
 
+  # example 25 from mods_to_cocina_originInfo.txt
   context 'with originInfo eventType matches date type' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L575'
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L604'
   end
 
+  # example 26 from mods_to_cocina_originInfo.txt
   context 'with originInfo eventType differs from date type' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L592'
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L621'
   end
 
+  # example 26b from mods_to_cocina_originInfo.txt
   context 'with originInfo eventType differs from date type, converted from MARC with multiple 264s' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L605'
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L634'
   end
 
+  # example 27 from mods_to_cocina_originInfo.txt
   context 'with place text (authorized)' do
     let(:xml) do
       <<~XML
@@ -588,6 +626,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 28 from mods_to_cocina_originInfo.txt
   context 'with place code' do
     let(:xml) do
       <<~XML
@@ -617,6 +656,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 29 from mods_to_cocina_originInfo.txt
   context 'with place text and code for same place' do
     let(:xml) do
       <<~XML
@@ -648,6 +688,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 30 from mods_to_cocina_originInfo.txt
   context 'with place code and text for different places' do
     let(:xml) do
       <<~XML
@@ -686,6 +727,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
   end
 
   describe 'publisher' do
+    # example 31 from mods_to_cocina_originInfo.txt
     context 'with one' do
       let(:xml) do
         <<~XML
@@ -725,19 +767,23 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
       end
     end
 
+    # example 32 from mods_to_cocina_originInfo.txt
     context 'when it is transliterated' do
       xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L772'
     end
 
+    # example 33 from mods_to_cocina_originInfo.txt
     context 'when it is in another language' do
       xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L821'
     end
 
+    # example 34 from mods_to_cocina_originInfo.txt
     context 'when there are multiple' do
       xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L868'
     end
   end
 
+  # example 35 from mods_to_cocina_originInfo.txt
   context 'with edition' do
     let(:xml) do
       <<~XML
@@ -762,6 +808,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 36 from mods_to_cocina_originInfo.txt
   context 'with issuance and frequency' do
     let(:xml) do
       <<~XML
@@ -794,6 +841,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 37 from mods_to_cocina_originInfo.txt
   context 'with issuance and frequency - authorized term' do
     let(:xml) do
       <<~XML
@@ -866,6 +914,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 38 from mods_to_cocina_originInfo.txt
   context 'with multiple originInfo elements for different events' do
     let(:xml) do
       <<~XML
@@ -916,10 +965,12 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  # example 39 from mods_to_cocina_originInfo.txt
   context 'with multilingual' do
     xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L1128'
   end
 
+  # example 40 from mods_to_cocina_originInfo.txt
   context 'with displayLabel' do
     let(:xml) do
       <<~XML

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -967,7 +967,156 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
 
   # example 39 from mods_to_cocina_originInfo.txt
   context 'with multilingual' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L1128'
+    let(:xml) do
+      <<~XML
+        <originInfo script="Latn" altRepGroup="1">
+          <place>
+            <placeTerm type="code" authority="marccountry">ja</placeTerm>
+          </place>
+          <place>
+            <placeTerm type="text">Kyōto-shi</placeTerm>
+          </place>
+          <publisher>Rinsen Shoten</publisher>
+          <dateIssued>Heisei 8 [1996]</dateIssued>
+          <dateIssued encoding="marc">1996</dateIssued>
+          <issuance>monographic</issuance>
+        </originInfo>
+        <originInfo script="Hani" altRepGroup="1">
+          <place>
+            <placeTerm type="text">京都市</placeTerm>
+          </place>
+          <publisher>臨川書店</publisher>
+          <dateIssued>平成 8 [1996]</dateIssued>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          type: 'publication',
+          location: [
+            {
+              parallelValue: [
+                {
+                  value: 'Kyōto-shi',
+                  valueLanguage: {
+                    valueScript: {
+                      code: 'Latn',
+                      source: {
+                        code: 'iso15924'
+                      }
+                    }
+                  }
+                },
+                {
+                  value: '京都市',
+                  valueLanguage: {
+                    valueScript: {
+                      code: 'Hani',
+                      source: {
+                        code: 'iso15924'
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              code: 'ja',
+              source: {
+                code: 'marccountry'
+              }
+            }
+          ],
+          contributor: [
+            {
+              type: 'organization',
+              name: [
+                {
+                  parallelValue: [
+                    {
+                      value: 'Rinsen Shoten',
+                      valueLanguage: {
+                        valueScript: {
+                          code: 'Latn',
+                          source: {
+                            code: 'iso15924'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      value: '臨川書店',
+                      valueLanguage: {
+                        valueScript: {
+                          code: 'Hani',
+                          source: {
+                            code: 'iso15924'
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              role: [
+                {
+                  value: 'publisher',
+                  code: 'pbl',
+                  uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                  source: {
+                    code: 'marcrelator',
+                    uri: 'http://id.loc.gov/vocabulary/relators/'
+                  }
+                }
+              ]
+            }
+          ],
+          date: [
+            {
+              parallelValue: [
+                {
+                  value: 'Heisei 8 [1996]',
+                  valueLanguage: {
+                    valueScript: {
+                      code: 'Latn',
+                      source: {
+                        code: 'iso15924'
+                      }
+                    }
+                  }
+                },
+                {
+                  value: '平成 8 [1996]',
+                  valueLanguage: {
+                    valueScript: {
+                      code: 'Hani',
+                      source: {
+                        code: 'iso15924'
+                      }
+                    }
+                  }
+                },
+                {
+                  value: '1996',
+                  encoding: {
+                    code: 'marc'
+                  }
+                }
+              ]
+            }
+          ],
+          note: [
+            {
+              value: 'monographic',
+              type: 'issuance',
+              source: { value: 'MODS issuance terms' }
+            }
+          ]
+        }
+      ]
+    end
   end
 
   # example 40 from mods_to_cocina_originInfo.txt
@@ -995,5 +1144,142 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
         }
       ]
     end
+  end
+
+  # example 41 from mods_to_cocina_originInfo.txt
+  context 'with multiscript originInfo with eventType production' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L1351'
+    # let(:xml) do
+    #   <<~XML
+    #     <originInfo eventType="production" lang="eng" script="Latn" altRepGroup="1">
+    #       <dateCreated keyDate="yes" encoding="w3cdtf">1999-09-09</dateCreated>
+    #       <place>
+    #         <placeTerm authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79076156">Moscow</placeTerm>
+    #       </place>
+    #     </originInfo>
+    #     <originInfo eventType="production" lang="rus" script="Cyrl" altRepGroup="1">
+    #     <place>
+    #       <placeTerm>Москва</placeTerm>
+    #     </place>
+    #     </originInfo>
+    #   XML
+    # end
+    #
+    # it 'builds the expected cocina data structure' do
+    #   expect(build).to eq [
+    #     {
+    #       "type": "creation",
+    #       "date": [
+    #         {
+    #           "value": "1999-09-09",
+    #           "status": "primary",
+    #           "encoding": {
+    #             "code": "w3cdtf"
+    #           }
+    #         }
+    #       ],
+    #       "location": [
+    #         {
+    #           "parallelValue": [
+    #             {
+    #               "value": "Moscow",
+    #               "uri": "http://id.loc.gov/authorities/names/n79076156",
+    #               "source": {
+    #                 "uri": "http://id.loc.gov/authorities/names/"
+    #               },
+    #               "valueLanguage": {
+    #                 "code": "eng",
+    #                 "source": {
+    #                   "code": "iso639-2b"
+    #                 },
+    #                 "valueScript": {
+    #                   "code": "Latn",
+    #                   "source": {
+    #                     "code": "iso15924"
+    #                   }
+    #                 }
+    #               }
+    #             },
+    #             {
+    #               "value": "Москва",
+    #               "valueLanguage": {
+    #                 "code": "rus",
+    #                 "source": {
+    #                   "code": "iso639-2b"
+    #                 },
+    #                 "valueScript": {
+    #                   "code": "Cyrl",
+    #                   "source": {
+    #                     "code": "iso15924"
+    #                   }
+    #                 }
+    #               }
+    #             }
+    #           ]
+    #         }
+    #       ]
+    #     }
+    #   ]
+    # end
+  end
+
+  # example 42 from mods_to_cocina_originInfo.txt
+  context 'with multiscript originInfo with eventType production' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L1420'
+    # let(:xml) do
+    #   <<~XML
+    #     <originInfo eventType="publication" lang="eng" script="Latn" altRepGroup="1">
+    #       <edition>First edition</edition>
+    #     </originInfo>
+    #     <originInfo eventType="publication" lang="rus" script="Cyrl" altRepGroup="1">
+    #       <edition>Первое издание</edition>
+    #     </originInfo>
+    #   XML
+    # end
+    #
+    # it 'builds the expected cocina data structure' do
+    #   expect(build).to eq [
+    #     {
+    #       "type": "publication",
+    #       "note": [
+    #         {
+    #           "type": "edition",
+    #           "parallelValue": [
+    #             {
+    #               "value": "First edition",
+    #               "valueLanguage": {
+    #                 "code": "eng",
+    #                 "source": {
+    #                   "code": "iso639-2b"
+    #                 },
+    #                 "valueScript": {
+    #                   "code": "Latn",
+    #                   "source": {
+    #                     "code": "iso15924"
+    #                   }
+    #                 }
+    #               }
+    #             },
+    #             {
+    #               "value": "Первое издание",
+    #               "valueLanguage": {
+    #                 "code": "rus",
+    #                 "source": {
+    #                   "code": "iso639-2b"
+    #                 },
+    #                 "valueScript": {
+    #                   "code": "Cyrl",
+    #                   "source": {
+    #                     "code": "iso15924"
+    #                   }
+    #                 }
+    #               }
+    #             }
+    #           ]
+    #         }
+    #       ]
+    #     }
+    #   ]
+    # end
   end
 end

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -1223,62 +1223,61 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
   end
 
   # example 42 from mods_to_cocina_originInfo.txt
-  context 'with multiscript originInfo with eventType production' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L1420'
-    # let(:xml) do
-    #   <<~XML
-    #     <originInfo eventType="publication" lang="eng" script="Latn" altRepGroup="1">
-    #       <edition>First edition</edition>
-    #     </originInfo>
-    #     <originInfo eventType="publication" lang="rus" script="Cyrl" altRepGroup="1">
-    #       <edition>Первое издание</edition>
-    #     </originInfo>
-    #   XML
-    # end
-    #
-    # it 'builds the expected cocina data structure' do
-    #   expect(build).to eq [
-    #     {
-    #       "type: "publication",
-    #       "note: [
-    #         {
-    #           "type: "edition",
-    #           "parallelValue: [
-    #             {
-    #               "value: "First edition",
-    #               "valueLanguage: {
-    #                 "code: "eng",
-    #                 "source: {
-    #                   "code: "iso639-2b"
-    #                 },
-    #                 "valueScript: {
-    #                   "code: "Latn",
-    #                   "source: {
-    #                     "code: "iso15924"
-    #                   }
-    #                 }
-    #               }
-    #             },
-    #             {
-    #               "value: "Первое издание",
-    #               "valueLanguage: {
-    #                 "code: "rus",
-    #                 "source: {
-    #                   "code: "iso639-2b"
-    #                 },
-    #                 "valueScript: {
-    #                   "code: "Cyrl",
-    #                   "source: {
-    #                     "code: "iso15924"
-    #                   }
-    #                 }
-    #               }
-    #             }
-    #           ]
-    #         }
-    #       ]
-    #     }
-    #   ]
-    # end
+  context 'with multilingual edition' do
+    let(:xml) do
+      <<~XML
+        <originInfo eventType="publication" lang="eng" script="Latn" altRepGroup="1">
+          <edition>First edition</edition>
+        </originInfo>
+        <originInfo eventType="publication" lang="rus" script="Cyrl" altRepGroup="1">
+          <edition>Первое издание</edition>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the expected cocina data structure' do
+      expect(build).to eq [
+        {
+          type: 'publication',
+          note: [
+            {
+              type: 'edition',
+              parallelValue: [
+                {
+                  value: 'First edition',
+                  valueLanguage: {
+                    code: 'eng',
+                    source: {
+                      code: 'iso639-2b'
+                    },
+                    valueScript: {
+                      code: 'Latn',
+                      source: {
+                        code: 'iso15924'
+                      }
+                    }
+                  }
+                },
+                {
+                  value: 'Первое издание',
+                  valueLanguage: {
+                    code: 'rus',
+                    source: {
+                      code: 'iso639-2b'
+                    },
+                    valueScript: {
+                      code: 'Cyrl',
+                      source: {
+                        code: 'iso15924'
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    end
   end
 end

--- a/spec/services/cocina/to_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/event_spec.rb
@@ -1614,67 +1614,66 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
 
   # example 42 from mods_to_cocina_originInfo.txt
   context 'with multilingual edition' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L1420'
-    # let(:events) do
-    #   [
-    #     Cocina::Models::Event.new(
-    #       {
-    #         type: 'publication',
-    #         note: [
-    #           {
-    #             type: 'edition',
-    #             parallelValue: [
-    #               {
-    #                 value: 'First edition',
-    #                 valueLanguage: {
-    #                   code: 'eng',
-    #                   source: {
-    #                     code: 'iso639-2b'
-    #                   },
-    #                   valueScript: {
-    #                     code: 'Latn',
-    #                     source: {
-    #                       code: 'iso15924'
-    #                     }
-    #                   }
-    #                 }
-    #               },
-    #               {
-    #                 value: 'Первое издание',
-    #                 valueLanguage: {
-    #                   code: 'rus',
-    #                   source: {
-    #                     code: 'iso639-2b'
-    #                   },
-    #                   valueScript: {
-    #                     code: 'Cyrl',
-    #                     source: {
-    #                       code: 'iso15924'
-    #                     }
-    #                   }
-    #                 }
-    #               }
-    #             ]
-    #           }
-    #         ]
-    #       }
-    #     )
-    #   ]
-    # end
-    #
-    # it 'builds the expected xml' do
-    #   expect(xml).to be_equivalent_to <<~XML
-    #     <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    #       xmlns="http://www.loc.gov/mods/v3" version="3.6"
-    #       xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-    #       <originInfo eventType="publication" lang="eng" script="Latn" altRepGroup="1">
-    #         <edition>First edition</edition>
-    #       </originInfo>
-    #       <originInfo eventType="publication" lang="rus" script="Cyrl" altRepGroup="1">
-    #         <edition>Первое издание</edition>
-    #       </originInfo>
-    #     </mods>
-    #   XML
-    # end
+    let(:events) do
+      [
+        Cocina::Models::Event.new(
+          {
+            type: 'publication',
+            note: [
+              {
+                type: 'edition',
+                parallelValue: [
+                  {
+                    value: 'First edition',
+                    valueLanguage: {
+                      code: 'eng',
+                      source: {
+                        code: 'iso639-2b'
+                      },
+                      valueScript: {
+                        code: 'Latn',
+                        source: {
+                          code: 'iso15924'
+                        }
+                      }
+                    }
+                  },
+                  {
+                    value: 'Первое издание',
+                    valueLanguage: {
+                      code: 'rus',
+                      source: {
+                        code: 'iso639-2b'
+                      },
+                      valueScript: {
+                        code: 'Cyrl',
+                        source: {
+                          code: 'iso15924'
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        )
+      ]
+    end
+
+    it 'builds the expected xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <originInfo eventType="publication" lang="eng" script="Latn" altRepGroup="0">
+            <edition>First edition</edition>
+          </originInfo>
+          <originInfo eventType="publication" lang="rus" script="Cyrl" altRepGroup="0">
+            <edition>Первое издание</edition>
+          </originInfo>
+        </mods>
+      XML
+    end
   end
 end

--- a/spec/services/cocina/to_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/event_spec.rb
@@ -1387,7 +1387,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo script="Latn" altRepGroup="0" eventType="publication">
+          <originInfo script="Latn" altRepGroup="1" eventType="publication">
             <place>
               <placeTerm type="code" authority="marccountry">ja</placeTerm>
             </place>
@@ -1399,7 +1399,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
             <dateIssued encoding="marc">1996</dateIssued>
             <issuance>monographic</issuance>
           </originInfo>
-          <originInfo script="Hani" altRepGroup="0" eventType="publication">
+          <originInfo script="Hani" altRepGroup="1" eventType="publication">
             <place>
               <placeTerm type="text">京都市</placeTerm>
             </place>
@@ -1596,13 +1596,13 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="production" lang="eng" script="Latn" altRepGroup="0">
+          <originInfo eventType="production" lang="eng" script="Latn" altRepGroup="1">
+            <dateCreated keyDate="yes" encoding="w3cdtf">1999-09-09</dateCreated>
             <place>
               <placeTerm authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79076156" type="text">Moscow</placeTerm>
             </place>
-            <dateCreated keyDate="yes" encoding="w3cdtf">1999-09-09</dateCreated>
           </originInfo>
-          <originInfo eventType="production" lang="rus" script="Cyrl" altRepGroup="0">
+          <originInfo eventType="production" lang="rus" script="Cyrl" altRepGroup="1">
             <place>
               <placeTerm type="text">Москва</placeTerm>
             </place>
@@ -1666,10 +1666,10 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication" lang="eng" script="Latn" altRepGroup="0">
+          <originInfo eventType="publication" lang="eng" script="Latn" altRepGroup="1">
             <edition>First edition</edition>
           </originInfo>
-          <originInfo eventType="publication" lang="rus" script="Cyrl" altRepGroup="0">
+          <originInfo eventType="publication" lang="rus" script="Cyrl" altRepGroup="1">
             <edition>Первое издание</edition>
           </originInfo>
         </mods>

--- a/spec/services/cocina/to_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/event_spec.rb
@@ -1529,4 +1529,152 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       XML
     end
   end
+
+  # example 41 from mods_to_cocina_originInfo.txt
+  context 'with multiscript originInfo with eventType production' do
+    let(:events) do
+      [
+        Cocina::Models::Event.new(
+          {
+            type: 'creation',
+            date: [
+              {
+                value: '1999-09-09',
+                status: 'primary',
+                encoding: {
+                  code: 'w3cdtf'
+                }
+              }
+            ],
+            location: [
+              {
+                parallelValue: [
+                  {
+                    value: 'Moscow',
+                    uri: 'http://id.loc.gov/authorities/names/n79076156',
+                    source: {
+                      uri: 'http://id.loc.gov/authorities/names/'
+                    },
+                    valueLanguage: {
+                      code: 'eng',
+                      source: {
+                        code: 'iso639-2b'
+                      },
+                      valueScript: {
+                        code: 'Latn',
+                        source: {
+                          code: 'iso15924'
+                        }
+                      }
+                    }
+                  },
+                  {
+                    value: 'Москва',
+                    valueLanguage: {
+                      code: 'rus',
+                      source: {
+                        code: 'iso639-2b'
+                      },
+                      valueScript: {
+                        code: 'Cyrl',
+                        source: {
+                          code: 'iso15924'
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        )
+      ]
+    end
+
+    it 'builds the expected xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <originInfo eventType="production" lang="eng" script="Latn" altRepGroup="0">
+            <place>
+              <placeTerm authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79076156" type="text">Moscow</placeTerm>
+            </place>
+            <dateCreated keyDate="yes" encoding="w3cdtf">1999-09-09</dateCreated>
+          </originInfo>
+          <originInfo eventType="production" lang="rus" script="Cyrl" altRepGroup="0">
+            <place>
+              <placeTerm type="text">Москва</placeTerm>
+            </place>
+          </originInfo>
+        </mods>
+      XML
+    end
+  end
+
+  # example 42 from mods_to_cocina_originInfo.txt
+  context 'with multilingual edition' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L1420'
+    # let(:events) do
+    #   [
+    #     Cocina::Models::Event.new(
+    #       {
+    #         type: 'publication',
+    #         note: [
+    #           {
+    #             type: 'edition',
+    #             parallelValue: [
+    #               {
+    #                 value: 'First edition',
+    #                 valueLanguage: {
+    #                   code: 'eng',
+    #                   source: {
+    #                     code: 'iso639-2b'
+    #                   },
+    #                   valueScript: {
+    #                     code: 'Latn',
+    #                     source: {
+    #                       code: 'iso15924'
+    #                     }
+    #                   }
+    #                 }
+    #               },
+    #               {
+    #                 value: 'Первое издание',
+    #                 valueLanguage: {
+    #                   code: 'rus',
+    #                   source: {
+    #                     code: 'iso639-2b'
+    #                   },
+    #                   valueScript: {
+    #                     code: 'Cyrl',
+    #                     source: {
+    #                       code: 'iso15924'
+    #                     }
+    #                   }
+    #                 }
+    #               }
+    #             ]
+    #           }
+    #         ]
+    #       }
+    #     )
+    #   ]
+    # end
+    #
+    # it 'builds the expected xml' do
+    #   expect(xml).to be_equivalent_to <<~XML
+    #     <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    #       xmlns="http://www.loc.gov/mods/v3" version="3.6"
+    #       xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+    #       <originInfo eventType="publication" lang="eng" script="Latn" altRepGroup="1">
+    #         <edition>First edition</edition>
+    #       </originInfo>
+    #       <originInfo eventType="publication" lang="rus" script="Cyrl" altRepGroup="1">
+    #         <edition>Первое издание</edition>
+    #       </originInfo>
+    #     </mods>
+    #   XML
+    # end
+  end
 end

--- a/spec/services/cocina/to_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/event_spec.rb
@@ -1258,28 +1258,28 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     let(:events) do
       [
         Cocina::Models::Event.new(
-          "type": 'publication',
-          "location": [
+          type: 'publication',
+          location: [
             {
-              "parallelValue": [
+              parallelValue: [
                 {
-                  "value": 'Kyōto-shi',
-                  "valueLanguage": {
-                    "valueScript": {
-                      "code": 'Latn',
-                      "source": {
-                        "code": 'iso15924'
+                  value: 'Kyōto-shi',
+                  valueLanguage: {
+                    valueScript: {
+                      code: 'Latn',
+                      source: {
+                        code: 'iso15924'
                       }
                     }
                   }
                 },
                 {
-                  "value": '京都市',
-                  "valueLanguage": {
-                    "valueScript": {
-                      "code": 'Hani',
-                      "source": {
-                        "code": 'iso15924'
+                  value: '京都市',
+                  valueLanguage: {
+                    valueScript: {
+                      code: 'Hani',
+                      source: {
+                        code: 'iso15924'
                       }
                     }
                   }
@@ -1287,36 +1287,36 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
               ]
             },
             {
-              "code": 'ja',
-              "source": {
-                "code": 'marccountry'
+              code: 'ja',
+              source: {
+                code: 'marccountry'
               }
             }
           ],
-          "contributor": [
+          contributor: [
             {
-              "type": 'organization',
-              "name": [
+              type: 'organization',
+              name: [
                 {
-                  "parallelValue": [
+                  parallelValue: [
                     {
-                      "value": 'Rinsen Shoten',
-                      "valueLanguage": {
-                        "valueScript": {
-                          "code": 'Latn',
-                          "source": {
-                            "code": 'iso15924'
+                      value: 'Rinsen Shoten',
+                      valueLanguage: {
+                        valueScript: {
+                          code: 'Latn',
+                          source: {
+                            code: 'iso15924'
                           }
                         }
                       }
                     },
                     {
-                      "value": '臨川書店',
-                      "valueLanguage": {
-                        "valueScript": {
-                          "code": 'Hani',
-                          "source": {
-                            "code": 'iso15924'
+                      value: '臨川書店',
+                      valueLanguage: {
+                        valueScript: {
+                          code: 'Hani',
+                          source: {
+                            code: 'iso15924'
                           }
                         }
                       }
@@ -1324,17 +1324,58 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
                   ]
                 }
               ],
-              "role": [
+              role: [
                 {
-                  "value": 'publisher',
-                  "code": 'pbl',
-                  "uri": 'http://id.loc.gov/vocabulary/relators/pbl',
-                  "source": {
-                    "code": 'marcrelator',
-                    "uri": 'http://id.loc.gov/vocabulary/relators/'
+                  value: 'publisher',
+                  code: 'pbl',
+                  uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                  source: {
+                    code: 'marcrelator',
+                    uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
                 }
               ]
+            }
+          ],
+          date: [
+            {
+              parallelValue: [
+                {
+                  value: 'Heisei 8 [1996]',
+                  valueLanguage: {
+                    valueScript: {
+                      code: 'Latn',
+                      source: {
+                        code: 'iso15924'
+                      }
+                    }
+                  }
+                },
+                {
+                  value: '平成 8 [1996]',
+                  valueLanguage: {
+                    valueScript: {
+                      code: 'Hani',
+                      source: {
+                        code: 'iso15924'
+                      }
+                    }
+                  }
+                },
+                {
+                  value: '1996',
+                  encoding: {
+                    code: 'marc'
+                  }
+                }
+              ]
+            }
+          ],
+          note: [
+            {
+              value: 'monographic',
+              type: 'issuance',
+              source: { value: 'MODS issuance terms' }
             }
           ]
         )
@@ -1346,7 +1387,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication" script="Latn" altRepGroup="1">
+          <originInfo script="Latn" altRepGroup="0" eventType="publication">
             <place>
               <placeTerm type="code" authority="marccountry">ja</placeTerm>
             </place>
@@ -1354,12 +1395,16 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
               <placeTerm type="text">Kyōto-shi</placeTerm>
             </place>
             <publisher>Rinsen Shoten</publisher>
+            <dateIssued>Heisei 8 [1996]</dateIssued>
+            <dateIssued encoding="marc">1996</dateIssued>
+            <issuance>monographic</issuance>
           </originInfo>
-          <originInfo eventType="publication" script="Hani" altRepGroup="1">
+          <originInfo script="Hani" altRepGroup="0" eventType="publication">
             <place>
               <placeTerm type="text">京都市</placeTerm>
             </place>
             <publisher>臨川書店</publisher>
+            <dateIssued>平成 8 [1996]</dateIssued>
           </originInfo>
         </mods>
       XML

--- a/spec/services/cocina/to_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/event_spec.rb
@@ -3,6 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::ToFedora::Descriptive::Event do
+  # mapping specification examples
+  # from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt
+
   subject(:xml) { writer.to_xml }
 
   let(:writer) do
@@ -29,6 +32,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 1 from mods_to_cocina_originInfo.txt
   context 'when it has a single dateCreated' do
     let(:events) do
       [
@@ -56,6 +60,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 2 from mods_to_cocina_originInfo.txt
   context 'when it has a single dateIssued (with encoding)' do
     let(:events) do
       [
@@ -88,6 +93,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 3 from mods_to_cocina_originInfo.txt
   context 'when it has a single copyrightDate' do
     let(:events) do
       [
@@ -117,6 +123,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 4 from mods_to_cocina_originInfo.txt
   context 'when it has a single dateCaptured (ISO 8601 encoding, keyDate)' do
     let(:events) do
       [
@@ -150,6 +157,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 5 from mods_to_cocina_originInfo.txt
   context 'when it has a single dateOther' do
     describe 'with note' do
       let(:events) do
@@ -253,6 +261,12 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 5b from mods_to_cocina_originInfo.txt
+  context 'when it has a single dateOther in Gregorian calendar' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L101'
+  end
+
+  # example 6 from mods_to_cocina_originInfo.txt
   context 'when it has a date range' do
     let(:events) do
       [
@@ -293,6 +307,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 7 from mods_to_cocina_originInfo.txt
   context 'when it has an approximate qualifer' do
     let(:events) do
       [
@@ -323,6 +338,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 8 from mods_to_cocina_originInfo.txt
   context 'when it has an approximate date range' do
     let(:events) do
       [
@@ -365,6 +381,17 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 9 from mods_to_cocina_originInfo.txt
+  context 'when it has an approximate start date only' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L199'
+  end
+
+  # example 10 from mods_to_cocina_originInfo.txt
+  context 'when it has an approximate end date only' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L228'
+  end
+
+  # example 11 from mods_to_cocina_originInfo.txt
   context 'when it has an inferred qualifer' do
     let(:events) do
       [
@@ -395,6 +422,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 12 from mods_to_cocina_originInfo.txt
   context 'when it has an questionable qualifer' do
     let(:events) do
       [
@@ -425,6 +453,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 13 from mods_to_cocina_originInfo.txt
   context 'when it has a date range and another date' do
     let(:events) do
       [
@@ -469,6 +498,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 14 from mods_to_cocina_originInfo.txt
   context 'when it has multiple single dates' do
     let(:events) do
       [
@@ -503,6 +533,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 15 from mods_to_cocina_originInfo.txt
   context 'when it has a BCE date' do
     let(:events) do
       [
@@ -535,6 +566,72 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 16 from mods_to_cocina_originInfo.txt
+  context 'when it has a BCE date range' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L367'
+  end
+
+  # example 17 from mods_to_cocina_originInfo.txt
+  context 'when it has a CE date' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L400'
+  end
+
+  # example 18 from mods_to_cocina_originInfo.txt
+  context 'when it has a CE date range' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L420'
+  end
+
+  # example 19 from mods_to_cocina_originInfo.txt
+  context 'when it has multiple date types' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L453'
+  end
+
+  # example 20 from mods_to_cocina_originInfo.txt
+  context 'when it has Julian calendar (MODS 3.6 and before)' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L485'
+  end
+
+  # example 20 from mods_to_cocina_originInfo.txt
+  context 'when it has Julian calendar (MODS 3.7 and beyond)' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L508'
+  end
+
+  # example 21 from mods_to_cocina_originInfo.txt
+  context 'when it has date range no start point' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L531'
+  end
+
+  # example 22 from mods_to_cocina_originInfo.txt
+  context 'when it has date range no end point' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L549'
+  end
+
+  # example 23 from mods_to_cocina_originInfo.txt
+  context 'when it has uncertain date MARC encoded' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L567'
+  end
+
+  # example 24 from mods_to_cocina_originInfo.txt
+  context 'when it has unencoded date' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L587'
+  end
+
+  # example 25 from mods_to_cocina_originInfo.txt
+  context 'when eventType matches date type' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L604'
+  end
+
+  # example 26 from mods_to_cocina_originInfo.txt
+  context 'when eventType differs from date type' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L621'
+  end
+
+  # example 26b from mods_to_cocina_originInfo.txt
+  context 'when eventType differs from date type, converted from MARC record with multiple 264s' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L634'
+  end
+
+  # example 27 from mods_to_cocina_originInfo.txt
   context 'when it has place text (authorized)' do
     let(:events) do
       [
@@ -570,6 +667,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 28 from mods_to_cocina_originInfo.txt
   context 'when it has place code' do
     let(:events) do
       [
@@ -605,6 +703,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 29 from mods_to_cocina_originInfo.txt
   context 'when it has text and code for same place' do
     let(:events) do
       [
@@ -642,6 +741,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 30 from mods_to_cocina_originInfo.txt
   context 'when it has text and code for different places' do
     let(:events) do
       [
@@ -681,6 +781,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 31 from mods_to_cocina_originInfo.txt
   context 'when it has a publisher' do
     let(:events) do
       [
@@ -758,6 +859,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 32 from mods_to_cocina_originInfo.txt
   context 'when it has a publisher that is transliterated' do
     let(:events) do
       [
@@ -817,6 +919,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 33 from mods_to_cocina_originInfo.txt
   context 'when it has a publisher in a different language' do
     let(:events) do
       [
@@ -872,6 +975,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 34 from mods_to_cocina_originInfo.txt
   context 'when it has multiple publishers' do
     let(:events) do
       [
@@ -935,6 +1039,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 35 from mods_to_cocina_originInfo.txt
   context 'with edition' do
     let(:events) do
       [
@@ -963,6 +1068,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 36 from mods_to_cocina_originInfo.txt
   context 'with issuance and frequency' do
     let(:events) do
       [
@@ -999,6 +1105,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 37 from mods_to_cocina_originInfo.txt
   context 'with issuance and frequency for authorized terms' do
     let(:events) do
       [
@@ -1038,6 +1145,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 38 from mods_to_cocina_originInfo.txt
   context 'with multiple events' do
     let(:events) do
       [
@@ -1145,6 +1253,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 39 from mods_to_cocina_originInfo.txt
   context 'with event represented in multiple languages' do
     let(:events) do
       [
@@ -1343,6 +1452,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
   end
 
+  # example 40 from mods_to_cocina_originInfo.txt
   context 'when it has a displayLabel' do
     let(:events) do
       [


### PR DESCRIPTION
Fixes #1478 

## Why was this change made?

Adds multilingual support for origin_info / event mappings.

Coverage drop is due to no tests for when we hit bizarro MODS and log errors and notify honeybadger.

## How was this change tested?

1. **unit tests** from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt, including 2 new ones added due to questions as I implemented this.

2. **roundtrip validations**

### Before

```
Status (n=100000):
  Success:   87516 (87.516%)
  Different: 11820 (11.82%)
  To Cocina error:     31 (0.031%)
  To Fedora error:     23 (0.023%)
  Missing:     610 (0.61%)
```

### After

```
Status (n=100000):
  Success:   87907 (87.907%)
  Different: 11429 (11.429%)
  To Cocina error:     31 (0.031%)
  To Fedora error:     23 (0.023%)
  Missing:     610 (0.61%)
```

See comments below for specific to-cocina and to-fedora errors; I am confused by the error counts above not matching those for the separate to-cocina and to-fedora runs ... but whatever.

## Which documentation and/or configurations were updated?

https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt

