### PR TITLE
Mappings related to originInfo copyright notice.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -191,7 +191,7 @@ module Cocina
         add_event_type('publication', origin_info_node) && next if date_issued_nodes.present?
 
         copyright_date_nodes = origin_info_node.xpath('mods:copyrightDate', mods: MODS_NS)
-        add_event_type('copyright notice', origin_info_node) && next if copyright_date_nodes.present?
+        add_event_type('copyright', origin_info_node) && next if copyright_date_nodes.present?
 
         date_created_nodes = origin_info_node.xpath('mods:dateCreated', mods: MODS_NS)
         add_event_type('production', origin_info_node) && next if date_created_nodes.present?
@@ -445,8 +445,6 @@ module Cocina
     def normalize_origin_info_date
       %w[dateIssued copyrightDate dateCreated dateCaptured dateValid dateOther].each do |date_type|
         ng_xml.root.xpath("//mods:originInfo/mods:#{date_type}", mods: MODS_NS)
-              .to_a
-              .filter { |date_node| date_node.content =~ /^\d{4}\.$/ }
               .each { |date_node| date_node.content = date_node.content.delete_suffix('.') }
       end
     end
@@ -505,7 +503,7 @@ module Cocina
 
     def normalize_origin_info_split
       # Split a single originInfo into multiple.
-      split_origin_info('dateIssued', 'copyrightDate', 'copyright notice')
+      split_origin_info('dateIssued', 'copyrightDate', 'copyright')
       split_origin_info('dateIssued', 'dateCaptured', 'capture')
       split_origin_info('dateIssued', 'dateValid', 'validity')
       split_origin_info('copyrightDate', 'publisher', 'publication')

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -589,12 +589,137 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
 
   # example 26 from mods_to_cocina_originInfo.txt
   context 'with originInfo eventType differs from date type' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L621'
+    let(:xml) do
+      <<~XML
+        <originInfo eventType="publication">
+          <copyrightDate>1980</copyrightDate>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'copyright',
+          "date": [
+            "value": '1980'
+          ]
+        }
+      ]
+    end
   end
 
   # example 26b from mods_to_cocina_originInfo.txt
   context 'with originInfo eventType differs from date type, converted from MARC with multiple 264s' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L634'
+    let(:xml) do
+      <<~XML
+        <originInfo>
+           <place>
+              <placeTerm type="code" authority="marccountry">ru</placeTerm>
+           </place>
+           <dateIssued encoding="marc">2019</dateIssued>
+           <copyrightDate encoding="marc">2018</copyrightDate>
+           <issuance>monographic</issuance>
+        </originInfo>
+        <originInfo eventType="publication">
+           <place>
+              <placeTerm type="text">Moskva</placeTerm>
+           </place>
+           <publisher>Izdatelʹstvo "Vesʹ Mir"</publisher>
+           <dateIssued>2019</dateIssued>
+        </originInfo>
+        <originInfo eventType="copyright notice">
+           <copyrightDate>©2018</copyrightDate>
+        </originInfo>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'publication',
+          "location": [
+            {
+              "code": 'ru',
+              "source": {
+                "code": 'marccountry'
+              }
+            }
+          ],
+          "date": [
+            {
+              "value": '2019',
+              "encoding": {
+                "code": 'marc'
+              }
+            }
+          ],
+          "note": [
+            {
+              "value": 'monographic',
+              "type": 'issuance',
+              "source": {
+                "value": 'MODS issuance terms'
+              }
+            }
+          ]
+        },
+        {
+          "type": 'copyright',
+          "date": [
+            {
+              "value": '2018',
+              "encoding": {
+                "code": 'marc'
+              }
+            }
+          ]
+        },
+        {
+          "type": 'publication',
+          "location": [
+            {
+              "value": 'Moskva'
+            }
+          ],
+          "contributor": [
+            {
+              "name": [
+                {
+                  "value": 'Izdatelʹstvo "Vesʹ Mir"'
+                }
+              ],
+              type: 'organization',
+              role: [
+                {
+                  value: 'publisher',
+                  code: 'pbl',
+                  uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                  source: {
+                    code: 'marcrelator',
+                    uri: 'http://id.loc.gov/vocabulary/relators/'
+                  }
+                }
+              ]
+            }
+          ],
+          "date": [
+            {
+              "value": '2019'
+            }
+          ]
+        },
+        {
+          "type": 'copyright',
+          "note": [
+            {
+              "value": '©2018',
+              "type": 'copyright statement'
+            }
+          ]
+        }
+      ]
+    end
   end
 
   # example 27 from mods_to_cocina_originInfo.txt
@@ -2065,9 +2190,10 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
         },
         {
           "type": 'copyright',
-          "date": [
+          "note": [
             {
-              "value": '©2020'
+              "value": '©2020',
+              "type": 'copyright statement'
             }
           ]
         }

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe Cocina::ModsNormalizer do
             <originInfo eventType="publication">
               <dateIssued>1930</dateIssued>
             </originInfo>
-            <originInfo eventType="copyright notice">
+            <originInfo eventType="copyright">
               <copyrightDate>1931</copyrightDate>
             </originInfo>
             <originInfo eventType="production">
@@ -1695,7 +1695,7 @@ RSpec.describe Cocina::ModsNormalizer do
             <publisher>[Stanford University]</publisher>
             <dateIssued>2020</dateIssued>
           </originInfo>
-          <originInfo eventType="copyright notice">
+          <originInfo eventType="copyright">
             <copyrightDate encoding="marc">2020</copyrightDate>
           </originInfo>
           <originInfo eventType="copyright notice">

--- a/spec/services/cocina/to_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/event_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
   end
 
   # 3. Single copyrightDate
-  # FIXME: discrepancy - eventType "copyright" vs "copyright notice"
   context 'when it has a single copyrightDate' do
     let(:events) do
       [
@@ -89,7 +88,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
     end
 
     it_behaves_like 'cocina to MODS', <<~XML
-      <originInfo eventType="copyright notice">
+      <originInfo eventType="copyright">
         <copyrightDate>1930</copyrightDate>
       </originInfo>
     XML
@@ -576,12 +575,136 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
 
   # example 26 from mods_to_cocina_originInfo.txt
   context 'when eventType differs from date type' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L621'
+    let(:events) do
+      [
+        Cocina::Models::Event.new(
+          "type": 'copyright',
+          "date": [
+            "value": '1980'
+          ]
+        )
+      ]
+    end
+
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="copyright">
+        <copyrightDate>1980</copyrightDate>
+      </originInfo>
+    XML
   end
 
   # example 26b from mods_to_cocina_originInfo.txt
   context 'when eventType differs from date type, converted from MARC record with multiple 264s' do
-    xit 'TODO: https://github.com/sul-dlss-labs/cocina-descriptive-metadata/blob/master/mods_cocina_mappings/mods_to_cocina_originInfo.txt#L634'
+    let(:events) do
+      [
+        Cocina::Models::Event.new(
+          "type": 'publication',
+          "location": [
+            {
+              "code": 'ru',
+              "source": {
+                "code": 'marccountry'
+              }
+            }
+          ],
+          "date": [
+            {
+              "value": '2019',
+              "encoding": {
+                "code": 'marc'
+              }
+            }
+          ],
+          "note": [
+            {
+              "value": 'monographic',
+              "type": 'issuance',
+              "source": {
+                "value": 'MODS issuance terms'
+              }
+            }
+          ]
+        ),
+        Cocina::Models::Event.new(
+          "type": 'copyright',
+          "date": [
+            {
+              "value": '2018',
+              "encoding": {
+                "code": 'marc'
+              }
+            }
+          ]
+        ),
+        Cocina::Models::Event.new(
+          "type": 'publication',
+          "location": [
+            {
+              "value": 'Moskva'
+            }
+          ],
+          "contributor": [
+            {
+              "name": [
+                {
+                  "value": 'Izdatelʹstvo "Vesʹ Mir"'
+                }
+              ],
+              type: 'organization',
+              role: [
+                {
+                  value: 'publisher',
+                  code: 'pbl',
+                  uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                  source: {
+                    code: 'marcrelator',
+                    uri: 'http://id.loc.gov/vocabulary/relators/'
+                  }
+                }
+              ]
+            }
+          ],
+          "date": [
+            {
+              "value": '2019'
+            }
+          ]
+        ),
+        Cocina::Models::Event.new(
+          "type": 'copyright',
+          "note": [
+            {
+              "value": '©2018',
+              "type": 'copyright statement'
+            }
+          ]
+        )
+
+      ]
+    end
+
+    it_behaves_like 'cocina to MODS', <<~XML
+      <originInfo eventType="publication">
+         <dateIssued encoding="marc">2019</dateIssued>
+         <place>
+            <placeTerm type="code" authority="marccountry">ru</placeTerm>
+         </place>
+         <issuance>monographic</issuance>
+      </originInfo>
+      <originInfo eventType="copyright">
+        <copyrightDate encoding="marc">2018</copyrightDate>
+      </originInfo>
+      <originInfo eventType="publication">
+         <place>
+            <placeTerm type="text">Moskva</placeTerm>
+         </place>
+         <publisher>Izdatelʹstvo "Vesʹ Mir"</publisher>
+         <dateIssued>2019</dateIssued>
+      </originInfo>
+      <originInfo eventType="copyright notice">
+         <copyrightDate>©2018</copyrightDate>
+      </originInfo>
+    XML
   end
 
   # example 27 from mods_to_cocina_originInfo.txt
@@ -1700,14 +1823,13 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
           }
         ),
         Cocina::Models::Event.new(
-          {
-            "type": 'copyright',
-            "date": [
-              {
-                "value": '©2020'
-              }
-            ]
-          }
+          "type": 'copyright',
+          "note": [
+            {
+              "value": '©2020',
+              "type": 'copyright statement'
+            }
+          ]
         )
       ]
     end
@@ -1720,7 +1842,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Event do
         </place>
         <issuance>monographic</issuance>
       </originInfo>
-      <originInfo eventType="copyright notice">
+      <originInfo eventType="copyright">
         <copyrightDate encoding="marc">2020</copyrightDate>
       </originInfo>
       <originInfo eventType="publication">


### PR DESCRIPTION
closes #1797

## Why was this change made?
Make sure Arcadia's changed related to originInfo copyright notice are incorporated.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


