### PR TITLE
Remove extrapolated role info from MODS contributor name mappings.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/name_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/name_builder.rb
@@ -161,8 +161,6 @@ module Cocina
           end.compact.presence
         end
 
-        MARC_RELATOR_PIECE = 'id.loc.gov/vocabulary/relators'
-
         # shameless green
         # rubocop:disable Metrics/AbcSize
         def role_for(ng_role)
@@ -179,7 +177,7 @@ module Cocina
           {}.tap do |role|
             source = {
               code: Authority.normalize_code(authority, notifier),
-              uri: authority == 'marcrelator' ? "http://#{MARC_RELATOR_PIECE}/" : Authority.normalize_uri(authority_uri)
+              uri: Authority.normalize_uri(authority_uri)
             }.compact
             role[:source] = source if source.present?
 
@@ -226,8 +224,7 @@ module Cocina
 
         def marc_relator_role?(role_authority, role_authority_uri, role_authority_value)
           role_authority == 'marcrelator' ||
-            role_authority_uri&.include?(MARC_RELATOR_PIECE) ||
-            role_authority_value&.include?(MARC_RELATOR_PIECE)
+            [role_authority_uri, role_authority_value].compact.any? { |check| check.include?('id.loc.gov/vocabulary/relators') }
         end
       end
     end

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -789,8 +789,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
                 value: 'author',
                 code: 'aut',
                 source: {
-                  code: 'marcrelator',
-                  uri: 'http://id.loc.gov/vocabulary/relators/'
+                  code: 'marcrelator'
                 }
               }
             ]

--- a/spec/services/cocina/from_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive_spec.rb
@@ -318,8 +318,7 @@ RSpec.describe Cocina::FromFedora::Descriptive do
             {
               code: 'ths',
               source: {
-                code: 'marcrelator',
-                uri: 'http://id.loc.gov/vocabulary/relators/'
+                code: 'marcrelator'
               }
             }
           ]
@@ -334,8 +333,7 @@ RSpec.describe Cocina::FromFedora::Descriptive do
             {
               code: 'ths',
               source: {
-                code: 'marcrelator',
-                uri: 'http://id.loc.gov/vocabulary/relators/'
+                code: 'marcrelator'
               }
             }
           ]
@@ -350,8 +348,7 @@ RSpec.describe Cocina::FromFedora::Descriptive do
             {
               code: 'ths',
               source: {
-                code: 'marcrelator',
-                uri: 'http://id.loc.gov/vocabulary/relators/'
+                code: 'marcrelator'
               }
             }
           ]

--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -368,7 +368,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     end
 
     # 7b. Role text only
-    #  FIXME: discrepancy - mods only has text, not code
     context 'when role has value but not code' do
       let(:contributors) do
         [
@@ -405,7 +404,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     end
 
     # 7c. Role code only
-    #  FIXME: discrepancy - mods has code only, not text
     context 'when role has code but not value' do
       let(:contributors) do
         [
@@ -476,7 +474,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     end
 
     # 7e. Role with authority as the only authority attribute
-    # FIXME: discrepancy - our mods includes authority attribute
     context 'when role has authority as the only authority attribute' do
       let(:contributors) do
         [
@@ -493,8 +490,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
                 value: 'author',
                 code: 'aut',
                 source: {
-                  code: 'marcrelator',
-                  uri: 'http://id.loc.gov/vocabulary/relators/'
+                  code: 'marcrelator'
                 }
               }
             ]
@@ -506,8 +502,8 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
         <name type="personal" usage="primary">
           <namePart>Dunnett, Dorothy</namePart>
           <role>
-            <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/">author</roleTerm>
-            <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/">aut</roleTerm>
+            <roleTerm type="text" authority="marcrelator">author</roleTerm>
+            <roleTerm type="code" authority="marcrelator">aut</roleTerm>
           </role>
         </name>
       XML


### PR DESCRIPTION
closes #1836

## Why was this change made?
Per Arcadia.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


