### PR TITLE
Stop warning on https PURLs.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/geographic.rb
+++ b/app/services/cocina/from_fedora/descriptive/geographic.rb
@@ -205,7 +205,7 @@ module Cocina
         end
 
         def check_purl
-          return if description['rdf:about']&.start_with?('http://purl.stanford.edu/')
+          return if description['rdf:about'] =~ %r{^https?://purl.stanford.edu/}
 
           notifier.warn('rdf:about does not contain a correctly formatted PURL')
         end

--- a/spec/services/cocina/from_fedora/descriptive/geographic_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/geographic_spec.rb
@@ -616,6 +616,26 @@ RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
     end
   end
 
+  context 'with an https PURL' do
+    let(:dc_type) { 'Image' }
+    let(:xml) do
+      <<~XML
+        <extension displayLabel="geo">
+          <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:gmd="http://www.isotc211.org/2005/gmd">
+            <rdf:Description rdf:about="http://purl.stanford.edu/zg154pd4168">
+              <dc:format>image/jpeg</dc:format>
+              <dc:type>#{dc_type}</dc:type>
+            </rdf:Description>
+          </rdf:RDF>
+        </extension>
+      XML
+    end
+
+    it 'does not warn' do
+      build
+    end
+  end
+
   context 'without dc:format' do
     let(:dc_type) { 'Image' }
     let(:xml) do


### PR DESCRIPTION
closes #1874

## Why was this change made?
Unnecessary warning


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


