### PR TITLE
cocina mappings: map displayLabel attribute for physicalLocation

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/location.rb
+++ b/app/services/cocina/from_fedora/descriptive/location.rb
@@ -92,6 +92,7 @@ module Cocina
               }.compact
               attrs[:source] = source unless source.empty?
               attrs[:type] = node[:type]
+              attrs[:displayLabel] = node[:displayLabel]
               attrs[:valueLanguage] = LanguageScript.build(node: node)
             end.compact
           end

--- a/app/services/cocina/to_fedora/descriptive/location.rb
+++ b/app/services/cocina/to_fedora/descriptive/location.rb
@@ -86,6 +86,7 @@ module Cocina
             attrs[:script] = cocina.valueLanguage&.valueScript&.code
             attrs[:lang] = cocina.valueLanguage&.code
             attrs[:type] = cocina.type
+            attrs[:displayLabel] = cocina.displayLabel
           end.compact
         end
 

--- a/spec/services/cocina/from_fedora/descriptive/location_access_condition_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/location_access_condition_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     XML
   end
 
+  # examples from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_accessCondition.txt
+
+  # example 1A from mods_to_cocina_accessCondition.txt
   context 'with a restriction on access' do
     let(:xml) do
       <<~XML
@@ -36,6 +39,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     end
   end
 
+  # example 1B from mods_to_cocina_accessCondition.txt
   context 'with a restriction on access without spaces' do
     let(:xml) do
       <<~XML
@@ -57,6 +61,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     end
   end
 
+  # example 2A from mods_to_cocina_accessCondition.txt
   context 'with a restriction on use and reproduction' do
     let(:xml) do
       <<~XML
@@ -78,6 +83,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     end
   end
 
+  # example 2B from mods_to_cocina_accessCondition.txt
   context 'with a restriction on use and reproduction without spaces' do
     let(:xml) do
       <<~XML
@@ -99,6 +105,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     end
   end
 
+  # example 3 from mods_to_cocina_accessCondition.txt
   context 'with a license' do
     let(:xml) do
       <<~XML

--- a/spec/services/cocina/from_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/location_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     XML
   end
 
+  # most examples from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_location.txt
+  # example 1 from mods_to_cocina_location.txt
   context 'with a physical location term (with authority)' do
     let(:xml) do
       <<~XML
@@ -42,6 +44,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     end
   end
 
+  # example 2 from mods_to_cocina_location.txt
   context 'with a physical location code' do
     let(:xml) do
       <<~XML
@@ -67,6 +70,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     end
   end
 
+  # example 3 from mods_to_cocina_location.txt
   context 'with a physical repository' do
     let(:xml) do
       <<~XML
@@ -113,6 +117,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     end
   end
 
+  # example 9 from mods_to_cocina_location.txt
   context 'with a physical repository with language and script' do
     let(:xml) do
       <<~XML
@@ -150,6 +155,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     end
   end
 
+  # example 4 from mods_to_cocina_location.txt
   context 'with a URL (with usage)' do
     let(:xml) do
       <<~XML
@@ -191,7 +197,8 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     end
   end
 
-  context 'with a URL (without usage)' do
+  # example 5 from mods_to_cocina_location.txt ???  If so, wrong result
+  context 'with a URL to purl' do
     let(:xml) do
       <<~XML
         <location>
@@ -205,6 +212,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     end
   end
 
+  # example 8 from mods_to_cocina_location.txt
   context 'with a URL with note' do
     let(:xml) do
       <<~XML
@@ -231,6 +239,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     end
   end
 
+  # example 6 from mods_to_cocina_location.txt
   context 'with a Web archive (with display label)' do
     let(:xml) do
       <<~XML
@@ -266,6 +275,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
     end
   end
 
+  # example 7 from mods_to_cocina_location.txt
   context 'with a Shelf locator' do
     let(:xml) do
       <<~XML
@@ -287,5 +297,93 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
         }
       )
     end
+  end
+
+  # example 10 from mods_to_cocina_location.txt
+  context 'with Physical location with type "discovery" mapping to digitalLocation' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_location.txt#L227'
+  end
+
+  # example 11 from mods_to_cocina_location.txt
+  context 'with Physical location with display label' do
+    let(:xml) do
+      <<~XML
+        <location>
+          <physicalLocation type="repository" displayLabel="Repository" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/no2014019980">Stanford University. Libraries. Department of Special Collections and University Archives</physicalLocation>
+          <physicalLocation>Call Number: SC0340, Accession 2005-101, Box: 51, Folder: 3</physicalLocation>
+        </location>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq(
+        "accessContact": [
+          {
+            "value": 'Stanford University. Libraries. Department of Special Collections and University Archives',
+            "uri": 'http://id.loc.gov/authorities/names/no2014019980',
+            "type": 'repository',
+            "displayLabel": 'Repository',
+            "source": {
+              "uri": 'http://id.loc.gov/authorities/names/'
+            }
+          }
+        ],
+        "physicalLocation": [
+          {
+            "value": 'Call Number: SC0340, Accession 2005-101, Box: 51, Folder: 3'
+          }
+        ]
+      )
+      # NOTE:  mapping spec also includes the following, per https://github.com/sul-dlss-labs/cocina-descriptive-metadata/commit/8351249d2008022f4a039846874fe76e58bbcb70
+      # "digitalRepository": [
+      #   {
+      #     "value": 'Stanford Digital Repository'
+      #   }
+      # ]
+    end
+  end
+
+  context 'with Physical location with display label - two location elements' do
+    let(:xml) do
+      <<~XML
+        <location>
+          <physicalLocation type="repository" displayLabel="Repository" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/no2014019980">Stanford University. Libraries. Department of Special Collections and University Archives</physicalLocation>
+        </location>
+        <location>
+          <physicalLocation>Call Number: SC0340, Accession 2005-101, Box: 51, Folder: 3</physicalLocation>
+        </location>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq(
+        "accessContact": [
+          {
+            "value": 'Stanford University. Libraries. Department of Special Collections and University Archives',
+            "uri": 'http://id.loc.gov/authorities/names/no2014019980',
+            "type": 'repository',
+            "displayLabel": 'Repository',
+            "source": {
+              "uri": 'http://id.loc.gov/authorities/names/'
+            }
+          }
+        ],
+        "physicalLocation": [
+          {
+            "value": 'Call Number: SC0340, Accession 2005-101, Box: 51, Folder: 3'
+          }
+        ]
+      )
+    end
+  end
+
+  # example 12 from mods_to_cocina_location.txt
+  context 'with multiple locations and URLs with usage="primary display"' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_location.txt#L308'
+  end
+
+  # example 13 from mods_to_cocina_location.txt
+  context 'with physical location with type "location"' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_location.txt#L308'
   end
 end

--- a/spec/services/cocina/to_fedora/descriptive/location_access_condition_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/location_access_condition_spec.rb
@@ -29,6 +29,9 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
     end
   end
 
+  # examples from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_accessCondition.txt
+
+  # example 1 from mods_to_cocina_accessCondition.txt
   context 'when it is a restriction on access' do
     let(:access) do
       Cocina::Models::DescriptiveAccessMetadata.new(
@@ -52,6 +55,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
     end
   end
 
+  # example 2 from mods_to_cocina_accessCondition.txt
   context 'when it is a restriction on use and reproduction' do
     let(:access) do
       Cocina::Models::DescriptiveAccessMetadata.new(
@@ -75,6 +79,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
     end
   end
 
+  # example 3 from mods_to_cocina_accessCondition.txt
   context 'when it is a license' do
     let(:access) do
       Cocina::Models::DescriptiveAccessMetadata.new(

--- a/spec/services/cocina/to_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/location_spec.rb
@@ -360,7 +360,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
 
     it 'builds the xml' do
       expect(xml).to be_equivalent_to <<~XML
-        <?xml version=\"1.0\"?>
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">

--- a/spec/services/cocina/to_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/location_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
   end
 
   let(:purl) { nil }
-
   let(:access) { nil }
+
+  # most examples from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_location.txt
 
   context 'when location and PURL is nil' do
     it 'builds the xml' do
@@ -31,6 +32,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
     end
   end
 
+  # example 1 from mods_to_cocina_location.txt
   context 'when it is a physical location term (with authority)' do
     let(:access) do
       Cocina::Models::DescriptiveAccessMetadata.new(
@@ -65,6 +67,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
     end
   end
 
+  # example 2 from mods_to_cocina_location.txt
   context 'when it is a physical location code' do
     let(:access) do
       Cocina::Models::DescriptiveAccessMetadata.new(
@@ -97,6 +100,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
     end
   end
 
+  # example 3 from mods_to_cocina_location.txt
   context 'when it is a physical repository' do
     let(:access) do
       Cocina::Models::DescriptiveAccessMetadata.new(
@@ -131,6 +135,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
     end
   end
 
+  # example 9 from mods_to_cocina_location.txt
   context 'when it is a physical repository with language and script' do
     let(:access) do
       Cocina::Models::DescriptiveAccessMetadata.new(
@@ -172,6 +177,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
     end
   end
 
+  # example 4 from mods_to_cocina_location.txt
   context 'when it is a URL (with usage)' do
     let(:access) do
       Cocina::Models::DescriptiveAccessMetadata.new(
@@ -202,6 +208,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
     end
   end
 
+  # example 8 from mods_to_cocina_location.txt
   context 'when it is a URL with note' do
     let(:access) do
       Cocina::Models::DescriptiveAccessMetadata.new(
@@ -237,6 +244,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
     end
   end
 
+  # example 5 from mods_to_cocina_location.txt - but not exactly
   context 'when it is a PURL' do
     let(:purl) { 'http://purl.stanford.edu/ys701qw6956' }
 
@@ -253,6 +261,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
     end
   end
 
+  # example 6 from mods_to_cocina_location.txt
   context 'when it is a Web archive (with display label)' do
     let(:access) do
       Cocina::Models::DescriptiveAccessMetadata.new(
@@ -301,6 +310,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
     end
   end
 
+  # example 7 from mods_to_cocina_location.txt
   context 'when it is a shelf locator' do
     let(:access) do
       Cocina::Models::DescriptiveAccessMetadata.new(
@@ -375,5 +385,65 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
         </mods>
       XML
     end
+  end
+
+  # example 10 from mods_to_cocina_location.txt
+  context 'with Physical location with type "discovery" mapping to digitalLocation' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_location.txt#L227'
+  end
+
+  # example 11 from mods_to_cocina_location.txt
+  context 'with Physical location with display label' do
+    let(:access) do
+      Cocina::Models::DescriptiveAccessMetadata.new(
+        "accessContact": [
+          {
+            "value": 'Stanford University. Libraries. Department of Special Collections and University Archives',
+            "uri": 'http://id.loc.gov/authorities/names/no2014019980',
+            "type": 'repository',
+            "displayLabel": 'Repository',
+            "source": {
+              "code": 'naf',
+              "uri": 'http://id.loc.gov/authorities/names/'
+            }
+          }
+        ],
+        "physicalLocation": [
+          {
+            "value": 'Call Number: SC0340, Accession 2005-101, Box: 51, Folder: 3'
+          }
+        ],
+        "digitalRepository": [
+          {
+            "value": 'Stanford Digital Repository'
+          }
+        ]
+      )
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <location>
+            <physicalLocation type="repository" displayLabel="Repository" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/no2014019980">Stanford University. Libraries. Department of Special Collections and University Archives</physicalLocation>
+          </location>
+          <location>
+            <physicalLocation>Call Number: SC0340, Accession 2005-101, Box: 51, Folder: 3</physicalLocation>
+          </location>
+        </mods>
+      XML
+    end
+  end
+
+  # example 12 from mods_to_cocina_location.txt
+  context 'with multiple locations and URLs with usage="primary display"' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_location.txt#L308'
+  end
+
+  # example 13 from mods_to_cocina_location.txt
+  context 'with physical location with type "location"' do
+    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_location.txt#L308'
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #1594  - map displayLabel for physicalLocation element fedora -> cocina -> fedora

## How was this change tested?

unit tests added.

### Before

```
Status (n=100000):
  Success:   86175 (86.175%)
  Different: 13159 (13.159%)
  To Cocina error:     32 (0.032%)
  To Fedora error:     24 (0.024%)
  Missing:     610 (0.61%)
```

### After

```
Status (n=100000):
  Success:   86763 (86.763%)
  Different: 12571 (12.571%)
  To Cocina error:     32 (0.032%)
  To Fedora error:     24 (0.024%)
  Missing:     610 (0.61%)
```


## Which documentation and/or configurations were updated?



