### PR TITLE
Normalizes unmatched nameTitleGroups.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -41,6 +41,7 @@ module Cocina
       normalize_name
       normalize_related_item_other_type
       normalize_unmatched_altrepgroup
+      normalize_unmatched_nametitlegroup
       normalize_xml_space
       normalize_language_term_type
       normalize_geo_purl
@@ -272,17 +273,25 @@ module Cocina
     end
 
     def normalize_unmatched_altrepgroup
-      altrepgroups = {}
-      ng_xml.root.xpath('//mods:*[@altRepGroup]', mods: MODS_NS).each do |node|
-        altrepgroup = node['altRepGroup']
-        altrepgroups[altrepgroup] = [] unless altrepgroups.include?(altrepgroup)
-        altrepgroups[altrepgroup] << node
+      remove_unmatched('altRepGroup')
+    end
+
+    def normalize_unmatched_nametitlegroup
+      remove_unmatched('nameTitleGroup')
+    end
+
+    def remove_unmatched(attr_name)
+      ids = {}
+      ng_xml.root.xpath("//mods:*[@#{attr_name}]", mods: MODS_NS).each do |node|
+        id = node[attr_name]
+        ids[id] ||= []
+        ids[id] << node
       end
 
-      altrepgroups.each do |_altrepgroup, nodes|
+      ids.each_value do |nodes|
         next unless nodes.size == 1
 
-        nodes.first.delete('altRepGroup')
+        nodes.first.delete(attr_name)
       end
     end
 

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -730,6 +730,46 @@ RSpec.describe Cocina::ModsNormalizer do
     end
   end
 
+  context 'when normalizing unmatches nameTitleGroups' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{mods_attributes}>
+          <titleInfo usage="primary" nameTitleGroup="1">
+            <title>Slaughterhouse-Five</title>
+          </titleInfo>
+          <titleInfo type="uniform" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n80008522" nameTitleGroup="0">
+            <title>Hamlet</title>
+          </titleInfo>
+          <name usage="primary" type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n78095332" nameTitleGroup="0">
+            <namePart>Shakespeare, William, 1564-1616</namePart>
+          </name>
+          <name usage="primary" type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n78095332" nameTitleGroup="3">
+            <namePart>Vonnegut, Kurt</namePart>
+          </name>
+        </mods>
+      XML
+    end
+
+    it 'removes unmatched' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{mods_attributes}>
+          <titleInfo usage="primary">
+            <title>Slaughterhouse-Five</title>
+          </titleInfo>
+          <titleInfo type="uniform" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n80008522" nameTitleGroup="0">
+            <title>Hamlet</title>
+          </titleInfo>
+          <name usage="primary" type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n78095332" nameTitleGroup="0">
+            <namePart>Shakespeare, William, 1564-1616</namePart>
+          </name>
+          <name usage="primary" type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n78095332">
+            <namePart>Vonnegut, Kurt</namePart>
+          </name>
+        </mods>
+      XML
+    end
+  end
+
   context 'when normalizing empty attributes' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML


### PR DESCRIPTION
closes #1749

## Why was this change made?
Remove unmatched nameTitleGroups.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


