### PR TITLE
Fix authority attribute for name subjects.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -222,13 +222,8 @@ module Cocina
         end
 
         def person(xml, subject)
-          subject_attributes = {}.tap do |attrs|
+          subject_attributes = topic_attributes_for(subject).tap do |attrs|
             attrs[:type] = name_type_for(subject)
-            if subject.source
-              attrs[:authority] = subject.source.code
-              attrs[:authorityURI] = subject.source.uri
-            end
-            attrs[:valueURI] = subject.uri
           end.compact
 
           xml.name subject_attributes do

--- a/spec/services/cocina/to_fedora/descriptive/subject_name_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_name_spec.rb
@@ -107,6 +107,36 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
     end
   end
 
+  context 'when it has a name subject with authority only' do
+    let(:subjects) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          {
+            "value": 'Sayers, Dorothy L. (Dorothy Leigh), 1893-1957',
+            "type": 'person',
+            "source": {
+              "code": 'naf'
+            }
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject authority="lcsh">
+            <name type="personal">
+              <namePart>Sayers, Dorothy L. (Dorothy Leigh), 1893-1957</namePart>
+            </name>
+          </subject>
+        </mods>
+      XML
+    end
+  end
+
   context 'when it has a name subject with additional terms' do
     let(:subjects) do
       [


### PR DESCRIPTION
closes #1600

## Why was this change made?
Only add authority attribute to `<name>` when has authorityURI or valueURI.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


