### PR TITLE
Avoid erroneous nameTitleGroups.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/name_title_group.rb
+++ b/app/services/cocina/to_fedora/descriptive/name_title_group.rb
@@ -37,17 +37,15 @@ module Cocina
         end
 
         def self.title_name_parts_for(title)
-          if title.structuredValue
-            structured_title = title.structuredValue.find { |check_structured_title| check_structured_title.type == 'name' }
-            if structured_title.nil?
-              nil
-            elsif structured_title.structuredValue
-              structured_title.structuredValue
-            else
-              [structured_title]
-            end
+          return nil unless title.structuredValue
+
+          structured_title = title.structuredValue.find { |check_structured_title| check_structured_title.type == 'name' }
+          if structured_title.nil?
+            nil
+          elsif structured_title.structuredValue
+            structured_title.structuredValue
           else
-            [title]
+            [structured_title]
           end
         end
         private_class_method :title_name_parts_for

--- a/spec/services/cocina/to_fedora/descriptive/title_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/title_spec.rb
@@ -838,5 +838,51 @@ RSpec.describe Cocina::ToFedora::Descriptive::Title do
         XML
       end
     end
+
+    context 'when it is a title and contributor have same value' do
+      let(:titles) do
+        [
+          Cocina::Models::Title.new(
+            {
+              "value": 'Stanford Alpine Club'
+            }
+          )
+        ]
+      end
+
+      let(:contributors) do
+        [
+          Cocina::Models::Contributor.new(
+            {
+              "name": [
+                {
+                  "value": 'Stanford Alpine Club',
+                  "uri": 'http://id.loc.gov/authorities/names/n99277320',
+                  "source": {
+                    "code": 'naf',
+                    "uri": 'http://id.loc.gov/authorities/names/'
+                  }
+                }
+              ],
+              "type": 'organization',
+              "status": 'primary'
+            }
+          )
+        ]
+      end
+
+      # Note that not made into nameTitleGroup
+      it 'builds the xml' do
+        expect(xml).to be_equivalent_to <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <titleInfo>
+              <title>Stanford Alpine Club</title>
+            </titleInfo>
+          </mods>
+        XML
+      end
+    end
   end
 end


### PR DESCRIPTION
closes #1750

## Why was this change made?
Avoid erroneous nameTitleGroups when contributor and title have same value.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


