### PR TITLE
Remove gml:id.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -53,6 +53,7 @@ module Cocina
       normalize_purl
       normalize_empty_notes
       normalize_empty_titles
+      normalize_gml_id
       # This should be last-ish.
       normalize_empty_related_items
       ng_xml
@@ -504,6 +505,12 @@ module Cocina
           split_node.remove
           new_origin_info_node << split_node
         end
+      end
+    end
+
+    def normalize_gml_id
+      ng_xml.root.xpath("//gml:Point[@gml:id='ID']", gml: 'http://www.opengis.net/gml/3.2/').each do |point_node|
+        point_node.delete('id')
       end
     end
   end

--- a/app/services/cocina/to_fedora/descriptive/geographic.rb
+++ b/app/services/cocina/to_fedora/descriptive/geographic.rb
@@ -99,7 +99,7 @@ module Cocina
           lat = geo.subject.first.structuredValue.find { |point| point.type.include? 'latitude' }.value
           long = geo.subject.first.structuredValue.find { |point| point.type.include? 'longitude' }.value
           xml['gmd'].centerPoint do
-            xml['gml'].Point('gml:id' => 'ID') do
+            xml['gml'].Point do
               xml['gml'].pos "#{lat} #{long}"
             end
           end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -1808,4 +1808,46 @@ RSpec.describe Cocina::ModsNormalizer do
       XML
     end
   end
+
+  context 'when normalizing gml:Point' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{mods_attributes}>
+          <extension displayLabel="geo">
+            <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:gmd="http://www.isotc211.org/2005/gmd">
+              <rdf:Description rdf:about="http://purl.stanford.edu/aa666bb1234">
+                <dc:format>image/jpeg</dc:format>
+                <dc:type>Image</dc:type>
+                <gmd:centerPoint>
+                  <gml:Point gml:id="ID">
+                    <gml:pos>41.893367 12.483736</gml:pos>
+                  </gml:Point>
+                </gmd:centerPoint>
+              </rdf:Description>
+            </rdf:RDF>
+          </extension>
+        </mods>
+      XML
+    end
+
+    it 'removes gml:ID' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{mods_attributes}>
+          <extension displayLabel="geo">
+            <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:gmd="http://www.isotc211.org/2005/gmd">
+              <rdf:Description rdf:about="http://purl.stanford.edu/aa666bb1234">
+                <dc:format>image/jpeg</dc:format>
+                <dc:type>Image</dc:type>
+                <gmd:centerPoint>
+                  <gml:Point>
+                    <gml:pos>41.893367 12.483736</gml:pos>
+                  </gml:Point>
+                </gmd:centerPoint>
+              </rdf:Description>
+            </rdf:RDF>
+          </extension>
+        </mods>
+      XML
+    end
+  end
 end

--- a/spec/services/cocina/to_fedora/descriptive/geographic_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/geographic_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
                 <dc:format>image/jpeg</dc:format>
                 <dc:type>Image</dc:type>
                 <gmd:centerPoint>
-                  <gml:Point gml:id="ID">
+                  <gml:Point>
                     <gml:pos>41.893367 12.483736</gml:pos>
                   </gml:Point>
                 </gmd:centerPoint>


### PR DESCRIPTION
closes #1782

## Why was this change made?
Remove gml:id.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


