### PR TITLE
Uses title builders/writers for title subjects.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -164,8 +164,7 @@ module Cocina
             name_attrs = NameBuilder.build(name_elements: [node], add_default_type: true)[:name]&.first
             name_attrs&.merge(attrs)
           when 'titleInfo'
-            query = node.xpath('mods:title', mods: DESC_METADATA_NS)
-            attrs.merge(value: query.first.text, type: 'title')
+            attrs.merge(TitleBuilder.build(title_info_element: node)).merge(type: 'title')
           when 'geographicCode'
             attrs.merge(code: node.text, type: 'place', source: { code: node['authority'] })
           when 'cartographics'

--- a/app/services/cocina/from_fedora/descriptive/title_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/title_builder.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Cocina
+  module FromFedora
+    class Descriptive
+      # Maps titles
+      class TitleBuilder
+        # @param [Nokogiri::XML::Element] title_info_element titleInfo element
+        # @return [Hash] a hash that can be mapped to a cocina model
+        def self.build(title_info_element:)
+          new(title_info_element: title_info_element).build
+        end
+
+        def initialize(title_info_element:)
+          @title_info_element = title_info_element
+        end
+
+        def build
+          # Find all the child nodes that have text
+          return nil if title_info_element.children.empty?
+
+          children = title_info_element.xpath('./*[child::node()[self::text()]]')
+          if children.empty?
+            Honeybadger.notify('[DATA ERROR] Empty title node', { tags: 'data_error' })
+            return nil
+          end
+
+          # If a displayLabel only with no title text element
+          # Note: this is an error condition,
+          # exceptions documented at: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_value_dependencies.txt
+          return {} if children.map(&:name) == []
+
+          # Is this a basic title or a title with parts
+          return simple_value(title_info_element) if simple_title?(children)
+
+          { structuredValue: structured_value(children), note: note(children) }.compact
+        end
+
+        private
+
+        attr_reader :title_info_element
+
+        def simple_title?(children)
+          return false if children.map(&:name) != ['title'] || children.size > 1
+
+          # There is only one child and it's a title element. If it has the
+          # @type attr set, it should not be treated as a simple value
+          children.first[:type].nil?
+        end
+
+        # @param [Nokogiri::XML::Element] node the titleInfo node
+        def simple_value(node)
+          value = node.xpath('./mods:title', mods: DESC_METADATA_NS).text
+
+          { value: value }
+        end
+
+        # @param [Nokogiri::XML::NodeSet] child_nodes the children of the titleInfo
+        def structured_value(child_nodes)
+          child_nodes.map do |node|
+            { value: node.text, type: Titles::TYPES[node.name] }
+          end
+        end
+
+        def note(child_nodes)
+          unsortable = child_nodes.select { |node| node.name == 'nonSort' }
+          return nil if unsortable.empty?
+
+          count = unsortable.sum do |node|
+            add = node.text.end_with?('-') || node.text.end_with?("'") ? 0 : 1
+            node.text.size + add
+          end
+          [{
+            "value": count.to_s,  # cast to String until cocina-models 0.40.0 is used. See https://github.com/sul-dlss/cocina-models/pull/146
+            "type": 'nonsorting character count'
+          }]
+        end
+      end
+    end
+  end
+end

--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -160,21 +160,20 @@ module Cocina
         end
 
         def write_topic(subject, is_parallel: false, is_basic: false)
+          topic_attributes = topic_attributes_for(subject, is_parallel: is_parallel, is_basic: is_basic)
           case subject.type
           when 'person'
-            xml.name topic_attributes_for(subject, is_parallel: is_parallel, is_basic: is_basic).merge(type: 'personal') do
+            xml.name topic_attributes.merge(type: 'personal') do
               xml.namePart subject.value
             end
           when 'title'
-            xml.titleInfo topic_attributes_for(subject, is_parallel: is_parallel, is_basic: is_basic) do
-              xml.title subject.value
-            end
+            title = subject.to_h
+            title.delete(:type)
+            Title.write(xml: xml, titles: [Cocina::Models::DescriptiveValue.new(title)], id_generator: id_generator, additional_attrs: topic_attributes)
           when 'place'
             geographic(subject, is_parallel: is_parallel)
           else
-            xml.public_send(TAG_NAME.fetch(subject.type, :topic),
-                            subject.value,
-                            topic_attributes_for(subject, is_parallel: is_parallel, is_basic: is_basic))
+            xml.public_send(TAG_NAME.fetch(subject.type, :topic), subject.value, topic_attributes)
           end
         end
 

--- a/spec/services/cocina/from_fedora/descriptive/subject_name_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_name_spec.rb
@@ -547,6 +547,62 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     end
   end
 
+  # From druid:mt538yc4849
+  context 'with a name-title subject where title has partNumber' do
+    let(:xml) do
+      <<~XML
+        <subject authority="lcsh">
+          <name type="corporate">
+            <namePart>California.</namePart>
+            <namePart>Sect. 7570.</namePart>
+          </name>
+          <titleInfo>
+            <title>Government Code</title>
+            <partNumber>Sect. 7570</partNumber>
+          </titleInfo>
+        </subject>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "source": {
+            "code": 'lcsh'
+          },
+          "structuredValue": [
+            {
+              "structuredValue": [
+                {
+                  "value": 'California.',
+                  "type": 'name'
+                },
+                {
+                  "value": 'Sect. 7570.',
+                  "type": 'name'
+                }
+              ],
+              "type": 'organization'
+            },
+            {
+              "structuredValue": [
+                {
+                  "value": 'Government Code',
+                  "type": 'main title'
+                },
+                {
+                  "value": 'Sect. 7570',
+                  "type": 'part number'
+                }
+              ],
+              "type": 'title'
+            }
+          ]
+        }
+      ]
+    end
+  end
+
   context 'without name type' do
     before do
       allow(Honeybadger).to receive(:notify)

--- a/spec/services/cocina/to_fedora/descriptive/subject_name_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_name_spec.rb
@@ -709,4 +709,64 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
       XML
     end
   end
+
+  # From druid:mt538yc4849
+  context 'with a name-title subject where title has partNumber' do
+    let(:subjects) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          "source": {
+            "code": 'lcsh'
+          },
+          "structuredValue": [
+            {
+              "structuredValue": [
+                {
+                  "value": 'California.',
+                  "type": 'name'
+                },
+                {
+                  "value": 'Sect. 7570.',
+                  "type": 'name'
+                }
+              ],
+              "type": 'organization'
+            },
+            {
+              "structuredValue": [
+                {
+                  "value": 'Government Code',
+                  "type": 'main title'
+                },
+                {
+                  "value": 'Sect. 7570',
+                  "type": 'part number'
+                }
+              ],
+              "type": 'title'
+            }
+          ]
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject authority="lcsh">
+            <name type="corporate">
+              <namePart>California.</namePart>
+              <namePart>Sect. 7570.</namePart>
+            </name>
+            <titleInfo>
+              <title>Government Code</title>
+              <partNumber>Sect. 7570</partNumber>
+            </titleInfo>
+          </subject>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #1747

## Why was this change made?
To provide more complete mapping of title subjects.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


