### PR TITLE
Map roles within translated names to cocina

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/name_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/name_builder.rb
@@ -30,12 +30,14 @@ module Cocina
         attr_reader :name_elements, :add_default_type
 
         def build_parallel
-          {
-            name: [{
-              parallelValue: name_elements.map { |name_node| build_parallel_name(name_node) },
-              type: type_for(name_elements.first['type'])
-            }.compact]
-          }
+          names = {
+            parallelValue: name_elements.map { |name_node| build_parallel_name(name_node) },
+            type: type_for(name_elements.first['type'])
+          }.compact
+          { name: [names] }.tap do |attrs|
+            roles = name_elements.flat_map { |name_node| build_roles(name_node) }.compact.uniq
+            attrs[:role] = roles.presence
+          end.compact
         end
 
         def build_parallel_name(name_node)
@@ -51,6 +53,7 @@ module Cocina
               }
             end
           end
+
           name_attrs = name_attrs.merge(common_name(name_node, name_attrs[:name]))
           name_parts = build_name_parts(name_node)
           Honeybadger.notify('[DATA ERROR] missing name/namePart element', { tags: 'data_error' }) if name_parts.all?(&:empty?)

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -133,6 +133,88 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     end
   end
 
+  context 'with translated name and roles' do
+    let(:xml) do
+      <<~XML
+        <name type="corporate" usage="primary" lang="jpn" script="Jpan" altRepGroup="1">
+          <namePart>&#x30EC;&#x30A2;&#x30E1;&#x30BF;&#x30EB;&#x8CC7;&#x6E90;&#x518D;&#x751F;&#x6280;&#x8853;&#x7814;&#x7A76;&#x4F1A;</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/cre">cre</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/cre">creator</roleTerm>
+          </role>
+        </name>
+        <name type="corporate" lang="jpn" script="Latn" transliteration="ALA-LC Romanization Tables" altRepGroup="1">
+          <namePart>Rea Metaru Shigen Saisei Gijutsu Kenky&#x16B;kai</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/cre">cre</roleTerm>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/cre">creator</roleTerm>
+          </role>
+        </name>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          name: [
+            {
+              parallelValue: [
+                {
+                  "status": 'primary',
+                  "valueLanguage": {
+                    "code": 'jpn',
+                    "source": {
+                      "code": 'iso639-2b'
+                    },
+                    "valueScript": {
+                      "code": 'Jpan',
+                      "source": {
+                        "code": 'iso15924'
+                      }
+                    }
+                  },
+                  "value": 'レアメタル資源再生技術研究会'
+                },
+                {
+                  "valueLanguage": {
+                    "code": 'jpn',
+                    "source": {
+                      "code": 'iso639-2b'
+                    },
+                    "valueScript": {
+                      "code": 'Latn',
+                      "source": {
+                        "code": 'iso15924'
+                      }
+                    }
+                  },
+                  "type": 'transliteration',
+                  "standard": {
+                    "value": 'ALA-LC Romanization Tables'
+                  },
+                  "value": 'Rea Metaru Shigen Saisei Gijutsu Kenkyūkai'
+                }
+              ],
+
+              type: 'organization'
+            }
+          ],
+          role: [
+            {
+              "value": 'creator',
+              "code": 'cre',
+              "uri": 'http://id.loc.gov/vocabulary/relators/cre',
+              "source": {
+                "code": 'marcrelator',
+                "uri": 'http://id.loc.gov/vocabulary/relators/'
+              }
+            }
+          ]
+        }
+      ]
+    end
+  end
+
   context 'with an invalid type' do
     context 'when miscapitalized' do
       let(:xml) do


### PR DESCRIPTION
## Why was this change made?

Fixes #1711

## How was this change tested?

Before:
```
Status (n=100000):
  Success:   95489 (95.489%)
  Different: 3849 (3.849%)
  To Cocina error:     52 (0.052%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

After:
```
Status (n=100000):
  Success:   95536 (95.536%)
  Different: 3802 (3.802%)
  To Cocina error:     52 (0.052%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
  ```

## Which documentation and/or configurations were updated?



