### PR TITLE
Normalize originInfo with publisher and copyrightDate.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -500,16 +500,17 @@ module Cocina
 
     def normalize_origin_info_split
       # Split a single originInfo into multiple.
-      split_origin_info('copyrightDate', 'copyright notice')
-      split_origin_info('dateCaptured', 'capture')
+      split_origin_info('dateIssued', 'copyrightDate', 'copyright notice')
+      split_origin_info('dateIssued', 'dateCaptured', 'capture')
+      split_origin_info('copyrightDate', 'publisher', 'publication')
     end
 
-    def split_origin_info(split_node_name, event_type)
-      ng_xml.root.xpath("//mods:originInfo[mods:dateIssued and mods:#{split_node_name}]", mods: MODS_NS).each do |origin_info_node|
+    def split_origin_info(split_node_name1, split_node_name2, event_type)
+      ng_xml.root.xpath("//mods:originInfo[mods:#{split_node_name1} and mods:#{split_node_name2}]", mods: MODS_NS).each do |origin_info_node|
         new_origin_info_node = Nokogiri::XML::Node.new('originInfo', Nokogiri::XML(nil))
         new_origin_info_node['eventType'] = event_type
         origin_info_node.parent << new_origin_info_node
-        split_nodes = origin_info_node.xpath("mods:#{split_node_name}", mods: MODS_NS)
+        split_nodes = origin_info_node.xpath("mods:#{split_node_name2}", mods: MODS_NS)
         split_nodes.each do |split_node|
           split_node.remove
           new_origin_info_node << split_node

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -1729,6 +1729,31 @@ RSpec.describe Cocina::ModsNormalizer do
     end
   end
 
+  context 'when normalizing originInfos with copyright date and publisher' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{mods_attributes}>
+          <originInfo eventType="copyright notice">
+            <publisher>Saturn Pictures</publisher>
+            <copyrightDate>1971</copyrightDate>
+          </originInfo>
+      XML
+    end
+
+    it 'moves publisher into its own originInfo' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{mods_attributes}>
+          <originInfo eventType="copyright notice">
+            <copyrightDate>1971</copyrightDate>
+          </originInfo>
+          <originInfo eventType="publication">
+            <publisher>Saturn Pictures</publisher>
+          </originInfo>
+        </mods>
+      XML
+    end
+  end
+
   context 'when normalizing cartographic coordinates' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML


### PR DESCRIPTION
closes #1754

## Why was this change made?
Normalize originInfo with publisher and copyrightDate.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


