### PR TITLE
Add occupation subject mapping from Cocina to Fedora

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -236,3 +236,8 @@ Lint/RedundantSafeNavigation: # (new in 0.93)
   Enabled: true
 Style/ClassEqualityComparison: # (new in 0.93)
   Enabled: true
+
+Rails/AttributeDefaultBlockValue: # (new in 2.9)
+  Enabled: true
+Rails/WhereEquals: # (new in 2.9)
+  Enabled: true

--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -8,7 +8,8 @@ module Cocina
       class Subject
         TAG_NAME = {
           'time' => :temporal,
-          'genre' => :genre
+          'genre' => :genre,
+          'occupation' => :occupation
         }.freeze
         DEORDINAL_REGEX = /(?<=[0-9])(?:st|nd|rd|th)/.freeze
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,6 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  database: "<%= ENV.fetch('DATABASE_NAME', 'dor_services') %>"
   username: "<%= ENV.fetch('DATABASE_USERNAME', 'postgres') %>"
   password: "<%= ENV.fetch('DATABASE_PASSWORD', 'sekret') %>"
   host: "<%= ENV.fetch('DATABASE_HOSTNAME', 'localhost') %>"
@@ -11,9 +10,12 @@ default: &default
 
 development:
   <<: *default
+  database: "<%= ENV.fetch('DATABASE_NAME', 'dor_services_development') %>"
 
 test:
   <<: *default
+  database: "<%= ENV.fetch('DATABASE_NAME', 'dor_services_test') %>"
 
 production:
   <<: *default
+  database: "<%= ENV.fetch('DATABASE_NAME', 'dor_services_production') %>"

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -716,7 +716,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     xit 'TODO https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_subject.txt#L754'
   end
 
-  context 'with a occupation subject' do
+  context 'with an occupation subject' do
     let(:xml) do
       <<~XML
         <subject>

--- a/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
@@ -56,6 +56,31 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
     end
   end
 
+  context 'when it has an occupation subject' do
+    let(:subjects) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          {
+            value: 'Notaries',
+            type: 'occupation'
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject>
+            <occupation>Notaries</occupation>
+          </subject>
+        </mods>
+      XML
+    end
+  end
+
   context 'when it has a multi-term topic subject' do
     let(:subjects) do
       [


### PR DESCRIPTION
Fixes #1252

## Why was this change made?

To fix #1252.

Also includes:
* Differentiate between env-specific database names …
  * This prevents Rails from warning the developer about using the same database for both dev and test, which most of us developers are straddling frequently. This does not affect deployed environments because the checked-in config/database.yml is overwritten with a file that is managed via Puppet. This is intended to remove drag on development.
* Add new Rubocop cops to remove warning

## How was this change tested?

CI and on sdr-deploy (in progress)

### BEFORE

```
Status (n=100000):
  Success:   91747 (91.747%)
  Different: 7612 (7.612%)
  To Cocina error:     31 (0.031%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

### AFTER

```
Status (n=100000):
  Success:   91750 (91.75%)
  Different: 7609 (7.609%)
  To Cocina error:     31 (0.031%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)

```

## Which documentation and/or configurations were updated?

None