### PR TITLE
Adds name mapping example 5b.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
@@ -165,7 +165,7 @@ module Cocina
           contributor.identifier.each do |identifier|
             id_attributes = {
               displayLabel: identifier.displayLabel,
-              type: identifier.uri ? 'uri' : FromFedora::Descriptive::IdentifierType.mods_type_for_cocina_type(identifier.type)
+              type: FromFedora::Descriptive::IdentifierType.mods_type_for_cocina_type(identifier.type)
             }.tap do |attrs|
               attrs[:invalid] = 'yes' if identifier.status == 'invalid'
             end.compact

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -271,6 +271,36 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     end
   end
 
+  # 5b. Name with untyped nameIdentifier
+  context 'with missing nameIdentifier type' do
+    let(:xml) do
+      <<~XML
+        <name type="personal">
+          <namePart>Burnett, Michael W.</namePart>
+          <nameIdentifier>https://orcid.org/0000-0001-5126-5568</nameIdentifier>
+        </name>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          identifier: [
+            {
+              value: 'https://orcid.org/0000-0001-5126-5568'
+            }
+          ],
+          name: [
+            {
+              value: 'Burnett, Michael W.'
+            }
+          ],
+          type: 'person'
+        }
+      ]
+    end
+  end
+
   context 'with namePart with empty type attribute' do
     context 'without role' do
       let(:xml) do

--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -265,6 +265,34 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     XML
   end
 
+  # 5b. Name with untyped nameIdentifier
+  context 'with untyped nameIdentifier' do
+    let(:contributors) do
+      [
+        Cocina::Models::Contributor.new(
+          "name": [
+            {
+              "value": 'Burnett, Michael W.'
+            }
+          ],
+          "type": 'person',
+          "identifier": [
+            {
+              "uri": 'https://orcid.org/0000-0001-5126-5568'
+            }
+          ]
+        )
+      ]
+    end
+
+    it_behaves_like 'cocina to MODS', <<~XML
+      <name type="personal">
+        <namePart>Burnett, Michael W.</namePart>
+        <nameIdentifier>https://orcid.org/0000-0001-5126-5568</nameIdentifier>
+      </name>
+    XML
+  end
+
   # 5c. Name with multiple untyped parts
   context 'with multiple untyped parts' do
     let(:contributors) do


### PR DESCRIPTION
closes #1848

## Why was this change made?
Per Arcadia, add new name mapping example.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


