### PR TITLE
Map form note types

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/form.rb
+++ b/app/services/cocina/from_fedora/descriptive/form.rb
@@ -147,8 +147,14 @@ module Cocina
 
         def add_note(forms, physical_description)
           physical_description.xpath('mods:note', mods: DESC_METADATA_NS).each do |node|
+            note = {
+              value: node.content,
+              displayLabel: node['displayLabel'],
+              type: node['type']
+            }.compact
+
             forms << {
-              note: [{ value: node.content, displayLabel: node['displayLabel'] }.compact]
+              note: [note]
             }
           end
         end

--- a/app/services/cocina/to_fedora/descriptive/form.rb
+++ b/app/services/cocina/to_fedora/descriptive/form.rb
@@ -70,9 +70,11 @@ module Cocina
             forms.each do |form|
               if form.note
                 form.note.each do |val|
-                  attributes = {}
-                  attributes[:displayLabel] = val.displayLabel
-                  xml.note val.value, attributes.compact
+                  attributes = {
+                    displayLabel: val.displayLabel,
+                    type: val.type
+                  }.compact
+                  xml.note val.value, attributes
                 end
               else
                 attributes = {}

--- a/spec/services/cocina/from_fedora/descriptive/form_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/form_spec.rb
@@ -712,6 +712,13 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
             <extent>1 sheet</extent>
             <digitalOrigin>reformatted digital</digitalOrigin>
             <note displayLabel="Condition">Small tear at top right corner.</note>
+            <note displayLabel="Material" type="material">Paper</note>
+            <note displayLabel="Layout" type="layout">34 and 24 lines to a page</note>
+            <note displayLabel="Height (mm)" type="dimensions">210</note>
+            <note displayLabel="Width (mm)" type="dimensions">146</note>
+            <note displayLabel="Collation" type="collation">1(8) 2(10) 3(8) 4(8) 5 (two) || a(16) (wants 16).</note>
+            <note displayLabel="Writing" type="handNote">change of hand</note>
+            <note displayLabel="Foliation" type="foliation">ff. i + 1-51 + ii-iii</note>
           </physicalDescription>
         XML
       end
@@ -752,6 +759,69 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
               {
                 "value": 'Small tear at top right corner.',
                 "displayLabel": 'Condition'
+              }
+            ]
+          },
+          {
+            note: [
+              {
+                value: 'Paper',
+                displayLabel: 'Material',
+                type: 'material'
+              }
+            ]
+          },
+          {
+            note: [
+              {
+                value: '34 and 24 lines to a page',
+                displayLabel: 'Layout',
+                type: 'layout'
+              }
+            ]
+          },
+          {
+            note: [
+              {
+                value: '210',
+                displayLabel: 'Height (mm)',
+                type: 'dimensions'
+              }
+            ]
+          },
+          {
+            note: [
+              {
+                value: '146',
+                displayLabel: 'Width (mm)',
+                type: 'dimensions'
+              }
+            ]
+          },
+          {
+            note: [
+              {
+                value: '1(8) 2(10) 3(8) 4(8) 5 (two) || a(16) (wants 16).',
+                displayLabel: 'Collation',
+                type: 'collation'
+              }
+            ]
+          },
+          {
+            note: [
+              {
+                value: 'change of hand',
+                displayLabel: 'Writing',
+                type: 'handNote'
+              }
+            ]
+          },
+          {
+            note: [
+              {
+                value: 'ff. i + 1-51 + ii-iii',
+                displayLabel: 'Foliation',
+                type: 'foliation'
               }
             ]
           }
@@ -822,7 +892,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
                  <form authority="marcform">print</form>
                  <extent>v. ; 24 cm.</extent>
               </physicalDescription>
-           </relatedItem>        
+           </relatedItem>
           <physicalDescription>
             <form>mezzotints (prints)</form>
           </physicalDescription>

--- a/spec/services/cocina/to_fedora/descriptive/form_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/form_spec.rb
@@ -615,10 +615,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Form do
             }
           ),
           Cocina::Models::DescriptiveValue.new(
-            "note": [
+            note: [
               {
-                "value": 'Small tear at top right corner.',
-                "displayLabel": 'Condition'
+                value: 'Small tear at top right corner.',
+                displayLabel: 'Condition',
+                type: 'condition'
               }
             ]
           ),
@@ -662,7 +663,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Form do
               <internetMediaType>image/jpeg</internetMediaType>
               <extent>1 sheet</extent>
               <digitalOrigin>reformatted digital</digitalOrigin>
-              <note displayLabel="Condition">Small tear at top right corner.</note>
+              <note displayLabel="Condition" type="condition">Small tear at top right corner.</note>
               <form type="media" authority="rdamedia">unmediated</form>
               <form type="carrier" authority="rdacarrier">volume</form>
               <form type="technique">estampe</form>


### PR DESCRIPTION
Fixes #1757

# Before

```
Status (n=100000):
  Success:   96705 (96.705%)
  Different: 2634 (2.634%)
  To Cocina error:     51 (0.051%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

# After

```
Status (n=100000):
  Success:   96706 (96.706%)
  Different: 2633 (2.633%)
  To Cocina error:     51 (0.051%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)

```