### PR TITLE
Map and normalize abstract with type=summary.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -58,6 +58,7 @@ module Cocina
       normalize_title_type
       normalize_gml_id
       normalize_empty_resource
+      normalize_abstract_summary
       # This should be last-ish.
       normalize_empty_related_items
       ng_xml
@@ -551,6 +552,12 @@ module Cocina
       ng_xml.root.xpath('//mods:publisher[@transliteration]', mods: MODS_NS).each do |publisher_node|
         publisher_node.parent['transliteration'] = publisher_node['transliteration']
         publisher_node.delete('transliteration')
+      end
+    end
+
+    def normalize_abstract_summary
+      ng_xml.root.xpath('//mods:abstract[@type="summary"]', mods: MODS_NS).each do |abstract_node|
+        abstract_node.delete('type')
       end
     end
   end

--- a/spec/services/cocina/from_fedora/descriptive/notes_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/notes_spec.rb
@@ -206,6 +206,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Notes do
     end
   end
 
+  # Example 3
   context 'with a single abstract with a displayLabel' do
     let(:xml) do
       <<~XML
@@ -238,6 +239,26 @@ RSpec.describe Cocina::FromFedora::Descriptive::Notes do
 
         {
           "value": 'This is a synopsis.',
+          "type": 'summary'
+        }
+
+      ]
+    end
+  end
+
+  # Example 4
+  context 'with an abstract with type "summary"' do
+    let(:xml) do
+      <<~XML
+        <abstract type="summary">This is a summary.</abstract>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+
+        {
+          "value": 'This is a summary.',
           "type": 'summary'
         }
 

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -1963,4 +1963,22 @@ RSpec.describe Cocina::ModsNormalizer do
       XML
     end
   end
+
+  context 'when normalizing abstract summary' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{mods_attributes}>
+          <abstract type="summary">This is a summary.</abstract>
+        </mods>
+      XML
+    end
+
+    it 'removes attribute' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{mods_attributes}>
+          <abstract>This is a summary.</abstract>
+        </mods>
+      XML
+    end
+  end
 end

--- a/spec/services/cocina/to_fedora/descriptive/note_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/note_spec.rb
@@ -137,6 +137,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Note do
     end
   end
 
+  # Example 1
   context 'when it has a simple abstract' do
     let(:notes) do
       [
@@ -160,6 +161,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Note do
     end
   end
 
+  # Example 2
   context 'when it has a multilingual abstract' do
     let(:notes) do
       [
@@ -215,6 +217,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Note do
     end
   end
 
+  # Example 3
   context 'when it has a display label' do
     let(:notes) do
       [
@@ -234,6 +237,28 @@ RSpec.describe Cocina::ToFedora::Descriptive::Note do
           xmlns="http://www.loc.gov/mods/v3" version="3.6"
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <abstract displayLabel="Synopsis">This is a synopsis.</abstract>
+        </mods>
+      XML
+    end
+  end
+
+  # Example 4
+  context 'when it has an astract with type "summary"' do
+    let(:notes) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          "value": 'This is a summary.',
+          "type": 'summary'
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <abstract>This is a summary.</abstract>
         </mods>
       XML
     end


### PR DESCRIPTION
closes #1796

## Why was this change made?
Map and normalize abstract with type=summary.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


