### PR TITLE
Use Mods 3.7 instead of Mods 3.6

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -2,6 +2,7 @@
 
 module Cocina
   # Normalizes a Fedora MODS document, accounting for differences between Fedora MODS and MODS generated from Cocina.
+  # these adjustments have been approved by our metadata authority, Arcadia.
   class ModsNormalizer
     MODS_NS = Cocina::FromFedora::Descriptive::DESC_METADATA_NS
 
@@ -83,8 +84,8 @@ module Cocina
       # Only normalize version when version isn't mapped.
       return if /MODS version (\d\.\d)/.match(ng_xml.root.at('//mods:recordInfo/mods:recordOrigin', mods: MODS_NS)&.content)
 
-      ng_xml.root['version'] = '3.6'
-      ng_xml.root['xsi:schemaLocation'] = 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd'
+      ng_xml.root['version'] = '3.7'
+      ng_xml.root['xsi:schemaLocation'] = 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd'
     end
 
     def normalize_authority_uris

--- a/app/services/cocina/to_fedora/descriptive.rb
+++ b/app/services/cocina/to_fedora/descriptive.rb
@@ -37,7 +37,7 @@ module Cocina
             match = /MODS version (\d\.\d)/.match(note.value)
             return match[1] if match
           end
-          '3.6'
+          '3.7'
         end
       end
 

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe Cocina::ModsNormalizer do
   let(:normalized_ng_xml) { described_class.normalize(mods_ng_xml: mods_ng_xml, druid: druid) }
 
   let(:mods_attributes) do
-    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" version="3.6"
-    xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd"'
+    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" version="3.7"
+    xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd"'
   end
   let(:druid) { 'druid:pf694bk4862' }
 
@@ -41,9 +42,9 @@ RSpec.describe Cocina::ModsNormalizer do
         XML
       end
 
-      it 'changes version to 3.6' do
-        expect(normalized_ng_xml.root['version']).to eq('3.6')
-        expect(normalized_ng_xml.root['xsi:schemaLocation']).to eq('http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd')
+      it 'changes version to 3.7' do
+        expect(normalized_ng_xml.root['version']).to eq('3.7')
+        expect(normalized_ng_xml.root['xsi:schemaLocation']).to eq('http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd')
       end
     end
   end

--- a/spec/services/cocina/to_fedora/descriptive/contributor_h2_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/contributor_h2_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
     Nokogiri::XML::Builder.new do |xml|
       xml.mods('xmlns' => 'http://www.loc.gov/mods/v3',
                'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-               'version' => '3.6',
-               'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd') do
+               'version' => '3.7',
+               'xsi:schemaLocation' => 'http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd') do
         described_class.write(xml: xml, contributors: contributors, titles: nil, id_generator: Cocina::ToFedora::Descriptive::IdGenerator.new)
       end
     end
@@ -22,8 +22,8 @@ RSpec.describe Cocina::ToFedora::Descriptive::Contributor do
   let(:mods_element_open) do
     <<~XML
       <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="http://www.loc.gov/mods/v3" version="3.6"
-        xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        xmlns="http://www.loc.gov/mods/v3" version="3.7"
+        xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
     XML
   end
   let(:mods_element_close) { '</mods>' }

--- a/spec/services/cocina/to_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Cocina::ToFedora::Descriptive do
     it 'builds the xml' do
       expect(xml).to be_equivalent_to <<~XML
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          xmlns="http://www.loc.gov/mods/v3" version="3.7"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
           <titleInfo>
             <title>Gaudy night</title>
           </titleInfo>
@@ -76,8 +76,8 @@ RSpec.describe Cocina::ToFedora::Descriptive do
     it 'builds the xml' do
       expect(xml).to be_equivalent_to <<~XML
         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.6"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          xmlns="http://www.loc.gov/mods/v3" version="3.7"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
           <titleInfo>
             <title>Gaudy night</title>
           </titleInfo>

--- a/spec/support/mods_mapping_spec_helper.rb
+++ b/spec/support/mods_mapping_spec_helper.rb
@@ -113,8 +113,8 @@ def ng_mods_for(snippet)
   xml = <<~XML
     <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'
-      xmlns="http://www.loc.gov/mods/v3" version="3.6"
-      xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+      xmlns="http://www.loc.gov/mods/v3" version="3.7"
+      xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
       #{snippet}
     </mods>
   XML


### PR DESCRIPTION
## Why was this change made?

Arcadia asked for it

## How was this change tested?

### mods 3.7 branch

```
Status (n=100000):
  Success:   98076 (98.076%)
  Different: 1286 (1.286%)
  To Cocina error:     28 (0.028%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

### main branch

```
Status (n=100000):
  Success:   98076 (98.076%)
  Different: 1286 (1.286%)
  To Cocina error:     28 (0.028%)
  To Fedora error:     0 (0.0%)
  Missing:     610 (0.61%)
```

## Which documentation and/or configurations were updated?



