### PR TITLE
to_fedora mapping specs get shared_example

### DIFF
--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -1,40 +1,24 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'support/mods_mapping_spec_helper'
 
-# numbered examples from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt
+# numbered examples refer to https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_name.txt
 RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
-  subject(:xml) { writer.to_xml }
-
+  # see spec/support/mods_mapping_spec_helper.rb for how writer is used in shared examples
   let(:writer) do
     Nokogiri::XML::Builder.new do |xml|
-      xml.mods('xmlns' => 'http://www.loc.gov/mods/v3',
-               'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-               'version' => '3.6',
-               'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd') do
+      xml.mods(mods_attributes) do
         described_class.write(xml: xml, contributors: contributors, titles: titles, id_generator: Cocina::ToFedora::Descriptive::IdGenerator.new)
       end
     end
   end
-  let(:mods_element_open) do
-    <<~XML
-      <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="http://www.loc.gov/mods/v3" version="3.6"
-        xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-    XML
-  end
-  let(:mods_element_close) { '</mods>' }
   let(:titles) { nil }
 
   context 'when contributors is nil' do
     let(:contributors) { nil }
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', '' # empty MODS
   end
 
   # 1. Personal name
@@ -53,15 +37,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name type="personal" usage="primary">
-            <namePart>Dunnett, Dorothy</namePart>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name type="personal" usage="primary">
+        <namePart>Dunnett, Dorothy</namePart>
+      </name>
+    XML
   end
 
   # 2. Corporate name
@@ -80,15 +60,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name type="corporate" usage="primary">
-            <namePart>Dorothy L. Sayers Society</namePart>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name type="corporate" usage="primary">
+        <namePart>Dorothy L. Sayers Society</namePart>
+      </name>
+    XML
   end
 
   # 3. Family name
@@ -107,15 +83,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name type="family" usage="primary">
-            <namePart>James family</namePart>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name type="family" usage="primary">
+        <namePart>James family</namePart>
+      </name>
+    XML
   end
 
   # 4. Conference name
@@ -134,15 +106,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name type="conference" usage="primary">
-            <namePart>Mystery Science Theater ConventioCon Expo Fest-o-rama</namePart>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name type="conference" usage="primary">
+        <namePart>Mystery Science Theater ConventioCon Expo Fest-o-rama</namePart>
+      </name>
+    XML
   end
 
   # FIXME: this example should be added to cdm (?) - see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/298
@@ -198,18 +166,14 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name type="corporate" usage="primary" lang="jpn" script="Jpan" altRepGroup="1">
-            <namePart>レアメタル資源再生技術研究会</namePart>
-          </name>
-          <name type="corporate" lang="jpn" script="Latn" transliteration="ALA-LC Romanization Tables" altRepGroup="1">
-            <namePart>Rea Metaru Shigen Saisei Gijutsu Kenky&#x16B;kai</namePart>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name type="corporate" usage="primary" lang="jpn" script="Jpan" altRepGroup="1">
+        <namePart>レアメタル資源再生技術研究会</namePart>
+      </name>
+      <name type="corporate" lang="jpn" script="Latn" transliteration="ALA-LC Romanization Tables" altRepGroup="1">
+        <namePart>Rea Metaru Shigen Saisei Gijutsu Kenky&#x16B;kai</namePart>
+      </name>
+    XML
   end
 
   # FIXME: this example should be added to cdm (?) - see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/298
@@ -227,15 +191,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name usage="primary">
-            <namePart>Dunnett, Dorothy</namePart>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name usage="primary">
+        <namePart>Dunnett, Dorothy</namePart>
+      </name>
+    XML
   end
 
   # 5. Name with additional subelements
@@ -291,22 +251,18 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name type="personal" usage="primary">
-            <namePart type="termsOfAddress">Dr.</namePart>
-            <namePart type="given">Terry</namePart>
-            <namePart type="family">Castle</namePart>
-            <namePart type="date">1953-</namePart>
-            <affiliation>Stanford University</affiliation>
-            <nameIdentifier type="wikidata">https://www.wikidata.org/wiki/Q7704207</nameIdentifier>
-            <displayForm>Castle, Terry</displayForm>
-            <description>Professor of English</description>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name type="personal" usage="primary">
+        <namePart type="termsOfAddress">Dr.</namePart>
+        <namePart type="given">Terry</namePart>
+        <namePart type="family">Castle</namePart>
+        <namePart type="date">1953-</namePart>
+        <affiliation>Stanford University</affiliation>
+        <nameIdentifier type="wikidata">https://www.wikidata.org/wiki/Q7704207</nameIdentifier>
+        <displayForm>Castle, Terry</displayForm>
+        <description>Professor of English</description>
+      </name>
+    XML
   end
 
   # FIXME: this example should be added to cdm (?) - see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/298
@@ -331,16 +287,12 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name type="corporate">
-            <namePart>United States</namePart>
-            <namePart>Office of Foreign Investment in the United States.</namePart>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name type="corporate">
+        <namePart>United States</namePart>
+        <namePart>Office of Foreign Investment in the United States.</namePart>
+      </name>
+    XML
   end
 
   # 6. Name with ordinal
@@ -376,19 +328,15 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
         ]
       end
 
-      it 'builds the xml' do
-        expect(xml).to be_equivalent_to <<~XML
-          #{mods_element_open}
-            <name type="personal" usage="primary">
-              <namePart>Dunnett, Dorothy</namePart>
-              <role>
-                <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-                <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
-              </role>
-            </name>
-          #{mods_element_close}
-        XML
-      end
+      it_behaves_like 'cocina to MODS', <<~XML
+        <name type="personal" usage="primary">
+          <namePart>Dunnett, Dorothy</namePart>
+          <role>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+          </role>
+        </name>
+      XML
     end
 
     # 7b. Role text only
@@ -418,18 +366,14 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
         ]
       end
 
-      it 'builds the xml' do
-        expect(xml).to be_equivalent_to <<~XML
-          #{mods_element_open}
-            <name type="personal" usage="primary">
-              <namePart>Dunnett, Dorothy</namePart>
-              <role>
-                <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-              </role>
-            </name>
-          #{mods_element_close}
-        XML
-      end
+      it_behaves_like 'cocina to MODS', <<~XML
+        <name type="personal" usage="primary">
+          <namePart>Dunnett, Dorothy</namePart>
+          <role>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+        </name>
+      XML
     end
 
     # FIXME: this example should be added to cdm - see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/298
@@ -452,18 +396,14 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
         ]
       end
 
-      it 'builds the xml' do
-        expect(xml).to be_equivalent_to <<~XML
-          #{mods_element_open}
-            <name type="personal">
-              <namePart>Dunnett, Dorothy</namePart>
-              <role>
-                <roleTerm type="text">Author</roleTerm>
-              </role>
-            </name>
-          #{mods_element_close}
-        XML
-      end
+      it_behaves_like 'cocina to MODS', <<~XML
+        <name type="personal">
+          <namePart>Dunnett, Dorothy</namePart>
+          <role>
+            <roleTerm type="text">Author</roleTerm>
+          </role>
+        </name>
+      XML
     end
 
     # 7c. Role code only
@@ -493,18 +433,14 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
         ]
       end
 
-      it 'builds the xml' do
-        expect(xml).to be_equivalent_to <<~XML
-          #{mods_element_open}
-            <name type="personal" usage="primary">
-              <namePart>Dunnett, Dorothy</namePart>
-              <role>
-                <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
-              </role>
-            </name>
-          #{mods_element_close}
-        XML
-      end
+      it_behaves_like 'cocina to MODS', <<~XML
+        <name type="personal" usage="primary">
+          <namePart>Dunnett, Dorothy</namePart>
+          <role>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+          </role>
+        </name>
+      XML
     end
 
     # 7d. Role with valueURI as the only authority attribute
@@ -530,19 +466,15 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
         ]
       end
 
-      it 'builds the xml' do
-        expect(xml).to be_equivalent_to <<~XML
-          #{mods_element_open}
-            <name type="personal" usage="primary">
-              <namePart>Dunnett, Dorothy</namePart>
-              <role>
-                <roleTerm type="text" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-                <roleTerm type="code" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
-              </role>
-            </name>
-          #{mods_element_close}
-        XML
-      end
+      it_behaves_like 'cocina to MODS', <<~XML
+        <name type="personal" usage="primary">
+          <namePart>Dunnett, Dorothy</namePart>
+          <role>
+            <roleTerm type="text" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+            <roleTerm type="code" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+          </role>
+        </name>
+      XML
     end
 
     # 7e. Role with authority as the only authority attribute
@@ -572,19 +504,15 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
         ]
       end
 
-      it 'builds the xml' do
-        expect(xml).to be_equivalent_to <<~XML
-          #{mods_element_open}
-            <name type="personal" usage="primary">
-              <namePart>Dunnett, Dorothy</namePart>
-              <role>
-                <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/">author</roleTerm>
-                <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/">aut</roleTerm>
-              </role>
-            </name>
-          #{mods_element_close}
-        XML
-      end
+      it_behaves_like 'cocina to MODS', <<~XML
+        <name type="personal" usage="primary">
+          <namePart>Dunnett, Dorothy</namePart>
+          <role>
+            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/">author</roleTerm>
+            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/">aut</roleTerm>
+          </role>
+        </name>
+      XML
     end
 
     # 7f, 7g: cocina model for contributor is empty :-)
@@ -598,12 +526,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
         ]
       end
 
-      it 'builds the (empty) xml' do
-        expect(xml).to be_equivalent_to <<~XML
-          #{mods_element_open}
-          #{mods_element_close}
-        XML
-      end
+      it_behaves_like 'cocina to MODS', '' # empty MODS
     end
 
     context 'with empty name value and empty role value' do
@@ -625,16 +548,12 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
         ]
       end
 
-      it 'builds empty namePart and role elements in the xml' do
-        expect(xml).to be_equivalent_to <<~XML
-          #{mods_element_open}
-            <name>
-              <namePart/>
-              <role/>
-            </name>
-          #{mods_element_close}
-        XML
-      end
+      it_behaves_like 'cocina to MODS', <<~XML
+        <name>
+          <namePart/>
+          <role/>
+        </name>
+      XML
     end
 
     context 'with empty name value and missing role' do
@@ -658,16 +577,12 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
         ]
       end
 
-      it 'builds empty namePart and role elements in the xml' do
-        expect(xml).to be_equivalent_to <<~XML
-          #{mods_element_open}
-            <name>
-              <namePart/>
-              <role/>
-            </name>
-          #{mods_element_close}
-        XML
-      end
+      it_behaves_like 'cocina to MODS', <<~XML
+        <name>
+          <namePart/>
+          <role/>
+        </name>
+      XML
     end
 
     # FIXME: this example should be added to cdm - see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/298
@@ -698,21 +613,17 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
         ]
       end
 
-      it 'builds the xml' do
-        expect(xml).to be_equivalent_to <<~XML
-          #{mods_element_open}
-            <name type="personal" usage="primary">
-              <namePart>Dunnett, Dorothy</namePart>
-                <role>
-                  <roleTerm type="text">primary advisor</roleTerm>
-                </role>
-                <role>
-                  <roleTerm authority="marcrelator" type="code" authorityURI="http://id.loc.gov/vocabulary/relators/">ths</roleTerm>
-                </role>
-            </name>
-          #{mods_element_close}
-        XML
-      end
+      it_behaves_like 'cocina to MODS', <<~XML
+        <name type="personal" usage="primary">
+          <namePart>Dunnett, Dorothy</namePart>
+            <role>
+              <roleTerm type="text">primary advisor</roleTerm>
+            </role>
+            <role>
+              <roleTerm authority="marcrelator" type="code" authorityURI="http://id.loc.gov/vocabulary/relators/">ths</roleTerm>
+            </role>
+        </name>
+      XML
     end
   end
 
@@ -737,15 +648,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name type="personal" usage="primary" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79046044">
-            <namePart>Sayers, Dorothy L. (Dorothy Leigh), 1893-1957</namePart>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name type="personal" usage="primary" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79046044">
+        <namePart>Sayers, Dorothy L. (Dorothy Leigh), 1893-1957</namePart>
+      </name>
+    XML
   end
 
   context 'with authority code only' do
@@ -766,15 +673,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name type="personal" usage="primary" authority="naf">
-            <namePart>Sayers, Dorothy L. (Dorothy Leigh), 1893-1957</namePart>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name type="personal" usage="primary" authority="naf">
+        <namePart>Sayers, Dorothy L. (Dorothy Leigh), 1893-1957</namePart>
+      </name>
+    XML
   end
 
   # 9. Multiple names, one primary
@@ -811,24 +714,20 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name type="personal" usage="primary">
-            <namePart>Bulgakov, Mikhail</namePart>
-            <role>
-              <roleTerm type="text">author</roleTerm>
-            </role>
-          </name>
-          <name type="personal">
-            <namePart>Burgin, Diana Lewis</namePart>
-            <role>
-              <roleTerm type="text">translator</roleTerm>
-            </role>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name type="personal" usage="primary">
+        <namePart>Bulgakov, Mikhail</namePart>
+        <role>
+          <roleTerm type="text">author</roleTerm>
+        </role>
+      </name>
+      <name type="personal">
+        <namePart>Burgin, Diana Lewis</namePart>
+        <role>
+          <roleTerm type="text">translator</roleTerm>
+        </role>
+      </name>
+    XML
   end
 
   # FIXME: this example should be added to cdm ??? - see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/298
@@ -868,20 +767,16 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name type="personal" usage="primary">
-            <namePart>Sarmiento, Domingo Faustino</namePart>
-            <namePart type="date">1811-1888</namePart>
-          </name>
-          <name type="personal">
-            <namePart>Rojas, Ricardo</namePart>
-            <namePart type="date">1882-1957</namePart>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name type="personal" usage="primary">
+        <namePart>Sarmiento, Domingo Faustino</namePart>
+        <namePart type="date">1811-1888</namePart>
+      </name>
+      <name type="personal">
+        <namePart>Rojas, Ricardo</namePart>
+        <namePart type="date">1882-1957</namePart>
+      </name>
+    XML
   end
 
   # 10. Multiple names, no primary
@@ -917,24 +812,20 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name type="personal">
-            <namePart>Gaiman, Neil</namePart>
-            <role>
-              <roleTerm type="text">author</roleTerm>
-            </role>
-          </name>
-          <name type="personal">
-            <namePart>Pratchett, Terry</namePart>
-            <role>
-              <roleTerm type="text">author</roleTerm>
-            </role>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name type="personal">
+        <namePart>Gaiman, Neil</namePart>
+        <role>
+          <roleTerm type="text">author</roleTerm>
+        </role>
+      </name>
+      <name type="personal">
+        <namePart>Pratchett, Terry</namePart>
+        <role>
+          <roleTerm type="text">author</roleTerm>
+        </role>
+      </name>
+    XML
   end
 
   context 'with multiple names, no primary, no roles' do
@@ -966,19 +857,15 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name type="corporate">
-            <namePart>Hawaii International Services Agency</namePart>
-          </name>
-          <name type="corporate">
-            <namePart>United States</namePart>
-            <namePart>Office of Foreign Investment in the United States.</namePart>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name type="corporate">
+        <namePart>Hawaii International Services Agency</namePart>
+      </name>
+      <name type="corporate">
+        <namePart>United States</namePart>
+        <namePart>Office of Foreign Investment in the United States.</namePart>
+      </name>
+    XML
   end
 
   # almost mods_to_cocina_titleInfo.txt example 6. Uniform title with authority
@@ -1041,15 +928,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name type="personal">
-            <namePart>Peele, Gregory</namePart>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name type="personal">
+        <namePart>Peele, Gregory</namePart>
+      </name>
+    XML
   end
 
   # 11. Single name, no primary (pseudonym)
@@ -1150,24 +1033,20 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        #{mods_element_open}
-          <name usage="primary" type="personal" script="Cyrl" altRepGroup="1" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/no2015139297">
-            <namePart>&#x411;&#x443;&#x43B;&#x433;&#x430;&#x43A;&#x43E;&#x432;, &#x41C;&#x438;&#x445;&#x430;&#x438;&#x43B; &#x410;&#x444;&#x430;&#x43D;&#x430;&#x441;&#x44C;&#x435;&#x432;&#x438;&#x447;</namePart>
-          </name>
-          <name type="personal" script="Latn" transliteration="ALA-LC Romanization Tables" altRepGroup="1">
-            <namePart>Bulgakov, Mikhail Afanas&#x2B9;evich</namePart>
-          </name>
-          <name type="personal" script="Cyrl" altRepGroup="2">
-            <namePart>&#x41E;&#x43B;&#x435;&#x448;&#x430;, &#x42E;&#x440;&#x438;&#x439; &#x41A;&#x430;&#x440;&#x43B;&#x43E;&#x432;&#x438;&#x447;</namePart>
-          </name>
-          <name type="personal" script="Latn" transliteration="ALA-LC Romanization Tables" altRepGroup="2">
-            <namePart>Olesha, I&#xFE20;U&#xFE21;ri&#x12D; Karlovich</namePart>
-          </name>
-        #{mods_element_close}
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name usage="primary" type="personal" script="Cyrl" altRepGroup="1" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/no2015139297">
+        <namePart>&#x411;&#x443;&#x43B;&#x433;&#x430;&#x43A;&#x43E;&#x432;, &#x41C;&#x438;&#x445;&#x430;&#x438;&#x43B; &#x410;&#x444;&#x430;&#x43D;&#x430;&#x441;&#x44C;&#x435;&#x432;&#x438;&#x447;</namePart>
+      </name>
+      <name type="personal" script="Latn" transliteration="ALA-LC Romanization Tables" altRepGroup="1">
+        <namePart>Bulgakov, Mikhail Afanas&#x2B9;evich</namePart>
+      </name>
+      <name type="personal" script="Cyrl" altRepGroup="2">
+        <namePart>&#x41E;&#x43B;&#x435;&#x448;&#x430;, &#x42E;&#x440;&#x438;&#x439; &#x41A;&#x430;&#x440;&#x43B;&#x43E;&#x432;&#x438;&#x447;</namePart>
+      </name>
+      <name type="personal" script="Latn" transliteration="ALA-LC Romanization Tables" altRepGroup="2">
+        <namePart>Olesha, I&#xFE20;U&#xFE21;ri&#x12D; Karlovich</namePart>
+      </name>
+    XML
   end
 
   # 13. Transliterated name with parts (name as structuredValue) - reference example only

--- a/spec/services/cocina/to_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/event_spec.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'support/mods_mapping_spec_helper'
 
+# numbered example comments refer to
+# from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt
 RSpec.describe Cocina::ToFedora::Descriptive::Event do
-  # mapping specification examples
-  # from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt
-
-  subject(:xml) { writer.to_xml }
-
+  # see spec/support/mods_mapping_spec_helper.rb for how writer is used in shared examples
   let(:writer) do
     Nokogiri::XML::Builder.new do |xml|
-      xml.mods('xmlns' => 'http://www.loc.gov/mods/v3',
-               'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-               'version' => '3.6',
-               'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd') do
+      xml.mods(mods_attributes) do
         described_class.write(xml: xml, events: events, id_generator: Cocina::ToFedora::Descriptive::IdGenerator.new)
       end
     end
@@ -22,17 +18,10 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
   context 'when events is nil' do
     let(:events) { nil }
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', '' # empty mods
   end
 
-  # example 1 from mods_to_cocina_originInfo.txt
+  # 1. Single dateCreated
   context 'when it has a single dateCreated' do
     let(:events) do
       [
@@ -47,20 +36,14 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="production">
-            <dateCreated>1980</dateCreated>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="production">
+        <dateCreated>1980</dateCreated>
+      </originInfo>
+    XML
   end
 
-  # example 2 from mods_to_cocina_originInfo.txt
+  # 2. Single dateIssued (with encoding)
   context 'when it has a single dateIssued (with encoding)' do
     let(:events) do
       [
@@ -80,20 +63,15 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication">
-            <dateIssued encoding="w3cdtf">1928</dateIssued>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="publication">
+        <dateIssued encoding="w3cdtf">1928</dateIssued>
+      </originInfo>
+    XML
   end
 
-  # example 3 from mods_to_cocina_originInfo.txt
+  # 3. Single copyrightDate
+  # FIXME: discrepancy - eventType "copyright" vs "copyright notice"
   context 'when it has a single copyrightDate' do
     let(:events) do
       [
@@ -110,20 +88,14 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="copyright notice">
-            <copyrightDate>1930</copyrightDate>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="copyright notice">
+        <copyrightDate>1930</copyrightDate>
+      </originInfo>
+    XML
   end
 
-  # example 4 from mods_to_cocina_originInfo.txt
+  # 4. Single dateCaptured (ISO 8601 encoding, keyDate)
   context 'when it has a single dateCaptured (ISO 8601 encoding, keyDate)' do
     let(:events) do
       [
@@ -144,17 +116,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="capture">
-            <dateCaptured keyDate="yes" encoding="iso8601">20131012231249</dateCaptured>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="capture">
+        <dateCaptured keyDate="yes" encoding="iso8601">20131012231249</dateCaptured>
+      </originInfo>
+    XML
   end
 
   # example 5 from mods_to_cocina_originInfo.txt
@@ -180,17 +146,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         ]
       end
 
-      it 'builds the xml' do
-        expect(xml).to be_equivalent_to <<~XML
-          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns="http://www.loc.gov/mods/v3" version="3.6"
-            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-            <originInfo>
-              <dateOther type="Islamic">1441 AH</dateOther>
-            </originInfo>
-          </mods>
-        XML
-      end
+      it_behaves_like 'cocina to MODS', <<~XML
+        <originInfo>
+          <dateOther type="Islamic">1441 AH</dateOther>
+        </originInfo>
+      XML
     end
 
     describe 'with eventType="acquisition"' do
@@ -214,17 +174,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         ]
       end
 
-      it 'builds the xml' do
-        expect(xml).to be_equivalent_to <<~XML
-          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns="http://www.loc.gov/mods/v3" version="3.6"
-            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-            <originInfo eventType="acquisition">
-              <dateOther keyDate="yes" encoding="w3cdtf">1970-11-23</dateOther>
-            </originInfo>
-          </mods>
-        XML
-      end
+      it_behaves_like 'cocina to MODS', <<~XML
+        <originInfo eventType="acquisition">
+          <dateOther keyDate="yes" encoding="w3cdtf">1970-11-23</dateOther>
+        </originInfo>
+      XML
     end
 
     describe 'without note, with displayLabel' do
@@ -247,17 +201,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         ]
       end
 
-      it 'builds the xml' do
-        expect(xml).to be_equivalent_to <<~XML
-          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns="http://www.loc.gov/mods/v3" version="3.6"
-            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-            <originInfo displayLabel="Acquisition date">
-              <dateOther keyDate="yes" encoding="w3cdtf">1970-11-23</dateOther>
-            </originInfo>
-          </mods>
-        XML
-      end
+      it_behaves_like 'cocina to MODS', <<~XML
+        <originInfo displayLabel="Acquisition date">
+          <dateOther keyDate="yes" encoding="w3cdtf">1970-11-23</dateOther>
+        </originInfo>
+      XML
     end
   end
 
@@ -293,18 +241,12 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="production">
-            <dateCreated keyDate="yes" point="start">1920</dateCreated>
-            <dateCreated point="end">1925</dateCreated>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="production">
+        <dateCreated keyDate="yes" point="start">1920</dateCreated>
+        <dateCreated point="end">1925</dateCreated>
+      </originInfo>
+    XML
   end
 
   # example 7 from mods_to_cocina_originInfo.txt
@@ -325,17 +267,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="production">
-            <dateCreated qualifier="approximate">1940</dateCreated>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="production">
+        <dateCreated qualifier="approximate">1940</dateCreated>
+      </originInfo>
+    XML
   end
 
   # example 8 from mods_to_cocina_originInfo.txt
@@ -367,18 +303,12 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="production">
-            <dateCreated keyDate="yes" point="start" qualifier="approximate">1940</dateCreated>
-            <dateCreated point="end" qualifier="approximate">1945</dateCreated>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="production">
+        <dateCreated keyDate="yes" point="start" qualifier="approximate">1940</dateCreated>
+        <dateCreated point="end" qualifier="approximate">1945</dateCreated>
+      </originInfo>
+    XML
   end
 
   # example 9 from mods_to_cocina_originInfo.txt
@@ -409,17 +339,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="production">
-            <dateCreated qualifier="inferred">1940</dateCreated>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="production">
+        <dateCreated qualifier="inferred">1940</dateCreated>
+      </originInfo>
+    XML
   end
 
   # example 12 from mods_to_cocina_originInfo.txt
@@ -440,17 +364,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="production">
-            <dateCreated qualifier="questionable">1940</dateCreated>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="production">
+        <dateCreated qualifier="questionable">1940</dateCreated>
+      </originInfo>
+    XML
   end
 
   # example 13 from mods_to_cocina_originInfo.txt
@@ -483,19 +401,13 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication">
-            <dateIssued keyDate="yes" point="start">1940</dateIssued>
-            <dateIssued point="end">1945</dateIssued>
-            <dateIssued>1948</dateIssued>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="publication">
+        <dateIssued keyDate="yes" point="start">1940</dateIssued>
+        <dateIssued point="end">1945</dateIssued>
+        <dateIssued>1948</dateIssued>
+      </originInfo>
+    XML
   end
 
   # example 14 from mods_to_cocina_originInfo.txt
@@ -519,18 +431,12 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication">
-            <dateIssued keyDate="yes">1940</dateIssued>
-            <dateIssued>1942</dateIssued>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="publication">
+        <dateIssued keyDate="yes">1940</dateIssued>
+        <dateIssued>1942</dateIssued>
+      </originInfo>
+    XML
   end
 
   # example 15 from mods_to_cocina_originInfo.txt
@@ -553,17 +459,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="production">
-            <dateCreated encoding="edtf">-0499</dateCreated>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="production">
+        <dateCreated encoding="edtf">-0499</dateCreated>
+      </originInfo>
+    XML
   end
 
   # example 16 from mods_to_cocina_originInfo.txt
@@ -663,21 +563,15 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="distribution">
-            <place>
-              <placeTerm type="text">Washington, DC</placeTerm>
-            </place>
-            <publisher>For sale by the Superintendent of Documents, U.S. Government Publishing Office</publisher>
-            <dateOther/>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="distribution">
+        <place>
+          <placeTerm type="text">Washington, DC</placeTerm>
+        </place>
+        <publisher>For sale by the Superintendent of Documents, U.S. Government Publishing Office</publisher>
+        <dateOther/>
+      </originInfo>
+    XML
   end
 
   # example 26 from mods_to_cocina_originInfo.txt
@@ -711,19 +605,13 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
-            <place>
-              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
-            </place>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo>
+        <place>
+          <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+        </place>
+      </originInfo>
+    XML
   end
 
   # example 28 from mods_to_cocina_originInfo.txt
@@ -747,19 +635,13 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
-            <place>
-              <placeTerm type="code" authority="marccountry" authorityURI="http://id.loc.gov/vocabulary/countries/" valueURI="http://id.loc.gov/vocabulary/countries/cau">cau</placeTerm>
-            </place>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo>
+        <place>
+          <placeTerm type="code" authority="marccountry" authorityURI="http://id.loc.gov/vocabulary/countries/" valueURI="http://id.loc.gov/vocabulary/countries/cau">cau</placeTerm>
+        </place>
+      </originInfo>
+    XML
   end
 
   # example 29 from mods_to_cocina_originInfo.txt
@@ -784,20 +666,14 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
-            <place>
-              <placeTerm type="text" authority="marccountry" authorityURI="http://id.loc.gov/vocabulary/countries/" valueURI="http://id.loc.gov/vocabulary/countries/cau">California</placeTerm>
-              <placeTerm type="code" authority="marccountry" authorityURI="http://id.loc.gov/vocabulary/countries/" valueURI="http://id.loc.gov/vocabulary/countries/cau">cau</placeTerm>
-            </place>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo>
+        <place>
+          <placeTerm type="text" authority="marccountry" authorityURI="http://id.loc.gov/vocabulary/countries/" valueURI="http://id.loc.gov/vocabulary/countries/cau">California</placeTerm>
+          <placeTerm type="code" authority="marccountry" authorityURI="http://id.loc.gov/vocabulary/countries/" valueURI="http://id.loc.gov/vocabulary/countries/cau">cau</placeTerm>
+        </place>
+      </originInfo>
+    XML
   end
 
   # example 30 from mods_to_cocina_originInfo.txt
@@ -822,22 +698,16 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
-            <place>
-              <placeTerm type="code" authority="marccountry">enk</placeTerm>
-            </place>
-            <place>
-              <placeTerm type="text">London</placeTerm>
-            </place>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo>
+        <place>
+          <placeTerm type="code" authority="marccountry">enk</placeTerm>
+        </place>
+        <place>
+          <placeTerm type="text">London</placeTerm>
+        </place>
+      </originInfo>
+    XML
   end
 
   # example 31 from mods_to_cocina_originInfo.txt
@@ -871,17 +741,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication">
-            <publisher>Virago</publisher>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="publication">
+        <publisher>Virago</publisher>
+      </originInfo>
+    XML
   end
 
   context 'when it has a publisher that is not marcrelator' do
@@ -905,17 +769,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the expected xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication">
-            <publisher>Stanford University Press</publisher>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="publication">
+        <publisher>Stanford University Press</publisher>
+      </originInfo>
+    XML
   end
 
   # example 32 from mods_to_cocina_originInfo.txt
@@ -965,17 +823,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication" lang="rus" script="Latn" transliteration="ALA-LC Romanization Tables">
-            <publisher>Institut russkoĭ literatury (Pushkinskiĭ Dom)</publisher>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="publication" lang="rus" script="Latn" transliteration="ALA-LC Romanization Tables">
+        <publisher>Institut russkoĭ literatury (Pushkinskiĭ Dom)</publisher>
+      </originInfo>
+    XML
   end
 
   # example 33 from mods_to_cocina_originInfo.txt
@@ -1021,17 +873,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication" lang="rus" script="Cyrl">
-            <publisher>СФУ</publisher>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="publication" lang="rus" script="Cyrl">
+        <publisher>СФУ</publisher>
+      </originInfo>
+    XML
   end
 
   # example 34 from mods_to_cocina_originInfo.txt
@@ -1084,18 +930,12 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication">
-            <publisher>Ardis</publisher>
-            <publisher>Commonplace Books</publisher>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="publication">
+        <publisher>Ardis</publisher>
+        <publisher>Commonplace Books</publisher>
+      </originInfo>
+    XML
   end
 
   # example 35 from mods_to_cocina_originInfo.txt
@@ -1114,17 +954,11 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication">
-            <edition>1st ed.</edition>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="publication">
+        <edition>1st ed.</edition>
+      </originInfo>
+    XML
   end
 
   # example 36 from mods_to_cocina_originInfo.txt
@@ -1150,18 +984,12 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication">
-            <issuance>serial</issuance>
-            <frequency>every full moon</frequency>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="publication">
+        <issuance>serial</issuance>
+        <frequency>every full moon</frequency>
+      </originInfo>
+    XML
   end
 
   # example 37 from mods_to_cocina_originInfo.txt
@@ -1190,18 +1018,12 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication">
-            <issuance>multipart monograph</issuance>
-            <frequency authority="marcfrequency">Annual</frequency>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="publication">
+        <issuance>multipart monograph</issuance>
+        <frequency authority="marcfrequency">Annual</frequency>
+      </originInfo>
+    XML
   end
 
   # example 38 from mods_to_cocina_originInfo.txt
@@ -1237,26 +1059,20 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="production">
-            <dateCreated>1899</dateCreated>
-            <place>
-              <placeTerm type="text">York</placeTerm>
-            </place>
-          </originInfo>
-          <originInfo eventType="publication">
-            <dateIssued>1901</dateIssued>
-            <place>
-              <placeTerm type="text">London</placeTerm>
-            </place>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="production">
+        <dateCreated>1899</dateCreated>
+        <place>
+          <placeTerm type="text">York</placeTerm>
+        </place>
+      </originInfo>
+      <originInfo eventType="publication">
+        <dateIssued>1901</dateIssued>
+        <place>
+          <placeTerm type="text">London</placeTerm>
+        </place>
+      </originInfo>
+    XML
   end
 
   context 'with multiple events and missing event type' do
@@ -1290,26 +1106,20 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="production">
-            <dateCreated>1899</dateCreated>
-            <place>
-              <placeTerm type="text">York</placeTerm>
-            </place>
-          </originInfo>
-          <originInfo>
-            <dateOther>1901</dateOther>
-            <place>
-              <placeTerm type="text">London</placeTerm>
-            </place>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="production">
+        <dateCreated>1899</dateCreated>
+        <place>
+          <placeTerm type="text">York</placeTerm>
+        </place>
+      </originInfo>
+      <originInfo>
+        <dateOther>1901</dateOther>
+        <place>
+          <placeTerm type="text">London</placeTerm>
+        </place>
+      </originInfo>
+    XML
   end
 
   # example 39 from mods_to_cocina_originInfo.txt
@@ -1441,33 +1251,27 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo script="Latn" altRepGroup="1" eventType="publication">
-            <place>
-              <placeTerm type="code" authority="marccountry">ja</placeTerm>
-            </place>
-            <place>
-              <placeTerm type="text">Kyōto-shi</placeTerm>
-            </place>
-            <publisher>Rinsen Shoten</publisher>
-            <dateIssued>Heisei 8 [1996]</dateIssued>
-            <dateIssued encoding="marc">1996</dateIssued>
-            <issuance>monographic</issuance>
-          </originInfo>
-          <originInfo script="Hani" altRepGroup="1" eventType="publication">
-            <place>
-              <placeTerm type="text">京都市</placeTerm>
-            </place>
-            <publisher>臨川書店</publisher>
-            <dateIssued>平成 8 [1996]</dateIssued>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo script="Latn" altRepGroup="1" eventType="publication">
+        <place>
+          <placeTerm type="code" authority="marccountry">ja</placeTerm>
+        </place>
+        <place>
+          <placeTerm type="text">Kyōto-shi</placeTerm>
+        </place>
+        <publisher>Rinsen Shoten</publisher>
+        <dateIssued>Heisei 8 [1996]</dateIssued>
+        <dateIssued encoding="marc">1996</dateIssued>
+        <issuance>monographic</issuance>
+      </originInfo>
+      <originInfo script="Hani" altRepGroup="1" eventType="publication">
+        <place>
+          <placeTerm type="text">京都市</placeTerm>
+        </place>
+        <publisher>臨川書店</publisher>
+        <dateIssued>平成 8 [1996]</dateIssued>
+      </originInfo>
+    XML
   end
 
   context 'when event location missing source' do
@@ -1483,19 +1287,13 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
-            <place>
-              <placeTerm type="code">xxu</placeTerm>
-            </place>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo>
+        <place>
+          <placeTerm type="code">xxu</placeTerm>
+        </place>
+      </originInfo>
+    XML
   end
 
   context 'when event location with code missing source' do
@@ -1512,19 +1310,13 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
-            <place>
-              <placeTerm type="code" valueURI="http://id.loc.gov/vocabulary/countries/cau">cau</placeTerm>
-            </place>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo>
+        <place>
+          <placeTerm type="code" valueURI="http://id.loc.gov/vocabulary/countries/cau">cau</placeTerm>
+        </place>
+      </originInfo>
+    XML
   end
 
   context 'when event location with value missing source' do
@@ -1541,19 +1333,13 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo>
-            <place>
-              <placeTerm type="text" valueURI="http://id.loc.gov/vocabulary/countries/cau">California</placeTerm>
-            </place>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo>
+        <place>
+          <placeTerm type="text" valueURI="http://id.loc.gov/vocabulary/countries/cau">California</placeTerm>
+        </place>
+      </originInfo>
+    XML
   end
 
   # example 40 from mods_to_cocina_originInfo.txt
@@ -1574,19 +1360,13 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo displayLabel="Origin" eventType="production">
-            <place>
-              <placeTerm type="text">Stanford (Calif.)</placeTerm>
-            </place>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo displayLabel="Origin" eventType="production">
+        <place>
+          <placeTerm type="text">Stanford (Calif.)</placeTerm>
+        </place>
+      </originInfo>
+    XML
   end
 
   # example 41 from mods_to_cocina_originInfo.txt
@@ -1650,25 +1430,19 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the expected xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="production" lang="eng" script="Latn" altRepGroup="1">
-            <dateCreated keyDate="yes" encoding="w3cdtf">1999-09-09</dateCreated>
-            <place>
-              <placeTerm authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79076156" type="text">Moscow</placeTerm>
-            </place>
-          </originInfo>
-          <originInfo eventType="production" lang="rus" script="Cyrl" altRepGroup="1">
-            <place>
-              <placeTerm type="text">Москва</placeTerm>
-            </place>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="production" lang="eng" script="Latn" altRepGroup="1">
+        <dateCreated keyDate="yes" encoding="w3cdtf">1999-09-09</dateCreated>
+        <place>
+          <placeTerm authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79076156" type="text">Moscow</placeTerm>
+        </place>
+      </originInfo>
+      <originInfo eventType="production" lang="rus" script="Cyrl" altRepGroup="1">
+        <place>
+          <placeTerm type="text">Москва</placeTerm>
+        </place>
+      </originInfo>
+    XML
   end
 
   # example 42 from mods_to_cocina_originInfo.txt
@@ -1720,20 +1494,14 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the expected xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication" lang="eng" script="Latn" altRepGroup="1">
-            <edition>First edition</edition>
-          </originInfo>
-          <originInfo eventType="publication" lang="rus" script="Cyrl" altRepGroup="1">
-            <edition>Первое издание</edition>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="publication" lang="eng" script="Latn" altRepGroup="1">
+        <edition>First edition</edition>
+      </originInfo>
+      <originInfo eventType="publication" lang="rus" script="Cyrl" altRepGroup="1">
+        <edition>Первое издание</edition>
+      </originInfo>
+    XML
   end
 
   # example 43a from mods_to_cocina_originInfo.txt
@@ -1820,38 +1588,32 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the expected xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo altRepGroup="1" eventType="publication">
-            <place>
-              <placeTerm type="code" authority="marccountry">cc</placeTerm>
-            </place>
-            <place>
-              <placeTerm type="text">Chengdu</placeTerm>
-            </place>
-            <publisher>Sichuan chu ban ji tuan, Sichuan wen yi chu ban she</publisher>
-            <dateIssued>2005</dateIssued>
-            <edition>Di 1 ban.</edition>
-            <issuance>monographic</issuance>
-          </originInfo>
-          <originInfo altRepGroup="1" eventType="publication">
-            <place>
-              <placeTerm type="code" authority="marccountry">cc</placeTerm>
-            </place>
-            <place>
-              <placeTerm type="text">[Chengdu in Chinese]</placeTerm>
-            </place>
-            <publisher>[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]</publisher>
-            <dateIssued>2005</dateIssued>
-            <edition>[Di 1 ban in Chinese]</edition>
-            <issuance>monographic</issuance>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo altRepGroup="1" eventType="publication">
+        <place>
+          <placeTerm type="code" authority="marccountry">cc</placeTerm>
+        </place>
+        <place>
+          <placeTerm type="text">Chengdu</placeTerm>
+        </place>
+        <publisher>Sichuan chu ban ji tuan, Sichuan wen yi chu ban she</publisher>
+        <dateIssued>2005</dateIssued>
+        <edition>Di 1 ban.</edition>
+        <issuance>monographic</issuance>
+      </originInfo>
+      <originInfo altRepGroup="1" eventType="publication">
+        <place>
+          <placeTerm type="code" authority="marccountry">cc</placeTerm>
+        </place>
+        <place>
+          <placeTerm type="text">[Chengdu in Chinese]</placeTerm>
+        </place>
+        <publisher>[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]</publisher>
+        <dateIssued>2005</dateIssued>
+        <edition>[Di 1 ban in Chinese]</edition>
+        <issuance>monographic</issuance>
+      </originInfo>
+    XML
   end
 
   # example 44 from mods_to_cocina_originInfo.txt
@@ -1950,34 +1712,28 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the expected xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication">
-            <dateIssued encoding="marc">2020</dateIssued>
-            <place>
-              <placeTerm type="code" authority="marccountry">cau</placeTerm>
-            </place>
-            <issuance>monographic</issuance>
-          </originInfo>
-          <originInfo eventType="copyright notice">
-            <copyrightDate encoding="marc">2020</copyrightDate>
-          </originInfo>
-          <originInfo eventType="publication">
-            <dateIssued>2020</dateIssued>
-            <place>
-              <placeTerm type="text">[Stanford, Calif.]</placeTerm>
-            </place>
-            <publisher>[Stanford University]</publisher>
-          </originInfo>
-          <originInfo eventType="copyright notice">
-            <copyrightDate>&#xA9;2020</copyrightDate>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="publication">
+        <dateIssued encoding="marc">2020</dateIssued>
+        <place>
+          <placeTerm type="code" authority="marccountry">cau</placeTerm>
+        </place>
+        <issuance>monographic</issuance>
+      </originInfo>
+      <originInfo eventType="copyright notice">
+        <copyrightDate encoding="marc">2020</copyrightDate>
+      </originInfo>
+      <originInfo eventType="publication">
+        <dateIssued>2020</dateIssued>
+        <place>
+          <placeTerm type="text">[Stanford, Calif.]</placeTerm>
+        </place>
+        <publisher>[Stanford University]</publisher>
+      </originInfo>
+      <originInfo eventType="copyright notice">
+        <copyrightDate>&#xA9;2020</copyrightDate>
+      </originInfo>
+    XML
   end
 
   # From druid:bm971cx9348
@@ -2049,27 +1805,21 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the expected xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="publication">
-            <dateIssued>[192-?]-[193-?]</dateIssued>
-            <dateIssued encoding="marc" point="start">1920</dateIssued>
-            <place>
-              <placeTerm type="text">London</placeTerm>
-            </place>
-            <place>
-              <placeTerm type="code" authority="marccountry">enk</placeTerm>
-            </place>
-            <publisher>H.M. Stationery Off</publisher>
-            <edition>2nd ed.</edition>
-            <issuance>monographic</issuance>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="publication">
+        <dateIssued>[192-?]-[193-?]</dateIssued>
+        <dateIssued encoding="marc" point="start">1920</dateIssued>
+        <place>
+          <placeTerm type="text">London</placeTerm>
+        </place>
+        <place>
+          <placeTerm type="code" authority="marccountry">enk</placeTerm>
+        </place>
+        <publisher>H.M. Stationery Off</publisher>
+        <edition>2nd ed.</edition>
+        <issuance>monographic</issuance>
+      </originInfo>
+    XML
   end
 
   # example 45 from mods_to_cocina_originInfo.txt
@@ -2116,23 +1866,17 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the expected xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo displayLabel="Place of Creation" eventType="production">
-            <place>
-              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
-            </place>
-            <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
-          </originInfo>
-          <originInfo eventType="development">
-            <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo displayLabel="Place of Creation" eventType="production">
+        <place>
+          <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+        </place>
+        <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
+      </originInfo>
+      <originInfo eventType="development">
+        <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
+      </originInfo>
+    XML
   end
 
   # From druid:ht706sj6651
@@ -2183,21 +1927,15 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the expected xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo displayLabel="Presented" eventType="presentation">
-            <place>
-              <placeTerm type="text" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
-            </place>
-            <publisher>Stanford Institute for Theoretical Economics</publisher>
-            <dateIssued keyDate="yes" encoding="w3cdtf">2018</dateIssued>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo displayLabel="Presented" eventType="presentation">
+        <place>
+          <placeTerm type="text" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+        </place>
+        <publisher>Stanford Institute for Theoretical Economics</publisher>
+        <dateIssued keyDate="yes" encoding="w3cdtf">2018</dateIssued>
+      </originInfo>
+    XML
   end
 
   # example 46 from mods_to_cocina_originInfo.txt
@@ -2232,19 +1970,13 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
       ]
     end
 
-    it 'builds the expected xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <originInfo eventType="production" displayLabel="Place of creation">
-            <dateCreated keyDate="yes" encoding="w3cdtf">1965</dateCreated>
-            <place supplied="yes">
-              <placeTerm authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n81127564" type="text">Selma (Ala.)</placeTerm>
-            </place>
-          </originInfo>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="production" displayLabel="Place of creation">
+        <dateCreated keyDate="yes" encoding="w3cdtf">1965</dateCreated>
+        <place supplied="yes">
+          <placeTerm authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n81127564" type="text">Selma (Ala.)</placeTerm>
+        </place>
+      </originInfo>
+    XML
   end
 end

--- a/spec/services/cocina/to_fedora/descriptive/note_target_audience_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/note_target_audience_spec.rb
@@ -1,23 +1,20 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'support/mods_mapping_spec_helper'
 
-# numbered examples here from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_targetAudience.txt
+# numbered examples refer to https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_targetAudience.txt
 RSpec.describe Cocina::ToFedora::Descriptive::Note do
-  subject(:xml) { writer.to_xml }
-
+  # see spec/support/mods_mapping_spec_helper.rb for how writer is used in shared examples
   let(:writer) do
     Nokogiri::XML::Builder.new do |xml|
-      xml.mods('xmlns' => 'http://www.loc.gov/mods/v3',
-               'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-               'version' => '3.6',
-               'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd') do
+      xml.mods(mods_attributes) do
         described_class.write(xml: xml, notes: notes, id_generator: Cocina::ToFedora::Descriptive::IdGenerator.new)
       end
     end
   end
 
-  # Example 1. Target audience with authority
+  # 1. Target audience with authority
   context 'with authority' do
     let(:notes) do
       [
@@ -31,18 +28,12 @@ RSpec.describe Cocina::ToFedora::Descriptive::Note do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <targetAudience authority="marctarget">juvenile</targetAudience>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <targetAudience authority="marctarget">juvenile</targetAudience>
+    XML
   end
 
-  # Example 2. Target audience without authority
+  # 2. Target audience without authority
   context 'without authority' do
     let(:notes) do
       [
@@ -53,14 +44,8 @@ RSpec.describe Cocina::ToFedora::Descriptive::Note do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <targetAudience>ages 3-6</targetAudience>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <targetAudience>ages 3-6</targetAudience>
+    XML
   end
 end

--- a/spec/services/cocina/to_fedora/descriptive/subject_classification_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_classification_spec.rb
@@ -1,18 +1,14 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'support/mods_mapping_spec_helper'
 
-# numbered examples here from https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_classification.txt
+# numbered examples refer to https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_classification.txt
 RSpec.describe Cocina::ToFedora::Descriptive::Subject do
-  subject(:xml) { writer.to_xml }
-
+  # see spec/support/mods_mapping_spec_helper.rb for how writer is used in shared examples
   let(:writer) do
     Nokogiri::XML::Builder.new do |xml|
-      xml.mods('xmlns' => 'http://www.loc.gov/mods/v3',
-               'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-               'version' => '3.6',
-               'xmlns:rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-               'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd') do
+      xml.mods(mods_attributes) do
         described_class.write(xml: xml, subjects: subjects, id_generator: Cocina::ToFedora::Descriptive::IdGenerator.new)
       end
     end
@@ -21,15 +17,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
   context 'when nil' do
     let(:subjects) { nil }
 
-    it 'builds empty MODS xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', '' # empty MODS
   end
 
   # 1. Classification with authority
@@ -48,16 +36,9 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <classification authority="lcc">G9801.S12 2015 .Z3</classification>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <classification authority="lcc">G9801.S12 2015 .Z3</classification>
+    XML
   end
 
   # missing example ticketed as https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/294
@@ -73,16 +54,9 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <classification>G9801.S12 2015 .Z3</classification>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <classification>G9801.S12 2015 .Z3</classification>
+    XML
   end
 
   # 2. Classification with edition
@@ -102,16 +76,9 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <classification authority="ddc" edition="11">683</classification>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <classification authority="ddc" edition="11">683</classification>
+    XML
   end
 
   # 3. Display label
@@ -131,16 +98,9 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <classification authority="lcc" displayLabel="Library of Congress classification">ML410.B3</classification>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <classification authority="lcc" displayLabel="Library of Congress classification">ML410.B3</classification>
+    XML
   end
 
   # 4. Multiple classifications
@@ -170,16 +130,9 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
       ]
     end
 
-    it 'builds the xml' do
-      expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <classification authority="ddc" edition="11">683</classification>
-          <classification authority="ddc" edition="12">684</classification>
-        </mods>
-      XML
-    end
+    it_behaves_like 'cocina to MODS', <<~XML
+      <classification authority="ddc" edition="11">683</classification>
+      <classification authority="ddc" edition="12">684</classification>
+    XML
   end
 end

--- a/spec/support/mods_mapping_spec_helper.rb
+++ b/spec/support/mods_mapping_spec_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'cocina to MODS' do |expected_xml|
+  subject(:xml) { writer.to_xml }
+
+  # writer object is declared in the context of calling examples
+
+  let(:mods_attributes) do
+    {
+      'xmlns' => 'http://www.loc.gov/mods/v3',
+      'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+      'version' => '3.6',
+      'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd'
+    }
+  end
+
+  it 'builds the expected xml' do
+    expect(xml).to be_equivalent_to <<~XML
+      <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.loc.gov/mods/v3" version="3.6"
+        xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        #{expected_xml}
+      </mods>
+    XML
+  end
+end


### PR DESCRIPTION
## Why was this change made?

To make it easier to read and maintain to_fedora mapping specs by getting rid of noise in them.  Note that the rest of the specs will be converted to use the shared_example as part of the cocina-descriptive-md alignment work.

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?



