### PR TITLE
Removes empty note displayLabels.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/notes.rb
+++ b/app/services/cocina/from_fedora/descriptive/notes.rb
@@ -41,7 +41,7 @@ module Cocina
         def common_note_for(node)
           {
             value: node.content,
-            displayLabel: node[:displayLabel],
+            displayLabel: node[:displayLabel].presence,
             type: node[:type]
           }.tap do |attributes|
             value_language = LanguageScript.build(node: node)
@@ -89,7 +89,7 @@ module Cocina
 
         def toc_for(node)
           {
-            displayLabel: node[:displayLabel]
+            displayLabel: node[:displayLabel].presence
           }.tap do |attributes|
             value_language = LanguageScript.build(node: node)
             attributes[:valueLanguage] = value_language if value_language

--- a/spec/services/cocina/from_fedora/descriptive/notes_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/notes_spec.rb
@@ -222,6 +222,25 @@ RSpec.describe Cocina::FromFedora::Descriptive::Notes do
     end
   end
 
+  context 'with an empty displayLabel' do
+    let(:xml) do
+      <<~XML
+        <abstract displayLabel="">This is a synopsis.</abstract>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+
+        {
+          "value": 'This is a synopsis.',
+          "type": 'summary'
+        }
+
+      ]
+    end
+  end
+
   # Example 1
   context 'with a simple table of contents' do
     let(:xml) do


### PR DESCRIPTION
closes #1664

## Why was this change made?
Nobody like empty displayLabels.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


