### PR TITLE
mapping specs - remove unnec comments

### DIFF
--- a/spec/services/cocina/from_fedora/descriptive/form_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/form_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
   end
 
   describe 'genre' do
-    # MODS genre mapping spec not in /mappings/mods/genre_spec.rb
-    # Arcadia to add it there or make a different decision
     context 'with authority missing valueURI' do
       let(:xml) do
         <<~XML
@@ -43,8 +41,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
       end
     end
 
-    # MODS genre mapping spec not in /mappings/mods/genre_spec.rb
-    # Arcadia to add it there or make a different decision
     context 'with authority missing authorityURI' do
       let(:xml) do
         <<~XML
@@ -66,8 +62,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
       end
     end
 
-    # MODS genre mapping spec not in /mappings/mods/genre_spec.rb
-    # Arcadia to add it there or make a different decision
     context 'with empty authority' do
       let(:xml) do
         <<~XML

--- a/spec/services/cocina/from_fedora/descriptive/geographic_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/geographic_spec.rb
@@ -78,8 +78,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
       }
     end
 
-    # MODS geo mapping spec not in /mappings/mods/geo_extension_spec.rb
-    # Arcadia to add it there or make a different decision
     context 'when dc:type does not have the expected capitalization' do
       let(:dc_type) { 'image' }
 
@@ -162,8 +160,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
       }
     end
 
-    # MODS geo mapping spec not in /mappings/mods/geo_extension_spec.rb
-    # Arcadia to add it there or make a different decision
     context 'when dc:type does not have the expected capitalization' do
       let(:dc_type) { 'image' }
 
@@ -179,8 +175,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
     end
   end
 
-  # MODS geo mapping spec not in /mappings/mods/geo_extension_spec.rb
-  # Arcadia to add it there or make a different decision
   context 'with a bad PURL' do
     let(:dc_type) { 'Image' }
     let(:xml) do
@@ -206,8 +200,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Geographic do
     end
   end
 
-  # MODS geo mapping spec not in /mappings/mods/geo_extension_spec.rb
-  # Arcadia to add it there or make a different decision
   context 'with an https PURL' do
     let(:dc_type) { 'Image' }
     let(:xml) do

--- a/spec/services/cocina/from_fedora/descriptive/notes_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/notes_spec.rb
@@ -133,8 +133,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Notes do
     end
   end
 
-  # MODS abstract mapping spec not in /mappings/mods/abstract_spec.rb
-  # Arcadia to add it there or make a different decision
   context 'with an empty displayLabel' do
     let(:xml) do
       <<~XML

--- a/spec/services/cocina/to_fedora/descriptive/geographic_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/geographic_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
     end
   end
 
-  # MODS geo mapping spec not in /mappings/mods/geo_extension_spec.rb
-  # Arcadia to add it there or make a different decision
   context 'when geo is nil' do
     let(:geos) { nil }
 
@@ -36,8 +34,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
     end
   end
 
-  # MODS geo mapping spec not in /mappings/mods/geo_extension_spec.rb
-  # Arcadia to add it there or make a different decision
   context 'with a bounding box from a polygon shapefile converted from ISO 19139 missing standard' do
     let(:geo) do
       Cocina::Models::DescriptiveGeographicMetadata.new(
@@ -121,8 +117,6 @@ RSpec.describe Cocina::ToFedora::Descriptive::Geographic do
     end
   end
 
-  # MODS geo mapping spec not in /mappings/mods/geo_extension_spec.rb
-  # Arcadia to add it there or make a different decision
   context 'when a polygon shapefile without subject' do
     let(:geo) do
       Cocina::Models::DescriptiveGeographicMetadata.new(


### PR DESCRIPTION
## Why was this change made?

@justinlittman convinced me these comments were just noise and would require extra future work.

## How was this change tested?

changes to specs only, and removing comments at that.

## Which documentation and/or configurations were updated?



