### PR TITLE
Add example 9b for multiple names with no roles to MODS name mappings.

### DIFF
--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -1093,9 +1093,8 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     end
   end
 
-  # FIXME: this example should be added to cdm ??? - see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/298
-  # kind of 18, except with multiple names
-  context 'with multiple names, one primary, dates, no roles' do
+  # 9b. Multiple names, no roles
+  context 'with multiple names, no roles' do
     let(:xml) do
       <<~XML
         <name type="personal" usage="primary">

--- a/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_spec.rb
@@ -788,9 +788,8 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     XML
   end
 
-  # FIXME: this example should be added to cdm ??? - see https://github.com/sul-dlss-labs/cocina-descriptive-metadata/issues/298
-  # kind of 18, except with multiple names
-  context 'with multiple names, one primary, dates, no roles' do
+  # 9b. Multiple names, no roles
+  context 'with multiple names, no roles' do
     let(:contributors) do
       [
         Cocina::Models::Contributor.new(


### PR DESCRIPTION
closes #1869

## Why was this change made?
Per Arcadia.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


