### PR TITLE
Handles adminMetadata events without dates.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/admin_metadata.rb
+++ b/app/services/cocina/to_fedora/descriptive/admin_metadata.rb
@@ -62,7 +62,11 @@ module Cocina
         def build_event_for(type, tag)
           Array(admin_metadata.event).select { |note| note.type == type }.each do |event|
             event.date.each do |date|
-              xml.public_send(tag, date.value, encoding: date.encoding.code)
+              attributes = {}.tap do |attrs|
+                attrs[:encoding] = date.encoding&.code
+              end.compact
+
+              xml.public_send(tag, date.value, attributes)
             end
           end
         end

--- a/spec/services/cocina/to_fedora/descriptive/admin_metadata_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/admin_metadata_spec.rb
@@ -292,4 +292,35 @@ RSpec.describe Cocina::ToFedora::Descriptive::AdminMetadata do
       XML
     end
   end
+
+  context 'when event is missing date' do
+    let(:admin_metadata) do
+      Cocina::Models::DescriptiveAdminMetadata.new(
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  "value": '2011-09-27T12:58:15.677+02:00'
+                }
+              ]
+            }
+          ]
+        }
+      )
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <recordInfo>
+            <recordCreationDate>2011-09-27T12:58:15.677+02:00</recordCreationDate>
+          </recordInfo>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #1625

## Why was this change made?
Map events without dates.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


