### PR TITLE
openapi.yml: updated with digitalLocation for access per cocina

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.43.0'
+gem 'cocina-models', '~> 0.44.0'
 gem 'dor-rights-auth', '>= 1.5.0' # required for new CDL rights
 gem 'dor-services', '~> 9.6'
 gem 'dor-workflow-client', '~> 3.17'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.43.0)
+    cocina-models (0.44.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -507,7 +507,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.43.0)
+  cocina-models (~> 0.44.0)
   committee
   config
   deprecation

--- a/openapi.yml
+++ b/openapi.yml
@@ -1316,6 +1316,11 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DescriptiveValue"
+        digitalLocation:
+          description: Location of a digital version of the resource, such as a file path for a born digital resource.
+          type: array
+          items:
+            $ref: "#/components/schemas/DescriptiveValue"
         accessContact:
           description: The library, organization, or person responsible for access to the resource.
           type: array


### PR DESCRIPTION
## Why was this change made?

For #1499, we need cocina-models DescriptiveAccessMetadata to have digitalLocation;  this tiny additive change to openapi.yml was merged into cocina-models.  I've just generated the new cocina-models and cut a new cocina-models gem release, 0.44.0;  this brings this app up to date.

## How was this change tested?

unit tests.

## Which documentation and/or configurations were updated?



