### PR TITLE
Mark purl as primary only if no other urls are marked as primary

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/location.rb
+++ b/app/services/cocina/to_fedora/descriptive/location.rb
@@ -81,15 +81,18 @@ module Cocina
           xml.url url.value, url_attrs
         end
 
+        def primary_url_is_not_purl?
+          Array(access&.url).any? { |url| url.status == 'primary' }
+        end
+
         def write_purl
-          attributes = {
-            usage: 'primary display'
-          }.tap do |attrs|
-            note_node = Array(access&.note).find { |node| node[:type] == 'purl access' }
-            attrs[:note] = note_node[:value] if note_node
-          end
+          attrs = {}
+          attrs[:usage] = 'primary display' unless primary_url_is_not_purl?
+          note_node = Array(access&.note).find { |node| node[:type] == 'purl access' }
+          attrs[:note] = note_node[:value] if note_node
+
           xml.location do
-            xml.url purl, attributes
+            xml.url purl, attrs
           end
         end
 

--- a/spec/services/cocina/to_fedora/descriptive/location_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/location_spec.rb
@@ -261,6 +261,41 @@ RSpec.describe Cocina::ToFedora::Descriptive::Location do
     end
   end
 
+  context 'when there is a PURL and a primary display URL' do
+    let(:access) do
+      Cocina::Models::DescriptiveAccessMetadata.new(
+        url: [
+          {
+            value: 'http://www.jgp.org/',
+            status: 'primary',
+            note: [
+              {
+                value: 'Available to Stanford-affiliated users at:'
+              }
+            ]
+          }
+        ]
+      )
+    end
+
+    let(:purl) { 'http://purl.stanford.edu/dq628sb8161' }
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <location>
+            <url>http://purl.stanford.edu/dq628sb8161</url>
+          </location>
+          <location>
+            <url usage="primary display" note="Available to Stanford-affiliated users at:">http://www.jgp.org/</url>
+          </location>
+        </mods>
+      XML
+    end
+  end
+
   # example 14 from mods_to_cocina_location.txt
   context 'when it is a PURL with note' do
     let(:purl) { 'http://purl.stanford.edu/nd782fm8171' }


### PR DESCRIPTION
Fixes #1712

# Before

```
Status (n=100000):
  Success:   91717 (91.717%)
  Different: 7621 (7.621%)
  To Cocina error:     52 (0.052%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

# After

```
Status (n=100000):
  Success:   92378 (92.378%)
  Different: 6960 (6.96%)
  To Cocina error:     52 (0.052%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```