### PR TITLE
Normalizes empty names.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -31,6 +31,7 @@ module Cocina
       normalize_subject_authority_naf
       normalize_text_role_term
       normalize_role_term_authority
+      normalize_name
       normalize_related_item_other_type
       normalize_unmatched_altrepgroup
       normalize_xml_space
@@ -304,6 +305,11 @@ module Cocina
       ng_xml.root.xpath('//mods:relatedItem/mods:part[count(mods:*)=1]/mods:detail[count(mods:*)=1]/mods:number[not(text())]', mods: MODS_NS).each do |number_node|
         number_node.parent.parent.remove
       end
+    end
+
+    def normalize_name
+      ng_xml.root.xpath('//mods:namePart[not(text())]', mods: MODS_NS).each(&:remove)
+      ng_xml.root.xpath('//mods:name[not(mods:namePart)]', mods: MODS_NS).each(&:remove)
     end
   end
 end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -379,6 +379,7 @@ RSpec.describe Cocina::ModsNormalizer do
       Nokogiri::XML <<~XML
         <mods #{mods_attributes}>
           <name>
+            <namePart>Dunnett, Dorothy</namePart>
             <role>
               <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
               <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">Photographer</roleTerm>
@@ -392,6 +393,7 @@ RSpec.describe Cocina::ModsNormalizer do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
         <mods #{mods_attributes}>
           <name>
+            <namePart>Dunnett, Dorothy</namePart>
             <role>
               <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
               <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">photographer</roleTerm>
@@ -407,6 +409,7 @@ RSpec.describe Cocina::ModsNormalizer do
       Nokogiri::XML <<~XML
         <mods #{mods_attributes}>
           <name>
+            <namePart>Dunnett, Dorothy</namePart>
             <role>
               <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
               <roleTerm type="text" authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pht">Photographer</roleTerm>
@@ -420,6 +423,7 @@ RSpec.describe Cocina::ModsNormalizer do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
         <mods #{mods_attributes}>
           <name>
+            <namePart>Dunnett, Dorothy</namePart>
             <role>
               <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
               <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">photographer</roleTerm>
@@ -847,6 +851,7 @@ RSpec.describe Cocina::ModsNormalizer do
           <identifier type="Xyz">123456789203</identifier>
           <identifier type="stock number">123456789203</identifier>
           <name>
+            <namePart>Dunnett, Dorothy</namePart>
             <nameIdentifier type="iSbn">1234 5678 9203</identifier>
             <nameIdentifier type="aRk">http://bnf.fr/ark:/13030/tf5p30086k</identifier>
             <nameIdentifier type="oClc">123456789203</identifier>
@@ -871,6 +876,7 @@ RSpec.describe Cocina::ModsNormalizer do
           <identifier type="Xyz">123456789203</identifier>
           <identifier type="stock-number">123456789203</identifier>
           <name>
+            <namePart>Dunnett, Dorothy</namePart>
             <nameIdentifier type="isbn">1234 5678 9203</identifier>
             <nameIdentifier type="ark">http://bnf.fr/ark:/13030/tf5p30086k</identifier>
             <nameIdentifier type="OCLC">123456789203</identifier>
@@ -1069,6 +1075,28 @@ RSpec.describe Cocina::ModsNormalizer do
               </detail>
             </part>
           </relatedItem>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when normalizing empty names' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{mods_attributes}>
+          <name>
+            <namePart/>
+            <role>
+              <roleTerm authority="marcrelator" type="text">author</roleTerm>
+            </role>
+          </name>
+        </mods>
+      XML
+    end
+
+    it 'removes name' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{mods_attributes}>
         </mods>
       XML
     end


### PR DESCRIPTION
closes #1649

## Why was this change made?
Infinite bad data.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


