### PR TITLE
Removes trailing periods from originInfo dates.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -308,7 +308,7 @@ module Cocina
 
         def build_date(event_type, node)
           {}.tap do |date|
-            date[:value] = node.text
+            date[:value] = clean_date(node.text)
             date[:qualifier] = node[:qualifier] if node[:qualifier]
             date[:encoding] = { code: node['encoding'] } if node['encoding']
             date[:status] = 'primary' if node['keyDate']
@@ -322,6 +322,12 @@ module Cocina
             end
             date[:type] = node['point'] if node['point']
           end
+        end
+
+        def clean_date(date)
+          return date unless date.match(/^\d{4}\.$/)
+
+          date.delete_suffix('.')
         end
 
         def date_other_event_type(origin, date)

--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -28,6 +28,7 @@ module Cocina
       normalize_origin_info_date_other_types
       normalize_origin_info_place_term_type
       normalize_origin_info_developed_date
+      normalize_origin_info_date
       normalize_parallel_origin_info
       normalize_origin_info_lang_script
       normalize_subject_authority
@@ -423,6 +424,15 @@ module Cocina
         new_origin_info << date_other.dup
         date_other.parent.parent << new_origin_info
         date_other.remove
+      end
+    end
+
+    def normalize_origin_info_date
+      %w[dateIssued copyrightDate dateCreated dateCaptured dateOther].each do |date_type|
+        ng_xml.root.xpath("//mods:originInfo/mods:#{date_type}", mods: MODS_NS)
+              .to_a
+              .filter { |date_node| date_node.content =~ /^\d{4}\.$/ }
+              .each { |date_node| date_node.content = date_node.content.delete_suffix('.') }
       end
     end
 

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -39,6 +39,29 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
     end
   end
 
+  context 'with a simple dateCreated with a trailing period' do
+    let(:xml) do
+      <<~XML
+        <originInfo>
+          <dateCreated>1980.</dateCreated>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'creation',
+          "date": [
+            {
+              "value": '1980'
+            }
+          ]
+        }
+      ]
+    end
+  end
+
   # example 2 from mods_to_cocina_originInfo.txt
   context 'with a simple dateIssued (with encoding)' do
     let(:xml) do

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -441,6 +441,62 @@ RSpec.describe Cocina::ModsNormalizer do
     end
   end
 
+  context 'when normalizing originInfo dates' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{mods_attributes}>
+          <originInfo eventType="publication">
+            <dateIssued>1930.</dateIssued>
+          </originInfo>
+          <originInfo eventType="copyright notice">
+            <copyrightDate>1931.</copyrightDate>
+          </originInfo>
+          <originInfo eventType="production">
+            <dateCreated>1932.</dateCreated>
+          </originInfo>
+          <originInfo eventType="capture">
+            <dateCaptured>1933.</dateCaptured>
+          </originInfo>
+          <originInfo eventType="publication">
+            <dateOther>1441.</dateOther>
+          </originInfo>
+          <relatedItem>
+            <originInfo eventType="capture">
+              <dateCaptured>1932.</dateCaptured>
+            </originInfo>
+          </relatedItem>
+        </mods>
+      XML
+    end
+
+    it 'removes trailing period' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{mods_attributes}>
+          <originInfo eventType="publication">
+            <dateIssued>1930</dateIssued>
+          </originInfo>
+          <originInfo eventType="copyright notice">
+            <copyrightDate>1931</copyrightDate>
+          </originInfo>
+          <originInfo eventType="production">
+            <dateCreated>1932</dateCreated>
+          </originInfo>
+          <originInfo eventType="capture">
+            <dateCaptured>1933</dateCaptured>
+          </originInfo>
+          <originInfo eventType="publication">
+            <dateOther>1441</dateOther>
+          </originInfo>
+          <relatedItem>
+            <originInfo eventType="capture">
+              <dateCaptured>1932</dateCaptured>
+            </originInfo>
+          </relatedItem>
+        </mods>
+      XML
+    end
+  end
+
   context 'when normalizing originInfo/place/placeTerm text values' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML


### PR DESCRIPTION
closes #1785

## Why was this change made?
Removes trailing periods from originInfo dates.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


