### PR TITLE
mapping specs for note targetAudience aligned with cocina-desc-md specs

### DIFF
--- a/spec/services/cocina/from_fedora/descriptive/notes_target_audience_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/notes_target_audience_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# numbered examples here from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_targetAudience.txt
 RSpec.describe Cocina::FromFedora::Descriptive::Notes do
   subject(:build) { described_class.build(resource_element: ng_xml.root) }
 
@@ -15,7 +16,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Notes do
     XML
   end
 
-  # Example 1
+  # Example 1. Target audience with authority
   context 'with authority' do
     let(:xml) do
       <<~XML
@@ -36,7 +37,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Notes do
     end
   end
 
-  # Example 2
+  # Example 2. Target audience without authority
   context 'without authority' do
     let(:xml) do
       <<~XML

--- a/spec/services/cocina/to_fedora/descriptive/note_target_audience_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/note_target_audience_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# numbered examples here from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_targetAudience.txt
 RSpec.describe Cocina::ToFedora::Descriptive::Note do
   subject(:xml) { writer.to_xml }
 
@@ -16,6 +17,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Note do
     end
   end
 
+  # Example 1. Target audience with authority
   context 'with authority' do
     let(:notes) do
       [
@@ -40,6 +42,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Note do
     end
   end
 
+  # Example 2. Target audience without authority
   context 'without authority' do
     let(:notes) do
       [


### PR DESCRIPTION
## Why was this change made?

To make it easy for dsa rspec code to be kept in synch with cocina-desc-md mapping specifications

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?



