### PR TITLE
add admin_metadata_h2_spec for cocina mappings

### DIFF
--- a/spec/services/cocina/mapping/descriptive/h2/admin_metadata_h2_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/admin_metadata_h2_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Cocina --> MODS mappings for adminMetadata (H2 specific)' do
+  let(:h2_version) { '1' }
+
+  describe 'New record' do
+    let(:create_date) { '2018-10-25' }
+
+    it_behaves_like 'cocina MODS mapping' do
+      let(:druid) { 'bc777tp9978' }
+
+      let(:cocina) do
+        {
+          adminMetadata: {
+            event: [
+              {
+                type: 'creation',
+                date: [
+                  {
+                    value: create_date,
+                    encoding: {
+                      code: 'w3cdtf'
+                    }
+                  }
+                ]
+              }
+            ],
+            note: [
+              {
+                value: "Metadata created by user via Stanford self-deposit application v.#{h2_version}",
+                type: 'record origin'
+              }
+            ]
+          }
+        }
+      end
+
+      let(:mods) do
+        <<~XML
+          <recordInfo>
+            <recordOrigin>Metadata created by user via Stanford self-deposit application v.#{h2_version}</recordOrigin>
+            <recordCreationDate encoding="w3cdtf">#{create_date}</recordCreationDate>
+          </recordInfo>
+        XML
+      end
+    end
+  end
+
+  describe 'Modified record' do
+    xit 'TODO: implement recordInfo/recordChangeDate as a note when mapping MODS -> cocina'
+
+    let(:create_date) { '2014-04-08' }
+
+    let(:modification_date) { '2014-10-22' }
+
+    let(:druid) { 'jv545yc8727' }
+
+    let(:cocina) do
+      {
+        adminMetadata: {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  value: create_date,
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'modification',
+              date: [
+                {
+                  value: modification_date,
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            }
+          ],
+          note: [
+            {
+              value: "Metadata created by user via Stanford self-deposit application v.#{h2_version}",
+              type: 'record origin'
+            },
+            {
+              value: "Metadata modified by user via Stanford self-deposit application v.#{h2_version}",
+              type: 'record origin'
+            }
+          ]
+        }
+      }
+    end
+
+    let(:mods) do
+      <<~XML
+        <recordInfo>
+          <recordOrigin>Metadata created by user via Stanford self-deposit application v.#{h2_version}</recordOrigin>
+          <recordCreationDate encoding="w3cdtf">#{create_date}</recordCreationDate>
+          <recordChangeDate encoding="w3cdtf">#{modification_date}</recordChangeDate>
+        </recordInfo>
+      XML
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

adding Arcadia's mappings for h2 MODS adminMetadata specs.

## How was this change tested?

it adds specs only

## Which documentation and/or configurations were updated?



