### PR TITLE
Handle authority on subject but not topic.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -76,12 +76,8 @@ module Cocina
               uri: Authority.normalize_uri(subject[:authorityURI]),
               version: edition_for(subject)
             }.compact
-            if subject[:valueURI]
-              attrs[:source] = source unless source.empty?
-              attrs[:uri] = ValueURI.sniff(subject[:valueURI])
-            elsif subject[:authority]
-              attrs[:source] = source unless source.empty?
-            end
+            attrs[:source] = source unless source.empty?
+            attrs[:uri] = ValueURI.sniff(subject[:valueURI])
             attrs[:encoding] = { code: subject[:encoding] } if subject[:encoding]
             language_script = LanguageScript.build(node: subject)
             attrs[:valueLanguage] = language_script if language_script
@@ -156,7 +152,7 @@ module Cocina
         end
 
         def simple_item(node, attrs = {})
-          attrs = attrs.merge(common_attrs(node))
+          attrs = attrs.deep_merge(common_attrs(node))
           case node.name
           when 'name'
             name_type = name_type_for_subject(node[:type])

--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -89,6 +89,7 @@ module Cocina
 
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/AbcSize
     def normalize_subject
       ng_xml.root.xpath('//mods:subject[count(mods:name|mods:topic|mods:geographic) = 1 and count(mods:*) = 1]', mods: MODS_NS).each do |subject_node|
         child_node = subject_node.xpath('mods:*', mods: MODS_NS).first
@@ -104,11 +105,14 @@ module Cocina
           subject_node.delete('valueURI')
         elsif child_node[:authority] && subject_node[:authority] == child_node[:authority] && !(child_node[:authorityURI] || child_node[:valueURI])
           child_node.delete('authority')
+        elsif subject_node[:authority] && !child_node[:authority] && (child_node[:authorityURI] || child_node[:valueURI])
+          child_node[:authority] = subject_node[:authority]
         end
       end
     end
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/AbcSize
 
     def normalize_coordinates
       ng_xml.root.xpath('//mods:coordinates[text()]', mods: MODS_NS).each do |coordinate_node|

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -274,11 +274,35 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     end
   end
 
-  context 'with a single-term topic subject with authority on the subject' do
+  context 'with a single-term topic subject with authority, authorityURI, and valueURI on the subject' do
     let(:xml) do
       <<~XML
         <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">
           <topic>Cats</topic>
+        </subject>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "value": 'Cats',
+          "type": 'topic',
+          "uri": 'http://id.loc.gov/authorities/subjects/sh85021262',
+          "source": {
+            "code": 'lcsh',
+            "uri": 'http://id.loc.gov/authorities/subjects/'
+          }
+        }
+      ]
+    end
+  end
+
+  context 'with a single-term topic subject with authority on the subject and authorityURI and valueURI on topic' do
+    let(:xml) do
+      <<~XML
+        <subject authority="lcsh">
+          <topic authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
         </subject>
       XML
     end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -93,6 +93,28 @@ RSpec.describe Cocina::ModsNormalizer do
       end
     end
 
+    context 'when normalizing topic with authority on subject and authorityURI and valueURI on topic' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{mods_attributes}>
+            <subject authority="fast">
+              <topic authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/1009447">Marine biology</topic>
+            </subject>
+          </mods>
+        XML
+      end
+
+      it 'adds authority to topic' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{mods_attributes}>
+            <subject authority="fast">
+              <topic authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/1009447">Marine biology</topic>
+            </subject>
+          </mods>
+        XML
+      end
+    end
+
     context 'when normalizing topic with authority only' do
       let(:mods_ng_xml) do
         Nokogiri::XML <<~XML


### PR DESCRIPTION
closes #1746

## Why was this change made?
Subject authority normalization is hard.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


