### PR TITLE
Maps complex multilingual title.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -68,8 +68,8 @@ module Cocina
         def parallel_type(node_set)
           # If both uniform, then uniform
           return 'uniform' if node_set.all? { |node| node[:type] == 'uniform' }
-          # If none of these nodes are marked as primary, set the type to parallel
-          return 'parallel' unless node_set.any? { |node| node['usage'] }
+          # If none of these nodes are marked as primary or don't have a type, set the type to parallel
+          return 'parallel' unless node_set.any? { |node| node['usage'] || !node['type'] }
 
           nil
         end
@@ -87,6 +87,7 @@ module Cocina
 
         def structured_name(node:, display_types: true)
           name_node = node.xpath("//mods:name[@nameTitleGroup='#{node['nameTitleGroup']}']", mods: DESC_METADATA_NS).first
+
           structured_values = if name_node.nil?
                                 Honeybadger.notify('[DATA ERROR] Name not found for title group', { tags: 'data_error' })
                                 []
@@ -94,7 +95,6 @@ module Cocina
                                 NameBuilder.build(name_elements: [name_node], add_default_type: true)[:name]
                               end
           structured_values.each { |structured_value| structured_value[:type] = 'name' }
-
           {
             structuredValue: [
               { type: 'title' }.merge(TitleBuilder.build(title_info_element: node))

--- a/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
@@ -384,6 +384,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
       end
     end
 
+    # Example 20 from mods_to_cocina_titleInfo.txt
     context 'when there are uniform titles with authority' do
       let(:ng_xml) do
         Nokogiri::XML <<~XML
@@ -419,7 +420,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
                 "value": 'Hamlet',
                 "type": 'title'
               },
-
               {
                 "value": 'Shakespeare, William, 1564-1616',
                 "type": 'name',
@@ -436,6 +436,92 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
               "uri": 'http://id.loc.gov/authorities/names/',
               "code": 'naf'
             }
+          }
+        ]
+      end
+    end
+
+    # Example 21 from mods_to_cocina_titleInfo.txt
+    context 'when there is a complex multilingual title' do
+      let(:ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <titleInfo type="uniform" nameTitleGroup="1" altRepGroup="01">
+              <title>Shaʻare ha-ḳedushah</title>
+            </titleInfo>
+            <name type="personal" usage="primary" nameTitleGroup="1">
+              <namePart>Vital, Ḥayyim ben Joseph</namePart>
+              <namePart type="date">1542 or 1543-1620</namePart>
+            </name>
+            <titleInfo altRepGroup="02">
+              <title>Sefer Shaʻare ha-ḳedushah in Hebrew</title>
+              <subTitle>zeh sefer le-yosher ha-adam la-ʻavodat borʼo in Hebrew</subTitle>
+            </titleInfo>
+            <titleInfo altRepGroup="02">
+              <title>Sefer Shaʻare ha-ḳedushah</title>
+              <subTitle>zeh sefer le-yosher ha-adam la-ʻavodat borʼo</subTitle>
+            </titleInfo>
+          </mods>
+        XML
+      end
+
+      it 'parses' do
+        expect { Cocina::Models::Description.new(title: build) }.not_to raise_error
+      end
+
+      it 'creates value from the authority record' do
+        expect(build).to eq [
+          {
+            "parallelValue": [
+              {
+                "structuredValue": [
+                  {
+                    "value": 'Sefer Shaʻare ha-ḳedushah in Hebrew',
+                    "type": 'main title'
+                  },
+                  {
+                    "value": 'zeh sefer le-yosher ha-adam la-ʻavodat borʼo in Hebrew',
+                    "type": 'subtitle'
+                  }
+                ]
+              },
+              {
+                "structuredValue": [
+                  {
+                    "value": 'Sefer Shaʻare ha-ḳedushah',
+                    "type": 'main title'
+                  },
+                  {
+                    "value": 'zeh sefer le-yosher ha-adam la-ʻavodat borʼo',
+                    "type": 'subtitle'
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "structuredValue": [
+              {
+                type: 'title',
+                value: 'Shaʻare ha-ḳedushah'
+              },
+              {
+                "structuredValue": [
+                  {
+                    "value": 'Vital, Ḥayyim ben Joseph',
+                    "type": 'name'
+                  },
+                  {
+                    "value": '1542 or 1543-1620',
+                    "type": 'life dates'
+                  }
+                ],
+                "type": 'name'
+              }
+            ],
+            "type": 'uniform'
           }
         ]
       end
@@ -613,7 +699,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
                     "value": 'Mishnah berurah in Hebrew characters',
                     "type": 'title'
                   },
-
                   {
                     "structuredValue": [
                       {

--- a/spec/services/cocina/to_fedora/descriptive/title_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/title_spec.rb
@@ -275,6 +275,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Title do
       end
     end
 
+    # Example 18
     context 'when it is a multilingual uniform title' do
       let(:titles) do
         [
@@ -883,6 +884,111 @@ RSpec.describe Cocina::ToFedora::Descriptive::Title do
           </mods>
         XML
       end
+    end
+  end
+
+  # Example 21
+  context 'when it is a complex multilingual title' do
+    let(:titles) do
+      [
+        Cocina::Models::Title.new(
+          "structuredValue": [
+            {
+              "structuredValue": [
+                {
+                  "value": 'Vital, Ḥayyim ben Joseph',
+                  "type": 'name'
+                },
+                {
+                  "value": '1542 or 1543-1620',
+                  "type": 'life dates'
+                }
+              ],
+              "type": 'name'
+            },
+            {
+              "value": 'Shaʻare ha-ḳedushah',
+              "type": 'title'
+            }
+          ],
+          "type": 'uniform'
+        ),
+        Cocina::Models::Title.new(
+          "parallelValue": [
+            {
+              "structuredValue": [
+                {
+                  "value": 'Sefer Shaʻare ha-ḳedushah in Hebrew',
+                  "type": 'main title'
+                },
+                {
+                  "value": 'zeh sefer le-yosher ha-adam la-ʻavodat borʼo in Hebrew',
+                  "type": 'subtitle'
+                }
+              ]
+            },
+            {
+              "structuredValue": [
+                {
+                  "value": 'Sefer Shaʻare ha-ḳedushah',
+                  "type": 'main title'
+                },
+                {
+                  "value": 'zeh sefer le-yosher ha-adam la-ʻavodat borʼo',
+                  "type": 'subtitle'
+                }
+              ]
+            }
+          ]
+        )
+      ]
+    end
+
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          "name": [
+            {
+              "structuredValue": [
+                {
+                  "value": 'Vital, Ḥayyim ben Joseph',
+                  "type": 'name'
+                },
+                {
+                  "value": '1542 or 1543-1620',
+                  "type": 'life dates'
+                }
+              ]
+            }
+          ],
+          "type": 'person',
+          "status": 'primary'
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <titleInfo type="uniform" nameTitleGroup="1">
+            <title>Shaʻare ha-ḳedushah</title>
+          </titleInfo>
+          <titleInfo altRepGroup="1">
+            <title>Sefer Shaʻare ha-ḳedushah in Hebrew</title>
+            <subTitle>zeh sefer le-yosher ha-adam la-ʻavodat borʼo in Hebrew</subTitle>
+          </titleInfo>
+          <titleInfo altRepGroup="1">
+            <title>Sefer Shaʻare ha-ḳedushah</title>
+            <subTitle>zeh sefer le-yosher ha-adam la-ʻavodat borʼo</subTitle>
+          </titleInfo>
+          <name type="personal" usage="primary" nameTitleGroup="1">
+            <namePart>Vital, Ḥayyim ben Joseph</namePart>
+            <namePart type="date">1542 or 1543-1620</namePart>
+          </name>
+        </mods>
+      XML
     end
   end
 end


### PR DESCRIPTION
closes #1738

## Why was this change made?
Because normal multilingual titles aren't complex enough.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


