### PR TITLE
Sniff value URIs and alert if they are unexpected

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
+++ b/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
@@ -81,7 +81,7 @@ module Cocina
 
           {
             code: description_standard['authority'],
-            uri: description_standard['valueURI'],
+            uri: ValueURI.sniff(description_standard['valueURI']),
             source: { uri: description_standard['authorityURI'] }
           }
         end
@@ -90,10 +90,10 @@ module Cocina
           return unless record_content_source
 
           [{
-            "name": [
+            name: [
               {
-                "code": record_content_source.text,
-                "uri": record_content_source['valueURI']
+                code: record_content_source.text,
+                uri: ValueURI.sniff(record_content_source['valueURI'])
               }.tap do |name_attrs|
                 source = {
                   code: record_content_source['authority'],
@@ -102,10 +102,10 @@ module Cocina
                 name_attrs[:source] = source unless source.empty?
               end.compact
             ],
-            "type": 'organization',
-            "role": [
+            type: 'organization',
+            role: [
               {
-                "value": 'original cataloging agency'
+                value: 'original cataloging agency'
               }
             ]
           }]

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -222,7 +222,7 @@ module Cocina
         end
 
         def with_uri_info(cocina, xml_node)
-          cocina[:uri] = xml_node['valueURI'] if xml_node['valueURI']
+          cocina[:uri] = ValueURI.sniff(xml_node['valueURI']) if xml_node['valueURI']
           source = {
             code: Authority.normalize_code(xml_node['authority']),
             uri: Authority.normalize_uri(xml_node['authorityURI'])

--- a/app/services/cocina/from_fedora/descriptive/form.rb
+++ b/app/services/cocina/from_fedora/descriptive/form.rb
@@ -60,7 +60,7 @@ module Cocina
             forms << {
               value: type.text,
               type: type['type'] || 'genre',
-              uri: type[:valueURI],
+              uri: ValueURI.sniff(type[:valueURI]),
               displayLabel: type[:displayLabel]
             }.tap do |item|
               source = {
@@ -179,7 +179,7 @@ module Cocina
           physical_description.xpath('mods:form', mods: DESC_METADATA_NS).each do |form_content|
             forms << {
               value: form_content.content,
-              uri: form_content['valueURI'],
+              uri: ValueURI.sniff(form_content['valueURI']),
               type: form_content['type'] || 'form',
               source: source_for(form_content).presence
             }.compact

--- a/app/services/cocina/from_fedora/descriptive/language_term.rb
+++ b/app/services/cocina/from_fedora/descriptive/language_term.rb
@@ -37,7 +37,7 @@ module Cocina
           {
             code: code_language_term&.text,
             value: text_language_term&.text,
-            uri: language_value_uri_for(code_language_term, text_language_term),
+            uri: ValueURI.sniff(language_value_uri_for(code_language_term, text_language_term)),
             appliesTo: language_applies_to,
             displayLabel: language_element['displayLabel']
           }.tap do |attrs|

--- a/app/services/cocina/from_fedora/descriptive/location.rb
+++ b/app/services/cocina/from_fedora/descriptive/location.rb
@@ -117,7 +117,7 @@ module Cocina
               else
                 attrs[:value] = node.text
               end
-              attrs[:uri] = node[:valueURI]
+              attrs[:uri] = ValueURI.sniff(node[:valueURI])
               source = {
                 code: Authority.normalize_code(node[:authority]),
                 uri: Authority.normalize_uri(node[:authorityURI])

--- a/app/services/cocina/from_fedora/descriptive/name_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/name_builder.rb
@@ -115,8 +115,7 @@ module Cocina
 
         def authority_attrs_for(name_node)
           {
-            uri: name_node['valueURI']
-
+            uri: ValueURI.sniff(name_node['valueURI'])
           }.tap do |attrs|
             source = {
               code: Authority.normalize_code(name_node['authority']),
@@ -174,7 +173,7 @@ module Cocina
             }.compact
             role[:source] = source if source.present?
 
-            role[:uri] = authority_value
+            role[:uri] = ValueURI.sniff(authority_value)
             role[:code] = code&.content
             marcrelator = marc_relator_role?(authority, authority_uri, authority_value)
             role[:value] = normalized_role_value(text.content, marcrelator) if text

--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -76,7 +76,7 @@ module Cocina
             }.compact
             if subject[:valueURI]
               attrs[:source] = source unless source.empty?
-              attrs[:uri] = subject[:valueURI]
+              attrs[:uri] = ValueURI.sniff(subject[:valueURI])
             elsif subject[:authority]
               attrs[:source] = source unless source.empty?
             end

--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -146,7 +146,7 @@ module Cocina
               uri: Authority.normalize_uri(title_info[:authorityURI])
             }.compact
             attrs[:source] = source if source.present?
-            attrs[:uri] = title_info[:valueURI]
+            attrs[:uri] = ValueURI.sniff(title_info[:valueURI])
 
             value_language = LanguageScript.build(node: title_info)
             attrs[:valueLanguage] = value_language if value_language

--- a/app/services/cocina/from_fedora/descriptive/value_uri.rb
+++ b/app/services/cocina/from_fedora/descriptive/value_uri.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Cocina
+  module FromFedora
+    class Descriptive
+      # Sniffs value URIs
+      class ValueURI
+        SUPPORTED_PREFIXES = [
+          'http'
+        ].freeze
+
+        def self.sniff(uri)
+          Honeybadger.notify("[DATA ERROR] Value URI has unexpected value: #{uri}", tags: 'data_error') if uri.present? &&
+                                                                                                           !uri.starts_with?(*SUPPORTED_PREFIXES)
+
+          uri
+        end
+      end
+    end
+  end
+end

--- a/spec/services/cocina/from_fedora/descriptive/value_uri_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/value_uri_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::FromFedora::Descriptive::ValueURI do
+  describe '.sniff' do
+    before do
+      allow(Honeybadger).to receive(:notify)
+    end
+
+    context 'with a nil uri' do
+      let(:uri) { nil }
+
+      it 'returns the uri and does not alert' do
+        expect(described_class.sniff(uri)).to eq(uri)
+        expect(Honeybadger).not_to have_received(:notify)
+      end
+    end
+
+    context 'with a string uri that starts with supported prefix' do
+      let(:uri) { 'http://foo.example.edu' }
+
+      it 'returns the uri and does not alert' do
+        expect(described_class.sniff(uri)).to eq(uri)
+        expect(Honeybadger).not_to have_received(:notify)
+      end
+    end
+
+    context 'with a string uri that does not start with supported prefix' do
+      let(:uri) { '(OCoLC)fst01204289' }
+
+      it 'returns the uri and sends an alert' do
+        expect(described_class.sniff(uri)).to eq(uri)
+        expect(Honeybadger).to have_received(:notify).with("[DATA ERROR] Value URI has unexpected value: #{uri}", tags: 'data_error').once
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1604

For the purposes of this commit, "unexpected" means that they are strings that do not begin with "http".

## Why was this change made?

To surface more data errors.

## How was this change tested?

CI.

## Which documentation and/or configurations were updated?

None

