### PR TITLE
mapping specs for subject classification aligned with cocina-desc-md specs

### DIFF
--- a/spec/services/cocina/from_fedora/descriptive/subject_classification_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_classification_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# numbered examples here from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_classification.txt
 RSpec.describe Cocina::FromFedora::Descriptive::Subject do
   subject(:build) { described_class.build(resource_element: ng_xml.root) }
 
@@ -27,6 +28,20 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
           "source": {
             "code": 'lcc'
           }
+        }
+      ]
+    end
+  end
+
+  # missing example ticketed as https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/294
+  context 'when given a classification without authority' do
+    let(:xml) { '<classification>G9801.S12 2015 .Z3</classification>' }
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'classification',
+          "value": 'G9801.S12 2015 .Z3'
         }
       ]
     end
@@ -68,6 +83,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     end
   end
 
+  # 4. Multiple classifications
   context 'when given multiple classifications' do
     let(:xml) do
       <<~XML
@@ -94,7 +110,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
             "version": '12th edition'
           }
         }
-
       ]
     end
   end

--- a/spec/services/cocina/to_fedora/descriptive/subject_classification_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_classification_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# numbered examples here from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_classification.txt
 RSpec.describe Cocina::ToFedora::Descriptive::Subject do
   subject(:xml) { writer.to_xml }
 
@@ -17,10 +18,10 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
     end
   end
 
-  context 'when classification is nil' do
+  context 'when nil' do
     let(:subjects) { nil }
 
-    it 'builds the xml' do
+    it 'builds empty MODS xml' do
       expect(xml).to be_equivalent_to <<~XML
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
@@ -54,6 +55,31 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <classification authority="lcc">G9801.S12 2015 .Z3</classification>
+        </mods>
+      XML
+    end
+  end
+
+  # missing example ticketed as https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/294
+  context 'when given a classification without authority' do
+    let(:subjects) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          {
+            "type": 'classification',
+            "value": 'G9801.S12 2015 .Z3'
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <classification>G9801.S12 2015 .Z3</classification>
         </mods>
       XML
     end
@@ -117,13 +143,28 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
     end
   end
 
-  context 'when given a classification without authority' do
+  # 4. Multiple classifications
+  context 'when given multiple classifications' do
     let(:subjects) do
       [
         Cocina::Models::DescriptiveValue.new(
           {
             "type": 'classification',
-            "value": 'G9801.S12 2015 .Z3'
+            "value": '683',
+            "source": {
+              "code": 'ddc',
+              "version": '11th edition'
+            }
+          }
+        ),
+        Cocina::Models::DescriptiveValue.new(
+          {
+            "type": 'classification',
+            "value": '684',
+            "source": {
+              "code": 'ddc',
+              "version": '12th edition'
+            }
           }
         )
       ]
@@ -135,7 +176,8 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <classification>G9801.S12 2015 .Z3</classification>
+          <classification authority="ddc" edition="11">683</classification>
+          <classification authority="ddc" edition="12">684</classification>
         </mods>
       XML
     end


### PR DESCRIPTION
## Why was this change made?

To make it easy for dsa rspec code to be kept in synch with cocina-desc-md mapping specifications


## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?



