### PR TITLE
Convert roles without URI to cocina

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/name_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/name_builder.rb
@@ -126,8 +126,9 @@ module Cocina
         end
 
         def authority_attrs_for(name_node)
+          Honeybadger.notify('[DATA ERROR] name has an xlink:href property', { tags: 'data_error' }) if name_node['xlink:href']
           {
-            uri: ValueURI.sniff(name_node['valueURI'])
+            uri: ValueURI.sniff(name_node['valueURI'] || name_node['xlink:href'])
           }.tap do |attrs|
             source = {
               code: Authority.normalize_code(name_node['authority']),

--- a/app/services/cocina/from_fedora/descriptive/name_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/name_builder.rb
@@ -68,7 +68,6 @@ module Cocina
             Honeybadger.notify('[DATA ERROR] missing name/namePart element', { tags: 'data_error' })
             return {}
           end
-
           {
             name: name_parts,
             type: type_for(name_node['type']),
@@ -80,7 +79,6 @@ module Cocina
           {
             note: build_notes(name_node),
             identifier: build_identifier(name_node)
-
           }.tap do |attrs|
             roles = build_roles(name_node)
             attrs[:role] = roles unless name.nil?
@@ -160,23 +158,18 @@ module Cocina
           end.compact.presence
         end
 
-        ROLE_CODE_XPATH = './mods:roleTerm[@type="code"]'
-        ROLE_TEXT_XPATH = './mods:roleTerm[@type="text"]'
-        ROLE_AUTHORITY_XPATH = './mods:roleTerm/@authority'
-        ROLE_AUTHORITY_URI_XPATH = './mods:roleTerm/@authorityURI'
-        ROLE_AUTHORITY_VALUE_XPATH = './mods:roleTerm/@valueURI'
         MARC_RELATOR_PIECE = 'id.loc.gov/vocabulary/relators'
 
         # shameless green
         # rubocop:disable Metrics/AbcSize
         def role_for(ng_role)
-          code = ng_role.xpath(ROLE_CODE_XPATH, mods: DESC_METADATA_NS).first
-          text = ng_role.xpath(ROLE_TEXT_XPATH, mods: DESC_METADATA_NS).first
+          code = ng_role.xpath('./mods:roleTerm[@type="code"]', mods: DESC_METADATA_NS).first
+          text = ng_role.xpath('./mods:roleTerm[@type="text"] | ./mods:roleTerm[not(@type)]', mods: DESC_METADATA_NS).first
           return if code.nil? && text.nil?
 
-          authority = ng_role.xpath(ROLE_AUTHORITY_XPATH, mods: DESC_METADATA_NS).first&.content
-          authority_uri = ng_role.xpath(ROLE_AUTHORITY_URI_XPATH, mods: DESC_METADATA_NS).first&.content
-          authority_value = ng_role.xpath(ROLE_AUTHORITY_VALUE_XPATH, mods: DESC_METADATA_NS).first&.content
+          authority = ng_role.xpath('./mods:roleTerm/@authority', mods: DESC_METADATA_NS).first&.content
+          authority_uri = ng_role.xpath('./mods:roleTerm/@authorityURI', mods: DESC_METADATA_NS).first&.content
+          authority_value = ng_role.xpath('./mods:roleTerm/@valueURI', mods: DESC_METADATA_NS).first&.content
 
           check_role_code(code, authority)
 

--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -340,6 +340,11 @@ module Cocina
     def normalize_name
       ng_xml.root.xpath('//mods:namePart[not(text())]', mods: MODS_NS).each(&:remove)
       ng_xml.root.xpath('//mods:name[not(mods:namePart)]', mods: MODS_NS).each(&:remove)
+
+      # Some MODS 3.3 items have xlink:href attributes. See https://argo.stanford.edu/view/druid:yy910cj7795
+      ng_xml.xpath('//mods:name[@xlink:href]', mods: MODS_NS, xlink: 'http://www.w3.org/1999/xlink').each do |node|
+        node['valueURI'] = node.remove_attribute('href').value
+      end
     end
 
     def normalize_empty_titles

--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -189,6 +189,11 @@ module Cocina
       ng_xml.root.xpath("//mods:roleTerm[@type='text']", mods: MODS_NS).each do |role_term_node|
         role_term_node.content = role_term_node.content.downcase
       end
+
+      # Add the type="text" attribute to roleTerms that don't have a type (seen in MODS 3.3 druid:yy910cj7795)
+      ng_xml.root.xpath('//mods:roleTerm[not(@type)]', mods: MODS_NS).each do |role_term_node|
+        role_term_node['type'] = 'text'
+      end
     end
 
     def normalize_role_term_authority

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -133,6 +133,40 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     end
   end
 
+  context 'with a role that has no URI' do
+    let(:xml) do
+      <<~XML
+        <name type="personal" authority="naf" xlink:href="http://id.loc.gov/authorities/names/n82087745">
+          <role>
+            <roleTerm>creator</roleTerm>
+          </role>
+          <namePart>Tirion, Isaak</namePart>
+        </name>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          name: [
+            {
+              value: 'Tirion, Isaak',
+              source: {
+                code: 'naf'
+              }
+            }
+          ],
+          role: [
+            {
+              "value": 'creator'
+            }
+          ],
+          type: 'person'
+        }
+      ]
+    end
+  end
+
   context 'with translated name and roles' do
     let(:xml) do
       <<~XML

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -133,7 +133,18 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     end
   end
 
-  context 'with a role that has no URI' do
+  context 'with a role that has no URI and has xlink uris from MODS 3.3' do
+    # MODS 3.3 header from druid:yy910cj7795
+    let(:ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.loc.gov/mods/v3" version="3.3"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
+          #{xml}
+        </mods>
+      XML
+    end
+
     let(:xml) do
       <<~XML
         <name type="personal" authority="naf" xlink:href="http://id.loc.gov/authorities/names/n82087745">
@@ -151,6 +162,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
           name: [
             {
               value: 'Tirion, Isaak',
+              uri: 'http://id.loc.gov/authorities/names/n82087745',
               source: {
                 code: 'naf'
               }

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -455,32 +455,62 @@ RSpec.describe Cocina::ModsNormalizer do
   end
 
   context 'when normalizing text roleTerm' do
-    let(:mods_ng_xml) do
-      Nokogiri::XML <<~XML
-        <mods #{mods_attributes}>
-          <name>
-            <namePart>Dunnett, Dorothy</namePart>
-            <role>
-              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
-              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">Photographer</roleTerm>
-            </role>
-          </name>
-        </mods>
-      XML
+    context 'when the content has capital letters' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{mods_attributes}>
+            <name>
+              <namePart>Dunnett, Dorothy</namePart>
+              <role>
+                <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
+                <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">Photographer</roleTerm>
+              </role>
+            </name>
+          </mods>
+        XML
+      end
+
+      it 'downcases text' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{mods_attributes}>
+            <name>
+              <namePart>Dunnett, Dorothy</namePart>
+              <role>
+                <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
+                <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">photographer</roleTerm>
+              </role>
+            </name>
+          </mods>
+        XML
+      end
     end
 
-    it 'downcases text' do
-      expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <mods #{mods_attributes}>
-          <name>
-            <namePart>Dunnett, Dorothy</namePart>
-            <role>
-              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
-              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">photographer</roleTerm>
-            </role>
-          </name>
-        </mods>
-      XML
+    context 'when the role term has no type' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{mods_attributes}>
+            <name>
+              <namePart>Dunnett, Dorothy</namePart>
+              <role>
+                <roleTerm>photographer</roleTerm>
+              </role>
+            </name>
+          </mods>
+        XML
+      end
+
+      it 'add type="text"' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{mods_attributes}>
+            <name>
+              <namePart>Dunnett, Dorothy</namePart>
+              <role>
+                <roleTerm type="text">photographer</roleTerm>
+              </role>
+            </name>
+          </mods>
+        XML
+      end
     end
   end
 

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -1204,6 +1204,28 @@ RSpec.describe Cocina::ModsNormalizer do
     end
   end
 
+  context 'when name has xlink:href' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{mods_attributes} xmlns:xlink="http://www.w3.org/1999/xlink">
+          <name type="personal" authority="naf" xlink:href="http://id.loc.gov/authorities/names/n82087745">
+            <namePart>Tirion, Isaak</namePart>
+          </name>
+        </mods>
+      XML
+    end
+
+    it 'is converted to valueURI' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{mods_attributes}>
+          <name type="personal" authority="naf" valueURI="http://id.loc.gov/authorities/names/n82087745">
+            <namePart>Tirion, Isaak</namePart>
+          </name>
+        </mods>
+      XML
+    end
+  end
+
   context 'when normalizing empty title' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML


### PR DESCRIPTION
## Why was this change made?


Fixes #1760

## How was this change tested?

Before

```
Status (n=100000):
  Success:   95997 (95.997%)
  Different: 3342 (3.342%)
  To Cocina error:     51 (0.051%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

After
```
  Success:   96009 (96.009%)
  Different: 3330 (3.33%)
  To Cocina error:     51 (0.051%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
  ```
  
  Note there is no change, because there are other problems with the record druid:yy910cj7795 (namely xlink:href)

## Which documentation and/or configurations were updated?



