### PR TITLE
Ignore empty location nodes when determining whether to add the digitalRepository node

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/access.rb
+++ b/app/services/cocina/from_fedora/descriptive/access.rb
@@ -41,8 +41,10 @@ module Cocina
 
         attr_reader :resource_element
 
+        # The number of location nodes that themselves that have child nodes.
+        # Hydrus is know to create location nodes with no children.
         def location_nodes_count
-          resource_element.xpath('mods:location', mods: DESC_METADATA_NS).count
+          resource_element.xpath('mods:location[*]', mods: DESC_METADATA_NS).count
         end
 
         def physical_location

--- a/app/services/cocina/from_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/from_fedora/descriptive/related_resource.rb
@@ -35,8 +35,8 @@ module Cocina
                   end
                 ]
               end
-            end.compact
-          end
+            end.compact.presence
+          end.compact
         end
 
         private

--- a/spec/services/cocina/from_fedora/descriptive/related_resource_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/related_resource_spec.rb
@@ -17,6 +17,25 @@ RSpec.describe Cocina::FromFedora::Descriptive::RelatedResource do
     XML
   end
 
+  context 'with empty location (from Hydrus)' do
+    let(:xml) do
+      <<~XML
+        <relatedItem>
+          <titleInfo>
+            <title/>
+          </titleInfo>
+          <location>
+
+          </location>
+        </relatedItem>
+      XML
+    end
+
+    it 'builds nothing' do
+      expect(build).to be_empty
+    end
+  end
+
   context 'with type' do
     let(:xml) do
       <<~XML


### PR DESCRIPTION
This prevents round tripping

## Why was this change made?
Fixes #1758


## How was this change tested?


```
$ bin/validate-cocina-roundtrip -d druid:xj351bk8174
Status (n=1):
  Success:   1 (100.0%)
  Different: 0 (0.0%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  Missing:     0 (0.0%)
```

```
Status (n=100000):
  Success:   96101 (96.101%)
  Different: 3238 (3.238%)
  To Cocina error:     51 (0.051%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
  ```


## Which documentation and/or configurations were updated?



