### PR TITLE
Mapping for name subject with role and displayForm

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
@@ -102,21 +102,7 @@ module Cocina
 
         def write_roles(contributor)
           Array(contributor.role).reject { |role| filtered_role?(role, contributor.type) }.each do |role|
-            xml.role do
-              attributes = {
-                valueURI: role.uri,
-                authority: role.source&.code,
-                authorityURI: role.source&.uri
-              }.compact
-              if role.value.present?
-                attributes[:type] = 'text'
-                xml.roleTerm role.value, attributes
-              end
-              if role.code.present?
-                attributes[:type] = 'code'
-                xml.roleTerm role.code, attributes
-              end
-            end
+            RoleWriter.write(xml: xml, role: role)
           end
         end
 

--- a/app/services/cocina/to_fedora/descriptive/role_writer.rb
+++ b/app/services/cocina/to_fedora/descriptive/role_writer.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Cocina
+  module ToFedora
+    class Descriptive
+      # Maps roles from cocina to MODS XML
+      class RoleWriter
+        # @params [Nokogiri::XML::Builder] xml
+        # @params [Cocina::Models::DescriptiveValue] role
+        def self.write(xml:, role:)
+          new(xml: xml, role: role).write
+        end
+
+        def initialize(xml:, role:)
+          @xml = xml
+          @role = role
+        end
+
+        def write
+          xml.role do
+            attributes = {
+              valueURI: role.uri,
+              authority: role.source&.code,
+              authorityURI: role.source&.uri
+            }.compact
+            if role.value.present?
+              attributes[:type] = 'text'
+              xml.roleTerm role.value, attributes
+            end
+            if role.code.present?
+              attributes[:type] = 'code'
+              xml.roleTerm role.code, attributes
+            end
+          end
+        end
+
+        private
+
+        attr_reader :xml, :role
+      end
+    end
+  end
+end

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -47,7 +47,7 @@ def write_result(druid, original_ng_xml, roundtrip_ng_xml, cocina, differences, 
       data_errors.each do |data_error|
         file.write("Data error: #{data_error.msg}")
         file.write(" (#{data_error.context}") if data_error.context.present?
-        file.write("Note that data errors are from the original XML, not the normalized XML shown below.\n\n")
+        file.write("\nNote that data errors are from the original XML, not the normalized XML shown below.\n\n")
       end
       file.write("\n")
     end

--- a/spec/services/cocina/from_fedora/descriptive/subject_name_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_name_spec.rb
@@ -723,4 +723,67 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
       expect(notifier).to have_received(:warn).with('Name type unrecognized', { type: 'topic' })
     end
   end
+
+  # 32. Name subject with display form and role
+  # Adapted from vx363td7520
+  context 'with name subject with display form and role' do
+    let(:xml) do
+      <<~XML
+        <subject>
+          <name type="personal">
+            <role>
+              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/dpc">depicted</roleTerm>
+              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/dpc">dpc</roleTerm>
+            </role>
+            <namePart type="family">Nole</namePart>
+            <namePart type="given">Andneas Colijns de</namePart>
+            <namePart type="date">1590-?</namePart>
+            <displayForm>Nole, Andneas Colijns de, 1590-?</displayForm>
+          </name>
+        </subject>
+      XML
+    end
+
+    it 'builds the cocina data structure' do
+      expect(build).to eq [
+        {
+          "type": 'person',
+          "parallelValue": [
+            {
+              "structuredValue": [
+                {
+                  "value": 'Nole',
+                  "type": 'surname'
+                },
+                {
+                  "value": 'Andneas Colijns de',
+                  "type": 'forename'
+                },
+                {
+                  "value": '1590-?',
+                  "type": 'life dates'
+                }
+              ]
+            },
+            {
+              "value": 'Nole, Andneas Colijns de, 1590-?',
+              "type": 'display'
+            }
+          ],
+          "note": [
+            {
+              "type": 'role',
+              "value": 'depicted',
+              "code": 'dpc',
+              "uri": 'http://id.loc.gov/vocabulary/relators/dpc',
+              "source": {
+                "code": 'marcrelator',
+                "uri": 'http://id.loc.gov/vocabulary/relators/'
+              }
+            }
+          ]
+        }
+      ]
+    end
+  end
 end

--- a/spec/services/cocina/to_fedora/descriptive/subject_name_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_name_spec.rb
@@ -769,4 +769,71 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
       XML
     end
   end
+
+  # 32. Name subject with display form and role
+  # Adapted from vx363td7520
+  context 'with name subject with display form and role' do
+    let(:subjects) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          "type": 'person',
+          "parallelValue": [
+            {
+              "structuredValue": [
+                {
+                  "value": 'Nole',
+                  "type": 'surname'
+                },
+                {
+                  "value": 'Andneas Colijns de',
+                  "type": 'forename'
+                },
+                {
+                  "value": '1590-?',
+                  "type": 'life dates'
+                }
+              ]
+            },
+            {
+              "value": 'Nole, Andneas Colijns de, 1590-?',
+              "type": 'display'
+            }
+          ],
+          "note": [
+            {
+              "type": 'role',
+              "value": 'depicted',
+              "code": 'dpc',
+              "uri": 'http://id.loc.gov/vocabulary/relators/dpc',
+              "source": {
+                "code": 'marcrelator',
+                "uri": 'http://id.loc.gov/vocabulary/relators/'
+              }
+            }
+          ]
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject>
+            <name type="personal">
+              <role>
+                <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/dpc">depicted</roleTerm>
+                <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/dpc">dpc</roleTerm>
+              </role>
+              <namePart type="family">Nole</namePart>
+              <namePart type="given">Andneas Colijns de</namePart>
+              <namePart type="date">1590-?</namePart>
+              <displayForm>Nole, Andneas Colijns de, 1590-?</displayForm>
+            </name>
+          </subject>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #1755

## Why was this change made?
Per Arcadia, map name subject with role and displayForm.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


