### PR TITLE
Warns when classification has no authority.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -149,6 +149,8 @@ module Cocina
         end
 
         def subject_classification(subject_classification_node, attrs)
+          notifier.warn('No source given for classification value', value: subject_classification_node.text) unless attrs[:uri] || attrs.dig(:source, :code) || attrs.dig(:source, :uri)
+
           values = {}.tap do |content|
             content[:type] = 'classification'
             content[:value] = subject_classification_node.text

--- a/spec/services/cocina/from_fedora/descriptive/subject_classification_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_classification_spec.rb
@@ -37,17 +37,21 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     end
   end
 
-  # missing example ticketed as https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/294
   context 'when given a classification without authority' do
     let(:xml) { '<classification>G9801.S12 2015 .Z3</classification>' }
 
-    it 'builds the cocina data structure' do
+    before do
+      allow(notifier).to receive(:warn)
+    end
+
+    it 'builds the cocina data structure and warns' do
       expect(build).to eq [
         {
           "type": 'classification',
           "value": 'G9801.S12 2015 .Z3'
         }
       ]
+      expect(notifier).to have_received(:warn).with('No source given for classification value', { value: 'G9801.S12 2015 .Z3' })
     end
   end
 


### PR DESCRIPTION
closes #1835

## Why was this change made?
Classifications without authority are bad.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


