### PR TITLE
Fix mapping and normalization of transliterated publisher.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -30,6 +30,7 @@ module Cocina
       normalize_origin_info_place_term_type
       normalize_origin_info_developed_date
       normalize_origin_info_date
+      normalize_origin_info_publisher
       normalize_parallel_origin_info
       normalize_origin_info_lang_script
       normalize_subject_authority
@@ -535,6 +536,21 @@ module Cocina
                         dc: 'http://purl.org/dc/elements/1.1/',
                         rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#').each do |coverage_node|
         coverage_node.delete('resource')
+      end
+    end
+
+    def normalize_origin_info_publisher
+      ng_xml.root.xpath('//mods:publisher[@lang]', mods: MODS_NS).each do |publisher_node|
+        publisher_node.parent['lang'] = publisher_node['lang']
+        publisher_node.delete('lang')
+      end
+      ng_xml.root.xpath('//mods:publisher[@script]', mods: MODS_NS).each do |publisher_node|
+        publisher_node.parent['script'] = publisher_node['script']
+        publisher_node.delete('script')
+      end
+      ng_xml.root.xpath('//mods:publisher[@transliteration]', mods: MODS_NS).each do |publisher_node|
+        publisher_node.parent['transliteration'] = publisher_node['transliteration']
+        publisher_node.delete('transliteration')
       end
     end
   end

--- a/app/services/cocina/to_fedora/descriptive/event.rb
+++ b/app/services/cocina/to_fedora/descriptive/event.rb
@@ -63,12 +63,15 @@ module Cocina
         end
 
         def write_basic(event, event_type)
+          names = Array(event.contributor).map { |contributor| contributor.name.first }
+          name = names.first
           attributes = {
             displayLabel: event.displayLabel,
-            eventType: event_type
+            eventType: event_type,
+            lang: name&.valueLanguage&.code,
+            script: name&.valueLanguage&.valueScript&.code,
+            transliteration: name&.standard&.value
           }.compact
-
-          names = Array(event.contributor).map { |contributor| contributor.name.first }
 
           write_event(event_type, event.date, event.location, names, event.note, attributes)
         end
@@ -178,7 +181,7 @@ module Cocina
               write_location(loc)
             end
             Array(names).each do |name|
-              write_name(name, is_parallel: is_parallel)
+              xml.publisher name.value
             end
             Array(notes).each do |note|
               write_note(note)
@@ -191,21 +194,6 @@ module Cocina
           attributes = {}
           attributes[:authority] = note.source.code if note&.source&.code
           xml.send(note.type || 'edition', note.value, attributes)
-        end
-
-        def write_name(name, is_parallel: false)
-          attributes = if is_parallel
-                         {}
-                       else
-                         {
-                           lang: name.valueLanguage&.code,
-                           script: name.valueLanguage&.valueScript&.code,
-                           transliteration: name.standard&.value
-
-                         }.compact
-                       end
-
-          xml.publisher(name.value, attributes)
         end
 
         def write_location(location)

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -2408,7 +2408,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
             }
           ]
         }
-
       ]
     end
   end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -1941,4 +1941,26 @@ RSpec.describe Cocina::ModsNormalizer do
       XML
     end
   end
+
+  context 'when normalizing publisher' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{mods_attributes}>
+          <originInfo>
+            <publisher lang="rus" script="Latn" transliteration="ALA-LC Romanization Tables">Institut russkoĭ literatury (Pushkinskiĭ Dom)</publisher>
+          </originInfo>
+        </mods>
+      XML
+    end
+
+    it 'moves lang, script, and transliteration to originInfo' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{mods_attributes}>
+          <originInfo eventType="publication" lang="rus" script="Latn" transliteration="ALA-LC Romanization Tables">
+            <publisher>Institut russkoĭ literatury (Pushkinskiĭ Dom)</publisher>
+          </originInfo>
+        </mods>
+      XML
+    end
+  end
 end

--- a/spec/services/cocina/to_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/event_spec.rb
@@ -970,8 +970,8 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication">
-            <publisher lang="rus" script="Latn" transliteration="ALA-LC Romanization Tables">Institut russkoĭ literatury (Pushkinskiĭ Dom)</publisher>
+          <originInfo eventType="publication" lang="rus" script="Latn" transliteration="ALA-LC Romanization Tables">
+            <publisher>Institut russkoĭ literatury (Pushkinskiĭ Dom)</publisher>
           </originInfo>
         </mods>
       XML
@@ -1026,8 +1026,8 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication">
-            <publisher lang="rus" script="Cyrl">СФУ</publisher>
+          <originInfo eventType="publication" lang="rus" script="Cyrl">
+            <publisher>СФУ</publisher>
           </originInfo>
         </mods>
       XML


### PR DESCRIPTION
closes #1784

## Why was this change made?
Fix mapping and normalization of transliterated publisher.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


