### PR TITLE
Map and normalize subjects with tgm authority

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/authority.rb
+++ b/app/services/cocina/from_fedora/descriptive/authority.rb
@@ -25,6 +25,11 @@ module Cocina
             return 'naf'
           end
 
+          if code == 'tgm'
+            Honeybadger.notify('[DATA ERROR] tgm authority code (should be lctgm)', tags: 'data_error')
+            return 'lctgm'
+          end
+
           if code == '#N/A'
             # This is not a fatal problem. Just warn.
             Honeybadger.notify('[DATA ERROR] "#N/A" authority code', tags: 'data_error')

--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -33,6 +33,7 @@ module Cocina
       normalize_subject_authority
       normalize_subject_authority_lcnaf
       normalize_subject_authority_naf
+      normalize_subject_authority_tgm
       normalize_subject_cartographics
       normalize_text_role_term
       normalize_role_term_authority
@@ -309,6 +310,12 @@ module Cocina
     def normalize_subject_authority_lcnaf
       ng_xml.root.xpath("//mods:*[@authority='lcnaf']", mods: MODS_NS).each do |node|
         node[:authority] = 'naf'
+      end
+    end
+
+    def normalize_subject_authority_tgm
+      ng_xml.root.xpath("//mods:*[@authority='tgm']", mods: MODS_NS).each do |node|
+        node[:authority] = 'lctgm'
       end
     end
 

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -72,6 +72,35 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     end
   end
 
+  context 'with tgm authority code' do
+    let(:xml) do
+      <<~XML
+        <subject authority="tgm" authorityURI="http://id.loc.gov/vocabulary/graphicMaterials" valueURI="http://id.loc.gov/vocabulary/graphicMaterials/tgm001818">
+          <topic>Celebrities</topic>
+        </subject>
+      XML
+    end
+
+    before do
+      allow(Honeybadger).to receive(:notify).once
+    end
+
+    it 'changes to lctgm and Honeybadger notifies' do
+      expect(build).to eq [
+        {
+          value: 'Celebrities',
+          type: 'topic',
+          uri: 'http://id.loc.gov/vocabulary/graphicMaterials/tgm001818',
+          source: {
+            code: 'lctgm',
+            uri: 'http://id.loc.gov/vocabulary/graphicMaterials'
+          }
+        }
+      ]
+      expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] tgm authority code (should be lctgm)', tags: 'data_error')
+    end
+  end
+
   context 'with invalid authority code and no authorityURI' do
     let(:xml) do
       <<~XML

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -995,6 +995,28 @@ RSpec.describe Cocina::ModsNormalizer do
     end
   end
 
+  context 'when normalizing tgm subject authority' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{mods_attributes}>
+          <subject authority="tgm">
+            <topic authority="tgm">Marine biology</topic>
+          </subject>
+        </mods>
+      XML
+    end
+
+    it 'changes tgm to lctgm' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{mods_attributes}>
+          <subject authority="lctgm">
+            <topic>Marine biology</topic>
+          </subject>
+        </mods>
+      XML
+    end
+  end
+
   context 'when normalizing physical location purl' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML


### PR DESCRIPTION
Fixes #1736

# Before

```
Status (n=150000):
  Success:   143893 (95.92866666666667%)
  Different: 5141 (3.4273333333333333%)
  To Cocina error:     81 (0.054%)
  To Fedora error:     0 (0.0%)
  Missing:     885 (0.59%)
```

# After

```
Status (n=150000):
  Success:   144022 (96.01466666666667%)
  Different: 5012 (3.3413333333333335%)
  To Cocina error:     81 (0.054%)
  To Fedora error:     0 (0.0%)
  Missing:     885 (0.59%)
```