### PR TITLE
Fixed Title with xml:space test.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ group :test, :development do
   gem 'parallel' # used for validating cocina tools
   gem 'pry-byebug'
   gem 'rack-console'
-  gem 'rspec-deep-ignore-order-matcher'
   gem 'rspec_junit_formatter'
   gem 'rspec-rails'
   gem 'rubocop', '~> 0.86'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,14 +383,8 @@ GEM
     rsolr (2.3.0)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
-    rspec-deep-ignore-order-matcher (0.0.5)
-      rspec (~> 3.0)
     rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
@@ -552,7 +546,6 @@ DEPENDENCIES
   rack-console
   rails (~> 5.2.0)
   retries
-  rspec-deep-ignore-order-matcher
   rspec-rails
   rspec_junit_formatter
   rubocop (~> 0.86)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,7 +13,6 @@ require 'rspec/rails'
 require "super_diff/rspec-rails"
 require 'support/foxml_helper'
 require 'support/factory_bot'
-require 'rspec_deep_ignore_order_matcher'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/services/cocina/mapping/descriptive/mods/title_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/title_info_spec.rb
@@ -322,7 +322,7 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
       }
     end
 
-    xit 'needs to be fixed'
+    xit 'broken'
   end
 
   describe 'Uniform title with multiple namePart subelements' do
@@ -850,59 +850,59 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
       XML
     end
 
-    xit 'implemented, but broken'
+    xit 'broken'
   end
 
   describe 'Title with xml:space="preserve"' do
-    let(:mods) do
-      <<~XML
-        <titleInfo>
-          <nonSort xml:space="preserve">A </nonSort>
-          <title>broken journey</title>
-          <subTitle>memoir of Mrs. Beatty, wife of Rev. William Beatty, Indian missionary</subTitle>
-        </titleInfo>
-      XML
-    end
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <titleInfo>
+            <nonSort xml:space="preserve">A </nonSort>
+            <title>broken journey</title>
+            <subTitle>memoir of Mrs. Beatty, wife of Rev. William Beatty, Indian missionary</subTitle>
+          </titleInfo>
+        XML
+      end
 
-    let(:cocina) do
-      {
-        "title": [
-          {
-            "structuredValue": [
-              {
-                "value": 'A',
-                "type": 'nonsorting characters'
-              },
-              {
-                "value": 'broken journey',
-                "type": 'main title'
-              },
-              {
-                "value": 'memoir of Mrs. Beatty, wife of Rev. William Beatty, Indian missionary',
-                "type": 'subtitle'
-              }
-            ],
-            "note": [
-              {
-                "value": '2',
-                "type": 'nonsorting character count'
-              }
-            ]
-          }
-        ]
-      }
-    end
+      let(:cocina) do
+        {
+          "title": [
+            {
+              "structuredValue": [
+                {
+                  "value": 'A',
+                  "type": 'nonsorting characters'
+                },
+                {
+                  "value": 'broken journey',
+                  "type": 'main title'
+                },
+                {
+                  "value": 'memoir of Mrs. Beatty, wife of Rev. William Beatty, Indian missionary',
+                  "type": 'subtitle'
+                }
+              ],
+              "note": [
+                {
+                  "value": '2',
+                  "type": 'nonsorting character count'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-    let(:roundtrip_mods) do
-      <<~XML
-        <titleInfo>
-          <nonSort>A </nonSort>
-          <title>broken journey</title>
-          <subTitle>memoir of Mrs. Beatty, wife of Rev. William Beatty, Indian missionary</subTitle>
-        </titleInfo>
-      XML
+      let(:roundtrip_mods) do
+        <<~XML
+          <titleInfo>
+            <nonSort>A </nonSort>
+            <title>broken journey</title>
+            <subTitle>memoir of Mrs. Beatty, wife of Rev. William Beatty, Indian missionary</subTitle>
+          </titleInfo>
+        XML
+      end
     end
-
-    xit 'broken'
   end
 end

--- a/spec/support/matchers/deep_ignore_order_matcher.rb
+++ b/spec/support/matchers/deep_ignore_order_matcher.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Based on https://github.com/amogil/rspec-deep-ignore-order-matcher/blob/master/lib/rspec_deep_ignore_order_matcher.rb
+RSpec::Matchers.define :be_deep_equal do |expected|
+  match { |actual| match? actual, expected }
+
+  # Added diffable because it is helpful for troubleshooting, even if it mistakingly diffs order differences.
+  diffable
+
+  failure_message do |actual|
+    "expected that #{actual} would be deep equal with #{expected}. Differences in order shown in diff CAN BE IGNORED."
+  end
+
+  failure_message_when_negated do |actual|
+    "expected that #{actual} would not be deep equal with #{expected}. Differences in order shown in diff CAN BE IGNORED."
+  end
+
+  description do
+    "be deep equal with #{expected}"
+  end
+
+  def match?(actual, expected)
+    return arrays_match?(actual, expected) if expected.is_a?(Array) && actual.is_a?(Array)
+    return hashes_match?(actual, expected) if expected.is_a?(Hash) && actual.is_a?(Hash)
+
+    expected == actual
+  end
+
+  def arrays_match?(actual, expected)
+    exp = expected.clone
+    actual.each do |a|
+      index = exp.find_index { |e| match? a, e }
+      return false if index.nil?
+
+      exp.delete_at(index)
+    end
+    exp.empty?
+  end
+
+  def hashes_match?(actual, expected)
+    return false unless actual.keys.sort == expected.keys.sort
+
+    actual.each { |key, value| return false unless match? value, expected[key] }
+    true
+  end
+end


### PR DESCRIPTION
 Also, added custom hash matcher that ignores order.

closes #1921

## Why was this change made?
* Less broken tests = better mapping.
* Show diff when comparing cocina hashes for easier debugging.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


