### PR TITLE
Map unknown authority codes.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/authority.rb
+++ b/app/services/cocina/from_fedora/descriptive/authority.rb
@@ -30,7 +30,10 @@ module Cocina
             return 'lctgm'
           end
 
-          notifier.warn('"#N/A" authority code') if code == '#N/A'
+          if code == '#N/A'
+            notifier.warn('"#N/A" authority code')
+            return nil
+          end
 
           code.presence
         end

--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -95,10 +95,7 @@ module Cocina
 
           return nil if code.nil?
 
-          unless SubjectAuthorityCodes::SUBJECT_AUTHORITY_CODES.include?(code)
-            notifier.warn('Subject has unknown authority code', { code: code })
-            return nil
-          end
+          notifier.warn('Subject has unknown authority code', { code: code }) unless SubjectAuthorityCodes::SUBJECT_AUTHORITY_CODES.include?(code)
 
           code
         end

--- a/spec/services/cocina/from_fedora/descriptive/subject_name_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_name_spec.rb
@@ -688,7 +688,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
           value: 'Hoveyda, Fereydoun' }
       ]
       expect(notifier).to have_received(:warn).with('Name type unrecognized', { type: '#N/A' })
-      expect(notifier).to have_received(:warn).with('Subject has unknown authority code', { code: '#N/A' })
+      expect(notifier).to have_received(:warn).with('"#N/A" authority code').twice
       expect(notifier).to have_received(:warn).with('Value URI has unexpected value', { uri: '#N/A' }).twice
     end
   end

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -60,14 +60,15 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
       allow(notifier).to receive(:warn)
     end
 
-    it 'ignores the invalid code and warns' do
+    it 'includes the invalid code and warns' do
       expect(build).to eq [
         {
           "value": 'College students',
           "type": 'topic',
           "uri": 'http://id.loc.gov/authorities/subjects/sh85028356',
           "source": {
-            "uri": 'http://id.loc.gov/authorities/subjects/'
+            "uri": 'http://id.loc.gov/authorities/subjects/',
+            "code": 'topic'
           }
         }
       ]
@@ -117,12 +118,15 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
       allow(notifier).to receive(:warn)
     end
 
-    it 'omits source and warns' do
+    it 'includes source and warns' do
       expect(build).to eq [
         {
           "value": 'College students',
           "type": 'topic',
-          "uri": 'http://id.loc.gov/authorities/subjects/sh85028356'
+          "uri": 'http://id.loc.gov/authorities/subjects/sh85028356',
+          "source": {
+            "code": 'topic'
+          }
         }
       ]
       expect(notifier).to have_received(:warn).with('Subject has unknown authority code', { code: 'topic' })


### PR DESCRIPTION
closes #1883

## Why was this change made?
Per Arcadia.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


