### PR TITLE
cocina mapping normalization: cover more cases where originInfo need eventType

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -98,6 +98,8 @@ module Cocina
     end
 
     # change original xml to have the event type that will be output
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     def normalize_origin_info_event_types
       ng_xml.root.xpath('//mods:originInfo', mods: MODS_NS).each do |origin_info_node|
         date_issued_nodes = origin_info_node.xpath('mods:dateIssued', mods: MODS_NS)
@@ -111,8 +113,22 @@ module Cocina
 
         date_captured_nodes = origin_info_node.xpath('mods:dateCaptured', mods: MODS_NS)
         add_event_type('capture', origin_info_node) && next if date_captured_nodes.present?
+
+        publisher = origin_info_node.xpath('mods:publisher', mods: MODS_NS)
+        add_event_type('publication', origin_info_node) && next if publisher.present?
+
+        edition = origin_info_node.xpath('mods:edition', mods: MODS_NS)
+        add_event_type('publication', origin_info_node) && next if edition.present?
+
+        issuance = origin_info_node.xpath('mods:issuance', mods: MODS_NS)
+        add_event_type('publication', origin_info_node) && next if issuance.present?
+
+        frequency = origin_info_node.xpath('mods:frequency', mods: MODS_NS)
+        add_event_type('publication', origin_info_node) && next if frequency.present?
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
 
     def add_event_type(value, origin_info_node)
       origin_info_node['eventType'] = value if origin_info_node[:eventType].blank?

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -173,46 +173,90 @@ RSpec.describe Cocina::ModsNormalizer do
   end
 
   context 'when normalizing originInfo eventTypes' do
-    let(:mods_ng_xml) do
-      Nokogiri::XML <<~XML
-        <mods #{mods_attributes}>
-          <originInfo>
-            <dateIssued>1930</dateIssued>
-          </originInfo>
-          <originInfo>
-            <copyrightDate>1931</copyrightDate>
-          </originInfo>
-          <originInfo>
-            <dateCreated>1932</dateCreated>
-          </originInfo>
-          <relatedItem>
+    context 'when event type assigning date element present' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{mods_attributes}>
             <originInfo>
-              <dateCaptured>1932</dateCaptured>
+              <dateIssued>1930</dateIssued>
             </originInfo>
-          </relatedItem>
-        </mods>
-      XML
+            <originInfo>
+              <copyrightDate>1931</copyrightDate>
+            </originInfo>
+            <originInfo>
+              <dateCreated>1932</dateCreated>
+            </originInfo>
+            <relatedItem>
+              <originInfo>
+                <dateCaptured>1932</dateCaptured>
+              </originInfo>
+            </relatedItem>
+          </mods>
+        XML
+      end
+
+      it 'adds eventType if missing' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{mods_attributes}>
+            <originInfo eventType="publication">
+              <dateIssued>1930</dateIssued>
+            </originInfo>
+            <originInfo eventType="copyright notice">
+              <copyrightDate>1931</copyrightDate>
+            </originInfo>
+            <originInfo eventType="production">
+              <dateCreated>1932</dateCreated>
+            </originInfo>
+            <relatedItem>
+              <originInfo eventType="capture">
+                <dateCaptured>1932</dateCaptured>
+              </originInfo>
+            </relatedItem>
+          </mods>
+        XML
+      end
     end
 
-    it 'adds eventType if missing' do
-      expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <mods #{mods_attributes}>
-          <originInfo eventType="publication">
-            <dateIssued>1930</dateIssued>
-          </originInfo>
-          <originInfo eventType="copyright notice">
-            <copyrightDate>1931</copyrightDate>
-          </originInfo>
-          <originInfo eventType="production">
-            <dateCreated>1932</dateCreated>
-          </originInfo>
-          <relatedItem>
-            <originInfo eventType="capture">
-              <dateCaptured>1932</dateCaptured>
+    context 'when no event type assigning date element is present' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{mods_attributes}>
+            <originInfo>
+              <publisher>Macro Hamster Press</publisher>
             </originInfo>
-          </relatedItem>
-        </mods>
-      XML
+            <relatedItem type="otherFormat">
+              <originInfo>
+                <publisher>Northwestern University Library</publisher>
+              </originInfo>
+            </relatedItem>
+            <relatedItem type="otherFormat">
+              <originInfo>
+                <edition>Euro-global ed.</edition>
+              </originInfo>
+            </relatedItem>
+          </mods>
+        XML
+      end
+
+      it 'adds eventType if missing' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{mods_attributes}>
+            <originInfo eventType="publication">
+              <publisher>Macro Hamster Press</publisher>
+            </originInfo>
+            <relatedItem type="otherFormat">
+              <originInfo eventType="publication">
+                <publisher>Northwestern University Library</publisher>
+              </originInfo>
+            </relatedItem>
+            <relatedItem type="otherFormat">
+              <originInfo eventType="publication">
+                <edition>Euro-global ed.</edition>
+              </originInfo>
+            </relatedItem>
+          </mods>
+        XML
+      end
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

To make more roundtrip cocina mappings successful by removing a difference that doesn't matter.

Fixes #1671 

## How was this change tested?

1.  unit tests added for mods_normalizer

2. roundtrip stats

#### Before

```
Status (n=100000):
  Success:   89169 (89.169%)
  Different: 10190 (10.19%)
  To Cocina error:     31 (0.031%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

#### After

```
Status (n=100000):
  Success:   89522 (89.522%)
  Different: 9837 (9.837%)
  To Cocina error:     31 (0.031%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```


## Which documentation and/or configurations were updated?



