### PR TITLE
H2 mappings - xit update

### DIFF
--- a/spec/services/cocina/mapping/descriptive/h2/access_h2_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/access_h2_spec.rb
@@ -4,16 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Cocina --> MODS mappings for access (H2 specific)' do
   describe 'Contact email' do
-    xit 'FIXME: get MODS mapping for email (is it part of name ?)'
-
-    # this is clearly wrong
-    let(:mods) do
-      <<~XML
-        <location>
-          <physicalLocation type="email" displayLabel="Contact">me@stanford.edu</physicalLocation>
-        </location>
-      XML
-    end
+    xit 'not mapped: email to MODS'
 
     let(:cocina) do
       {
@@ -36,9 +27,7 @@ RSpec.describe 'Cocina --> MODS mappings for access (H2 specific)' do
   end
 
   describe 'Contact email not provided' do
-    xit 'FIXME: cocina -> MODS ok, but no way to get back'
-
-    let(:mods) { '' }
+    xit 'not mapped: access.digitalRepository to MODS'
 
     let(:cocina) do
       {

--- a/spec/services/cocina/mapping/descriptive/h2/admin_metadata_h2_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/admin_metadata_h2_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe 'Cocina --> MODS mappings for adminMetadata (H2 specific)' do
     let(:create_date) { '2018-10-25' }
 
     it_behaves_like 'cocina MODS mapping' do
-      let(:druid) { 'bc777tp9978' }
-
+      # Adapted from druid:bc777tp9978.
       let(:cocina) do
         {
           adminMetadata: {
@@ -49,63 +48,102 @@ RSpec.describe 'Cocina --> MODS mappings for adminMetadata (H2 specific)' do
   end
 
   describe 'Modified record' do
-    xit 'TODO: implement recordInfo/recordChangeDate as a note when mapping MODS -> cocina'
+    xit 'not implemented: recordInfo/recordChangeDate as a note when mapping MODS -> cocina'
 
     let(:create_date) { '2014-04-08' }
 
     let(:modification_date) { '2014-10-22' }
 
-    let(:druid) { 'jv545yc8727' }
+    it_behaves_like 'cocina MODS mapping' do
+      # adapted from jv545yc8727
 
-    let(:cocina) do
-      {
-        adminMetadata: {
-          event: [
-            {
-              type: 'creation',
-              date: [
-                {
-                  value: create_date,
-                  encoding: {
-                    code: 'w3cdtf'
+      let(:cocina) do
+        {
+          adminMetadata: {
+            event: [
+              {
+                type: 'creation',
+                date: [
+                  {
+                    value: create_date,
+                    encoding: {
+                      code: 'w3cdtf'
+                    }
                   }
-                }
-              ]
-            },
-            {
-              type: 'modification',
-              date: [
-                {
-                  value: modification_date,
-                  encoding: {
-                    code: 'w3cdtf'
+                ]
+              },
+              {
+                type: 'modification',
+                date: [
+                  {
+                    value: modification_date,
+                    encoding: {
+                      code: 'w3cdtf'
+                    }
                   }
-                }
-              ]
-            }
-          ],
-          note: [
-            {
-              value: "Metadata created by user via Stanford self-deposit application v.#{h2_version}",
-              type: 'record origin'
-            },
-            {
-              value: "Metadata modified by user via Stanford self-deposit application v.#{h2_version}",
-              type: 'record origin'
-            }
-          ]
+                ]
+              }
+            ],
+            note: [
+              {
+                value: "Metadata created by user via Stanford self-deposit application v.#{h2_version}",
+                type: 'record origin'
+              },
+              {
+                value: "Metadata modified by user via Stanford self-deposit application v.#{h2_version}",
+                type: 'record origin'
+              }
+            ]
+          }
         }
-      }
-    end
+      end
 
-    let(:mods) do
-      <<~XML
-        <recordInfo>
-          <recordOrigin>Metadata created by user via Stanford self-deposit application v.#{h2_version}</recordOrigin>
-          <recordCreationDate encoding="w3cdtf">#{create_date}</recordCreationDate>
-          <recordChangeDate encoding="w3cdtf">#{modification_date}</recordChangeDate>
-        </recordInfo>
-      XML
+      let(:roundtrip_cocina) do
+        {
+          adminMetadata: {
+            event: [
+              {
+                type: 'creation',
+                date: [
+                  {
+                    value: create_date,
+                    encoding: {
+                      code: 'w3cdtf'
+                    }
+                  }
+                ]
+              },
+              {
+                type: 'modification',
+                date: [
+                  {
+                    value: modification_date,
+                    encoding: {
+                      code: 'w3cdtf'
+                    }
+                  }
+                ]
+              }
+            ],
+            note: [
+              {
+                value: "Metadata created by user via Stanford self-deposit application v.#{h2_version}",
+                type: 'record origin'
+              }
+            ]
+          }
+        }
+      end
+
+      let(:mods) do
+        <<~XML
+          <recordInfo>
+            <recordOrigin>Metadata created by user via Stanford self-deposit application v.#{h2_version}</recordOrigin>
+            <recordCreationDate encoding="w3cdtf">#{create_date}</recordCreationDate>
+            <recordChangeDate encoding="w3cdtf">#{modification_date}</recordChangeDate>
+          </recordInfo>
+        XML
+      end
     end
   end
 end

--- a/spec/services/cocina/mapping/descriptive/h2/event_h2_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/event_h2_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'Creation date range: 2020-01-01 to 2021-01-01' do
-    xit 'to be implemented: date encoding is in wrong place for structuredValue'
+    xit 'not implemented: date encoding is in wrong place for structuredValue'
     # date encoding is in wrong place for structuredValue.
     # Per Arcadia: "the pattern is for properties to be at the highest level to which they apply"
 
@@ -106,7 +106,7 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'Approximate creation date: approx. 1900' do
-    xit 'to be implemented: date encoding and qualifier in wrong place for structuredValue'
+    xit 'not implemented: date encoding and qualifier in wrong place for structuredValue'
     # Per Arcadia: "the pattern is for properties to be at the highest level to which they apply"
 
     let(:cocina) do
@@ -149,7 +149,7 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
 
   describe 'Release date: 2022-01-01' do
     xit 'not implemented: release type nor appliesTo'
-    # Ask Arcadia if she wants to add release or if she meant something else
+    # Ask Arcadia if she wants to add release to types or if she meant something else
 
     let(:cocina) do
       {

--- a/spec/services/cocina/mapping/descriptive/h2/form_h2_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/form_h2_spec.rb
@@ -7,10 +7,9 @@ RSpec.describe 'Cocina --> MODS mappings for form (H2 specific)' do
   # https://docs.google.com/spreadsheets/d/1EiGgVqtb6PUJE2cI_jhqnAoiQkiwZtar4tF7NHwSMz8/edit?usp=sharing
 
   describe 'Text - Article (AAT genre)' do
-    xit 'TODO: DataCite mapping not yet implemented'
+    xit 'not implemented: DataCite mapping'
 
     it_behaves_like 'cocina MODS mapping' do
-      # WITHOUT DataCite
       let(:cocina) do
         {
           form: [
@@ -44,14 +43,52 @@ RSpec.describe 'Cocina --> MODS mappings for form (H2 specific)' do
               source: {
                 value: 'MODS resource types'
               }
+            },
+            {
+              value: 'Text',
+              type: 'resource type',
+              source: {
+                value: 'DataCite resource types'
+              }
             }
-            # {
-            #   value: 'Text',
-            #   type: 'resource type',
-            #   source: {
-            #     value: 'DataCite resource types'
-            #   }
-            # }
+          ]
+        }
+      end
+
+      let(:roundtrip_cocina) do
+        {
+          form: [
+            {
+              structuredValue: [
+                {
+                  value: 'Text',
+                  type: 'type'
+                },
+                {
+                  value: 'Article',
+                  type: 'subtype'
+                }
+              ],
+              source: {
+                value: 'Stanford self-deposit resource types'
+              },
+              type: 'resource type'
+            },
+            {
+              value: 'articles',
+              type: 'genre',
+              uri: 'http://vocab.getty.edu/page/aat/300048715',
+              source: {
+                code: 'aat'
+              }
+            },
+            {
+              value: 'text',
+              type: 'resource type',
+              source: {
+                value: 'MODS resource types'
+              }
+            }
           ]
         }
       end
@@ -68,10 +105,9 @@ RSpec.describe 'Cocina --> MODS mappings for form (H2 specific)' do
   end
 
   describe 'Text - Essay (LC genre)' do
-    xit 'TODO: DataCite mapping not yet implemented'
+    xit 'not implemented: DataCite mapping'
 
     it_behaves_like 'cocina MODS mapping' do
-      # WITHOUT DataCite
       let(:cocina) do
         {
           form: [
@@ -105,14 +141,52 @@ RSpec.describe 'Cocina --> MODS mappings for form (H2 specific)' do
               source: {
                 value: 'MODS resource types'
               }
+            },
+            {
+              value: 'Text',
+              type: 'resource type',
+              source: {
+                value: 'DataCite resource types'
+              }
             }
-            # {
-            #   value: 'Text',
-            #   type: 'resource type',
-            #   source: {
-            #     value: 'DataCite resource types'
-            #   }
-            # }
+          ]
+        }
+      end
+
+      let(:roundtrip_cocina) do
+        {
+          form: [
+            {
+              structuredValue: [
+                {
+                  value: 'Text',
+                  type: 'type'
+                },
+                {
+                  value: 'Essays',
+                  type: 'subtype'
+                }
+              ],
+              source: {
+                value: 'Stanford self-deposit resource types'
+              },
+              type: 'resource type'
+            },
+            {
+              value: 'Essays',
+              type: 'genre',
+              uri: 'http://id.loc.gov/authorities/genreForms/gf2014026094',
+              source: {
+                code: 'lcgft'
+              }
+            },
+            {
+              value: 'text',
+              type: 'resource type',
+              source: {
+                value: 'MODS resource types'
+              }
+            }
           ]
         }
       end
@@ -129,10 +203,9 @@ RSpec.describe 'Cocina --> MODS mappings for form (H2 specific)' do
   end
 
   describe 'Data - 3D model (unauthorized genre)' do
-    xit 'TODO: DataCite mapping not yet implemented'
+    xit 'not implemented: DataCite mapping'
 
     it_behaves_like 'cocina MODS mapping' do
-      # WITHOUT DataCite
       let(:cocina) do
         {
           form: [
@@ -162,14 +235,48 @@ RSpec.describe 'Cocina --> MODS mappings for form (H2 specific)' do
               source: {
                 value: 'MODS resource types'
               }
+            },
+            {
+              value: 'Dataset',
+              type: 'resource type',
+              source: {
+                value: 'DataCite resource types'
+              }
             }
-            # {
-            #   value: 'Dataset',
-            #   type: 'resource type',
-            #   source: {
-            #     value: 'DataCite resource types'
-            #   }
-            # }
+          ]
+        }
+      end
+
+      let(:roundtrip_cocina) do
+        {
+          form: [
+            {
+              structuredValue: [
+                {
+                  value: 'Data',
+                  type: 'type'
+                },
+                {
+                  value: '3D model',
+                  type: 'subtype'
+                }
+              ],
+              source: {
+                value: 'Stanford self-deposit resource types'
+              },
+              type: 'resource type'
+            },
+            {
+              value: 'Three dimensional scan',
+              type: 'genre'
+            },
+            {
+              value: 'three dimensional object',
+              type: 'resource type',
+              source: {
+                value: 'MODS resource types'
+              }
+            }
           ]
         }
       end
@@ -186,10 +293,9 @@ RSpec.describe 'Cocina --> MODS mappings for form (H2 specific)' do
   end
 
   describe 'Data - GIS (multiple genres, multiple types of resource)' do
-    xit 'TODO: DataCite mapping not yet implemented'
+    xit 'not implemented: DataCite mapping'
 
     it_behaves_like 'cocina MODS mapping' do
-      # WITHOUT DataCite
       let(:cocina) do
         {
           form: [
@@ -234,14 +340,63 @@ RSpec.describe 'Cocina --> MODS mappings for form (H2 specific)' do
               source: {
                 value: 'MODS resource types'
               }
+            },
+            {
+              value: 'Dataset',
+              type: 'resource type',
+              source: {
+                value: 'DataCite resource types'
+              }
             }
-            # {
-            #   value: 'Dataset',
-            #   type: 'resource type',
-            #   source: {
-            #     value: 'DataCite resource types'
-            #   }
-            # }
+          ]
+        }
+      end
+
+      let(:roundtrip_cocina) do
+        {
+          form: [
+            {
+              structuredValue: [
+                {
+                  value: 'Data',
+                  type: 'type'
+                },
+                {
+                  value: 'GIS',
+                  type: 'subtype'
+                }
+              ],
+              source: {
+                value: 'Stanford self-deposit resource types'
+              },
+              type: 'resource type'
+            },
+            {
+              value: 'Geographic information systems',
+              type: 'genre',
+              uri: 'http://id.loc.gov/authorities/genreForms/gf2011026294',
+              source: {
+                code: 'lcgft'
+              }
+            },
+            {
+              value: 'dataset',
+              type: 'genre'
+            },
+            {
+              value: 'cartographic',
+              type: 'resource type',
+              source: {
+                value: 'MODS resource types'
+              }
+            },
+            {
+              value: 'software, multimedia',
+              type: 'resource type',
+              source: {
+                value: 'MODS resource types'
+              }
+            }
           ]
         }
       end
@@ -260,10 +415,9 @@ RSpec.describe 'Cocina --> MODS mappings for form (H2 specific)' do
   end
 
   describe 'Software - Code, Documentation (multiple subtypes)' do
-    xit 'TODO: DataCite mapping not yet implemented'
+    xit 'not implemented: DataCite mapping'
 
     it_behaves_like 'cocina MODS mapping' do
-      # WITHOUT DataCite
       let(:cocina) do
         {
           form: [
@@ -316,21 +470,78 @@ RSpec.describe 'Cocina --> MODS mappings for form (H2 specific)' do
               source: {
                 value: 'MODS resource types'
               }
+            },
+            {
+              value: 'Software',
+              type: 'resource type',
+              source: {
+                value: 'DataCite resource types'
+              }
+            },
+            {
+              value: 'Text',
+              type: 'resource type',
+              source: {
+                value: 'DataCite resource types'
+              }
             }
-            # {
-            #   value: 'Software',
-            #   type: 'resource type',
-            #   source: {
-            #     value: 'DataCite resource types'
-            #   }
-            # },
-            # {
-            #   value: 'Text',
-            #   type: 'resource type',
-            #   source: {
-            #     value: 'DataCite resource types'
-            #   }
-            # }
+          ]
+        }
+      end
+
+      let(:roundtrip_cocina) do
+        {
+          form: [
+            {
+              structuredValue: [
+                {
+                  value: 'Software',
+                  type: 'type'
+                },
+                {
+                  value: 'Code',
+                  type: 'subtype'
+                },
+                {
+                  value: 'Documentation',
+                  type: 'subtype'
+                }
+              ],
+              source: {
+                value: 'Stanford self-deposit resource types'
+              },
+              type: 'resource type'
+            },
+            {
+              value: 'programs (computer)',
+              type: 'genre',
+              uri: 'http://vocab.getty.edu/page/aat/300312188',
+              source: {
+                code: 'aat'
+              }
+            },
+            {
+              value: 'technical manuals',
+              type: 'genre',
+              uri: 'http://vocab.getty.edu/aat/300026413',
+              source: {
+                code: 'aat'
+              }
+            },
+            {
+              value: 'software, multimedia',
+              type: 'resource type',
+              source: {
+                value: 'MODS resource types'
+              }
+            },
+            {
+              value: 'text',
+              type: 'resource type',
+              source: {
+                value: 'MODS resource types'
+              }
+            }
           ]
         }
       end
@@ -350,10 +561,9 @@ RSpec.describe 'Cocina --> MODS mappings for form (H2 specific)' do
   end
 
   describe 'Other - Dance notation (Other type with user-entered subtype)' do
-    xit 'TODO: DataCite mapping not yet implemented'
+    xit 'not implemented: DataCite mapping'
 
     it_behaves_like 'cocina MODS mapping' do
-      # WITHOUT DataCite
       let(:cocina) do
         {
           form: [
@@ -372,14 +582,37 @@ RSpec.describe 'Cocina --> MODS mappings for form (H2 specific)' do
                 value: 'Stanford self-deposit resource types'
               },
               type: 'resource type'
+            },
+            {
+              value: 'Dataset',
+              type: 'resource type',
+              source: {
+                value: 'DataCite resource types'
+              }
             }
-            # {
-            #   value: 'Dataset',
-            #   type: 'resource type',
-            #   source: {
-            #     value: 'DataCite resource types'
-            #   }
-            # }
+          ]
+        }
+      end
+
+      let(:roundtrip_cocina) do
+        {
+          form: [
+            {
+              structuredValue: [
+                {
+                  value: 'Other',
+                  type: 'type'
+                },
+                {
+                  value: 'Dance notation',
+                  type: 'subtype'
+                }
+              ],
+              source: {
+                value: 'Stanford self-deposit resource types'
+              },
+              type: 'resource type'
+            }
           ]
         }
       end

--- a/spec/services/cocina/mapping/descriptive/h2/subject_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/subject_spec.rb
@@ -289,6 +289,6 @@ RSpec.describe 'Cocina --> MODS mappings for FAST subjects' do
       XML
     end
 
-    xit 'mapping not completed'
+    xit 'not mapped'
   end
 end


### PR DESCRIPTION
## Why was this change made?

Standardizing xit practices on mapping specs.  Also, I forgot about roundtrip_cocina so was able to add some specs to admin_metadata.

## How was this change tested?

it's all spec code

## Which documentation and/or configurations were updated?



