### PR TITLE
Map tranliterated title to fedora

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/title.rb
+++ b/app/services/cocina/to_fedora/descriptive/title.rb
@@ -72,6 +72,9 @@ module Cocina
               end
             elsif title.type == 'uniform'
               title_info_attrs[:type] = 'uniform'
+            elsif parallel_title.type == 'transliterated'
+              title_info_attrs[:type] = 'translated'
+              title_info_attrs[:transliteration] = parallel_title.standard.value
             end
 
             title_info_attrs[:nameTitleGroup] = name_title_group_for(parallel_title)

--- a/spec/services/cocina/to_fedora/descriptive/title_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/title_spec.rb
@@ -422,7 +422,65 @@ RSpec.describe Cocina::ToFedora::Descriptive::Title do
     end
 
     context 'when it is transliterated (title is value)' do
-      xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_titleInfo.txt#L157'
+      # https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_titleInfo.txt#L157'
+      let(:titles) do
+        [
+          Cocina::Models::Title.new(
+            "parallelValue": [
+              {
+                "value": 'Война и миръ',
+                "status": 'primary',
+                "valueLanguage": {
+                  "code": 'rus',
+                  "source": {
+                    "code": 'iso639-2b'
+                  },
+                  "valueScript": {
+                    "code": 'Cyrl',
+                    "source": {
+                      "code": 'iso15924'
+                    }
+                  }
+                }
+              },
+              {
+                "value": 'Voĭna i mir',
+                "valueLanguage": {
+                  "code": 'rus',
+                  "source": {
+                    "code": 'iso639-2b'
+                  },
+                  "valueScript": {
+                    "code": 'Latn',
+                    "source": {
+                      "code": 'iso15924'
+                    }
+                  }
+                },
+                "type": 'transliterated',
+                "standard": {
+                  "value": 'ALA-LC Romanization Tables'
+                }
+              }
+            ]
+          )
+        ]
+      end
+
+      it 'creates the equivalent MODS' do
+        expect(xml).to be_equivalent_to <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <titleInfo usage="primary" lang="rus" script="Cyrl" altRepGroup="1">
+              <title>Война и миръ</title>
+            </titleInfo>
+            <titleInfo type="translated" lang="rus" script="Latn" transliteration="ALA-LC Romanization Tables" altRepGroup="1">
+              <title>Voĭna i mir</title>
+            </titleInfo>
+          </mods>
+        XML
+      end
     end
 
     context 'when there is a title with script but no lang' do


### PR DESCRIPTION
## Why was this change made?

Fixes #1710

## How was this change tested?

Before:
```
Status (n=100000):
  Success:   93094 (93.094%)
  Different: 6244 (6.244%)
  To Cocina error:     52 (0.052%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

After
```
Status (n=100000):
  Success:   93095 (93.095%)
  Different: 6243 (6.243%)
  To Cocina error:     52 (0.052%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
  ```

## Which documentation and/or configurations were updated?



