### PR TITLE
Normalizes dc:type image.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -33,6 +33,7 @@ module Cocina
       normalize_xml_space
       normalize_language_term_type
       normalize_geo_purl
+      normalize_dc_image
       normalize_access_condition
       normalize_identifier_type
       normalize_location_physical_location
@@ -218,6 +219,14 @@ module Cocina
                         mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS,
                         rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#').each do |attr|
         attr.value = "http://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
+      end
+    end
+
+    def normalize_dc_image
+      ng_xml.root.xpath('//mods:extension[@displayLabel="geo"]//dc:type[text() = "image"]',
+                        mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS,
+                        dc: 'http://purl.org/dc/elements/1.1/').each do |node|
+        node.content = 'Image'
       end
     end
 

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -896,4 +896,88 @@ RSpec.describe Cocina::ModsNormalizer do
       XML
     end
   end
+
+  context 'when normalizing dc:type image' do
+    context 'when image (lowercase I)' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3"
+            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+            version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <extension displayLabel="geo">
+              <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+                <rdf:Description rdf:about="https://www.stanford.edu/pf694bk4862">
+                  <dc:format>image/jpeg</dc:format>
+                  <dc:type>image</dc:type>
+                </rdf:Description>
+              </rdf:RDF>
+            </extension>
+          </mods>
+        XML
+      end
+
+      it 'fix capitalization (capitalizes I)' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3"
+            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+            version="3.6"          
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <extension displayLabel="geo">
+              <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+                <rdf:Description rdf:about="http://purl.stanford.edu/pf694bk4862">
+                  <dc:format>image/jpeg</dc:format>
+                  <dc:type>Image</dc:type>
+                </rdf:Description>
+              </rdf:RDF>
+            </extension>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when Image (uppercase I)' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3"
+            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+            version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <extension displayLabel="geo">
+              <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+                <rdf:Description rdf:about="https://www.stanford.edu/pf694bk4862">
+                  <dc:format>image/jpeg</dc:format>
+                  <dc:type>Image</dc:type>
+                </rdf:Description>
+              </rdf:RDF>
+            </extension>
+          </mods>
+        XML
+      end
+
+      it 'leaves capitalization' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3"
+            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+            version="3.6"          
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <extension displayLabel="geo">
+              <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+                <rdf:Description rdf:about="http://purl.stanford.edu/pf694bk4862">
+                  <dc:format>image/jpeg</dc:format>
+                  <dc:type>Image</dc:type>
+                </rdf:Description>
+              </rdf:RDF>
+            </extension>
+          </mods>
+        XML
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes #1631

## Why was this change made?
Nornalize bad data.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


