### PR TITLE
Map originInfo with development dateOther.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -26,6 +26,7 @@ module Cocina
       normalize_origin_info_event_types
       normalize_origin_info_date_other_types
       normalize_origin_info_place_term_type
+      normalize_origin_info_developed_date
       normalize_subject_authority
       normalize_subject_authority_lcnaf
       normalize_subject_authority_naf
@@ -319,6 +320,17 @@ module Cocina
       ng_xml.root.xpath('//mods:title[not(text())]', mods: MODS_NS).each(&:remove)
       ng_xml.root.xpath('//mods:subTitle[not(text())]', mods: MODS_NS).each(&:remove)
       ng_xml.root.xpath('//mods:titleInfo[not(mods:*)]', mods: MODS_NS).each(&:remove)
+    end
+
+    def normalize_origin_info_developed_date
+      ng_xml.root.xpath('//mods:originInfo/mods:dateOther[@type="developed"]', mods: MODS_NS).each do |date_other|
+        # Move to own originInfo
+        new_origin_info = Nokogiri::XML::Node.new('originInfo', Nokogiri::XML(nil))
+        new_origin_info[:eventType] = 'development'
+        new_origin_info << date_other.dup
+        date_other.parent.parent << new_origin_info
+        date_other.remove
+      end
     end
   end
 end

--- a/app/services/cocina/to_fedora/descriptive/event.rb
+++ b/app/services/cocina/to_fedora/descriptive/event.rb
@@ -19,7 +19,8 @@ module Cocina
           'distribution' => 'distribution',
           'manufacture' => 'manufacture',
           'publication' => 'publication',
-          'acquisition' => 'acquisition'
+          'acquisition' => 'acquisition',
+          'development' => 'development'
         }.freeze
 
         # @params [Nokogiri::XML::Builder] xml
@@ -128,6 +129,7 @@ module Cocina
           attributes[:qualifier] = date.qualifier if date.qualifier
           attributes[:keyDate] = 'yes' if date.status == 'primary'
           attributes[:type] = date.note.find { |note| note.type == 'date type' }.value if tag == :dateOther && date.note
+          attributes[:type] = 'developed' if event_type == 'development'
 
           xml.public_send(tag, value, attributes)
         end

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -1333,4 +1333,58 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
       ]
     end
   end
+
+  # example 45 from mods_to_cocina_originInfo.txt
+  context 'with dateOther with type="developed"' do
+    let(:xml) do
+      <<~XML
+        <originInfo displayLabel="Place of Creation" eventType="production">
+          <place>
+            <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+          </place>
+          <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
+          <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the expected cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'creation',
+          "displayLabel": 'Place of Creation',
+          "location": [
+            {
+              "value": 'Stanford (Calif.)',
+              "uri": 'http://id.loc.gov/authorities/names/n50046557',
+              "source": {
+                "code": 'naf',
+                "uri": 'http://id.loc.gov/authorities/names/'
+              }
+            }
+          ],
+          "date": [
+            {
+              "value": '2003-11-29',
+              "status": 'primary',
+              "encoding": {
+                "code": 'w3cdtf'
+              }
+            }
+          ]
+        },
+        {
+          "type": 'development',
+          "date": [
+            {
+              "value": '2003-12-01',
+              "encoding": {
+                "code": 'w3cdtf'
+              }
+            }
+          ]
+        }
+      ]
+    end
+  end
 end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -1138,4 +1138,36 @@ RSpec.describe Cocina::ModsNormalizer do
       XML
     end
   end
+
+  context 'when normalizing originInfo with developed date' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{mods_attributes}>
+          <originInfo displayLabel="Place of Creation" eventType="production">
+            <place>
+              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+            </place>
+            <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
+            <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
+          </originInfo>
+        </mods>
+      XML
+    end
+
+    it 'moves to own originInfo' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{mods_attributes}>
+          <originInfo displayLabel="Place of Creation" eventType="production">
+            <place>
+              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+            </place>
+            <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
+          </originInfo>
+          <originInfo eventType="development">
+            <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
+          </originInfo>
+        </mods>
+      XML
+    end
+  end
 end

--- a/spec/services/cocina/to_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/event_spec.rb
@@ -1735,4 +1735,67 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       XML
     end
   end
+
+  # example 45 from mods_to_cocina_originInfo.txt
+  context 'with dateOther with type="developed"' do
+    let(:events) do
+      [
+        Cocina::Models::Event.new(
+          {
+            "type": 'creation',
+            "displayLabel": 'Place of Creation',
+            "location": [
+              {
+                "value": 'Stanford (Calif.)',
+                "uri": 'http://id.loc.gov/authorities/names/n50046557',
+                "source": {
+                  "code": 'naf',
+                  "uri": 'http://id.loc.gov/authorities/names/'
+                }
+              }
+            ],
+            "date": [
+              {
+                "value": '2003-11-29',
+                "status": 'primary',
+                "encoding": {
+                  "code": 'w3cdtf'
+                }
+              }
+            ]
+          }
+        ),
+        Cocina::Models::Event.new(
+          "type": 'development',
+          "date": [
+            {
+              "value": '2003-12-01',
+              "encoding": {
+                "code": 'w3cdtf'
+              }
+            }
+          ]
+        )
+
+      ]
+    end
+
+    it 'builds the expected xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <originInfo displayLabel="Place of Creation" eventType="production">
+            <place>
+              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+            </place>
+            <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
+          </originInfo>
+          <originInfo eventType="development">
+            <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
+          </originInfo>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #1684

## Why was this change made?
Map originInfo with development dateOther.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


