### PR TITLE
Normalizes dateCaptured into own event.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -467,15 +467,19 @@ module Cocina
 
     def normalize_origin_info_split
       # Split a single originInfo into multiple.
-      # Currently, this is splitting out copyright dates from originInfos with date issued. However, probably are other cases.
-      ng_xml.root.xpath('//mods:originInfo[mods:dateIssued and mods:copyrightDate]', mods: MODS_NS).each do |origin_info_node|
+      split_origin_info('copyrightDate', 'copyright notice')
+      split_origin_info('dateCaptured', 'capture')
+    end
+
+    def split_origin_info(split_node_name, event_type)
+      ng_xml.root.xpath("//mods:originInfo[mods:dateIssued and mods:#{split_node_name}]", mods: MODS_NS).each do |origin_info_node|
         new_origin_info_node = Nokogiri::XML::Node.new('originInfo', Nokogiri::XML(nil))
-        new_origin_info_node['eventType'] = 'copyright notice'
+        new_origin_info_node['eventType'] = event_type
         origin_info_node.parent << new_origin_info_node
-        copyright_nodes = origin_info_node.xpath('mods:copyrightDate', mods: MODS_NS)
-        copyright_nodes.each do |copyright_node|
-          copyright_node.remove
-          new_origin_info_node << copyright_node
+        split_nodes = origin_info_node.xpath("mods:#{split_node_name}", mods: MODS_NS)
+        split_nodes.each do |split_node|
+          split_node.remove
+          new_origin_info_node << split_node
         end
       end
     end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -1566,6 +1566,41 @@ RSpec.describe Cocina::ModsNormalizer do
     end
   end
 
+  context 'when normalizing originInfos with captured dates' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{mods_attributes}>
+          <originInfo eventType="publication">
+            <place>
+              <placeTerm type="code" authority="marccountry">tnu</placeTerm>
+            </place>
+            <dateIssued encoding="marc">2016</dateIssued>
+            <dateCaptured encoding="iso8601" point="start">20141010</dateCaptured>
+            <dateCaptured encoding="iso8601" point="end">20141012</dateCaptured>
+            <issuance>monographic</issuance>
+          </originInfo>
+      XML
+    end
+
+    it 'moves copyright into its own originInfo' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{mods_attributes}>
+          <originInfo eventType="publication">
+            <place>
+              <placeTerm type="code" authority="marccountry">tnu</placeTerm>
+            </place>
+            <dateIssued encoding="marc">2016</dateIssued>
+            <issuance>monographic</issuance>
+          </originInfo>
+          <originInfo eventType="capture">
+            <dateCaptured encoding="iso8601" point="start">20141010</dateCaptured>
+            <dateCaptured encoding="iso8601" point="end">20141012</dateCaptured>
+          </originInfo>
+        </mods>
+      XML
+    end
+  end
+
   context 'when normalizing cartographic coordinates' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML


### PR DESCRIPTION
closes #1739

## Why was this change made?
Another case of event that need to be split into own `<originInfo>`.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


