### PR TITLE
mods record_info mapping spec labelled broken in xit

### DIFF
--- a/spec/services/cocina/mapping/descriptive/mods/record_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/record_info_spec.rb
@@ -176,6 +176,8 @@ RSpec.describe 'MODS recordInfo <--> cocina mappings' do
   end
 
   describe 'Converted from MARC' do
+    xit 'broken: MARC to MODS conversion needs to use MODS 3.7 and then this spec will pass'
+
     let(:mods) do
       <<~XML
         <recordInfo>
@@ -266,8 +268,6 @@ RSpec.describe 'MODS recordInfo <--> cocina mappings' do
         }
       }
     end
-
-    xit 'TODO: MARC to MODS conversion needs to use MODS 3.7 and then this spec will pass'
   end
 
   describe 'Converted from ISO 19139' do


### PR DESCRIPTION
## Why was this change made?

to highlight that we have a broken spec that should be fixed.

## How was this change tested?

change is to a spec.

## Which documentation and/or configurations were updated?



