### PR TITLE
Normalize multiple subject cartographics

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -30,6 +30,7 @@ module Cocina
       normalize_subject_authority
       normalize_subject_authority_lcnaf
       normalize_subject_authority_naf
+      normalize_subject_cartographics
       normalize_text_role_term
       normalize_role_term_authority
       normalize_name
@@ -96,6 +97,17 @@ module Cocina
         elsif child_node[:authority] && subject_node[:authority] == child_node[:authority]
           child_node.delete('authority')
         end
+      end
+    end
+
+    # Collapse multiple subject/cartographics nodes into a single one
+    def normalize_subject_cartographics
+      cartographics_nodes = ng_xml.root.xpath('//mods:subject/mods:cartographics', mods: MODS_NS)
+      return if cartographics_nodes.count.in?([0, 1]) # nothing to normalize if there aren't multiple cartographics
+
+      cartographics_nodes[1..-1].each do |node|
+        cartographics_nodes[0] << node.child
+        node.remove
       end
     end
 

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -192,6 +192,64 @@ RSpec.describe Cocina::ModsNormalizer do
         XML
       end
     end
+
+    context 'when normalizing multiple cartographics' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{mods_attributes}>
+            <subject>
+              <cartographics>
+                <scale>Scale 1:100,000 :</scale>
+              </cartographics>
+              <cartographics>
+                <projection>universal transverse Mercator proj.</projection>
+              </cartographics>
+            </subject>
+          </mods>
+        XML
+      end
+
+      it 'combines multiple elements into a single one' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{mods_attributes}>
+            <subject>
+              <cartographics>
+                <scale>Scale 1:100,000 :</scale>
+                <projection>universal transverse Mercator proj.</projection>
+              </cartographics>
+            </subject>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when normalizing single cartographics' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{mods_attributes}>
+            <subject>
+              <cartographics>
+                <scale>Scale 1:100,000 :</scale>
+                <projection>universal transverse Mercator proj.</projection>
+              </cartographics>
+            </subject>
+          </mods>
+        XML
+      end
+
+      it 'returns the single node' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{mods_attributes}>
+            <subject>
+              <cartographics>
+                <scale>Scale 1:100,000 :</scale>
+                <projection>universal transverse Mercator proj.</projection>
+              </cartographics>
+            </subject>
+          </mods>
+        XML
+      end
+    end
   end
 
   context 'when normalizing originInfo eventTypes' do


### PR DESCRIPTION
Fixes #1661

## Why was this change made?

Combine multiple cartographics nodes into a single one for normalization purposes.

## How was this change tested?

CI and sdr-deploy.

### BEFORE

```
Status (n=100000):
  Success:   91786 (91.786%)
  Different: 7552 (7.552%)
  To Cocina error:     52 (0.052%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

### AFTER

```
Status (n=100000):
  Success:   91801 (91.801%)
  Different: 7537 (7.537%)
  To Cocina error:     52 (0.052%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

## Which documentation and/or configurations were updated?

None

