### PR TITLE
Add example 7j for name with multiple roles to MODS name mappings.

### DIFF
--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -967,8 +967,8 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
       end
     end
 
-    # FIXME: this example should be added to cdm - see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/298
-    context 'when multiple roles' do
+    # 7j. Name with multiple roles
+    context 'when name with multiple roles' do
       let(:xml) do
         <<~XML
           <name type="personal" usage="primary">

--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -614,37 +614,8 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
       XML
     end
 
-    context 'with empty name value and missing role' do
-      let(:contributors) do
-        [
-          Cocina::Models::Contributor.new(
-            "name": [
-              {
-                "value": ''
-              }
-            ],
-            "role": [
-              {
-                "source":
-                  {
-                    "code": 'marcreleator'
-                  }
-              }
-            ]
-          )
-        ]
-      end
-
-      it_behaves_like 'cocina to MODS', <<~XML
-        <name>
-          <namePart/>
-          <role/>
-        </name>
-      XML
-    end
-
-    # FIXME: this example should be added to cdm - see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/298
-    context 'when multiple roles' do
+    # 7j. Name with multiple roles
+    context 'when name with multiple roles' do
       let(:contributors) do
         [
           Cocina::Models::Contributor.new(
@@ -680,6 +651,35 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
             <role>
               <roleTerm authority="marcrelator" type="code" authorityURI="http://id.loc.gov/vocabulary/relators/">ths</roleTerm>
             </role>
+        </name>
+      XML
+    end
+
+    context 'with empty name value and missing role' do
+      let(:contributors) do
+        [
+          Cocina::Models::Contributor.new(
+            "name": [
+              {
+                "value": ''
+              }
+            ],
+            "role": [
+              {
+                "source":
+                  {
+                    "code": 'marcreleator'
+                  }
+              }
+            ]
+          )
+        ]
+      end
+
+      it_behaves_like 'cocina to MODS', <<~XML
+        <name>
+          <namePart/>
+          <role/>
         </name>
       XML
     end


### PR DESCRIPTION
closes #1867

## Why was this change made?
Per Arcadia.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


