### PR TITLE
Normalizes geographic subjects.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -21,8 +21,7 @@ module Cocina
       normalize_default_namespace
       normalize_version
       normalize_empty_attributes
-      normalize_topics
-      normalize_subject_name
+      normalize_subject
       normalize_authority_uris
       normalize_origin_info_event_types
       normalize_origin_info_date_other_types
@@ -67,13 +66,6 @@ module Cocina
       ng_xml.root['xsi:schemaLocation'] = 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd'
     end
 
-    def normalize_topics
-      ng_xml.root.xpath('//mods:subject[count(mods:topic) = 1 and count(mods:*) = 1]', mods: MODS_NS).each do |subject_node|
-        topic_node = subject_node.xpath('mods:topic', mods: MODS_NS).first
-        normalize_subject(subject_node, topic_node)
-      end
-    end
-
     def normalize_authority_uris
       Cocina::FromFedora::Descriptive::Authority::NORMALIZE_AUTHORITY_URIS.each do |authority_uri|
         ng_xml.root.xpath("//mods:*[@authorityURI='#{authority_uri}']", mods: MODS_NS).each do |node|
@@ -82,24 +74,20 @@ module Cocina
       end
     end
 
-    def normalize_subject_name
-      ng_xml.root.xpath('//mods:subject[count(mods:name) = 1 and count(mods:*) = 1]', mods: MODS_NS).each do |subject_node|
-        name_node = subject_node.xpath('mods:name', mods: MODS_NS).first
-        normalize_subject(subject_node, name_node)
+    def normalize_subject
+      ng_xml.root.xpath('//mods:subject[count(mods:name|mods:topic|mods:geographic) = 1 and count(mods:*) = 1]', mods: MODS_NS).each do |subject_node|
+        child_node = subject_node.xpath('mods:*', mods: MODS_NS).first
+        next unless subject_node[:authorityURI] || subject_node[:valueURI]
+
+        # If subject has authority and child doesn't, copy to child.
+        child_node[:authority] = subject_node[:authority] if subject_node[:authority] && !child_node[:authority]
+        # If subject has authorityURI and child doesn't, move to child.
+        child_node[:authorityURI] = subject_node[:authorityURI] if subject_node[:authorityURI] && !child_node[:authorityURI]
+        subject_node.delete('authorityURI')
+        # If subject has valueURI and child doesn't, move to child.
+        child_node[:valueURI] = subject_node[:valueURI] if subject_node[:valueURI] && !child_node[:valueURI]
+        subject_node.delete('valueURI')
       end
-    end
-
-    def normalize_subject(subject_node, child_node)
-      return unless subject_node[:authorityURI] || subject_node[:valueURI]
-
-      # If subject has authority and child doesn't, copy to child.
-      child_node[:authority] = subject_node[:authority] if subject_node[:authority] && !child_node[:authority]
-      # If subject has authorityURI and child doesn't, move to child.
-      child_node[:authorityURI] = subject_node[:authorityURI] if subject_node[:authorityURI] && !child_node[:authorityURI]
-      subject_node.delete('authorityURI')
-      # If subject has valueURI and child doesn't, move to child.
-      child_node[:valueURI] = subject_node[:valueURI] if subject_node[:valueURI] && !child_node[:valueURI]
-      subject_node.delete('valueURI')
     end
 
     def normalize_subject_authority_naf

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -48,103 +48,127 @@ RSpec.describe Cocina::ModsNormalizer do
     end
   end
 
-  context 'when normalizing topic' do
-    let(:mods_ng_xml) do
-      Nokogiri::XML <<~XML
-        <mods #{mods_attributes}>
-          <subject authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/1009447">
-            <topic>Marine biology</topic>
-          </subject>
-        </mods>
-      XML
+  context 'when normalizing subject' do
+    context 'when normalizing topic' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{mods_attributes}>
+            <subject authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/1009447">
+              <topic>Marine biology</topic>
+            </subject>
+          </mods>
+        XML
+      end
+
+      it 'moves authority, authorityURI, valueURI to topic' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{mods_attributes}>
+            <subject authority="fast">
+              <topic authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/1009447">Marine biology</topic>
+            </subject>
+          </mods>
+        XML
+      end
     end
 
-    it 'moves authority, authorityURI, valueURI to topic' do
-      expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <mods #{mods_attributes}>
-          <subject authority="fast">
-            <topic authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/1009447">Marine biology</topic>
-          </subject>
-        </mods>
-      XML
-    end
-  end
+    context 'when normalizing topic with additional term' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{mods_attributes}>
+            <subject authority="lcsh">
+              <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85046193">Excavations (Archaeology)</topic>
+              <geographic>Turkey</geographic>
+            </subject>
+          </mods>
+        XML
+      end
 
-  context 'when normalizing topic with additional term' do
-    let(:mods_ng_xml) do
-      Nokogiri::XML <<~XML
-        <mods #{mods_attributes}>
-          <subject authority="lcsh">
-            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85046193">Excavations (Archaeology)</topic>
-            <geographic>Turkey</geographic>
-          </subject>
-        </mods>
-      XML
+      it 'leaves unchanged' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{mods_attributes}>
+            <subject authority="lcsh">
+              <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85046193">Excavations (Archaeology)</topic>
+              <geographic>Turkey</geographic>
+            </subject>
+          </mods>
+        XML
+      end
     end
 
-    it 'leaves unchanged' do
-      expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <mods #{mods_attributes}>
-          <subject authority="lcsh">
-            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85046193">Excavations (Archaeology)</topic>
-            <geographic>Turkey</geographic>
-          </subject>
-        </mods>
-      XML
-    end
-  end
+    context 'when normalizing normalized_ng_xml name' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{mods_attributes}>
+            <subject authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/270223">
+              <name type="personal">
+                <namePart>Anning, Mary, 1799-1847</namePart>
+              </name>
+            </subject>
+          </mods>
+        XML
+      end
 
-  context 'when normalizing normalized_ng_xml name' do
-    let(:mods_ng_xml) do
-      Nokogiri::XML <<~XML
-        <mods #{mods_attributes}>
-          <subject authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/270223">
-            <name type="personal">
-              <namePart>Anning, Mary, 1799-1847</namePart>
+      it 'moves authority, authorityURI, valueURI to topic' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{mods_attributes}>
+            <subject authority="fast">
+              <name type="personal" authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/270223">
+                <namePart>Anning, Mary, 1799-1847</namePart>
+              </name>
+            </subject>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when normalizing authorityURIs' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{mods_attributes}>
+            <name authorityURI="http://id.loc.gov/authorities/names">
+              <namePart authorityURI="http://id.loc.gov/authorities/subjects">Anning, Mary, 1799-1847</namePart>
+              <role>
+                <roleTerm authority="marcrelator" type="text" authorityURI="http://id.loc.gov/vocabulary/relators">creator</roleTerm>
+              </role>
             </name>
-          </subject>
-        </mods>
-      XML
-    end
+          </mods>
+        XML
+      end
 
-    it 'moves authority, authorityURI, valueURI to topic' do
-      expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <mods #{mods_attributes}>
-          <subject authority="fast">
-            <name type="personal" authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/270223">
-              <namePart>Anning, Mary, 1799-1847</namePart>
+      it 'adds trailing slash' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{mods_attributes}>
+            <name authorityURI="http://id.loc.gov/authorities/names/">
+              <namePart authorityURI="http://id.loc.gov/authorities/subjects/">Anning, Mary, 1799-1847</namePart>
+              <role>
+                <roleTerm authority="marcrelator" type="text" authorityURI="http://id.loc.gov/vocabulary/relators/">creator</roleTerm>
+              </role>
             </name>
-          </subject>
-        </mods>
-      XML
-    end
-  end
-
-  context 'when normalizing authorityURIs' do
-    let(:mods_ng_xml) do
-      Nokogiri::XML <<~XML
-        <mods #{mods_attributes}>
-          <name authorityURI="http://id.loc.gov/authorities/names">
-            <namePart authorityURI="http://id.loc.gov/authorities/subjects">Anning, Mary, 1799-1847</namePart>
-            <role>
-              <roleTerm authority="marcrelator" type="text" authorityURI="http://id.loc.gov/vocabulary/relators">creator</roleTerm>
-            </role>
-          </name>
-        </mods>
-      XML
+          </mods>
+        XML
+      end
     end
 
-    it 'adds trailing slash' do
-      expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <mods #{mods_attributes}>
-          <name authorityURI="http://id.loc.gov/authorities/names/">
-            <namePart authorityURI="http://id.loc.gov/authorities/subjects/">Anning, Mary, 1799-1847</namePart>
-            <role>
-              <roleTerm authority="marcrelator" type="text" authorityURI="http://id.loc.gov/vocabulary/relators/">creator</roleTerm>
-            </role>
-          </name>
-        </mods>
-      XML
+    context 'when normalizing geographic' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{mods_attributes}>
+            <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85005490">
+              <geographic>Antarctica</geographic>
+            </subject>
+          </mods>
+        XML
+      end
+
+      it 'moves authority, authorityURI, valueURI to geographic' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{mods_attributes}>
+            <subject authority="lcsh">
+              <geographic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85005490">Antarctica</geographic>
+            </subject>
+          </mods>
+        XML
+      end
     end
   end
 


### PR DESCRIPTION
closes #1660

## Why was this change made?
Because geographic are subjects too.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


