### PR TITLE
Add external link mapping to table of contents spec

### DIFF
--- a/spec/services/cocina/mapping/descriptive/mods/table_of_contents_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/table_of_contents_spec.rb
@@ -110,6 +110,27 @@ RSpec.describe 'MODS tableOfContents <--> cocina mappings' do
     end
   end
 
+  describe 'Link to external value only' do
+    xit 'not implemented'
+
+    let(:mods) do
+      <<~XML
+        <tableOfContents xlink:href="http://contents.org/contents" />
+      XML
+    end
+
+    let(:cocina) do
+      {
+        "note": [
+          {
+            "valueAt": 'http://contents.org/contents',
+            "type": 'table of contents'
+          }
+        ]
+      }
+    end
+  end
+
   describe 'Display label' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do


### PR DESCRIPTION
## Why was this change made?
Partially addresses #1936 


## How was this change tested?
n/a


## Which documentation and/or configurations were updated?
n/a


