### PR TITLE
Use default Hydrus title only when no titles exist

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/hydrus_default_title_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/hydrus_default_title_builder.rb
@@ -9,7 +9,10 @@ module Cocina
         # @param [boolean] require_title raise Cocina::Mapper::MissingTitle if true and title is missing.
         # @return [Hash] a hash that can be mapped to a cocina model
         def self.build(resource_element:, require_title: nil)
-          [{ value: 'Hydrus' }]
+          titles = resource_element.xpath('mods:titleInfo/mods:title[string-length() > 0]', mods: DESC_METADATA_NS)
+          return [{ value: 'Hydrus' }] if titles.empty?
+
+          Titles.build(resource_element: resource_element)
         end
       end
     end

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe 'Create object' do
       # rubocop:enable Layout/LineLength
     end
 
-    context 'when hydrus' do
+    context 'with a hydrus object lacking a title' do
       # Hydrus has special handling of descriptive metadata
       let(:label) { 'Hydrus' }
       let(:title) { label }
@@ -247,7 +247,7 @@ RSpec.describe 'Create object' do
         Dor::Item.new(pid: druid,
                       admin_policy_object_id: 'druid:dd999df4567',
                       source_id: 'googlebooks:999999',
-                      label: 'Hydrus')
+                      label: label)
       end
 
       let(:expected_desc_md) do
@@ -264,6 +264,58 @@ RSpec.describe 'Create object' do
       let(:search_result) { [] }
 
       before do
+        allow(Dor::Item).to receive(:new).and_return(item)
+        allow(item).to receive(:collections).and_return([])
+        allow(item).to receive(:save!)
+      end
+
+      it 'registers the object with the registration service and immediately indexes' do
+        post '/v1/objects',
+             params: data,
+             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+        expect(a_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:gg777gg7777')).to have_been_made
+        expect(response.body).to eq expected.to_json
+        expect(response.status).to eq(201)
+        expect(response.location).to eq "/v1/objects/#{druid}"
+
+        # Identity metadata set correctly.
+        expect(item.objectId).to eq(druid)
+        expect(item.objectCreator.first).to eq('DOR')
+        expect(item.objectLabel.first).to eq(expected_label)
+        expect(item.objectType.first).to eq('item')
+
+        # Descriptive metadata set correctly.
+        expect(item.descMetadata.ng_xml.to_xml).to be_equivalent_to(expected_desc_md)
+      end
+    end
+
+    context 'with a hydrus object that has a title' do
+      # Hydrus has special handling of descriptive metadata
+      let(:label) { 'Hydrus' }
+      let(:title) { 'My Very Special Hydrus Title' }
+
+      let(:item) do
+        Dor::Item.new(pid: druid,
+                      admin_policy_object_id: 'druid:dd999df4567',
+                      source_id: 'googlebooks:999999',
+                      label: label)
+      end
+
+      let(:expected_desc_md) do
+        <<~XML
+          <?xml version="1.0"?>
+          <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <titleInfo>
+              <title>#{title}</title>
+            </titleInfo>
+          </mods>
+        XML
+      end
+
+      let(:search_result) { [] }
+
+      before do
+        item.descMetadata.title_info.main_title = title
         allow(Dor::Item).to receive(:new).and_return(item)
         allow(item).to receive(:collections).and_return([])
         allow(item).to receive(:save!)


### PR DESCRIPTION
Fixes #1665

## Why was this change made?

To fix #1665.

## How was this change tested?

CI and sdr-deploy

### BEFORE

```
Status (n=100000):
  Success:   91801 (91.801%)
  Different: 7537 (7.537%)
  To Cocina error:     52 (0.052%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

### AFTER

```
Status (n=100000):
  Success:   91806 (91.806%)
  Different: 7532 (7.532%)
  To Cocina error:     52 (0.052%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

## Which documentation and/or configurations were updated?

None

