### PR TITLE
Improves MODS equivalent service handling of non-unique nameTitleGrou…

### DIFF
--- a/app/services/mods_equivalent_service.rb
+++ b/app/services/mods_equivalent_service.rb
@@ -26,11 +26,13 @@ class ModsEquivalentService
   def initialize(mods_ng_xml1, mods_ng_xml2)
     @mods_ng_xml1 = mods_ng_xml1
     @mods_ng_xml2 = mods_ng_xml2
-    # Map of altRepGroup ids from mods_ng_xml1 to mods_ng_xml2
+    # Map of [altRepGroup ids, parent node] from mods_ng_xml1 to mods_ng_xml2
+    # The parent node is necessary because ids are unique for mods/relatedItem not entire document.
     @altrepgroup_ids = {}
     # Map of equivalent nodes with altRepGroup attributes.
     @altrepgroup_nodes = {}
-    # Map of nameTitleGroup ids from mods_ng_xml1 to mods_ng_xml2
+    # Map of [nameTitleGroup ids, parent node] from mods_ng_xml1 to mods_ng_xml2
+    # The parent node is necessary because ids are unique for mods/relatedItem not entire document.
     @nametitlegroup_ids = {}
     # Map of equivalent nodes with nameTitleGroup attributes.
     @nametitlegroup_nodes = {}
@@ -92,11 +94,11 @@ class ModsEquivalentService
     equiv = EquivalentXml.equivalent?(norm_node1, norm_node2)
     if equiv
       if altrepgroup1
-        altrepgroup_ids[altrepgroup1.value] = altrepgroup2.value if altrepgroup2
+        altrepgroup_ids[[altrepgroup1.value, node1.parent]] = altrepgroup2.value if altrepgroup2
         altrepgroup_nodes[node1] = node2
       end
       if nametitlegroup1
-        nametitlegroup_ids[nametitlegroup1.value] = nametitlegroup2.value if nametitlegroup2
+        nametitlegroup_ids[[nametitlegroup1.value, node1.parent]] = nametitlegroup2.value if nametitlegroup2
         nametitlegroup_nodes[node1] = node2
       end
     end
@@ -164,7 +166,7 @@ class ModsEquivalentService
       node1_altrepgroup = node1['altRepGroup']
       node2 = altrepgroup_nodes[node1]
       node2_altrepgroup = node2 ? node2['altRepGroup'] : nil
-      expected_node2_altrepgroup = altrepgroup_ids[node1_altrepgroup]
+      expected_node2_altrepgroup = altrepgroup_ids[[node1_altrepgroup, node1.parent]]
 
       next nil if expected_node2_altrepgroup && expected_node2_altrepgroup == node2_altrepgroup
 
@@ -177,7 +179,7 @@ class ModsEquivalentService
       node1_nametitlegroup = node1['nameTitleGroup']
       node2 = nametitlegroup_nodes[node1]
       node2_nametitlegroup = node2 ? node2['nameTitleGroup'] : nil
-      expected_node2_nametitlegroup = nametitlegroup_ids[node1_nametitlegroup]
+      expected_node2_nametitlegroup = nametitlegroup_ids[[node1_nametitlegroup, node1.parent]]
 
       next nil if expected_node2_nametitlegroup && expected_node2_nametitlegroup == node2_nametitlegroup
 

--- a/spec/services/mods_equivalent_service_spec.rb
+++ b/spec/services/mods_equivalent_service_spec.rb
@@ -242,6 +242,94 @@ RSpec.describe ModsEquivalentService do
     end
   end
 
+  context 'when matching altRepGroup with same id in relatedItem' do
+    let(:mods_ng_xml1) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <note lang="eng" altRepGroup="1">This is a note.</note>
+          <note lang="fre" altRepGroup="1">C'est une note.</note>
+          <relatedItem>
+            <note lang="eng" altRepGroup="1">This is a related note.</note>
+            <note lang="fre" altRepGroup="1">C'est une related note.</note>
+          </relatedItem>
+        </mods>
+      XML
+    end
+
+    let(:mods_ng_xml2) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <note lang="eng" altRepGroup="2">This is a note.</note>
+          <note lang="fre" altRepGroup="2">C'est une note.</note>
+          <relatedItem>
+            <note lang="eng" altRepGroup="1">This is a related note.</note>
+            <note lang="fre" altRepGroup="1">C'est une related note.</note>
+          </relatedItem>
+        </mods>
+      XML
+    end
+
+    it 'returns success' do
+      expect(result.success?).to be(true)
+    end
+
+    it 'returns true' do
+      expect(bool_result).to be(true)
+    end
+  end
+
+  context 'when mismatched altRepGroup with same id in relatedItem' do
+    let(:mods_ng_xml1) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <note lang="eng" altRepGroup="1">This is a note.</note>
+          <note lang="fre" altRepGroup="1">C'est une note.</note>
+          <relatedItem>
+            <note lang="eng" altRepGroup="1">This is not a related note.</note>
+            <note lang="fre" altRepGroup="1">C'est une related note.</note>
+          </relatedItem>
+        </mods>
+      XML
+    end
+
+    let(:mods_ng_xml2) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <note lang="eng" altRepGroup="2">This is a note.</note>
+          <note lang="fre" altRepGroup="2">C'est une note.</note>
+          <relatedItem>
+            <note lang="eng" altRepGroup="1">This is a related note.</note>
+            <note lang="fre" altRepGroup="1">C'est une related note.</note>
+          </relatedItem>
+        </mods>
+      XML
+    end
+
+    it 'returns failure' do
+      expect(result.failure?).to be(true)
+    end
+
+    it 'returns diff' do
+      expect(result.failure.size).to eq(1)
+      expect(result.failure.first.mods_node1.to_s).to eq("<relatedItem>\n    <note lang=\"eng\" altRepGroup=\"1\">This is not a related note.</note>\n    " \
+"<note lang=\"fre\" altRepGroup=\"1\">C'est une related note.</note>\n  </relatedItem>")
+      expect(result.failure.first.mods_node2.to_s).to eq("<relatedItem>\n    <note lang=\"eng\" altRepGroup=\"1\">This is a related note.</note>\n    " \
+"<note lang=\"fre\" altRepGroup=\"1\">C'est une related note.</note>\n  </relatedItem>")
+    end
+
+    it 'returns false' do
+      expect(bool_result).to be(false)
+    end
+  end
+
   context 'when matching nameTitleGroup with different ids' do
     let(:mods_ng_xml1) do
       Nokogiri::XML <<~XML
@@ -371,6 +459,122 @@ RSpec.describe ModsEquivalentService do
 
     it 'returns false' do
       expect(bool_result).to be(false)
+    end
+  end
+
+  context 'when matching nameTitleGroup with same id in relatedItem' do
+    let(:mods_ng_xml1) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <titleInfo nameTitleGroup="0">
+            <title>Hamlet</title>
+          </titleInfo>
+          <name nameTitleGroup="0">
+            <namePart>Shakespeare, William, 1564-1616</namePart>
+          </name>
+          <relatedItem>
+            <titleInfo nameTitleGroup="0">
+              <title>Romeo and Juliet</title>
+            </titleInfo>
+            <name nameTitleGroup="0">
+              <namePart>Shakespeare, William, 1564-1616</namePart>
+            </name>
+          </relatedItem>
+        </mods>
+      XML
+    end
+
+    let(:mods_ng_xml2) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <titleInfo nameTitleGroup="1">
+            <title>Hamlet</title>
+          </titleInfo>
+          <name nameTitleGroup="1">
+            <namePart>Shakespeare, William, 1564-1616</namePart>
+          </name>
+          <relatedItem>
+            <titleInfo nameTitleGroup="2">
+              <title>Romeo and Juliet</title>
+            </titleInfo>
+            <name nameTitleGroup="2">
+              <namePart>Shakespeare, William, 1564-1616</namePart>
+            </name>
+          </relatedItem>
+        </mods>
+      XML
+    end
+
+    it 'returns success' do
+      expect(result.success?).to be(true)
+    end
+
+    it 'returns true' do
+      expect(bool_result).to be(true)
+    end
+  end
+
+  context 'when mismatched nameTitleGroup with same id in relatedItem' do
+    let(:mods_ng_xml1) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <titleInfo nameTitleGroup="0">
+            <title>Hamlet</title>
+          </titleInfo>
+          <name nameTitleGroup="0">
+            <namePart>Shakespeare, William, 1564-1616</namePart>
+          </name>
+          <relatedItem>
+            <titleInfo nameTitleGroup="0">
+              <title>Romeo and Juliet</title>
+            </titleInfo>
+            <name nameTitleGroup="0">
+              <namePart>Shakespeare, William, 1564-1616</namePart>
+            </name>
+          </relatedItem>
+        </mods>
+      XML
+    end
+
+    let(:mods_ng_xml2) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <titleInfo nameTitleGroup="1">
+            <title>Hamlet</title>
+          </titleInfo>
+          <name nameTitleGroup="1">
+            <namePart>Shakespeare, William, 1564-1616</namePart>
+          </name>
+          <relatedItem>
+            <titleInfo nameTitleGroup="2">
+              <title>Hamlet</title>
+            </titleInfo>
+            <name nameTitleGroup="2">
+              <namePart>Shakespeare, William, 1564-1616</namePart>
+            </name>
+          </relatedItem>
+        </mods>
+      XML
+    end
+
+    it 'returns failure' do
+      expect(result.failure?).to be(true)
+    end
+
+    it 'returns diff' do
+      expect(result.failure.size).to eq(1)
+      expect(result.failure.first.mods_node1.to_s).to eq("<relatedItem>\n    <titleInfo nameTitleGroup=\"0\">\n      <title>Romeo and Juliet</title>\n    " \
+"</titleInfo>\n    <name nameTitleGroup=\"0\">\n      <namePart>Shakespeare, William, 1564-1616</namePart>\n    </name>\n  </relatedItem>")
+      expect(result.failure.first.mods_node2.to_s).to eq("<relatedItem>\n    <titleInfo nameTitleGroup=\"2\">\n      <title>Hamlet</title>\n    " \
+"</titleInfo>\n    <name nameTitleGroup=\"2\">\n      <namePart>Shakespeare, William, 1564-1616</namePart>\n    </name>\n  </relatedItem>")
     end
   end
 


### PR DESCRIPTION
…p and altRepGroup ids.

closes #1737

## Why was this change made?
IDs are unique for a `<mods> / <relatedItem>` not the entire doc.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


