### PR TITLE
Handle parallel subjects with different types.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -39,8 +39,9 @@ module Cocina
 
         def build_parallel_subject(parallel_subject_nodes)
           parallel_subjects = parallel_subject_nodes.map { |subject_node| build_subject(subject_node) }
-          # Moving type up from parallel subjects
-          type = parallel_subjects.map { |subject| subject.delete(:type) }.compact.first
+          # Moving type up from parallel subjects if they are all the same.
+          move_type = parallel_subjects.uniq { |subject| subject[:type] }.size == 1
+          type = move_type ? parallel_subjects.map { |subject| subject.delete(:type) }.compact.first : nil
           {
             parallelValue: parallel_subjects,
             type: type

--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -119,7 +119,7 @@ module Cocina
 
           if type == 'classification'
             write_classification(subject.value, subject_attributes)
-          elsif FromFedora::Descriptive::Contributor::ROLES.values.include?(type)
+          elsif FromFedora::Descriptive::Contributor::ROLES.values.include?(type) || type == 'name'
             xml.subject(subject_attributes) do
               person(subject)
             end

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -740,6 +740,44 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     end
   end
 
+  context 'with a parallel subject but different types' do
+    let(:xml) do
+      <<~XML
+        <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85135212" altRepGroup="2">
+          <geographic>Tiber River (Italy)</geographic>
+        </subject>
+        <subject authority="local" altRepGroup="2">
+          <topic>Tevere</topic>
+        </subject>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "parallelValue": [
+            {
+              "source": {
+                "code": 'lcsh',
+                "uri": 'http://id.loc.gov/authorities/subjects/'
+              },
+              "uri": 'http://id.loc.gov/authorities/subjects/sh85135212',
+              "value": 'Tiber River (Italy)',
+              "type": 'place'
+            },
+            {
+              "source": {
+                "code": 'local'
+              },
+              "value": 'Tevere',
+              "type": 'topic'
+            }
+          ]
+        }
+      ]
+    end
+  end
+
   context 'with a subject with lang, script, and displayLabel' do
     let(:xml) do
       <<~XML

--- a/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_spec.rb
@@ -619,6 +619,64 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
     end
   end
 
+  context 'with a parallel subject but different types' do
+    let(:subjects) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          {
+            "parallelValue": [
+              {
+                "source": {
+                  "code": 'lcsh',
+                  "uri": 'http://id.loc.gov/authorities/subjects/'
+                },
+                "uri": 'http://id.loc.gov/authorities/subjects/sh85135212',
+                "value": 'Tiber River (Italy)',
+                "type": 'place'
+              },
+              {
+                "source": {
+                  "code": 'local'
+                },
+                "value": 'Tevere',
+                "type": 'topic'
+              },
+              {
+                "value": 'Tiber River',
+                "type": 'name',
+                "source": {
+                  "code": 'lcsh',
+                  "uri": 'http://id.loc.gov/authorities/names/'
+                },
+                "uri": 'http://id.loc.gov/authorities/names/n97042879'
+              }
+            ]
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject authority="lcsh" altRepGroup="1">
+            <geographic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85135212">Tiber River (Italy)</geographic>
+          </subject>
+          <subject authority="local" altRepGroup="1">
+            <topic>Tevere</topic>
+          </subject>
+          <subject authority="lcsh" altRepGroup="1">
+            <name authority="lcsh" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n97042879">
+              <namePart>Tiber River</namePart>
+            </name>
+          </subject>
+        </mods>
+      XML
+    end
+  end
+
   context 'when it has a subject with lang and script' do
     let(:subjects) do
       [


### PR DESCRIPTION
closes #1718

## Why was this change made?
Handle parallel subjects with different types


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


