### PR TITLE
Adds correct labels for name mapping example 5c.

### DIFF
--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -361,8 +361,8 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     end
   end
 
-  # FIXME: this example should be added to cdm - see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/298
-  context 'with multiple nameParts without types' do
+  # 5c. Name with multiple untyped parts
+  context 'with multiple untyped parts' do
     let(:xml) do
       <<~XML
         <name type="corporate">

--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -265,8 +265,8 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     XML
   end
 
-  # FIXME: this example should be added to cdm (?) - see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/298
-  context 'with multiple nameParts without types' do
+  # 5c. Name with multiple untyped parts
+  context 'with multiple untyped parts' do
     let(:contributors) do
       [
         Cocina::Models::Contributor.new(


### PR DESCRIPTION
closes #1851

## Why was this change made?
Adds labels for that examples can be identified.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


