### PR TITLE
Upgrade to solr 8 for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     ports:
       - 6379:6379
   solr:
-    image: solr:7
+    image: solr:slim
     volumes:
       - ./solr_conf/conf/:/myconfig
     command: solr-create -c dorservices -d /myconfig


### PR DESCRIPTION
This change only affects the development environment.

## Why was this change made?

This is what we run in production

## How was this change tested?



## Which documentation and/or configurations were updated?



