### PR TITLE
Map form technique and material

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/form.rb
+++ b/app/services/cocina/to_fedora/descriptive/form.rb
@@ -14,7 +14,9 @@ module Cocina
           'extent' => :extent,
           'digital origin' => :digitalOrigin,
           'media' => :form,
-          'carrier' => :form
+          'carrier' => :form,
+          'material' => :form,
+          'technique' => :form
         }.freeze
 
         # @params [Nokogiri::XML::Builder] xml

--- a/spec/services/cocina/from_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive_spec.rb
@@ -241,6 +241,9 @@ RSpec.describe Cocina::FromFedora::Descriptive do
             <extent>1 online resource.</extent>
             <form type="media" authority="rdamedia">computer</form>
             <form type="carrier" authority="rdacarrier">online resource</form>
+            <form type="technique">estampe</form>
+            <form type="material">eau-forte</form>
+            <form type="material">gravure au pointill&#xE9;</form>
           </physicalDescription>
           <abstract displayLabel="Abstract">Blah blah blah, I believe in science!</abstract>
           <note type="statement of responsibility">John Doe Jr.</note>
@@ -391,7 +394,10 @@ RSpec.describe Cocina::FromFedora::Descriptive do
             code: 'rdacarrier'
           }
         },
-        { value: '1 online resource.', type: 'extent' }
+        { value: '1 online resource.', type: 'extent' },
+        { value: 'estampe', type: 'technique' },
+        { value: 'eau-forte', type: 'material' },
+        { value: 'gravure au pointillé', type: 'material' }
       ]
     end
   end

--- a/spec/services/cocina/to_fedora/descriptive/form_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/form_spec.rb
@@ -635,6 +635,18 @@ RSpec.describe Cocina::ToFedora::Descriptive::Form do
             "source": {
               "code": 'rdacarrier'
             }
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            "value": 'estampe',
+            "type": 'technique'
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            "value": 'eau-forte',
+            "type": 'material'
+          ),
+          Cocina::Models::DescriptiveValue.new(
+            "value": 'gravure au pointillé',
+            "type": 'material'
           )
         ]
       end
@@ -653,6 +665,9 @@ RSpec.describe Cocina::ToFedora::Descriptive::Form do
               <note displayLabel="Condition">Small tear at top right corner.</note>
               <form type="media" authority="rdamedia">unmediated</form>
               <form type="carrier" authority="rdacarrier">volume</form>
+              <form type="technique">estampe</form>
+              <form type="material">eau-forte</form>
+              <form type="material">gravure au pointill&#xE9;</form>
             </physicalDescription>
           </mods>
         XML


### PR DESCRIPTION
Fixes #1708

## Why was this change made?

To make progress on round-tripping

## How was this change tested?

CI, and sdr-deploy:

### BEFORE

```
Status (n=100000):
  Success:   91715 (91.715%)
  Different: 7623 (7.623%)
  To Cocina error:     52 (0.052%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

### AFTER

```
Status (n=100000):
  Success:   91717 (91.717%)
  Different: 7621 (7.621%)
  To Cocina error:     52 (0.052%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)

```

## Which documentation and/or configurations were updated?

None

