### PR TITLE
allow for adminMetadata to have multiple description standards

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
+++ b/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
@@ -77,16 +77,20 @@ module Cocina
         end
 
         def build_standard
-          return unless description_standard
+          return unless description_standards
 
-          return [{ code: description_standard.text }] unless description_standard['authority']
-
-          [{
-            code: description_standard['authority'],
-            uri: ValueURI.sniff(description_standard['valueURI'], notifier),
-            value: description_standard.text.presence,
-            source: { uri: description_standard['authorityURI'] }
-          }.compact].presence
+          description_standards.map do |description_standard|
+            if description_standard['authority']
+              {
+                code: description_standard['authority'],
+                uri: ValueURI.sniff(description_standard['valueURI'], notifier),
+                value: description_standard.text.presence,
+                source: { uri: description_standard['authorityURI'] }
+              }.compact
+            else
+              { code: description_standard.text }
+            end
+          end.presence
         end
 
         def build_contributor
@@ -137,8 +141,8 @@ module Cocina
           @record_content_source ||= record_info.xpath('mods:recordContentSource', mods: DESC_METADATA_NS).first
         end
 
-        def description_standard
-          @description_standard ||= record_info.xpath('mods:descriptionStandard', mods: DESC_METADATA_NS).first
+        def description_standards
+          @description_standards ||= record_info.xpath('mods:descriptionStandard', mods: DESC_METADATA_NS)
         end
 
         def record_origin

--- a/app/services/cocina/to_fedora/descriptive/admin_metadata.rb
+++ b/app/services/cocina/to_fedora/descriptive/admin_metadata.rb
@@ -47,11 +47,12 @@ module Cocina
         def build_description_standard
           return if admin_metadata.metadataStandard.blank?
 
-          standard = admin_metadata.metadataStandard.first
-          if standard.uri
-            xml.descriptionStandard standard.value, with_uri_info(standard).merge(authority: standard.code)
-          else
-            xml.descriptionStandard standard.code
+          admin_metadata.metadataStandard.each do |standard|
+            if standard.uri
+              xml.descriptionStandard standard.value, with_uri_info(standard).merge(authority: standard.code)
+            else
+              xml.descriptionStandard standard.code
+            end
           end
         end
 

--- a/spec/services/cocina/from_fedora/descriptive/admin_metadata_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/admin_metadata_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::AdminMetadata do
           </languageOfCataloging>
           <recordContentSource authority="marcorg" authorityURI="http://id.loc.gov/vocabulary/organizations/" valueURI="http://id.loc.gov/vocabulary/organizations/cst">CSt</recordContentSource>
           <descriptionStandard authority="dacs" authorityURI="http://id.loc.gov/vocabulary/descriptionConventions/" valueURI="http://id.loc.gov/vocabulary/descriptionConventions/dacs"></descriptionStandard>
+          <descriptionStandard>aacr</descriptionStandard>
           <recordOrigin>human prepared</recordOrigin>
         </recordInfo>
       XML
@@ -84,6 +85,9 @@ RSpec.describe Cocina::FromFedora::Descriptive::AdminMetadata do
             "source": {
               "uri": 'http://id.loc.gov/vocabulary/descriptionConventions/'
             }
+          },
+          {
+            "code": 'aacr'
           }
         ],
         "note": [

--- a/spec/services/cocina/to_fedora/descriptive/admin_metadata_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/admin_metadata_spec.rb
@@ -245,6 +245,13 @@ RSpec.describe Cocina::ToFedora::Descriptive::AdminMetadata do
         "metadataStandard": [
           {
             "code": 'aacr'
+          },
+          {
+            "code": 'dacs',
+            "uri": 'http://id.loc.gov/vocabulary/descriptionConventions/dacs',
+            "source": {
+              "uri": 'http://id.loc.gov/vocabulary/descriptionConventions/'
+            }
           }
         ],
         "identifier": [
@@ -277,6 +284,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::AdminMetadata do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <recordInfo>
             <descriptionStandard>aacr</descriptionStandard>
+            <descriptionStandard authority="dacs" authorityURI="http://id.loc.gov/vocabulary/descriptionConventions/" valueURI="http://id.loc.gov/vocabulary/descriptionConventions/dacs"></descriptionStandard>
             <recordContentSource authority="marcorg">CSt</recordContentSource>
             <recordCreationDate encoding="marc">180305</recordCreationDate>
             <recordChangeDate encoding='iso8601'>20200718050001.0</recordChangeDate>


### PR DESCRIPTION
## Why was this change made?

fix #1798

## How was this change tested?

unit tests, `validate-cocina-roundtrip` script on sdr-deploy

## Which documentation and/or configurations were updated?

n/a