### PR TITLE
cocina mapping normalization: sometimes originInfo/place/placeTerm needs type=text

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -25,6 +25,7 @@ module Cocina
       normalize_authority_uris
       normalize_origin_info_event_types
       normalize_origin_info_date_other_types
+      normalize_origin_info_place_term_type
       normalize_subject_authority
       normalize_subject_authority_lcnaf
       normalize_subject_authority_naf
@@ -128,6 +129,16 @@ module Cocina
 
           date_other_node.remove_attribute('type') if origin_info_event_type.match?(date_other_node['type'])
         end
+      end
+    end
+
+    # if the cocina model doesn't have a code, then it will have a value;
+    #   this is output as attribute type=text on the roundtripped placeTerm element
+    def normalize_origin_info_place_term_type
+      ng_xml.root.xpath('//mods:originInfo/mods:place/mods:placeTerm', mods: MODS_NS).each do |place_term_node|
+        next if place_term_node.content.blank?
+
+        place_term_node['type'] = 'text' if place_term_node.attributes['type'].blank?
       end
     end
 

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -250,6 +250,42 @@ RSpec.describe Cocina::ModsNormalizer do
     end
   end
 
+  context 'when normalizing originInfo/place/placeTerm text values' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{mods_attributes}>
+          <originInfo eventType="production" displayLabel="Place of Creation">
+            <place supplied="yes">
+              <placeTerm authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79118971">Oakland (Calif.)</placeTerm>
+            </place>
+          </originInfo>
+          <originInfo eventType="publication" displayLabel="publisher">
+            <place>
+              <placeTerm>[Stanford, California] :</placeTerm>
+            </place>
+          </originInfo>
+        </mods>
+      XML
+    end
+
+    it 'adds type text attribute if appropriate' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{mods_attributes}>
+          <originInfo eventType="production" displayLabel="Place of Creation">
+            <place supplied="yes">
+              <placeTerm type="text" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79118971">Oakland (Calif.)</placeTerm>
+            </place>
+          </originInfo>
+          <originInfo eventType="publication" displayLabel="publisher">
+            <place>
+              <placeTerm type="text">[Stanford, California] :</placeTerm>
+            </place>
+          </originInfo>
+        </mods>
+      XML
+    end
+  end
+
   context 'when normalizing subject authority' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML


### PR DESCRIPTION
## Why was this change made?

To make more roundtrip cocina mappings successful by removing a difference that doesn't matter.

Fixes #1674

## How was this change tested?

1. **unit tests**

2. **roundtrip stats**

#### Before

```
Status (n=100000):
  Success:   89169 (89.169%)
  Different: 10190 (10.19%)
  To Cocina error:     31 (0.031%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

#### After

```
Status (n=100000):
  Success:   89387 (89.387%)
  Different: 9972 (9.972%)
  To Cocina error:     31 (0.031%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

## Which documentation and/or configurations were updated?



