### PR TITLE
Map uniform title with multiple title subelements to Fedora

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -499,6 +499,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Usage: bin/generate-cache [options]
     -a, --auto                       Automatically choose sample based on 14 day cycle.
     -d, --druids DRUIDS              List of druids (instead of druids.txt).
     -h, --help                       Displays help.
-        
+
 $ bin/generate-cache
 ```
 
@@ -172,7 +172,7 @@ Usage: bin/validate-to-cocina [options]
     -s, --sample SAMPLE              Sample size, otherwise all druids.
     -u, --unique-filename            Result file named for branch and runtime
     -h, --help                       Displays help.
-    
+
 $ bin/validate-to-cocina -s 10
 Testing |Time: 00:00:00 | ===================================================================== | Time: 00:00:00
 
@@ -203,7 +203,7 @@ Usage: bin/validate-to-fedora [options]
     -s, --sample SAMPLE              Sample size, otherwise all druids.
     -u, --unique-filename            Result file named for branch and runtime
     -h, --help                       Displays help.
-    
+
 $ bin/validate-to-fedora
 Testing |Time: 00:00:06 | ============================================================= | Time: 00:00:06
 To Fedora error: 21 of 7500 (0.28%)
@@ -272,7 +272,7 @@ $ echo $FEDORA_CACHE
 /opt/app/deploy/dor-services-app/cache
 ```
 
-Test with `bin/validate-cocina-roundtrip`, comparing results from master against your branch. The sample size to you is up to you; biggers samples are recommended for more complex changes.
+Test with `bin/validate-cocina-roundtrip`, comparing results from master against your branch. The sample size to you is up to you; bigger samples are recommended for more complex changes.
 
 ```
 $ git checkout master

--- a/app/services/cocina/to_fedora/descriptive/title.rb
+++ b/app/services/cocina/to_fedora/descriptive/title.rb
@@ -106,11 +106,26 @@ module Cocina
           title_info_attrs = title_info_attrs_for(title).merge(title_info_attrs)
 
           xml.titleInfo(with_uri_info(title, title_info_attrs)) do
-            title.structuredValue.reject { |structured_title| NAME_TYPES.include?(structured_title.type) }.each do |title_part|
+            title_parts = flatten_structured_value(title)
+            title_parts_without_names = title_parts_without_names(title_parts)
+
+            title_parts_without_names.each do |title_part|
               title_type = tag_name_for(title_part)
               xml.public_send(title_type, title_part.value) unless title_part.note
             end
           end
+        end
+
+        # Flatten the structuredValues into a simple list.
+        def flatten_structured_value(title)
+          leafs = title.structuredValue.select(&:value)
+          nodes = title.structuredValue.select(&:structuredValue)
+          leafs + nodes.flat_map { |node| flatten_structured_value(node) }
+        end
+
+        # Filter out name types
+        def title_parts_without_names(parts)
+          parts.reject { |structured_title| NAME_TYPES.include?(structured_title.type) }
         end
 
         def write_title_names(title_names, name_title_group, title, title_name_attrs)

--- a/spec/services/cocina/to_fedora/descriptive/title_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/title_spec.rb
@@ -159,6 +159,88 @@ RSpec.describe Cocina::ToFedora::Descriptive::Title do
       end
     end
 
+    context 'when it is a uniform title with multiple title subelements' do
+      let(:titles) do
+        [
+          Cocina::Models::Title.new(
+            {
+              structuredValue: [
+                {
+                  type: 'title',
+                  structuredValue: [
+                    {
+                      value: 'Concertos, recorder, string orchestra',
+                      type: 'main title'
+                    },
+                    {
+                      value: 'RV 441, C minor',
+                      type: 'part number'
+                    }
+                  ]
+                },
+                {
+                  structuredValue: [
+                    {
+                      value: 'Vivaldi, Antonio',
+                      type: 'name'
+                    },
+                    {
+                      value: '1678-1741',
+                      type: 'life dates'
+                    }
+                  ],
+                  type: 'name'
+                }
+              ],
+              type: 'uniform'
+            }
+          )
+        ]
+      end
+
+      let(:contributors) do
+        [
+          Cocina::Models::Contributor.new(
+            {
+              "name": [
+                {
+                  "structuredValue": [
+                    {
+                      "value": 'Vivaldi, Antonio',
+                      "type": 'name'
+                    },
+                    {
+                      "value": '1678-1741',
+                      "type": 'life dates'
+                    }
+                  ]
+                }
+              ],
+              "type": 'person',
+              "status": 'primary'
+            }
+          )
+        ]
+      end
+
+      it 'builds the xml' do
+        expect(xml).to be_equivalent_to <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <titleInfo type="uniform" nameTitleGroup="1">
+              <title>Concertos, recorder, string orchestra</title>
+              <partNumber>RV 441, C minor</partNumber>
+            </titleInfo>
+            <name type="personal" usage="primary" nameTitleGroup="1">
+              <namePart>Vivaldi, Antonio</namePart>
+              <namePart type="date">1678-1741</namePart>
+            </name>
+          </mods>
+        XML
+      end
+    end
+
     context 'when it is a multilingual uniform title' do
       let(:titles) do
         [


### PR DESCRIPTION
Fixes #1719


## How was this change tested?
Before:
```
Status (n=100000):
  Success:   93094 (93.094%)
  Different: 6244 (6.244%)
  To Cocina error:     52 (0.052%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

After:

```
Status (n=100000):
  Success:   93146 (93.146%)
  Different: 6192 (6.192%)
  To Cocina error:     52 (0.052%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
 ```



## Which documentation and/or configurations were updated?



