### PR TITLE
cocina/to_fedora/descriptive: ensure utf-8 encoding

### DIFF
--- a/app/services/cocina/to_fedora/descriptive.rb
+++ b/app/services/cocina/to_fedora/descriptive.rb
@@ -18,7 +18,7 @@ module Cocina
       end
 
       def transform
-        Nokogiri::XML::Builder.new do |xml|
+        Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
           xml.mods(mods_attributes) do
             Descriptive::DescriptiveWriter.write(xml: xml, descriptive: descriptive, druid: druid)
           end


### PR DESCRIPTION
## Why was this change made?

Are you sick of mapping tests that spew out unicode characters as XML encoded unicode character points?  Me too.   This fixes that.

Did this as part of working on refactoring mappings specs as part of spec alignment.  It works.

## How was this change tested?

### This branch

```
Status (n=10000):
  Success:   9789 (97.89%)
  Different: 140 (1.4%)
  To Cocina error:     3 (0.03%)
  To Fedora error:     0 (0.0%)
  Missing:     68 (0.68%)
```

### main branch

```
Status (n=10000):
  Success:   9789 (97.89%)
  Different: 140 (1.4%)
  To Cocina error:     3 (0.03%)
  To Fedora error:     0 (0.0%)
  Missing:     68 (0.68%)

```

## Which documentation and/or configurations were updated?



