### PR TITLE
Removed hardcoding of hierarchical geo hierarchy when mapping to fedora.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -241,12 +241,7 @@ module Cocina
 
         def hierarchical_geographic(subject)
           xml.hierarchicalGeographic do
-            continent = subject.structuredValue.find { |geo| geo.type == 'continent' }&.value
-            xml.continent continent if continent
-            country = subject.structuredValue.find { |geo| geo.type == 'country' }&.value
-            xml.country country if country
-            city = subject.structuredValue.find { |geo| geo.type == 'city' }&.value
-            xml.city city if city
+            subject.structuredValue.each { |structured_value| xml.send(structured_value.type, structured_value.value) }
           end
         end
 


### PR DESCRIPTION
closes #1659

## Why was this change made?
To remove hardcoding of hierarchical geo hierarchy when mapping to fedora and instead just use the type as the tag.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


