### PR TITLE
Mods name specs tweak

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -34,8 +34,9 @@ module Cocina
 
         def build
           grouped_altrepgroup_name_nodes, other_name_nodes = AltRepGroup.split(nodes: resource_element.xpath('mods:name', mods: DESC_METADATA_NS))
-          grouped_altrepgroup_name_nodes.map { |name_nodes| build_name_nodes(name_nodes) } + \
-            other_name_nodes.map { |name_node| build_name_nodes([name_node]) }
+          contributors = grouped_altrepgroup_name_nodes.map { |name_nodes| build_name_nodes(name_nodes) } + \
+                         other_name_nodes.map { |name_node| build_name_nodes([name_node]) }
+          contributors.compact.presence
         end
 
         private
@@ -44,7 +45,7 @@ module Cocina
 
         def build_name_nodes(name_nodes)
           name_nodes.each { |name_node| notifier.warn('Missing or empty name type attribute') if name_node['type'].blank? }
-          NameBuilder.build(name_elements: name_nodes, notifier: notifier)
+          NameBuilder.build(name_elements: name_nodes, notifier: notifier).presence
         end
       end
     end

--- a/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/contributor_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
     end
 
     it 'builds the cocina data structure and warns' do
-      expect(build).to eq [{}]
+      expect(build).to eq nil
       expect(notifier).to have_received(:warn).with('Missing or empty name type attribute')
       expect(notifier).to have_received(:warn).with('name/namePart missing value')
       expect(notifier).to have_received(:warn).with('Missing name/namePart element')
@@ -454,7 +454,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Contributor do
       end
 
       it 'builds the cocina data structure and warns' do
-        expect(build).to eq [{}]
+        expect(build).to eq nil
         expect(notifier).to have_received(:warn).with('Missing name/namePart element')
       end
     end

--- a/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
@@ -549,7 +549,7 @@ RSpec.describe 'MODS name <--> cocina mappings' do
 
       let(:roundtrip_mods) { nil }
 
-      let(:cocina) { nil }
+      let(:cocina) { {} }
 
       let(:warnings) do
         [
@@ -576,7 +576,7 @@ RSpec.describe 'MODS name <--> cocina mappings' do
 
       let(:roundtrip_mods) { nil }
 
-      let(:cocina) { nil }
+      let(:cocina) { {} }
 
       let(:warnings) do
         [

--- a/spec/support/mods_mapping_spec_helper.rb
+++ b/spec/support/mods_mapping_spec_helper.rb
@@ -66,15 +66,7 @@ RSpec.shared_examples 'MODS cocina mapping' do
     end
 
     it 'MODS maps to expected cocina' do
-      if cocina
-        expect(actual_cocina_props).to be_deep_equal(cocina)
-      else
-        actual_cocina_props.each_key do |key|
-          return true if actual_cocina_props[key].blank?
-
-          expect(actual_cocina_props[key] == [{}]).to eq true
-        end
-      end
+      expect(actual_cocina_props).to be_deep_equal(cocina)
     end
 
     it 'notifier receives warning and/or error messages as specified' do
@@ -118,17 +110,7 @@ RSpec.shared_examples 'MODS cocina mapping' do
     end
 
     it 'MODS maps to expected cocina' do
-      if defined?(roundtrip_mods)
-        if cocina
-          expect(actual_cocina_props).to be_deep_equal(cocina)
-        else
-          actual_cocina_props.each_key do
-            return true if actual_cocina_props[key].blank?
-
-            expect(actual_cocina_props[key] == [{}]).to eq true
-          end
-        end
-      end
+      expect(actual_cocina_props).to be_deep_equal(cocina) if defined?(roundtrip_mods)
     end
   end
 


### PR DESCRIPTION
## Why was this change made?
So that contributor correctly return nil when empty rather than an empty structure.


## How was this change tested?

Unit

## Which documentation and/or configurations were updated?
NA


