### PR TITLE
cocina/MODS event mapping handles event types distribution and manufacture

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -61,31 +61,30 @@ module Cocina
 
     def normalize_version
       # Only normalize version when version isn't mapped.
-      unless /MODS version (\d\.\d)/.match(ng_xml.root.at('//mods:recordInfo/mods:recordOrigin',
-                                                          mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS)&.content)
-        ng_xml.root['version'] = '3.6'
-        ng_xml.root['xsi:schemaLocation'] = 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd'
-      end
+      return if /MODS version (\d\.\d)/.match(ng_xml.root.at('//mods:recordInfo/mods:recordOrigin', mods: MODS_NS)&.content)
+
+      ng_xml.root['version'] = '3.6'
+      ng_xml.root['xsi:schemaLocation'] = 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd'
     end
 
     def normalize_topics
-      ng_xml.root.xpath('//mods:subject[count(mods:topic) = 1 and count(mods:*) = 1]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |subject_node|
-        topic_node = subject_node.xpath('mods:topic', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).first
+      ng_xml.root.xpath('//mods:subject[count(mods:topic) = 1 and count(mods:*) = 1]', mods: MODS_NS).each do |subject_node|
+        topic_node = subject_node.xpath('mods:topic', mods: MODS_NS).first
         normalize_subject(subject_node, topic_node)
       end
     end
 
     def normalize_authority_uris
       Cocina::FromFedora::Descriptive::Authority::NORMALIZE_AUTHORITY_URIS.each do |authority_uri|
-        ng_xml.root.xpath("//mods:*[@authorityURI='#{authority_uri}']", mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+        ng_xml.root.xpath("//mods:*[@authorityURI='#{authority_uri}']", mods: MODS_NS).each do |node|
           node[:authorityURI] = "#{authority_uri}/"
         end
       end
     end
 
     def normalize_subject_name
-      ng_xml.root.xpath('//mods:subject[count(mods:name) = 1 and count(mods:*) = 1]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |subject_node|
-        name_node = subject_node.xpath('mods:name', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).first
+      ng_xml.root.xpath('//mods:subject[count(mods:name) = 1 and count(mods:*) = 1]', mods: MODS_NS).each do |subject_node|
+        name_node = subject_node.xpath('mods:name', mods: MODS_NS).first
         normalize_subject(subject_node, name_node)
       end
     end
@@ -104,24 +103,24 @@ module Cocina
     end
 
     def normalize_subject_authority_naf
-      ng_xml.root.xpath("//mods:subject[@authority='naf']", mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |subject_node|
+      ng_xml.root.xpath("//mods:subject[@authority='naf']", mods: MODS_NS).each do |subject_node|
         subject_node[:authority] = 'lcsh'
       end
     end
 
     # change original xml to have the event type that will be output
     def normalize_origin_info_event_types
-      ng_xml.root.xpath('//mods:originInfo', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |origin_info_node|
-        date_issued_nodes = origin_info_node.xpath('mods:dateIssued', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS)
+      ng_xml.root.xpath('//mods:originInfo', mods: MODS_NS).each do |origin_info_node|
+        date_issued_nodes = origin_info_node.xpath('mods:dateIssued', mods: MODS_NS)
         add_event_type('publication', origin_info_node) && next if date_issued_nodes.present?
 
-        copyright_date_nodes = origin_info_node.xpath('mods:copyrightDate', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS)
+        copyright_date_nodes = origin_info_node.xpath('mods:copyrightDate', mods: MODS_NS)
         add_event_type('copyright notice', origin_info_node) && next if copyright_date_nodes.present?
 
-        date_created_nodes = origin_info_node.xpath('mods:dateCreated', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS)
+        date_created_nodes = origin_info_node.xpath('mods:dateCreated', mods: MODS_NS)
         add_event_type('production', origin_info_node) && next if date_created_nodes.present?
 
-        date_captured_nodes = origin_info_node.xpath('mods:dateCaptured', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS)
+        date_captured_nodes = origin_info_node.xpath('mods:dateCaptured', mods: MODS_NS)
         add_event_type('capture', origin_info_node) && next if date_captured_nodes.present?
       end
     end
@@ -144,13 +143,13 @@ module Cocina
     end
 
     def normalize_text_role_term
-      ng_xml.root.xpath("//mods:roleTerm[@type='text']", mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |role_term_node|
+      ng_xml.root.xpath("//mods:roleTerm[@type='text']", mods: MODS_NS).each do |role_term_node|
         role_term_node.content = role_term_node.content.downcase
       end
     end
 
     def normalize_role_term_authority
-      ng_xml.root.xpath("//mods:roleTerm[@authority='marcrelator']", mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |role_term_node|
+      ng_xml.root.xpath("//mods:roleTerm[@authority='marcrelator']", mods: MODS_NS).each do |role_term_node|
         role_term_node['authorityURI'] = 'http://id.loc.gov/vocabulary/relators/'
       end
     end
@@ -166,11 +165,11 @@ module Cocina
     end
 
     def location_nodes(ng_xml)
-      ng_xml.root.xpath('//mods:location', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS)
+      ng_xml.root.xpath('//mods:location', mods: MODS_NS)
     end
 
     def url_nodes(location_node)
-      location_node.xpath('mods:url', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS)
+      location_node.xpath('mods:url', mods: MODS_NS)
     end
 
     def has_primary_usage?(url_nodes)
@@ -178,7 +177,7 @@ module Cocina
     end
 
     def normalize_related_item_other_type
-      ng_xml.root.xpath('//mods:relatedItem[@type and @otherType]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |related_node|
+      ng_xml.root.xpath('//mods:relatedItem[@type and @otherType]', mods: MODS_NS).each do |related_node|
         related_node.delete('otherType')
         related_node.delete('otherTypeURI')
         related_node.delete('otherTypeAuth')
@@ -186,12 +185,12 @@ module Cocina
     end
 
     def normalize_empty_notes
-      ng_xml.root.xpath('//mods:note[not(text())]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each(&:remove)
+      ng_xml.root.xpath('//mods:note[not(text())]', mods: MODS_NS).each(&:remove)
     end
 
     def normalize_unmatched_altrepgroup
       altrepgroups = {}
-      ng_xml.root.xpath('//mods:*[@altRepGroup]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+      ng_xml.root.xpath('//mods:*[@altRepGroup]', mods: MODS_NS).each do |node|
         altrepgroup = node['altRepGroup']
         altrepgroups[altrepgroup] = [] unless altrepgroups.include?(altrepgroup)
         altrepgroups[altrepgroup] << node
@@ -205,33 +204,33 @@ module Cocina
     end
 
     def normalize_empty_attributes
-      ng_xml.root.xpath('//mods:*[@*=""]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+      ng_xml.root.xpath('//mods:*[@*=""]', mods: MODS_NS).each do |node|
         node.each { |attr_name, attr_value| node.delete(attr_name) if attr_value.blank? }
       end
     end
 
     def normalize_xml_space
-      ng_xml.root.xpath('//mods:*[@xml:space]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+      ng_xml.root.xpath('//mods:*[@xml:space]', mods: MODS_NS).each do |node|
         node.delete('space')
       end
     end
 
     def normalize_language_term_type
-      ng_xml.root.xpath('//mods:languageTerm[not(@type)]', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+      ng_xml.root.xpath('//mods:languageTerm[not(@type)]', mods: MODS_NS).each do |node|
         node['type'] = 'code'
       end
     end
 
     def normalize_subject_authority
       ng_xml.root.xpath('//mods:subject[not(@authority) and count(mods:*) = 1 and not(mods:geographicCode)]/mods:*[@authority]',
-                        mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+                        mods: MODS_NS).each do |node|
         node.parent['authority'] = node['authority']
       end
     end
 
     def normalize_geo_purl
       ng_xml.root.xpath('//mods:extension[@displayLabel="geo"]//rdf:Description/@rdf:about',
-                        mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS,
+                        mods: MODS_NS,
                         rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#').each do |attr|
         attr.value = "http://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
       end
@@ -239,34 +238,29 @@ module Cocina
 
     def normalize_dc_image
       ng_xml.root.xpath('//mods:extension[@displayLabel="geo"]//dc:type[text() = "image"]',
-                        mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS,
+                        mods: MODS_NS,
                         dc: 'http://purl.org/dc/elements/1.1/').each do |node|
         node.content = 'Image'
       end
     end
 
     def normalize_access_condition
-      ng_xml.root.xpath('//mods:accessCondition[@type="restrictionOnAccess"]',
-                        mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+      ng_xml.root.xpath('//mods:accessCondition[@type="restrictionOnAccess"]', mods: MODS_NS).each do |node|
         node['type'] = 'restriction on access'
       end
-      ng_xml.root.xpath('//mods:accessCondition[@type="useAndReproduction"]',
-                        mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+      ng_xml.root.xpath('//mods:accessCondition[@type="useAndReproduction"]', mods: MODS_NS).each do |node|
         node['type'] = 'use and reproduction'
       end
     end
 
     def normalize_identifier_type
-      ng_xml.root.xpath('//mods:identifier[@type]',
-                        mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+      ng_xml.root.xpath('//mods:identifier[@type]', mods: MODS_NS).each do |node|
         node['type'] = normalized_identifier_type_for(node['type'])
       end
-      ng_xml.root.xpath('//mods:nameIdentifier[@type]',
-                        mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+      ng_xml.root.xpath('//mods:nameIdentifier[@type]', mods: MODS_NS).each do |node|
         node['type'] = normalized_identifier_type_for(node['type'])
       end
-      ng_xml.root.xpath('//mods:recordIdentifier[@source]',
-                        mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+      ng_xml.root.xpath('//mods:recordIdentifier[@source]', mods: MODS_NS).each do |node|
         node['source'] = normalized_identifier_type_for(node['source'])
       end
     end
@@ -280,14 +274,14 @@ module Cocina
     end
 
     def normalize_subject_authority_lcnaf
-      ng_xml.root.xpath("//mods:*[@authority='lcnaf']", mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+      ng_xml.root.xpath("//mods:*[@authority='lcnaf']", mods: MODS_NS).each do |node|
         node[:authority] = 'naf'
       end
     end
 
     def normalize_location_physical_location
       location_nodes(ng_xml).each do |location_node|
-        location_node.xpath('mods:physicalLocation|mods:url|mods:shelfLocator', mods: Cocina::FromFedora::Descriptive::DESC_METADATA_NS).each do |node|
+        location_node.xpath('mods:physicalLocation|mods:url|mods:shelfLocator', mods: MODS_NS).each do |node|
           new_location = Nokogiri::XML::Node.new('location', Nokogiri::XML(nil))
           new_location << node
           location_node.parent << new_location

--- a/app/services/cocina/to_fedora/descriptive/event.rb
+++ b/app/services/cocina/to_fedora/descriptive/event.rb
@@ -16,6 +16,8 @@ module Cocina
           'capture' => 'capture',
           'copyright' => 'copyright notice',
           'creation' => 'production',
+          'distribution' => 'distribution',
+          'manufacture' => 'manufacture',
           'publication' => 'publication',
           'acquisition' => 'acquisition'
         }.freeze

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -586,6 +586,59 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L604'
   end
 
+  context 'when eventType matches date type "distribution"' do
+    let(:xml) do
+      <<~XML
+        <originInfo eventType="distribution">
+          <place>
+            <placeTerm type="text">Washington, DC</placeTerm>
+          </place>
+          <publisher>For sale by the Superintendent of Documents, U.S. Government Publishing Office</publisher>
+          <dateOther type="distribution"/>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          type: 'distribution',
+          date: [
+            {
+              value: ''
+            }
+          ],
+          contributor: [
+            {
+              name: [
+                {
+                  value: 'For sale by the Superintendent of Documents, U.S. Government Publishing Office'
+                }
+              ],
+              type: 'organization',
+              role: [
+                {
+                  value: 'publisher',
+                  code: 'pbl',
+                  uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                  source: {
+                    code: 'marcrelator',
+                    uri: 'http://id.loc.gov/vocabulary/relators/'
+                  }
+                }
+              ]
+            }
+          ],
+          location: [
+            {
+              value: 'Washington, DC'
+            }
+          ]
+        }
+      ]
+    end
+  end
+
   # example 26 from mods_to_cocina_originInfo.txt
   context 'with originInfo eventType differs from date type' do
     xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L621'
@@ -601,9 +654,9 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     let(:xml) do
       <<~XML
         <originInfo>
-        <place>
-          <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
-        </place>
+          <place>
+            <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+          </place>
         </originInfo>
       XML
     end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -213,6 +213,45 @@ RSpec.describe Cocina::ModsNormalizer do
     end
   end
 
+
+  context 'when normalizing originInfo dateOther[@type]' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <originInfo eventType="distribution">
+            <dateOther type="distribution"/>
+          </originInfo>
+          <originInfo eventType="manufacture">
+            <dateOther type="manufacture"/>
+          </originInfo>
+          <originInfo eventType="distribution">
+            <dateOther type="distribution">1937</dateOther>
+          </originInfo>
+        </mods>
+      XML
+    end
+
+    it 'removes dateOther type attribute if it matches eventType and dateOther is empty' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <originInfo eventType="distribution">
+            <dateOther/>
+          </originInfo>
+          <originInfo eventType="manufacture">
+            <dateOther/>
+          </originInfo>
+          <originInfo eventType="distribution">
+            <dateOther type="distribution">1937</dateOther>
+          </originInfo>
+        </mods>
+      XML
+    end
+  end
+
   context 'when normalizing subject authority' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
@@ -693,7 +732,7 @@ RSpec.describe Cocina::ModsNormalizer do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3"
           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-          version="3.6"          
+          version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <extension displayLabel="geo">
             <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -725,7 +764,7 @@ RSpec.describe Cocina::ModsNormalizer do
         <?xml version="1.0"?>
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3"
-          version="3.6"          
+          version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <accessCondition type="restriction on access">Available to Stanford researchers only.</accessCondition>
         </mods>
@@ -750,7 +789,7 @@ RSpec.describe Cocina::ModsNormalizer do
         <?xml version="1.0"?>
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3"
-          version="3.6"          
+          version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <accessCondition type="use and reproduction">User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.</accessCondition>
         </mods>
@@ -791,7 +830,7 @@ RSpec.describe Cocina::ModsNormalizer do
         <?xml version="1.0"?>
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3"
-          version="3.6"          
+          version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <identifier type="isbn">1234 5678 9203</identifier>
           <identifier type="ark">http://bnf.fr/ark:/13030/tf5p30086k</identifier>
@@ -870,7 +909,7 @@ RSpec.describe Cocina::ModsNormalizer do
         <?xml version="1.0"?>
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3"
-          version="3.6"          
+          version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <location>
             <url usage="primary display">http://purl.stanford.edu/cy979mw6316</url>
@@ -924,7 +963,7 @@ RSpec.describe Cocina::ModsNormalizer do
           <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns="http://www.loc.gov/mods/v3"
             xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-            version="3.6"          
+            version="3.6"
             xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
             <extension displayLabel="geo">
               <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
@@ -965,7 +1004,7 @@ RSpec.describe Cocina::ModsNormalizer do
           <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns="http://www.loc.gov/mods/v3"
             xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-            version="3.6"          
+            version="3.6"
             xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
             <extension displayLabel="geo">
               <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -5,6 +5,10 @@ require 'rails_helper'
 RSpec.describe Cocina::ModsNormalizer do
   let(:normalized_ng_xml) { described_class.normalize(mods_ng_xml: mods_ng_xml, druid: druid) }
 
+  let(:mods_attributes) do
+    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.6"
+    xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd"'
+  end
   let(:druid) { 'druid:pf694bk4862' }
 
   context 'when normalizing version' do
@@ -47,9 +51,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing topic' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/1009447">
             <topic>Marine biology</topic>
           </subject>
@@ -59,10 +61,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'moves authority, authorityURI, valueURI to topic' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject authority="fast">
             <topic authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/1009447">Marine biology</topic>
           </subject>
@@ -74,9 +73,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing topic with additional term' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject authority="lcsh">
             <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85046193">Excavations (Archaeology)</topic>
             <geographic>Turkey</geographic>
@@ -87,10 +84,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'leaves unchanged' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject authority="lcsh">
             <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85046193">Excavations (Archaeology)</topic>
             <geographic>Turkey</geographic>
@@ -103,9 +97,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing normalized_ng_xml name' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/270223">
             <name type="personal">
               <namePart>Anning, Mary, 1799-1847</namePart>
@@ -117,10 +109,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'moves authority, authorityURI, valueURI to topic' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject authority="fast">
             <name type="personal" authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/270223">
               <namePart>Anning, Mary, 1799-1847</namePart>
@@ -134,9 +123,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing authorityURIs' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <name authorityURI="http://id.loc.gov/authorities/names">
             <namePart authorityURI="http://id.loc.gov/authorities/subjects">Anning, Mary, 1799-1847</namePart>
             <role>
@@ -149,10 +136,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'adds trailing slash' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <name authorityURI="http://id.loc.gov/authorities/names/">
             <namePart authorityURI="http://id.loc.gov/authorities/subjects/">Anning, Mary, 1799-1847</namePart>
             <role>
@@ -167,9 +151,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing originInfo eventTypes' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <originInfo>
             <dateIssued>1930</dateIssued>
           </originInfo>
@@ -190,10 +172,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'adds eventType if missing' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <originInfo eventType="publication">
             <dateIssued>1930</dateIssued>
           </originInfo>
@@ -213,13 +192,10 @@ RSpec.describe Cocina::ModsNormalizer do
     end
   end
 
-
   context 'when normalizing originInfo dateOther[@type]' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <originInfo eventType="distribution">
             <dateOther type="distribution"/>
           </originInfo>
@@ -235,9 +211,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'removes dateOther type attribute if it matches eventType and dateOther is empty' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <originInfo eventType="distribution">
             <dateOther/>
           </originInfo>
@@ -255,9 +229,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing subject authority' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject authority="naf">
             <topic>Marine biology</topic>
           </subject>
@@ -267,10 +239,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'changes naf to lcsh' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject authority="lcsh">
             <topic>Marine biology</topic>
           </subject>
@@ -282,9 +251,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing text roleTerm' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <name>
             <role>
               <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
@@ -297,10 +264,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'downcases text' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <name>
             <role>
               <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
@@ -315,9 +279,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing roleTerm authorityURI' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <name>
             <role>
               <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
@@ -330,10 +292,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'adds authorityURI' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <name>
             <role>
               <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
@@ -348,9 +307,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing PURL' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <location>
             <url>http://purl.stanford.edu/bw502ns3302</url>
           </location>
@@ -360,10 +317,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'adds usage' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <location>
             <url usage="primary display">http://purl.stanford.edu/bw502ns3302</url>
           </location>
@@ -375,9 +329,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing PURL but existing primary display in same <location> node' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <location>
             <url>http://purl.stanford.edu/bw502ns3302</url>
             <url usage="primary display">http://www.stanford.edu</url>
@@ -388,10 +340,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'does not add usage' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <location>
             <url>http://purl.stanford.edu/bw502ns3302</url>
           </location>
@@ -406,9 +355,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing PURL but existing primary display in different <location> node' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <location>
             <url>http://purl.stanford.edu/bw502ns3302</url>
           </location>
@@ -421,10 +368,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'does not add usage' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <location>
             <url>http://purl.stanford.edu/bw502ns3302</url>
           </location>
@@ -439,9 +383,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing relatedType with type and otherType' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <relatedItem type="otherFormat" otherType="Online version:" displayLabel="Online version:">
             <titleInfo>
               <title>Sitzungsberichte der Kaiserlichen Akademie der Wissenschaften. Mathematisch-Naturwissenschaftliche Classe. Abt. 2, Mathematik, Physik, Chemie, Physiologie, Meteorologie, physische Geographie und Astronomie</title>
@@ -454,10 +396,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'does not add otherType' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <relatedItem type="otherFormat" displayLabel="Online version:">
             <titleInfo>
               <title>Sitzungsberichte der Kaiserlichen Akademie der Wissenschaften. Mathematisch-Naturwissenschaftliche Classe. Abt. 2, Mathematik, Physik, Chemie, Physiologie, Meteorologie, physische Geographie und Astronomie</title>
@@ -472,9 +411,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing empty notes' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <note type="statement of responsibility" altRepGroup="00" script="Latn"/>
           <note>Includes various issues of some sheets.</note>
         </mods>
@@ -483,10 +420,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'removes' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <note>Includes various issues of some sheets.</note>
         </mods>
       XML
@@ -496,9 +430,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing unmatches altRepGroups' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject altRepGroup='1'>
             <topic>Marine biology</topic>
           </subject>
@@ -514,10 +446,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'removes unmatched' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject altRepGroup='1'>
             <topic>Marine biology</topic>
           </subject>
@@ -535,9 +464,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing empty attributes' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <classification authority="">Y 1.1/2:</mods:classification>
         </mods>
       XML
@@ -545,10 +472,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'removes unmatched' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <classification>Y 1.1/2:</mods:classification>
         </mods>
       XML
@@ -558,9 +482,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing xml:space' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <titleInfo>
             <nonSort xml:space="preserve">The</nonSort>
             <title>registers of the parish church of Adel, in the county of York, from 1606 to 1812</title>
@@ -572,10 +494,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'removes xml:space' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <titleInfo>
             <nonSort>The</nonSort>
             <title>registers of the parish church of Adel, in the county of York, from 1606 to 1812</title>
@@ -589,9 +508,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing languageTerm types' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <recordInfo>
             <languageOfCataloging>
               <languageTerm authority="iso639-2b">eng</languageTerm>
@@ -603,10 +520,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'removes unmatched' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <recordInfo>
             <languageOfCataloging>
               <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
@@ -620,9 +534,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing subject authority' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject>
             <name type="personal" authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/270223">
               <namePart>Anning, Mary, 1799-1847</namePart>
@@ -634,10 +546,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'adds authority' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject authority="fast">
             <name type="personal" authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/270223">
               <namePart>Anning, Mary, 1799-1847</namePart>
@@ -651,9 +560,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing subject authority when child authority is naf' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject>
             <name type="corporate" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n80034013">
               <namePart>Institute for the Future</namePart>
@@ -665,10 +572,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'adds lcsh authority' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject authority="lcsh">
             <name type="corporate" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n80034013">
               <namePart>Institute for the Future</namePart>
@@ -682,9 +586,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing subject authority with geographicCode child' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject>
             <geographicCode authority="marcgac">n-us-md</geographicCode>
           </subject>
@@ -694,10 +596,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'does not add authority' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject>
             <geographicCode authority="marcgac">n-us-md</geographicCode>
           </subject>
@@ -709,11 +608,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing geo PURL' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3"
-          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-          version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes} xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
           <extension displayLabel="geo">
             <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
               <rdf:Description rdf:about="https://www.stanford.edu/pf694bk4862">
@@ -728,12 +623,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'uses correct PURL' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3"
-          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-          version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes} xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
           <extension displayLabel="geo">
             <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
               <rdf:Description rdf:about="http://purl.stanford.edu/pf694bk4862">
@@ -750,10 +640,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing restriction on access without spaces' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3"
-          version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <accessCondition type="restrictionOnAccess">Available to Stanford researchers only.</accessCondition>
         </mods>
       XML
@@ -761,11 +648,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'adds spaces' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3"
-          version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <accessCondition type="restriction on access">Available to Stanford researchers only.</accessCondition>
         </mods>
       XML
@@ -775,10 +658,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing restriction on use and reproduction without spaces' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3"
-          version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <accessCondition type="useAndReproduction">User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.</accessCondition>
         </mods>
       XML
@@ -786,11 +666,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'adds spaces' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3"
-          version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <accessCondition type="use and reproduction">User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.</accessCondition>
         </mods>
       XML
@@ -800,10 +676,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing identifiers' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3"
-          version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <identifier type="Isbn">1234 5678 9203</identifier>
           <identifier type="Ark">http://bnf.fr/ark:/13030/tf5p30086k</identifier>
           <identifier type="Oclc">123456789203</identifier>
@@ -827,11 +700,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'fixes capitalization' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3"
-          version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <identifier type="isbn">1234 5678 9203</identifier>
           <identifier type="ark">http://bnf.fr/ark:/13030/tf5p30086k</identifier>
           <identifier type="OCLC">123456789203</identifier>
@@ -857,9 +726,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing lcnaf subject authority' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject authority="lcsh">
             <topic authority="lcnaf">Marine biology</topic>
           </subject>
@@ -869,10 +736,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'changes lcnaf to naf' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <subject authority="lcsh">
             <topic authority="naf">Marine biology</topic>
           </subject>
@@ -884,10 +748,7 @@ RSpec.describe Cocina::ModsNormalizer do
   context 'when normalizing physical location purl' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3"
-          version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <location>
             <url usage="primary display">http://purl.stanford.edu/cy979mw6316</url>
             <physicalLocation>Stanford University Libraries</physicalLocation>
@@ -906,11 +767,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
     it 'combines the location blocks' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3"
-          version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods #{mods_attributes}>
           <location>
             <url usage="primary display">http://purl.stanford.edu/cy979mw6316</url>
           </location>
@@ -940,11 +797,7 @@ RSpec.describe Cocina::ModsNormalizer do
     context 'when image (lowercase I)' do
       let(:mods_ng_xml) do
         Nokogiri::XML <<~XML
-          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns="http://www.loc.gov/mods/v3"
-            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-            version="3.6"
-            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <mods #{mods_attributes} xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
             <extension displayLabel="geo">
               <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
                 <rdf:Description rdf:about="https://www.stanford.edu/pf694bk4862">
@@ -959,12 +812,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
       it 'fix capitalization (capitalizes I)' do
         expect(normalized_ng_xml).to be_equivalent_to <<~XML
-          <?xml version="1.0"?>
-          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns="http://www.loc.gov/mods/v3"
-            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-            version="3.6"
-            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <mods #{mods_attributes} xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
             <extension displayLabel="geo">
               <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
                 <rdf:Description rdf:about="http://purl.stanford.edu/pf694bk4862">
@@ -981,11 +829,7 @@ RSpec.describe Cocina::ModsNormalizer do
     context 'when Image (uppercase I)' do
       let(:mods_ng_xml) do
         Nokogiri::XML <<~XML
-          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns="http://www.loc.gov/mods/v3"
-            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-            version="3.6"
-            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <mods #{mods_attributes} xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
             <extension displayLabel="geo">
               <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
                 <rdf:Description rdf:about="https://www.stanford.edu/pf694bk4862">
@@ -1000,12 +844,7 @@ RSpec.describe Cocina::ModsNormalizer do
 
       it 'leaves capitalization' do
         expect(normalized_ng_xml).to be_equivalent_to <<~XML
-          <?xml version="1.0"?>
-          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns="http://www.loc.gov/mods/v3"
-            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-            version="3.6"
-            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <mods #{mods_attributes} xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
             <extension displayLabel="geo">
               <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
                 <rdf:Description rdf:about="http://purl.stanford.edu/pf694bk4862">

--- a/spec/services/cocina/to_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/event_spec.rb
@@ -621,6 +621,65 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L604'
   end
 
+  context 'when eventType matches date type "distribution"' do
+    let(:events) do
+      [
+        Cocina::Models::Event.new(
+          {
+            type: 'distribution',
+            date: [
+              {
+                value: ''
+              }
+            ],
+            contributor: [
+              {
+                name: [
+                  {
+                    value: 'For sale by the Superintendent of Documents, U.S. Government Publishing Office'
+                  }
+                ],
+                type: 'organization',
+                role: [
+                  {
+                    value: 'publisher',
+                    code: 'pbl',
+                    uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                    source: {
+                      code: 'marcrelator',
+                      uri: 'http://id.loc.gov/vocabulary/relators/'
+                    }
+                  }
+                ]
+              }
+            ],
+            location: [
+              {
+                value: 'Washington, DC'
+              }
+            ]
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <originInfo eventType="distribution">
+            <place>
+              <placeTerm type="text">Washington, DC</placeTerm>
+            </place>
+            <publisher>For sale by the Superintendent of Documents, U.S. Government Publishing Office</publisher>
+            <dateOther/>
+          </originInfo>
+        </mods>
+      XML
+    end
+  end
+
   # example 26 from mods_to_cocina_originInfo.txt
   context 'when eventType differs from date type' do
     xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L621'


### PR DESCRIPTION
~~(blocked by PR #1616 - once that is merged, this will be rebased and will be a single commit.)~~

## Why was this change made?

Fixes #1637 
Fixes sul-dlss-labs/cocina-descriptive-metadata/issues/212

Arcadia sent me to https://docs.google.com/spreadsheets/d/1d5PokzgXqNykvQeckG2ND43B6i9_CsjfIVwS_IsphS8/edit#gid=0 to map "manufacture" and "distribution" event types.  This PR takes care of these:

```
To Fedora error: 23 of 100000 (0.023%)
To Cocina error: 0 of 100000 (0.0%)
Data error: 31 of 100000 (0.031%)
Missing: 610 of 100000 (0.61%)

To Fedora error: key not found: "distribution" (17 errors)
Examples: druid:xv158sd4671, druid:rm699mr9758, druid:xy550sj6776, druid:vs150vc8193, druid:wk559hh5663, druid:vn937yt0550, druid:hb169xx0561, druid:tk855ws1561, druid:xr732hv7282, druid:hg031yt9438
To Fedora error: key not found: "manufacture" (6 errors)
Examples: druid:qx562pf7510, druid:vy980tx4948, druid:yg421fh9248, druid:dk301jn6138, druid:gx027py7165, druid:ws347hn5418
```


## How was this change tested?

1. **unit tests**

2.  round trip mapping tests

#### Before

```
Status (n=100000):
  Success:   88122 (88.122%)
  Different: 11216 (11.216%)
  To Cocina error:     31 (0.031%)
  To Fedora error:     21 (0.021%)
  Missing:     610 (0.61%)
```

#### After

```
Status (n=100000):
  Success:   88135 (88.135%)
  Different: 11224 (11.224%)
  To Cocina error:     31 (0.031%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

3.  to fedora tests


#### Before

```
To Fedora error: 21 of 100000 (0.021%)
To Cocina error: 0 of 100000 (0.0%)
Data error: 31 of 100000 (0.031%)
Missing: 610 of 100000 (0.61%)

To Fedora error: key not found: "distribution" (15 errors)
Examples: druid:xv158sd4671, druid:rm699mr9758, druid:vs150vc8193, druid:wk559hh5663, druid:vn937yt0550, druid:tk855ws1561, druid:xr732hv7282, druid:hg031yt9438, druid:fm225bn7532, druid:zs120gv1463
To Fedora error: key not found: "manufacture" (6 errors)
Examples: druid:qx562pf7510, druid:vy980tx4948, druid:yg421fh9248, druid:dk301jn6138, druid:gx027py7165, druid:ws347hn5418
```

#### After

```
To Fedora error: 0 of 100000 (0.0%)
To Cocina error: 0 of 100000 (0.0%)
Data error: 31 of 100000 (0.031%)
Missing: 610 of 100000 (0.61%)
```


## Which documentation and/or configurations were updated?



