### PR TITLE
cocina mapping MODS location/physicalLocation with type attribute

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/location.rb
+++ b/app/services/cocina/from_fedora/descriptive/location.rb
@@ -28,6 +28,7 @@ module Cocina
           {}.tap do |access|
             physical_locations = physical_location + shelf_location
             access[:physicalLocation] = physical_locations if physical_locations.present?
+            access[:digitalLocation] = digital_location if digital_location.present?
             access[:accessContact] = access_contact if access_contact.present?
             access[:url] = url if url.present?
             notes = note + purl_note
@@ -40,7 +41,11 @@ module Cocina
         attr_reader :resource_element
 
         def physical_location
-          descriptive_value_for(resource_element.xpath("mods:location/mods:physicalLocation[not(@type='repository')]", mods: DESC_METADATA_NS))
+          descriptive_value_for(resource_element.xpath("mods:location/mods:physicalLocation[not(@type='repository')][not(@type='discovery')]", mods: DESC_METADATA_NS))
+        end
+
+        def digital_location
+          descriptive_value_for(resource_element.xpath("mods:location/mods:physicalLocation[(@type='discovery')]", mods: DESC_METADATA_NS))
         end
 
         def access_contact

--- a/app/services/cocina/to_fedora/descriptive/location.rb
+++ b/app/services/cocina/to_fedora/descriptive/location.rb
@@ -31,6 +31,7 @@ module Cocina
           end
 
           write_physical_locations
+          write_digital_locations
           write_shelf_locators
           write_access_contact_locations
         end
@@ -43,6 +44,14 @@ module Cocina
           Array(access.physicalLocation).reject { |physical_location| shelf_locator?(physical_location) }.each do |physical_location|
             xml.location do
               xml.physicalLocation physical_location.value || physical_location.code, descriptive_attrs(physical_location)
+            end
+          end
+        end
+
+        def write_digital_locations
+          Array(access.digitalLocation).select { |digital_location| digital_location.type == 'discovery' }.each do |digital_location|
+            xml.location do
+              xml.physicalLocation digital_location.value || digital_location.code, descriptive_attrs(digital_location)
             end
           end
         end

--- a/spec/services/cocina/from_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/location_spec.rb
@@ -357,7 +357,38 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
 
   # example 10 from mods_to_cocina_location.txt
   context 'with Physical location with type "discovery" mapping to digitalLocation' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_location.txt#L227'
+    let(:xml) do
+      <<~'XML'
+        <location>
+          <physicalLocation type="repository" authority="naf" valueURI="http://id.loc.gov/authorities/names/no2014019980">Stanford University. Libraries. Department of Special Collections and University Archives.</physicalLocation>
+          <physicalLocation type="discovery">VICTOR\PLUS_PHOTOS_DAN\PLUS_TARD_PHOTOS_DAN_20071017\IMG_0852.JPG</physicalLocation>
+          <url usage="primary display">http://purl.stanford.edu/hn970dy7259</url>
+        </location>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq(
+        {
+          "accessContact": [
+            {
+              "value": 'Stanford University. Libraries. Department of Special Collections and University Archives.',
+              "type": 'repository',
+              "uri": 'http://id.loc.gov/authorities/names/no2014019980',
+              "source": {
+                "code": 'naf'
+              }
+            }
+          ],
+          "digitalLocation": [
+            {
+              "value": 'VICTOR\PLUS_PHOTOS_DAN\PLUS_TARD_PHOTOS_DAN_20071017\IMG_0852.JPG',
+              "type": 'discovery'
+            }
+          ]
+        }
+      )
+    end
   end
 
   # example 11 from mods_to_cocina_location.txt

--- a/spec/services/cocina/from_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/location_spec.rb
@@ -440,6 +440,40 @@ RSpec.describe Cocina::FromFedora::Descriptive::Location do
 
   # example 13 from mods_to_cocina_location.txt
   context 'with physical location with type "location"' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_location.txt#L308'
+    let(:xml) do
+      <<~XML
+        <location>
+          <physicalLocation type="repository" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/no2014019980">Stanford University. Libraries. Department of Special Collections and University Archives</physicalLocation>
+          <physicalLocation type="location">Box: 20, Folder: Engineering laboratories -- exterior -- #1</physicalLocation>
+          <shelfLocator>SC1071</shelfLocator>
+        </location>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq(
+        "accessContact": [
+          {
+            "value": 'Stanford University. Libraries. Department of Special Collections and University Archives',
+            "type": 'repository',
+            "uri": 'http://id.loc.gov/authorities/names/no2014019980',
+            "source": {
+              "code": 'naf',
+              "uri": 'http://id.loc.gov/authorities/names/'
+            }
+          }
+        ],
+        "physicalLocation": [
+          {
+            "value": 'Box: 20, Folder: Engineering laboratories -- exterior -- #1',
+            "type": 'location'
+          },
+          {
+            "value": 'SC1071',
+            "type": 'shelf locator'
+          }
+        ]
+      )
+    end
   end
 end

--- a/spec/services/cocina/to_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/location_spec.rb
@@ -472,6 +472,48 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
 
   # example 13 from mods_to_cocina_location.txt
   context 'with physical location with type "location"' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_location.txt#L308'
+    let(:access) do
+      Cocina::Models::DescriptiveAccessMetadata.new(
+        "accessContact": [
+          {
+            "value": 'Stanford University. Libraries. Department of Special Collections and University Archives',
+            "type": 'repository',
+            "uri": 'http://id.loc.gov/authorities/names/no2014019980',
+            "source": {
+              "code": 'naf',
+              "uri": 'http://id.loc.gov/authorities/names/'
+            }
+          }
+        ],
+        "physicalLocation": [
+          {
+            "value": 'Box: 20, Folder: Engineering laboratories -- exterior -- #1',
+            "type": 'location'
+          },
+          {
+            "value": 'SC1071',
+            "type": 'shelf locator'
+          }
+        ]
+      )
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <location>
+            <physicalLocation type="repository" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/no2014019980">Stanford University. Libraries. Department of Special Collections and University Archives</physicalLocation>
+          </location>
+          <location>
+            <physicalLocation type="location">Box: 20, Folder: Engineering laboratories -- exterior -- #1</physicalLocation>
+          </location>
+          <location>
+            <shelfLocator>SC1071</shelfLocator>
+          </location>
+        </mods>
+      XML
+    end
   end
 end

--- a/spec/services/cocina/to_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/location_spec.rb
@@ -417,7 +417,50 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
 
   # example 10 from mods_to_cocina_location.txt
   context 'with Physical location with type "discovery" mapping to digitalLocation' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_location.txt#L227'
+    let(:purl) { 'http://purl.stanford.edu/hn970dy7259' }
+    let(:access) do
+      Cocina::Models::DescriptiveAccessMetadata.new(
+        "accessContact": [
+          {
+            "value": 'Stanford University. Libraries. Department of Special Collections and University Archives.',
+            "type": 'repository',
+            "uri": 'http://id.loc.gov/authorities/names/no2014019980',
+            "source": {
+              "code": 'naf'
+            }
+          }
+        ],
+        "digitalLocation": [
+          {
+            "value": 'VICTOR\PLUS_PHOTOS_DAN\PLUS_TARD_PHOTOS_DAN_20071017\IMG_0852.JPG',
+            "type": 'discovery'
+          }
+        ],
+        "digitalRepository": [
+          {
+            "value": 'Stanford Digital Repository'
+          }
+        ]
+      )
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~'XML'
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <location>
+            <physicalLocation type="repository" authority="naf" valueURI="http://id.loc.gov/authorities/names/no2014019980">Stanford University. Libraries. Department of Special Collections and University Archives.</physicalLocation>
+          </location>
+          <location>
+            <physicalLocation type="discovery">VICTOR\PLUS_PHOTOS_DAN\PLUS_TARD_PHOTOS_DAN_20071017\IMG_0852.JPG</physicalLocation>
+          </location>
+          <location>
+            <url usage="primary display">http://purl.stanford.edu/hn970dy7259</url>
+          </location>
+        </mods>
+      XML
+    end
   end
 
   # example 11 from mods_to_cocina_location.txt


### PR DESCRIPTION
## Why was this change made?

Fixes #1499.  Or ... at least doesn't make things worse?   See test stats.

## How was this change tested?

unit tests from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_location.txt

#### Before

```
Status (n=100000):
  Success:   90365 (90.365%)
  Different: 8994 (8.994%)
  To Cocina error:     31 (0.031%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

```
$ bin/validate-cocina-roundtrip -d druid:hn970dy7259

Status (n=1):
  Success:   1 (100.0%)
  Different: 0 (0.0%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  Missing:     0 (0.0%)
```


#### After

```
Status (n=100000):
  Success:   90365 (90.365%)
  Different: 8994 (8.994%)
  To Cocina error:     31 (0.031%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

```
$ bin/validate-cocina-roundtrip -d druid:hn970dy7259

Status (n=1):
  Success:   1 (100.0%)
  Different: 0 (0.0%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  Missing:     0 (0.0%)
```


## Which documentation and/or configurations were updated?



