### PR TITLE
Removes normalization of role term authority.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -40,7 +40,6 @@ module Cocina
       normalize_coordinates # Must be before normalize_subject_cartographics
       normalize_subject_cartographics
       normalize_text_role_term
-      normalize_role_term_authority
       normalize_name
       normalize_related_item_other_type
       normalize_unmatched_altrepgroup
@@ -254,12 +253,6 @@ module Cocina
       # Add the type="text" attribute to roleTerms that don't have a type (seen in MODS 3.3 druid:yy910cj7795)
       ng_xml.root.xpath('//mods:roleTerm[not(@type)]', mods: MODS_NS).each do |role_term_node|
         role_term_node['type'] = 'text'
-      end
-    end
-
-    def normalize_role_term_authority
-      ng_xml.root.xpath("//mods:roleTerm[@authority='marcrelator']", mods: MODS_NS).each do |role_term_node|
-        role_term_node['authorityURI'] = 'http://id.loc.gov/vocabulary/relators/'
       end
     end
 

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -627,36 +627,6 @@ RSpec.describe Cocina::ModsNormalizer do
     end
   end
 
-  context 'when normalizing roleTerm authorityURI' do
-    let(:mods_ng_xml) do
-      Nokogiri::XML <<~XML
-        <mods #{mods_attributes}>
-          <name>
-            <namePart>Dunnett, Dorothy</namePart>
-            <role>
-              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
-              <roleTerm type="text" authority="marcrelator" valueURI="http://id.loc.gov/vocabulary/relators/pht">Photographer</roleTerm>
-            </role>
-          </name>
-        </mods>
-      XML
-    end
-
-    it 'adds authorityURI' do
-      expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <mods #{mods_attributes}>
-          <name>
-            <namePart>Dunnett, Dorothy</namePart>
-            <role>
-              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">pht</roleTerm>
-              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/pht">photographer</roleTerm>
-            </role>
-          </name>
-        </mods>
-      XML
-    end
-  end
-
   context 'when normalizing PURL' do
     let(:druid) { 'druid:bw502ns3302' }
 


### PR DESCRIPTION
closes #1836

## Why was this change made?
Since no longer added in mapping, no longer need to normalize.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


