### PR TITLE
mapping specs use ruby hashes

### DIFF
--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_place_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_place_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe 'MODS originInfo place <--> cocina mappings' do
         <<~XML
           <originInfo>
             <place>
-              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/"
+                valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
             </place>
           </originInfo>
         XML
@@ -19,7 +20,8 @@ RSpec.describe 'MODS originInfo place <--> cocina mappings' do
         <<~XML
           <originInfo eventType="publication">
             <place>
-              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/"
+                valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
             </place>
           </originInfo>
         XML
@@ -27,16 +29,16 @@ RSpec.describe 'MODS originInfo place <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "location": [
+              type: 'publication',
+              location: [
                 {
-                  "value": 'Stanford (Calif.)',
-                  "uri": 'http://id.loc.gov/authorities/names/n50046557',
-                  "source": {
-                    "code": 'naf',
-                    "uri": 'http://id.loc.gov/authorities/names/'
+                  value: 'Stanford (Calif.)',
+                  uri: 'http://id.loc.gov/authorities/names/n50046557',
+                  source: {
+                    code: 'naf',
+                    uri: 'http://id.loc.gov/authorities/names/'
                   }
                 }
               ]
@@ -53,7 +55,8 @@ RSpec.describe 'MODS originInfo place <--> cocina mappings' do
         <<~XML
           <originInfo eventType="publication">
             <place>
-              <placeTerm type="code" authority="marccountry" authorityURI="http://id.loc.gov/vocabulary/countries/" valueURI="http://id.loc.gov/vocabulary/countries/cau">cau</placeTerm>
+              <placeTerm type="code" authority="marccountry" authorityURI="http://id.loc.gov/vocabulary/countries/"
+                valueURI="http://id.loc.gov/vocabulary/countries/cau">cau</placeTerm>
             </place>
           </originInfo>
         XML
@@ -61,16 +64,16 @@ RSpec.describe 'MODS originInfo place <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "location": [
+              type: 'publication',
+              location: [
                 {
-                  "code": 'cau',
-                  "uri": 'http://id.loc.gov/vocabulary/countries/cau',
-                  "source": {
-                    "code": 'marccountry',
-                    "uri": 'http://id.loc.gov/vocabulary/countries/'
+                  code: 'cau',
+                  uri: 'http://id.loc.gov/vocabulary/countries/cau',
+                  source: {
+                    code: 'marccountry',
+                    uri: 'http://id.loc.gov/vocabulary/countries/'
                   }
                 }
               ]
@@ -96,17 +99,17 @@ RSpec.describe 'MODS originInfo place <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "location": [
+              type: 'publication',
+              location: [
                 {
-                  "value": 'California',
-                  "code": 'cau',
-                  "uri": 'http://id.loc.gov/vocabulary/countries/cau',
-                  "source": {
-                    "code": 'marccountry',
-                    "uri": 'http://id.loc.gov/vocabulary/countries/'
+                  value: 'California',
+                  code: 'cau',
+                  uri: 'http://id.loc.gov/vocabulary/countries/cau',
+                  source: {
+                    code: 'marccountry',
+                    uri: 'http://id.loc.gov/vocabulary/countries/'
                   }
                 }
               ]
@@ -134,18 +137,18 @@ RSpec.describe 'MODS originInfo place <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "location": [
+              type: 'publication',
+              location: [
                 {
-                  "code": 'enk',
-                  "source": {
-                    "code": 'marccountry'
+                  code: 'enk',
+                  source: {
+                    code: 'marccountry'
                   }
                 },
                 {
-                  "value": 'London'
+                  value: 'London'
                 }
               ]
             }
@@ -161,8 +164,10 @@ RSpec.describe 'MODS originInfo place <--> cocina mappings' do
       <<~XML
         <originInfo eventType="publication">
           <place>
-            <placeTerm type="code" authority="marccountry" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">cau</placeTerm>
-            <placeTerm type="text" authority="marccountry" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+            <placeTerm type="code" authority="marccountry" authorityURI="http://id.loc.gov/authorities/names/"
+              valueURI="http://id.loc.gov/authorities/names/n50046557">cau</placeTerm>
+            <placeTerm type="text" authority="marccountry" authorityURI="http://id.loc.gov/authorities/names/"
+              valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
           </place>
         </originInfo>
       XML
@@ -170,21 +175,21 @@ RSpec.describe 'MODS originInfo place <--> cocina mappings' do
 
     let(:cocina) do
       {
-        "event": [
+        event: [
           {
-            "type": 'publication',
-            "location": [
+            type: 'publication',
+            location: [
               {
-                "code": 'cau',
-                "source": {
-                  "code": 'marccountry'
+                code: 'cau',
+                source: {
+                  code: 'marccountry'
                 }
               },
               {
-                "value": 'Stanford (Calif.)',
-                "uri": 'http://id.loc.gov/authorities/names/n50046557',
-                "source": {
-                  "uri": 'http://id.loc.gov/authorities/names/'
+                value: 'Stanford (Calif.)',
+                uri: 'http://id.loc.gov/authorities/names/n50046557',
+                source: {
+                  uri: 'http://id.loc.gov/authorities/names/'
                 }
               }
             ]
@@ -204,7 +209,8 @@ RSpec.describe 'MODS originInfo place <--> cocina mappings' do
         <<~XML
           <originInfo eventType="production" displayLabel="Place of creation">
             <place supplied="yes">
-              <placeTerm authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n81127564" type="text">Selma (Ala.)</placeTerm>
+              <placeTerm authorityURI="http://id.loc.gov/authorities/names/"
+                valueURI="http://id.loc.gov/authorities/names/n81127564" type="text">Selma (Ala.)</placeTerm>
             </place>
             <dateCreated keyDate="yes" encoding="w3cdtf">1965</dateCreated>
           </originInfo>
@@ -213,27 +219,27 @@ RSpec.describe 'MODS originInfo place <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "displayLabel": 'Place of creation',
-              "location": [
+              type: 'creation',
+              displayLabel: 'Place of creation',
+              location: [
                 {
-                  "type": 'supplied',
-                  "value": 'Selma (Ala.)',
-                  "uri": 'http://id.loc.gov/authorities/names/n81127564',
-                  "source": {
-                    "uri": 'http://id.loc.gov/authorities/names/'
+                  type: 'supplied',
+                  value: 'Selma (Ala.)',
+                  uri: 'http://id.loc.gov/authorities/names/n81127564',
+                  source: {
+                    uri: 'http://id.loc.gov/authorities/names/'
                   }
                 }
               ],
-              "date": [
+              date: [
                 {
-                  "value": '1965',
-                  "encoding": {
-                    "code": 'w3cdtf'
+                  value: '1965',
+                  encoding: {
+                    code: 'w3cdtf'
                   },
-                  "status": 'primary'
+                  status: 'primary'
                 }
               ]
             }

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_publisher_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_publisher_spec.rb
@@ -23,25 +23,25 @@ RSpec.describe 'MODS originInfo publisher <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "contributor": [
+              type: 'publication',
+              contributor: [
                 {
-                  "name": [
+                  name: [
                     {
-                      "value": 'Virago'
+                      value: 'Virago'
                     }
                   ],
-                  "type": 'organization',
-                  "role": [
+                  type: 'organization',
+                  role: [
                     {
-                      "value": 'publisher',
-                      "code": 'pbl',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/pbl',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
@@ -59,7 +59,8 @@ RSpec.describe 'MODS originInfo publisher <--> cocina mappings' do
       let(:mods) do
         <<~XML
           <originInfo>
-            <publisher lang="rus" script="Latn" transliteration="ALA-LC Romanization Tables">Institut russkoĭ literatury (Pushkinskiĭ Dom)</publisher>
+            <publisher lang="rus" script="Latn"
+              transliteration="ALA-LC Romanization Tables">Institut russkoĭ literatury (Pushkinskiĭ Dom)</publisher>
           </originInfo>
         XML
       end
@@ -74,41 +75,41 @@ RSpec.describe 'MODS originInfo publisher <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "contributor": [
+              type: 'publication',
+              contributor: [
                 {
-                  "name": [
+                  name: [
                     {
-                      "value": 'Institut russkoĭ literatury (Pushkinskiĭ Dom)',
-                      "type": 'transliteration',
-                      "standard": {
-                        "value": 'ALA-LC Romanization Tables'
+                      value: 'Institut russkoĭ literatury (Pushkinskiĭ Dom)',
+                      type: 'transliteration',
+                      standard: {
+                        value: 'ALA-LC Romanization Tables'
                       },
-                      "valueLanguage": {
-                        "code": 'rus',
-                        "source": {
-                          "code": 'iso639-2b'
+                      valueLanguage: {
+                        code: 'rus',
+                        source: {
+                          code: 'iso639-2b'
                         },
-                        "valueScript": {
-                          "code": 'Latn',
-                          "source": {
-                            "code": 'iso15924'
+                        valueScript: {
+                          code: 'Latn',
+                          source: {
+                            code: 'iso15924'
                           }
                         }
                       }
                     }
                   ],
-                  "type": 'organization',
-                  "role": [
+                  type: 'organization',
+                  role: [
                     {
-                      "value": 'publisher',
-                      "code": 'pbl',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/pbl',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
@@ -141,37 +142,37 @@ RSpec.describe 'MODS originInfo publisher <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "contributor": [
+              type: 'publication',
+              contributor: [
                 {
-                  "name": [
+                  name: [
                     {
-                      "value": 'СФУ',
-                      "valueLanguage": {
-                        "code": 'rus',
-                        "source": {
-                          "code": 'iso639-2b'
+                      value: 'СФУ',
+                      valueLanguage: {
+                        code: 'rus',
+                        source: {
+                          code: 'iso639-2b'
                         },
-                        "valueScript": {
-                          "code": 'Cyrl',
-                          "source": {
-                            "code": 'iso15924'
+                        valueScript: {
+                          code: 'Cyrl',
+                          source: {
+                            code: 'iso15924'
                           }
                         }
                       }
                     }
                   ],
-                  "type": 'organization',
-                  "role": [
+                  type: 'organization',
+                  role: [
                     {
-                      "value": 'publisher',
-                      "code": 'pbl',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/pbl',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
@@ -206,44 +207,44 @@ RSpec.describe 'MODS originInfo publisher <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "contributor": [
+              type: 'publication',
+              contributor: [
                 {
-                  "name": [
+                  name: [
                     {
-                      "value": 'Ardis'
+                      value: 'Ardis'
                     }
                   ],
-                  "type": 'organization',
-                  "role": [
+                  type: 'organization',
+                  role: [
                     {
-                      "value": 'publisher',
-                      "code": 'pbl',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/pbl',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
                 },
                 {
-                  "name": [
+                  name: [
                     {
-                      "value": 'Commonplace Books'
+                      value: 'Commonplace Books'
                     }
                   ],
-                  "type": 'organization',
-                  "role": [
+                  type: 'organization',
+                  role: [
                     {
-                      "value": 'publisher',
-                      "code": 'pbl',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/pbl',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
@@ -269,33 +270,33 @@ RSpec.describe 'MODS originInfo publisher <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'production',
-              "contributor": [
+              type: 'production',
+              contributor: [
                 {
-                  "name": [
+                  name: [
                     {
-                      "value": 'Stanford University'
+                      value: 'Stanford University'
                     }
                   ],
-                  "type": 'organization',
-                  "role": [
+                  type: 'organization',
+                  role: [
                     {
-                      "value": 'issuing body',
-                      "code": 'isb',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/isb',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'issuing body',
+                      code: 'isb',
+                      uri: 'http://id.loc.gov/vocabulary/relators/isb',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
                 }
               ],
-              "date": [
+              date: [
                 {
-                  "value": '2020'
+                  value: '2020'
                 }
               ]
             }
@@ -318,33 +319,33 @@ RSpec.describe 'MODS originInfo publisher <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'distribution',
-              "contributor": [
+              type: 'distribution',
+              contributor: [
                 {
-                  "name": [
+                  name: [
                     {
-                      "value": 'Stanford University'
+                      value: 'Stanford University'
                     }
                   ],
-                  "type": 'organization',
-                  "role": [
+                  type: 'organization',
+                  role: [
                     {
-                      "value": 'distributor',
-                      "code": 'dst',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/dst',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'distributor',
+                      code: 'dst',
+                      uri: 'http://id.loc.gov/vocabulary/relators/dst',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
                 }
               ],
-              "date": [
+              date: [
                 {
-                  "value": '2020'
+                  value: '2020'
                 }
               ]
             }
@@ -367,33 +368,33 @@ RSpec.describe 'MODS originInfo publisher <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'manufacture',
-              "contributor": [
+              type: 'manufacture',
+              contributor: [
                 {
-                  "name": [
+                  name: [
                     {
-                      "value": 'Stanford University'
+                      value: 'Stanford University'
                     }
                   ],
-                  "type": 'organization',
-                  "role": [
+                  type: 'organization',
+                  role: [
                     {
-                      "value": 'manufacturer',
-                      "code": 'mfr',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/mfr',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'manufacturer',
+                      code: 'mfr',
+                      uri: 'http://id.loc.gov/vocabulary/relators/mfr',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
                 }
               ],
-              "date": [
+              date: [
                 {
-                  "value": '2020'
+                  value: '2020'
                 }
               ]
             }
@@ -432,39 +433,39 @@ RSpec.describe 'MODS originInfo publisher <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'production',
-              "displayLabel": 'producer',
-              "location": [
+              type: 'production',
+              displayLabel: 'producer',
+              location: [
                 {
-                  "value": 'Stanford, Calif.'
+                  value: 'Stanford, Calif.'
                 }
               ],
-              "contributor": [
+              contributor: [
                 {
-                  "name": [
+                  name: [
                     {
-                      "value": 'Stanford University, Department of Biostatistics'
+                      value: 'Stanford University, Department of Biostatistics'
                     }
                   ],
-                  "type": 'organization',
-                  "role": [
+                  type: 'organization',
+                  role: [
                     {
-                      "value": 'issuing body',
-                      "code": 'isb',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/isb',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'issuing body',
+                      code: 'isb',
+                      uri: 'http://id.loc.gov/vocabulary/relators/isb',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
                 }
               ],
-              "date": [
+              date: [
                 {
-                  "value": '2002'
+                  value: '2002'
                 }
               ]
             }

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "value": '1980'
+                  value: '1980'
                 }
               ]
             }
@@ -58,14 +58,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "date": [
+              type: 'publication',
+              date: [
                 {
-                  "value": '1928',
-                  "encoding": {
-                    "code": 'w3cdtf'
+                  value: '1928',
+                  encoding: {
+                    code: 'w3cdtf'
                   }
                 }
               ]
@@ -96,12 +96,12 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'copyright',
-              "date": [
+              type: 'copyright',
+              date: [
                 {
-                  "value": '1930'
+                  value: '1930'
                 }
               ]
             }
@@ -131,16 +131,16 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'capture',
-              "date": [
+              type: 'capture',
+              date: [
                 {
-                  "value": '20131012231249',
-                  "encoding": {
-                    "code": 'iso8601'
+                  value: '20131012231249',
+                  encoding: {
+                    code: 'iso8601'
                   },
-                  "status": 'primary'
+                  status: 'primary'
                 }
               ]
             }
@@ -162,16 +162,16 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "date": [
+              type: 'publication',
+              date: [
                 {
-                  "value": '1441 AH',
-                  "note": [
+                  value: '1441 AH',
+                  note: [
                     {
-                      "value": 'Islamic',
-                      "type": 'date type'
+                      value: 'Islamic',
+                      type: 'date type'
                     }
                   ]
                 }
@@ -195,15 +195,15 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'acquisition',
-              "displayLabel": 'Acquisition date',
-              "date": [
+              type: 'acquisition',
+              displayLabel: 'Acquisition date',
+              date: [
                 {
-                  "value": '1992',
-                  "encoding": {
-                    "code": 'w3cdtf'
+                  value: '1992',
+                  encoding: {
+                    code: 'w3cdtf'
                   }
                 }
               ]
@@ -236,20 +236,20 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "structuredValue": [
+                  structuredValue: [
                     {
-                      "value": '1920',
-                      "type": 'start',
-                      "status": 'primary'
+                      value: '1920',
+                      type: 'start',
+                      status: 'primary'
                     },
                     {
-                      "value": '1925',
-                      "type": 'end'
+                      value: '1925',
+                      type: 'end'
                     }
                   ]
                 }
@@ -281,13 +281,13 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "value": '1940',
-                  "qualifier": 'approximate'
+                  value: '1940',
+                  qualifier: 'approximate'
                 }
               ]
             }
@@ -319,22 +319,22 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "structuredValue": [
+                  structuredValue: [
                     {
-                      "value": '1940',
-                      "type": 'start',
-                      "status": 'primary',
-                      "qualifier": 'approximate'
+                      value: '1940',
+                      type: 'start',
+                      status: 'primary',
+                      qualifier: 'approximate'
                     },
                     {
-                      "value": '1945',
-                      "type": 'end',
-                      "qualifier": 'approximate'
+                      value: '1945',
+                      type: 'end',
+                      qualifier: 'approximate'
                     }
                   ]
                 }
@@ -368,21 +368,21 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "structuredValue": [
+                  structuredValue: [
                     {
-                      "value": '1940',
-                      "type": 'start',
-                      "status": 'primary',
-                      "qualifier": 'approximate'
+                      value: '1940',
+                      type: 'start',
+                      status: 'primary',
+                      qualifier: 'approximate'
                     },
                     {
-                      "value": '1945',
-                      "type": 'end'
+                      value: '1945',
+                      type: 'end'
                     }
                   ]
                 }
@@ -416,21 +416,21 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "structuredValue": [
+                  structuredValue: [
                     {
-                      "value": '1940',
-                      "type": 'start',
-                      "status": 'primary'
+                      value: '1940',
+                      type: 'start',
+                      status: 'primary'
                     },
                     {
-                      "value": '1945',
-                      "type": 'end',
-                      "qualifier": 'approximate'
+                      value: '1945',
+                      type: 'end',
+                      qualifier: 'approximate'
                     }
                   ]
                 }
@@ -462,13 +462,13 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "value": '1940',
-                  "qualifier": 'inferred'
+                  value: '1940',
+                  qualifier: 'inferred'
                 }
               ]
             }
@@ -498,13 +498,13 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "value": '1940',
-                  "qualifier": 'questionable'
+                  value: '1940',
+                  qualifier: 'questionable'
                 }
               ]
             }
@@ -538,23 +538,23 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "date": [
+              type: 'publication',
+              date: [
                 {
-                  "value": '1948'
+                  value: '1948'
                 },
                 {
-                  "structuredValue": [
+                  structuredValue: [
                     {
-                      "value": '1940',
-                      "type": 'start',
-                      "status": 'primary'
+                      value: '1940',
+                      type: 'start',
+                      status: 'primary'
                     },
                     {
-                      "value": '1945',
-                      "type": 'end'
+                      value: '1945',
+                      type: 'end'
                     }
                   ]
                 }
@@ -588,16 +588,16 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "date": [
+              type: 'publication',
+              date: [
                 {
-                  "value": '1940',
-                  "status": 'primary'
+                  value: '1940',
+                  status: 'primary'
                 },
                 {
-                  "value": '1942'
+                  value: '1942'
                 }
               ]
             }
@@ -627,14 +627,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "value": '-0499',
-                  "encoding": {
-                    "code": 'edtf'
+                  value: '-0499',
+                  encoding: {
+                    code: 'edtf'
                   }
                 }
               ]
@@ -667,24 +667,24 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "structuredValue": [
+                  structuredValue: [
                     {
-                      "value": '-0499',
-                      "type": 'start',
-                      "encoding": {
-                        "code": 'edtf'
+                      value: '-0499',
+                      type: 'start',
+                      encoding: {
+                        code: 'edtf'
                       }
                     },
                     {
-                      "value": '-0599',
-                      "type": 'end',
-                      "encoding": {
-                        "code": 'edtf'
+                      value: '-0599',
+                      type: 'end',
+                      encoding: {
+                        code: 'edtf'
                       }
                     }
                   ]
@@ -717,14 +717,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "value": '0800',
-                  "encoding": {
-                    "code": 'edtf'
+                  value: '0800',
+                  encoding: {
+                    code: 'edtf'
                   }
                 }
               ]
@@ -757,24 +757,24 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "structuredValue": [
+                  structuredValue: [
                     {
-                      "value": '0800',
-                      "type": 'start',
-                      "encoding": {
-                        "code": 'edtf'
+                      value: '0800',
+                      type: 'start',
+                      encoding: {
+                        code: 'edtf'
                       }
                     },
                     {
-                      "value": '1000',
-                      "type": 'end',
-                      "encoding": {
-                        "code": 'edtf'
+                      value: '1000',
+                      type: 'end',
+                      encoding: {
+                        code: 'edtf'
                       }
                     }
                   ]
@@ -811,20 +811,20 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "date": [
+              type: 'publication',
+              date: [
                 {
-                  "value": '1955'
+                  value: '1955'
                 }
               ]
             },
             {
-              "type": 'copyright',
-              "date": [
+              type: 'copyright',
+              date: [
                 {
-                  "value": '1940'
+                  value: '1940'
                 }
               ]
             }
@@ -845,16 +845,16 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
     let(:cocina) do
       {
-        "event": [
+        event: [
           {
-            "type": 'creation',
-            "date": [
+            type: 'creation',
+            date: [
               {
-                "value": '1544-02-02',
-                "note": [
+                value: '1544-02-02',
+                note: [
                   {
-                    "value": 'Julian',
-                    "type": 'date type'
+                    value: 'Julian',
+                    type: 'date type'
                   }
                 ]
               }
@@ -878,16 +878,16 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
     let(:cocina) do
       {
-        "event": [
+        event: [
           {
-            "type": 'creation',
-            "date": [
+            type: 'creation',
+            date: [
               {
-                "value": '1544-02-02',
-                "note": [
+                value: '1544-02-02',
+                note: [
                   {
-                    "value": 'Julian',
-                    "type": 'date type'
+                    value: 'Julian',
+                    type: 'date type'
                   }
                 ]
               }
@@ -920,13 +920,13 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "date": [
+              type: 'publication',
+              date: [
                 {
-                  "value": '1980',
-                  "type": 'end'
+                  value: '1980',
+                  type: 'end'
                 }
               ]
             }
@@ -956,13 +956,13 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "date": [
+              type: 'publication',
+              date: [
                 {
-                  "value": '1975',
-                  "type": 'start'
+                  value: '1975',
+                  type: 'start'
                 }
               ]
             }
@@ -992,14 +992,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "value": '19uu',
-                  "encoding": {
-                    "code": 'marc'
+                  value: '19uu',
+                  encoding: {
+                    code: 'marc'
                   }
                 }
               ]
@@ -1030,12 +1030,12 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "value": '11th century'
+                  value: '11th century'
                 }
               ]
             }
@@ -1057,12 +1057,12 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "date": [
+              type: 'publication',
+              date: [
                 {
-                  "value": '1980'
+                  value: '1980'
                 }
               ]
             }
@@ -1092,12 +1092,12 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'copyright',
-              "date": [
+              type: 'copyright',
+              date: [
                 {
-                  "value": '1980'
+                  value: '1980'
                 }
               ]
             }
@@ -1160,86 +1160,86 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "location": [
+              type: 'publication',
+              location: [
                 {
-                  "code": 'ru',
-                  "source": {
-                    "code": 'marccountry'
+                  code: 'ru',
+                  source: {
+                    code: 'marccountry'
                   }
                 }
               ],
-              "date": [
+              date: [
                 {
-                  "value": '2019',
-                  "encoding": {
-                    "code": 'marc'
+                  value: '2019',
+                  encoding: {
+                    code: 'marc'
                   }
                 }
               ],
-              "note": [
+              note: [
                 {
-                  "value": 'monographic',
-                  "type": 'issuance',
-                  "source": {
-                    "value": 'MODS issuance terms'
+                  value: 'monographic',
+                  type: 'issuance',
+                  source: {
+                    value: 'MODS issuance terms'
                   }
                 }
               ]
             },
             {
-              "type": 'copyright',
-              "date": [
+              type: 'copyright',
+              date: [
                 {
-                  "value": '2018',
-                  "encoding": {
-                    "code": 'marc'
+                  value: '2018',
+                  encoding: {
+                    code: 'marc'
                   }
                 }
               ]
             },
             {
-              "type": 'publication',
-              "location": [
+              type: 'publication',
+              location: [
                 {
-                  "value": 'Moskva'
+                  value: 'Moskva'
                 }
               ],
-              "contributor": [
+              contributor: [
                 {
-                  "name": [
+                  name: [
                     {
-                      "value": 'Izdatelʹstvo "Vesʹ Mir"'
+                      value: 'Izdatelʹstvo "Vesʹ Mir"'
                     }
                   ],
-                  "type": 'organization',
-                  "role": [
+                  type: 'organization',
+                  role: [
                     {
-                      "value": 'publisher',
-                      "code": 'pbl',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/pbl',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
                 }
               ],
-              "date": [
+              date: [
                 {
-                  "value": '2019'
+                  value: '2019'
                 }
               ]
             },
             {
-              "type": 'copyright',
-              "note": [
+              type: 'copyright',
+              note: [
                 {
-                  "value": '©2018',
-                  "type": 'copyright statement'
+                  value: '©2018',
+                  type: 'copyright statement'
                 }
               ]
             }
@@ -1269,13 +1269,13 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "note": [
+              type: 'publication',
+              note: [
                 {
-                  "value": '1st ed.',
-                  "type": 'edition'
+                  value: '1st ed.',
+                  type: 'edition'
                 }
               ]
             }
@@ -1307,20 +1307,20 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "note": [
+              type: 'publication',
+              note: [
                 {
-                  "value": 'serial',
-                  "type": 'issuance',
-                  "source": {
-                    "value": 'MODS issuance terms'
+                  value: 'serial',
+                  type: 'issuance',
+                  source: {
+                    value: 'MODS issuance terms'
                   }
                 },
                 {
-                  "value": 'every full moon',
-                  "type": 'frequency'
+                  value: 'every full moon',
+                  type: 'frequency'
                 }
               ]
             }
@@ -1352,22 +1352,22 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "note": [
+              type: 'publication',
+              note: [
                 {
-                  "value": 'multipart monograph',
-                  "type": 'issuance',
-                  "source": {
-                    "value": 'MODS issuance terms'
+                  value: 'multipart monograph',
+                  type: 'issuance',
+                  source: {
+                    value: 'MODS issuance terms'
                   }
                 },
                 {
-                  "value": 'Annual',
-                  "type": 'frequency',
-                  "source": {
-                    "code": 'marcfrequency'
+                  value: 'Annual',
+                  type: 'frequency',
+                  source: {
+                    code: 'marcfrequency'
                   }
                 }
               ]
@@ -1399,30 +1399,30 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "value": '1899'
+                  value: '1899'
                 }
               ],
-              "location": [
+              location: [
                 {
-                  "value": 'York'
+                  value: 'York'
                 }
               ]
             },
             {
-              "type": 'publication',
-              "date": [
+              type: 'publication',
+              date: [
                 {
-                  "value": '1901'
+                  value: '1901'
                 }
               ],
-              "location": [
+              location: [
                 {
-                  "value": 'London'
+                  value: 'London'
                 }
               ]
             }
@@ -1487,30 +1487,30 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
       # See Parallel value with no script given in MODS for mapping when both attributes are absent.
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "location": [
+              type: 'publication',
+              location: [
                 {
-                  "parallelValue": [
+                  parallelValue: [
                     {
-                      "value": 'Kyōto-shi',
-                      "valueLanguage": {
-                        "valueScript": {
-                          "code": 'Latn',
-                          "source": {
-                            "code": 'iso15924'
+                      value: 'Kyōto-shi',
+                      valueLanguage: {
+                        valueScript: {
+                          code: 'Latn',
+                          source: {
+                            code: 'iso15924'
                           }
                         }
                       }
                     },
                     {
-                      "value": '京都市',
-                      "valueLanguage": {
-                        "valueScript": {
-                          "code": 'Hani',
-                          "source": {
-                            "code": 'iso15924'
+                      value: '京都市',
+                      valueLanguage: {
+                        valueScript: {
+                          code: 'Hani',
+                          source: {
+                            code: 'iso15924'
                           }
                         }
                       }
@@ -1518,36 +1518,36 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                   ]
                 },
                 {
-                  "code": 'ja',
-                  "source": {
-                    "code": 'marccountry'
+                  code: 'ja',
+                  source: {
+                    code: 'marccountry'
                   }
                 }
               ],
-              "contributor": [
+              contributor: [
                 {
-                  "type": 'organization',
-                  "name": [
+                  type: 'organization',
+                  name: [
                     {
-                      "parallelValue": [
+                      parallelValue: [
                         {
-                          "value": 'Rinsen Shoten',
-                          "valueLanguage": {
-                            "valueScript": {
-                              "code": 'Latn',
-                              "source": {
-                                "code": 'iso15924'
+                          value: 'Rinsen Shoten',
+                          valueLanguage: {
+                            valueScript: {
+                              code: 'Latn',
+                              source: {
+                                code: 'iso15924'
                               }
                             }
                           }
                         },
                         {
-                          "value": '臨川書店',
-                          "valueLanguage": {
-                            "valueScript": {
-                              "code": 'Hani',
-                              "source": {
-                                "code": 'iso15924'
+                          value: '臨川書店',
+                          valueLanguage: {
+                            valueScript: {
+                              code: 'Hani',
+                              source: {
+                                code: 'iso15924'
                               }
                             }
                           }
@@ -1555,40 +1555,40 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                       ]
                     }
                   ],
-                  "role": [
+                  role: [
                     {
-                      "value": 'publisher',
-                      "code": 'pbl',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/pbl',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
                 }
               ],
-              "date": [
+              date: [
                 {
-                  "parallelValue": [
+                  parallelValue: [
                     {
-                      "value": 'Heisei 8 [1996]',
-                      "valueLanguage": {
-                        "valueScript": {
-                          "code": 'Latn',
-                          "source": {
-                            "code": 'iso15924'
+                      value: 'Heisei 8 [1996]',
+                      valueLanguage: {
+                        valueScript: {
+                          code: 'Latn',
+                          source: {
+                            code: 'iso15924'
                           }
                         }
                       }
                     },
                     {
-                      "value": '平成 8 [1996]',
-                      "valueLanguage": {
-                        "valueScript": {
-                          "code": 'Hani',
-                          "source": {
-                            "code": 'iso15924'
+                      value: '平成 8 [1996]',
+                      valueLanguage: {
+                        valueScript: {
+                          code: 'Hani',
+                          source: {
+                            code: 'iso15924'
                           }
                         }
                       }
@@ -1596,18 +1596,18 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                   ]
                 },
                 {
-                  "value": '1996',
-                  "encoding": {
-                    "code": 'marc'
+                  value: '1996',
+                  encoding: {
+                    code: 'marc'
                   }
                 }
               ],
-              "note": [
+              note: [
                 {
-                  "value": 'monographic',
-                  "type": 'issuance',
-                  "source": {
-                    "value": 'MODS issuance terms'
+                  value: 'monographic',
+                  type: 'issuance',
+                  source: {
+                    value: 'MODS issuance terms'
                   }
                 }
               ]
@@ -1632,13 +1632,13 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "displayLabel": 'Origin',
-              "location": [
+              type: 'creation',
+              displayLabel: 'Origin',
+              location: [
                 {
-                  "value": 'Stanford (Calif.)'
+                  value: 'Stanford (Calif.)'
                 }
               ]
             }
@@ -1655,7 +1655,8 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
           <originInfo eventType="production" lang="eng" script="Latn" altRepGroup="1">
             <dateCreated keyDate="yes" encoding="w3cdtf">1999-09-09</dateCreated>
             <place>
-              <placeTerm authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79076156">Moscow</placeTerm>
+              <placeTerm authorityURI="http://id.loc.gov/authorities/names/"
+                valueURI="http://id.loc.gov/authorities/names/n79076156">Moscow</placeTerm>
             </place>
           </originInfo>
           <originInfo eventType="production" lang="rus" script="Cyrl" altRepGroup="1">
@@ -1671,7 +1672,8 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
            <originInfo script="Latn" lang="eng" altRepGroup="1" eventType="production">
             <dateCreated encoding="w3cdtf" keyDate="yes">1999-09-09</dateCreated>
             <place>
-              <placeTerm type="text" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79076156">Moscow</placeTerm>
+              <placeTerm type="text" authorityURI="http://id.loc.gov/authorities/names/"
+                valueURI="http://id.loc.gov/authorities/names/n79076156">Moscow</placeTerm>
             </place>
           </originInfo>
           <originInfo script="Cyrl" lang="rus" altRepGroup="1" eventType="production">
@@ -1686,51 +1688,51 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "date": [
+              type: 'creation',
+              date: [
                 {
-                  "value": '1999-09-09',
-                  "status": 'primary',
-                  "encoding": {
-                    "code": 'w3cdtf'
+                  value: '1999-09-09',
+                  status: 'primary',
+                  encoding: {
+                    code: 'w3cdtf'
                   }
                 }
               ],
-              "location": [
+              location: [
                 {
-                  "parallelValue": [
+                  parallelValue: [
                     {
-                      "value": 'Moscow',
-                      "uri": 'http://id.loc.gov/authorities/names/n79076156',
-                      "source": {
-                        "uri": 'http://id.loc.gov/authorities/names/'
+                      value: 'Moscow',
+                      uri: 'http://id.loc.gov/authorities/names/n79076156',
+                      source: {
+                        uri: 'http://id.loc.gov/authorities/names/'
                       },
-                      "valueLanguage": {
-                        "code": 'eng',
-                        "source": {
-                          "code": 'iso639-2b'
+                      valueLanguage: {
+                        code: 'eng',
+                        source: {
+                          code: 'iso639-2b'
                         },
-                        "valueScript": {
-                          "code": 'Latn',
-                          "source": {
-                            "code": 'iso15924'
+                        valueScript: {
+                          code: 'Latn',
+                          source: {
+                            code: 'iso15924'
                           }
                         }
                       }
                     },
                     {
-                      "value": 'Москва',
-                      "valueLanguage": {
-                        "code": 'rus',
-                        "source": {
-                          "code": 'iso639-2b'
+                      value: 'Москва',
+                      valueLanguage: {
+                        code: 'rus',
+                        source: {
+                          code: 'iso639-2b'
                         },
-                        "valueScript": {
-                          "code": 'Cyrl',
-                          "source": {
-                            "code": 'iso15924'
+                        valueScript: {
+                          code: 'Cyrl',
+                          source: {
+                            code: 'iso15924'
                           }
                         }
                       }
@@ -1760,39 +1762,39 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "note": [
+              type: 'publication',
+              note: [
                 {
-                  "type": 'edition',
-                  "parallelValue": [
+                  type: 'edition',
+                  parallelValue: [
                     {
-                      "value": 'First edition',
-                      "valueLanguage": {
-                        "code": 'eng',
-                        "source": {
-                          "code": 'iso639-2b'
+                      value: 'First edition',
+                      valueLanguage: {
+                        code: 'eng',
+                        source: {
+                          code: 'iso639-2b'
                         },
-                        "valueScript": {
-                          "code": 'Latn',
-                          "source": {
-                            "code": 'iso15924'
+                        valueScript: {
+                          code: 'Latn',
+                          source: {
+                            code: 'iso15924'
                           }
                         }
                       }
                     },
                     {
-                      "value": 'Первое издание',
-                      "valueLanguage": {
-                        "code": 'rus',
-                        "source": {
-                          "code": 'iso639-2b'
+                      value: 'Первое издание',
+                      valueLanguage: {
+                        code: 'rus',
+                        source: {
+                          code: 'iso639-2b'
                         },
-                        "valueScript": {
-                          "code": 'Cyrl',
-                          "source": {
-                            "code": 'iso15924'
+                        valueScript: {
+                          code: 'Cyrl',
+                          source: {
+                            code: 'iso15924'
                           }
                         }
                       }
@@ -1872,77 +1874,77 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "location": [
+              type: 'publication',
+              location: [
                 {
-                  "parallelValue": [
+                  parallelValue: [
                     {
-                      "value": 'Chengdu'
+                      value: 'Chengdu'
                     },
                     {
-                      "value": '[Chengdu in Chinese]'
+                      value: '[Chengdu in Chinese]'
                     }
                   ]
                 },
                 {
-                  "code": 'cc',
-                  "source": {
-                    "code": 'marccountry'
+                  code: 'cc',
+                  source: {
+                    code: 'marccountry'
                   }
                 }
               ],
-              "contributor": [
+              contributor: [
                 {
-                  "type": 'organization',
-                  "name": [
+                  type: 'organization',
+                  name: [
                     {
-                      "parallelValue": [
+                      parallelValue: [
                         {
-                          "value": 'Sichuan chu ban ji tuan, Sichuan wen yi chu ban she'
+                          value: 'Sichuan chu ban ji tuan, Sichuan wen yi chu ban she'
                         },
                         {
-                          "value": '[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]'
+                          value: '[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]'
                         }
                       ]
                     }
                   ],
-                  "role": [
+                  role: [
                     {
-                      "value": 'publisher',
-                      "code": 'pbl',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/pbl',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
                 }
               ],
-              "date": [
+              date: [
                 {
-                  "value": '2005'
+                  value: '2005'
                 }
               ],
-              "note": [
+              note: [
                 {
-                  "type": 'edition',
-                  "parallelValue": [
+                  type: 'edition',
+                  parallelValue: [
                     {
-                      "value": 'Di 1 ban.'
+                      value: 'Di 1 ban.'
                     },
                     {
-                      "value": '[Di 1 ban in Chinese]'
+                      value: '[Di 1 ban in Chinese]'
                     }
                   ]
                 },
                 {
-                  "type": 'issuance',
-                  "value": 'monographic',
-                  "source": {
-                    "value": 'MODS issuance terms'
+                  type: 'issuance',
+                  value: 'monographic',
+                  source: {
+                    value: 'MODS issuance terms'
                   }
 
                 }
@@ -2027,86 +2029,86 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "location": [
+              type: 'publication',
+              location: [
                 {
-                  "parallelValue": [
+                  parallelValue: [
                     {
-                      "value": '[Ruijin]'
+                      value: '[Ruijin]'
                     },
                     {
-                      "value": '[Ruijin] in Chinese'
+                      value: '[Ruijin] in Chinese'
                     }
                   ]
                 },
                 {
-                  "code": 'cc',
-                  "source": {
-                    "code": 'marccountry'
+                  code: 'cc',
+                  source: {
+                    code: 'marccountry'
                   }
                 }
               ],
-              "date": [
+              date: [
                 {
-                  "structuredValue": [
+                  structuredValue: [
                     {
-                      "value": '1933',
-                      "type": 'start',
-                      "encoding": {
-                        "code": 'marc'
+                      value: '1933',
+                      type: 'start',
+                      encoding: {
+                        code: 'marc'
                       }
                     },
                     {
-                      "value": 'uuuu',
-                      "type": 'end',
-                      "encoding": {
-                        "code": 'marc'
+                      value: 'uuuu',
+                      type: 'end',
+                      encoding: {
+                        code: 'marc'
                       }
                     }
                   ]
                 }
               ],
-              "contributor": [
+              contributor: [
                 {
-                  "type": 'organization',
-                  "name": [
+                  type: 'organization',
+                  name: [
                     {
-                      "parallelValue": [
+                      parallelValue: [
                         {
-                          "value": 'Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu'
+                          value: 'Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu'
                         },
                         {
-                          "value": 'Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu in Chinese'
+                          value: 'Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu in Chinese'
                         }
                       ]
                     }
                   ],
-                  "role": [
+                  role: [
                     {
-                      "value": 'publisher',
-                      "code": 'pbl',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/pbl',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
                 }
               ],
-              "note": [
+              note: [
                 {
-                  "type": 'issuance',
-                  "value": 'serial',
-                  "source": {
-                    "value": 'MODS issuance terms'
+                  type: 'issuance',
+                  value: 'serial',
+                  source: {
+                    value: 'MODS issuance terms'
                   }
                 },
                 {
-                  "type": 'frequency',
-                  "value": 'Irregular'
+                  type: 'frequency',
+                  value: 'Irregular'
                 }
               ]
             }
@@ -2183,91 +2185,91 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "location": [
+              type: 'publication',
+              location: [
                 {
-                  "parallelValue": [
+                  parallelValue: [
                     {
-                      "value": 'Guangdong'
+                      value: 'Guangdong'
                     },
                     {
-                      "value": 'Guangdong in Chinese'
+                      value: 'Guangdong in Chinese'
                     }
                   ]
                 },
                 {
-                  "code": 'cc',
-                  "source": {
-                    "code": 'marccountry'
+                  code: 'cc',
+                  source: {
+                    code: 'marccountry'
                   }
                 }
               ],
-              "contributor": [
+              contributor: [
                 {
-                  "type": 'organization',
-                  "name": [
+                  type: 'organization',
+                  name: [
                     {
-                      "parallelValue": [
+                      parallelValue: [
                         {
-                          "value": 'Guangdong lu jun ce liang ju'
+                          value: 'Guangdong lu jun ce liang ju'
                         },
                         {
-                          "value": 'Guangdong lu jun ce liang ju in Chinese'
+                          value: 'Guangdong lu jun ce liang ju in Chinese'
                         }
                       ]
                     }
                   ],
-                  "role": [
+                  role: [
                     {
-                      "value": 'publisher',
-                      "code": 'pbl',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/pbl',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
                 }
               ],
-              "date": [
+              date: [
                 {
-                  "parallelValue": [
+                  parallelValue: [
                     {
-                      "value": 'Minguo 11-18 [1922-1929]'
+                      value: 'Minguo 11-18 [1922-1929]'
                     },
                     {
-                      "value": 'Minguo 11-18 [1922-1929] in Chinese'
+                      value: 'Minguo 11-18 [1922-1929] in Chinese'
                     }
                   ]
                 },
                 {
-                  "structuredValue": [
+                  structuredValue: [
                     {
-                      "value": '1922',
-                      "type": 'start',
-                      "encoding": {
-                        "code": 'marc'
+                      value: '1922',
+                      type: 'start',
+                      encoding: {
+                        code: 'marc'
                       }
                     },
                     {
-                      "value": '1929',
-                      "type": 'end',
-                      "encoding": {
-                        "code": 'marc'
+                      value: '1929',
+                      type: 'end',
+                      encoding: {
+                        code: 'marc'
                       }
                     }
                   ]
                 }
               ],
-              "note": [
+              note: [
                 {
-                  "type": 'issuance',
-                  "value": 'monographic',
-                  "source": {
-                    "value": 'MODS issuance terms'
+                  type: 'issuance',
+                  value: 'monographic',
+                  source: {
+                    value: 'MODS issuance terms'
                   }
                 }
               ]
@@ -2336,86 +2338,86 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "location": [
+              type: 'publication',
+              location: [
                 {
-                  "code": 'cau',
-                  "source": {
-                    "code": 'marccountry'
+                  code: 'cau',
+                  source: {
+                    code: 'marccountry'
                   }
                 }
               ],
-              "date": [
+              date: [
                 {
-                  "value": '2020',
-                  "encoding": {
-                    "code": 'marc'
+                  value: '2020',
+                  encoding: {
+                    code: 'marc'
                   }
                 }
               ],
-              "note": [
+              note: [
                 {
-                  "type": 'issuance',
-                  "value": 'monographic',
-                  "source": {
-                    "value": 'MODS issuance terms'
+                  type: 'issuance',
+                  value: 'monographic',
+                  source: {
+                    value: 'MODS issuance terms'
                   }
                 }
               ]
             },
             {
-              "type": 'copyright',
-              "date": [
+              type: 'copyright',
+              date: [
                 {
-                  "value": '2020',
-                  "encoding": {
-                    "code": 'marc'
+                  value: '2020',
+                  encoding: {
+                    code: 'marc'
                   }
                 }
               ]
             },
             {
-              "type": 'publication',
-              "location": [
+              type: 'publication',
+              location: [
                 {
-                  "value": '[Stanford, Calif.]'
+                  value: '[Stanford, Calif.]'
                 }
               ],
-              "contributor": [
+              contributor: [
                 {
-                  "name": [
+                  name: [
                     {
-                      "value": '[Stanford University]'
+                      value: '[Stanford University]'
                     }
                   ],
-                  "type": 'organization',
-                  "role": [
+                  type: 'organization',
+                  role: [
                     {
-                      "value": 'publisher',
-                      "code": 'pbl',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/pbl',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
                 }
               ],
-              "date": [
+              date: [
                 {
-                  "value": '2020'
+                  value: '2020'
                 }
               ]
             },
             {
-              "type": 'copyright',
-              "note": [
+              type: 'copyright',
+              note: [
                 {
-                  "value": '©2020',
-                  "type": 'copyright statement'
+                  value: '©2020',
+                  type: 'copyright statement'
                 }
               ]
             }
@@ -2431,7 +2433,8 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         <<~XML
           <originInfo displayLabel="Place of Creation" eventType="production">
             <place>
-              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names"
+                valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
             </place>
             <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
             <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
@@ -2443,7 +2446,8 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         <<~XML
           <originInfo displayLabel="Place of Creation" eventType="production">
             <place>
-              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/"
+                valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
             </place>
             <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
           </originInfo>
@@ -2455,37 +2459,37 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'creation',
-              "displayLabel": 'Place of Creation',
-              "location": [
+              type: 'creation',
+              displayLabel: 'Place of Creation',
+              location: [
                 {
-                  "value": 'Stanford (Calif.)',
-                  "uri": 'http://id.loc.gov/authorities/names/n50046557',
-                  "source": {
-                    "code": 'naf',
-                    "uri": 'http://id.loc.gov/authorities/names/'
+                  value: 'Stanford (Calif.)',
+                  uri: 'http://id.loc.gov/authorities/names/n50046557',
+                  source: {
+                    code: 'naf',
+                    uri: 'http://id.loc.gov/authorities/names/'
                   }
                 }
               ],
-              "date": [
+              date: [
                 {
-                  "value": '2003-11-29',
-                  "status": 'primary',
-                  "encoding": {
-                    "code": 'w3cdtf'
+                  value: '2003-11-29',
+                  status: 'primary',
+                  encoding: {
+                    code: 'w3cdtf'
                   }
                 }
               ]
             },
             {
-              "type": 'development',
-              "date": [
+              type: 'development',
+              date: [
                 {
-                  "value": '2003-12-01',
-                  "encoding": {
-                    "code": 'w3cdtf'
+                  value: '2003-12-01',
+                  encoding: {
+                    code: 'w3cdtf'
                   }
                 }
               ]
@@ -2532,58 +2536,58 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "event": [
+          event: [
             {
-              "type": 'publication',
-              "contributor": [
+              type: 'publication',
+              contributor: [
                 {
-                  "name": [
+                  name: [
                     {
-                      "value": 'Articque informatique'
+                      value: 'Articque informatique'
                     }
                   ],
-                  "type": 'organization',
-                  "role": [
+                  type: 'organization',
+                  role: [
                     {
-                      "value": 'publisher',
-                      "code": 'pbl',
-                      "uri": 'http://id.loc.gov/vocabulary/relators/pbl',
-                      "source": {
-                        "code": 'marcrelator',
-                        "uri": 'http://id.loc.gov/vocabulary/relators/'
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
                     }
                   ]
                 }
               ],
-              "location": [
+              location: [
                 {
-                  "value": 'Fondettes, FR'
+                  value: 'Fondettes, FR'
                 }
               ],
-              "date": [
+              date: [
                 {
-                  "value": '2010',
-                  "encoding": {
-                    "code": 'w3cdtf'
+                  value: '2010',
+                  encoding: {
+                    code: 'w3cdtf'
                   },
-                  "status": 'primary'
+                  status: 'primary'
                 }
               ],
-              "note": [
+              note: [
                 {
-                  "type": 'edition',
-                  "value": '1'
+                  type: 'edition',
+                  value: '1'
                 }
               ]
             },
             {
-              "type": 'validity',
-              "date": [
+              type: 'validity',
+              date: [
                 {
-                  "value": '2010',
-                  "encoding": {
-                    "code": 'w3cdtf'
+                  value: '2010',
+                  encoding: {
+                    code: 'w3cdtf'
                   }
                 }
               ]

--- a/spec/services/cocina/mapping/descriptive/mods/subject_cartographic_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_cartographic_spec.rb
@@ -20,20 +20,20 @@ RSpec.describe 'MODS subject cartographic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "form": [
+          form: [
             {
-              "value": '1:22,000,000',
-              "type": 'map scale'
+              value: '1:22,000,000',
+              type: 'map scale'
             },
             {
-              "value": 'Conic proj',
-              "type": 'map projection'
+              value: 'Conic proj',
+              type: 'map projection'
             }
           ],
-          "subject": [
+          subject: [
             {
-              "value": 'E 72°--E 148°/N 13°--N 18°',
-              "type": 'map coordinates'
+              value: 'E 72°--E 148°/N 13°--N 18°',
+              type: 'map coordinates'
             }
           ]
         }
@@ -84,29 +84,29 @@ RSpec.describe 'MODS subject cartographic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "form": [
+          form: [
             {
-              "value": 'Scale not given.',
-              "type": 'map scale'
+              value: 'Scale not given.',
+              type: 'map scale'
             },
             {
-              "value": 'Custom projection',
-              "type": 'map projection'
+              value: 'Custom projection',
+              type: 'map projection'
             },
             {
-              "value": 'EPSG::4326',
-              "type": 'map projection',
-              "uri": 'http://opengis.net/def/crs/EPSG/0/4326',
-              "source": {
-                "code": 'EPSG'
+              value: 'EPSG::4326',
+              type: 'map projection',
+              uri: 'http://opengis.net/def/crs/EPSG/0/4326',
+              source: {
+                code: 'EPSG'
               },
-              "displayLabel": 'WGS84'
+              displayLabel: 'WGS84'
             }
           ],
-          "subject": [
+          subject: [
             {
-              "value": 'E 72°34ʹ58ʺ--E 73°52ʹ24ʺ/S 52°54ʹ8ʺ--S 53°11ʹ42ʺ',
-              "type": 'map coordinates'
+              value: 'E 72°34ʹ58ʺ--E 73°52ʹ24ʺ/S 52°54ʹ8ʺ--S 53°11ʹ42ʺ',
+              type: 'map coordinates'
             }
           ]
         }
@@ -132,15 +132,15 @@ RSpec.describe 'MODS subject cartographic <--> cocina mappings' do
 
     let(:cocina) do
       {
-        "form": [
-          "parallelValue": [
+        form: [
+          parallelValue: [
             {
-              "value": 'Scale 1:650,000.',
-              "type": 'map scale'
+              value: 'Scale 1:650,000.',
+              type: 'map scale'
             },
             {
-              "value": '比例尺 1:650,000.',
-              "type": 'map scale'
+              value: '比例尺 1:650,000.',
+              type: 'map scale'
             }
           ]
         ]
@@ -184,7 +184,7 @@ RSpec.describe 'MODS subject cartographic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
               type: 'map coordinates',
               value: 'W0750700 W0741200 N0443400 N0431200'
@@ -194,10 +194,10 @@ RSpec.describe 'MODS subject cartographic <--> cocina mappings' do
               value: 'W 75⁰07ʹ00ʹ--W 74⁰12ʹ00ʹ/N 44⁰34ʹ00ʹ--N 43⁰12ʹ00ʹ'
             }
           ],
-          "form": [
+          form: [
             {
-              "value": 'Scale ca. 1:126,720. 1 in. to 2 miles.',
-              "type": 'map scale'
+              value: 'Scale ca. 1:126,720. 1 in. to 2 miles.',
+              type: 'map scale'
             }
           ]
         }

--- a/spec/services/cocina/mapping/descriptive/mods/subject_geographic_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_geographic_spec.rb
@@ -16,16 +16,16 @@ RSpec.describe 'MODS subject geographic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": 'Cats',
-                  "type": 'topic'
+                  value: 'Cats',
+                  type: 'topic'
                 },
                 {
-                  "value": 'Europe',
-                  "type": 'place'
+                  value: 'Europe',
+                  type: 'place'
                 }
               ]
             }
@@ -51,23 +51,23 @@ RSpec.describe 'MODS subject geographic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": 'North America',
-                  "type": 'continent'
+                  value: 'North America',
+                  type: 'continent'
                 },
                 {
-                  "value": 'Canada',
-                  "type": 'country'
+                  value: 'Canada',
+                  type: 'country'
                 },
                 {
-                  "value": 'Vancouver',
-                  "type": 'city'
+                  value: 'Vancouver',
+                  type: 'city'
                 }
               ],
-              "type": 'place'
+              type: 'place'
             }
           ]
         }
@@ -87,12 +87,12 @@ RSpec.describe 'MODS subject geographic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "code": 'n-us-md',
-              "type": 'place',
-              "source": {
-                "code": 'marcgac'
+              code: 'n-us-md',
+              type: 'place',
+              source: {
+                code: 'marcgac'
               }
             }
           ]
@@ -114,23 +114,23 @@ RSpec.describe 'MODS subject geographic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "parallelValue": [
+              parallelValue: [
                 {
-                  "value": 'United States',
-                  "source": {
-                    "code": 'lcsh'
+                  value: 'United States',
+                  source: {
+                    code: 'lcsh'
                   }
                 },
                 {
-                  "code": 'us',
-                  "source": {
-                    "code": 'iso3166'
+                  code: 'us',
+                  source: {
+                    code: 'iso3166'
                   }
                 }
               ],
-              "type": 'place'
+              type: 'place'
             }
           ]
         }
@@ -158,15 +158,15 @@ RSpec.describe 'MODS subject geographic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "value": 'Antarctica',
-              "uri": 'http://id.loc.gov/authorities/subjects/sh85005490',
-              "source": {
-                "code": 'lcsh',
-                "uri": 'http://id.loc.gov/authorities/subjects/'
+              value: 'Antarctica',
+              uri: 'http://id.loc.gov/authorities/subjects/sh85005490',
+              source: {
+                code: 'lcsh',
+                uri: 'http://id.loc.gov/authorities/subjects/'
               },
-              "type": 'place'
+              type: 'place'
             }
           ]
         }
@@ -194,21 +194,21 @@ RSpec.describe 'MODS subject geographic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "value": 'Arctic Ocean',
-              "valueLanguage": {
-                "code": 'eng',
-                "source": {
-                  "code": 'iso639-2b'
+              value: 'Arctic Ocean',
+              valueLanguage: {
+                code: 'eng',
+                source: {
+                  code: 'iso639-2b'
                 }
               },
-              "uri": 'http://sws.geonames.org/2960860/',
-              "source": {
-                "code": 'geonames',
-                "uri": 'http://www.geonames.org/ontology#'
+              uri: 'http://sws.geonames.org/2960860/',
+              source: {
+                code: 'geonames',
+                uri: 'http://www.geonames.org/ontology#'
               },
-              "type": 'place'
+              type: 'place'
             }
           ]
         }

--- a/spec/services/cocina/mapping/descriptive/mods/subject_name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_name_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "value": 'Dunnett, Dorothy',
-              "type": 'person'
+              value: 'Dunnett, Dorothy',
+              type: 'person'
             }
           ]
         }
@@ -44,21 +44,21 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": 'Nakahama, Manjirō',
-                  "type": 'name'
+                  value: 'Nakahama, Manjirō',
+                  type: 'name'
                 },
                 {
-                  "value": '1827-1898',
-                  "type": 'life dates'
+                  value: '1827-1898',
+                  type: 'life dates'
                 }
               ],
-              "type": 'person',
-              "source": {
-                "code": 'lcsh'
+              type: 'person',
+              source: {
+                code: 'lcsh'
               }
             }
           ]
@@ -82,21 +82,21 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": 'Saki',
-                  "type": 'name'
+                  value: 'Saki',
+                  type: 'name'
                 },
                 {
-                  "value": '1870-1916',
-                  "type": 'life dates'
+                  value: '1870-1916',
+                  type: 'life dates'
                 }
               ],
-              "type": 'person',
-              "source": {
-                "code": 'lcsh'
+              type: 'person',
+              source: {
+                code: 'lcsh'
               }
             }
           ]
@@ -110,7 +110,8 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
       let(:mods) do
         <<~XML
           <subject authority="lcsh">
-            <name type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n79046044">
+            <name type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names/"
+              valueURI="http://id.loc.gov/authorities/names/n79046044">
               <namePart>Sayers, Dorothy L. (Dorothy Leigh), 1893-1957</namePart>
             </name>
           </subject>
@@ -119,14 +120,14 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "value": 'Sayers, Dorothy L. (Dorothy Leigh), 1893-1957',
-              "type": 'person',
-              "uri": 'http://id.loc.gov/authorities/names/n79046044',
-              "source": {
-                "code": 'naf',
-                "uri": 'http://id.loc.gov/authorities/names/'
+              value: 'Sayers, Dorothy L. (Dorothy Leigh), 1893-1957',
+              type: 'person',
+              uri: 'http://id.loc.gov/authorities/names/n79046044',
+              source: {
+                code: 'naf',
+                uri: 'http://id.loc.gov/authorities/names/'
               }
             }
           ]
@@ -150,16 +151,16 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": 'Shakespeare, William, 1564-1616',
-                  "type": 'person'
+                  value: 'Shakespeare, William, 1564-1616',
+                  type: 'person'
                 },
                 {
-                  "value": 'Homes and haunts',
-                  "type": 'topic'
+                  value: 'Homes and haunts',
+                  type: 'topic'
                 }
               ]
             }
@@ -173,7 +174,8 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
-          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85120951">
+          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+            valueURI="http://id.loc.gov/authorities/subjects/sh85120951">
             <name type="personal">
               <namePart>Shakespeare, William, 1564-1616</namePart>
             </name>
@@ -184,22 +186,22 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": 'Shakespeare, William, 1564-1616',
-                  "type": 'person'
+                  value: 'Shakespeare, William, 1564-1616',
+                  type: 'person'
                 },
                 {
-                  "value": 'Homes and haunts',
-                  "type": 'topic'
+                  value: 'Homes and haunts',
+                  type: 'topic'
                 }
               ],
-              "uri": 'http://id.loc.gov/authorities/subjects/sh85120951',
-              "source": {
-                "code": 'lcsh',
-                "uri": 'http://id.loc.gov/authorities/subjects/'
+              uri: 'http://id.loc.gov/authorities/subjects/sh85120951',
+              source: {
+                code: 'lcsh',
+                uri: 'http://id.loc.gov/authorities/subjects/'
               }
             }
           ]
@@ -213,35 +215,37 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
       let(:mods) do
         <<~XML
           <subject authority="lcsh">
-            <name type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n78095332">
+            <name type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names/"
+              valueURI="http://id.loc.gov/authorities/names/n78095332">
               <namePart>Shakespeare, William, 1564-1616</namePart>
             </name>
-            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh99005711">Homes and haunts</topic>
+            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+              valueURI="http://id.loc.gov/authorities/subjects/sh99005711">Homes and haunts</topic>
           </subject>
         XML
       end
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": 'Shakespeare, William, 1564-1616',
-                  "type": 'person',
-                  "uri": 'http://id.loc.gov/authorities/names/n78095332',
-                  "source": {
-                    "code": 'naf',
-                    "uri": 'http://id.loc.gov/authorities/names/'
+                  value: 'Shakespeare, William, 1564-1616',
+                  type: 'person',
+                  uri: 'http://id.loc.gov/authorities/names/n78095332',
+                  source: {
+                    code: 'naf',
+                    uri: 'http://id.loc.gov/authorities/names/'
                   }
                 },
                 {
-                  "value": 'Homes and haunts',
-                  "type": 'topic',
-                  "uri": 'http://id.loc.gov/authorities/subjects/sh99005711',
-                  "source": {
-                    "code": 'lcsh',
-                    "uri": 'http://id.loc.gov/authorities/subjects/'
+                  value: 'Homes and haunts',
+                  type: 'topic',
+                  uri: 'http://id.loc.gov/authorities/subjects/sh99005711',
+                  source: {
+                    code: 'lcsh',
+                    uri: 'http://id.loc.gov/authorities/subjects/'
                   }
                 }
               ]
@@ -256,43 +260,46 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
-          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85120951">
-            <name type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n78095332">
+          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+            valueURI="http://id.loc.gov/authorities/subjects/sh85120951">
+            <name type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names/"
+              valueURI="http://id.loc.gov/authorities/names/n78095332">
               <namePart>Shakespeare, William, 1564-1616</namePart>
             </name>
-            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh99005711">Homes and haunts</topic>
+            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+              valueURI="http://id.loc.gov/authorities/subjects/sh99005711">Homes and haunts</topic>
           </subject>
         XML
       end
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": 'Shakespeare, William, 1564-1616',
-                  "type": 'person',
-                  "uri": 'http://id.loc.gov/authorities/names/n78095332',
-                  "source": {
-                    "code": 'naf',
-                    "uri": 'http://id.loc.gov/authorities/names/'
+                  value: 'Shakespeare, William, 1564-1616',
+                  type: 'person',
+                  uri: 'http://id.loc.gov/authorities/names/n78095332',
+                  source: {
+                    code: 'naf',
+                    uri: 'http://id.loc.gov/authorities/names/'
                   }
                 },
                 {
-                  "value": 'Homes and haunts',
-                  "type": 'topic',
-                  "uri": 'http://id.loc.gov/authorities/subjects/sh99005711',
-                  "source": {
-                    "code": 'lcsh',
-                    "uri": 'http://id.loc.gov/authorities/subjects/'
+                  value: 'Homes and haunts',
+                  type: 'topic',
+                  uri: 'http://id.loc.gov/authorities/subjects/sh99005711',
+                  source: {
+                    code: 'lcsh',
+                    uri: 'http://id.loc.gov/authorities/subjects/'
                   }
                 }
               ],
-              "uri": 'http://id.loc.gov/authorities/subjects/sh85120951',
-              "source": {
-                "code": 'lcsh',
-                "uri": 'http://id.loc.gov/authorities/subjects/'
+              uri: 'http://id.loc.gov/authorities/subjects/sh85120951',
+              source: {
+                code: 'lcsh',
+                uri: 'http://id.loc.gov/authorities/subjects/'
               }
             }
           ]
@@ -305,7 +312,8 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
-          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n97075542">
+          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/names/"
+            valueURI="http://id.loc.gov/authorities/names/n97075542">
             <name type="personal">
               <namePart>Dunnett, Dorothy</namePart>
             </name>
@@ -318,22 +326,22 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": 'Dunnett, Dorothy',
-                  "type": 'person'
+                  value: 'Dunnett, Dorothy',
+                  type: 'person'
                 },
                 {
-                  "value": 'Lymond chronicles',
-                  "type": 'title'
+                  value: 'Lymond chronicles',
+                  type: 'title'
                 }
               ],
-              "uri": 'http://id.loc.gov/authorities/names/n97075542',
-              "source": {
-                "code": 'naf',
-                "uri": 'http://id.loc.gov/authorities/names/'
+              uri: 'http://id.loc.gov/authorities/names/n97075542',
+              source: {
+                code: 'naf',
+                uri: 'http://id.loc.gov/authorities/names/'
               }
             }
           ]
@@ -346,8 +354,10 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
-          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n97075542">
-            <name authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50025011" type="personal">
+          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/names/"
+            valueURI="http://id.loc.gov/authorities/names/n97075542">
+            <name authority="naf" authorityURI="http://id.loc.gov/authorities/names/"
+              valueURI="http://id.loc.gov/authorities/names/n50025011" type="personal">
               <namePart>Dunnett, Dorothy</namePart>
             </name>
             <titleInfo>
@@ -359,27 +369,27 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": 'Dunnett, Dorothy',
-                  "type": 'person',
-                  "uri": 'http://id.loc.gov/authorities/names/n50025011',
-                  "source": {
-                    "code": 'naf',
-                    "uri": 'http://id.loc.gov/authorities/names/'
+                  value: 'Dunnett, Dorothy',
+                  type: 'person',
+                  uri: 'http://id.loc.gov/authorities/names/n50025011',
+                  source: {
+                    code: 'naf',
+                    uri: 'http://id.loc.gov/authorities/names/'
                   }
                 },
                 {
-                  "value": 'Lymond chronicles',
-                  "type": 'title'
+                  value: 'Lymond chronicles',
+                  type: 'title'
                 }
               ],
-              "uri": 'http://id.loc.gov/authorities/names/n97075542',
-              "source": {
-                "code": 'naf',
-                "uri": 'http://id.loc.gov/authorities/names/'
+              uri: 'http://id.loc.gov/authorities/names/n97075542',
+              source: {
+                code: 'naf',
+                uri: 'http://id.loc.gov/authorities/names/'
               }
             }
           ]
@@ -392,7 +402,8 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
     # Authority is not applied to form because the term may be a subject subdivision, with a different term for being used alone.
     let(:mods) do
       <<~XML
-        <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85120809">
+        <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+          valueURI="http://id.loc.gov/authorities/subjects/sh85120809">
           <name type="personal">
             <namePart>Shakespeare, William, 1564-1616</namePart>
           </name>
@@ -406,7 +417,8 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
 
     let(:roundtrip_mods) do
       <<~XML
-        <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85120809">
+        <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+          valueURI="http://id.loc.gov/authorities/subjects/sh85120809">
           <name type="personal">
             <namePart>Shakespeare, William, 1564-1616</namePart>
           </name>
@@ -421,33 +433,33 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
 
     let(:cocina) do
       {
-        "subject": [
+        subject: [
           {
-            "structuredValue": [
+            structuredValue: [
               {
-                "value": 'Shakespeare, William, 1564-1616',
-                "type": 'person'
+                value: 'Shakespeare, William, 1564-1616',
+                type: 'person'
               },
               {
-                "value": 'Hamlet',
-                "type": 'title'
+                value: 'Hamlet',
+                type: 'title'
               },
               {
-                "value": 'Bibliographies',
-                "type": 'genre'
+                value: 'Bibliographies',
+                type: 'genre'
               }
             ],
-            "uri": 'http://id.loc.gov/authorities/subjects/sh85120809',
-            "source": {
-              "code": 'lcsh',
-              "uri": 'http://id.loc.gov/authorities/subjects/'
+            uri: 'http://id.loc.gov/authorities/subjects/sh85120809',
+            source: {
+              code: 'lcsh',
+              uri: 'http://id.loc.gov/authorities/subjects/'
             }
           }
         ],
-        "form": [
+        form: [
           {
-            "value": 'Bibliographies',
-            "type": 'genre'
+            value: 'Bibliographies',
+            type: 'genre'
           }
         ]
       }
@@ -460,13 +472,16 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
     let(:mods) do
       <<~XML
         <subject authority="lcsh">
-          <name type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n78095332">
+          <name type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names/"
+            valueURI="http://id.loc.gov/authorities/names/n78095332">
             <namePart>Shakespeare, William, 1564-1616</namePart>
           </name>
-          <titleInfo authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n80008522">
+          <titleInfo authority="naf" authorityURI="http://id.loc.gov/authorities/names/"
+            valueURI="http://id.loc.gov/authorities/names/n80008522">
             <title>Hamlet</title>
           </titleInfo>
-          <genre authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh99001362">Bibliographies</genre>
+          <genre authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+            valueURI="http://id.loc.gov/authorities/subjects/sh99001362">Bibliographies</genre>
         </subject>
       XML
     end
@@ -474,13 +489,16 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
     let(:roundtrip_mods) do
       <<~XML
         <subject authority="lcsh">
-          <name type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n78095332">
+          <name type="personal" authority="naf" authorityURI="http://id.loc.gov/authorities/names"
+            valueURI="http://id.loc.gov/authorities/names/n78095332">
             <namePart>Shakespeare, William, 1564-1616</namePart>
           </name>
-          <titleInfo authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n80008522">
+          <titleInfo authority="naf" authorityURI="http://id.loc.gov/authorities/names"
+            valueURI="http://id.loc.gov/authorities/names/n80008522">
             <title>Hamlet</title>
           </titleInfo>
-          <genre authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects" valueURI="http://id.loc.gov/authorities/subjects/sh99001362">Bibliographies</genre>
+          <genre authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects"
+            valueURI="http://id.loc.gov/authorities/subjects/sh99001362">Bibliographies</genre>
         </subject>
         <genre>Bibliographies</genre>
       XML
@@ -488,43 +506,43 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
 
     let(:cocina) do
       {
-        "subject": [
+        subject: [
           {
-            "structuredValue": [
+            structuredValue: [
               {
-                "value": 'Shakespeare, William, 1564-1616',
-                "type": 'person',
-                "uri": 'http://id.loc.gov/authorities/names/n78095332',
-                "source": {
-                  "code": 'naf',
-                  "uri": 'http://id.loc.gov/authorities/names/'
+                value: 'Shakespeare, William, 1564-1616',
+                type: 'person',
+                uri: 'http://id.loc.gov/authorities/names/n78095332',
+                source: {
+                  code: 'naf',
+                  uri: 'http://id.loc.gov/authorities/names/'
                 }
               },
               {
-                "value": 'Hamlet',
-                "type": 'title',
-                "uri": 'http://id.loc.gov/authorities/names/n80008522',
-                "source": {
-                  "code": 'naf',
-                  "uri": 'http://id.loc.gov/authorities/names/'
+                value: 'Hamlet',
+                type: 'title',
+                uri: 'http://id.loc.gov/authorities/names/n80008522',
+                source: {
+                  code: 'naf',
+                  uri: 'http://id.loc.gov/authorities/names/'
                 }
               },
               {
-                "value": 'Bibliographies',
-                "type": 'genre',
-                "uri": 'http://id.loc.gov/authorities/subjects/sh99001362',
-                "source": {
-                  "code": 'lcsh',
-                  "uri": 'http://id.loc.gov/authorities/subjects/'
+                value: 'Bibliographies',
+                type: 'genre',
+                uri: 'http://id.loc.gov/authorities/subjects/sh99001362',
+                source: {
+                  code: 'lcsh',
+                  uri: 'http://id.loc.gov/authorities/subjects/'
                 }
               }
             ]
           }
         ],
-        "form": [
+        form: [
           {
-            "value": 'Bibliographies',
-            "type": 'genre'
+            value: 'Bibliographies',
+            type: 'genre'
           }
         ]
       }
@@ -549,29 +567,29 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "structuredValue": [
+                  structuredValue: [
                     {
-                      "value": 'Debord, Guy',
-                      "type": 'name'
+                      value: 'Debord, Guy',
+                      type: 'name'
                     },
                     {
-                      "value": '1931-1994',
-                      "type": 'life dates'
+                      value: '1931-1994',
+                      type: 'life dates'
                     }
                   ],
-                  "type": 'person'
+                  type: 'person'
                 },
                 {
-                  "value": 'Criticism and interpretation',
-                  "type": 'topic'
+                  value: 'Criticism and interpretation',
+                  type: 'topic'
                 }
               ],
-              "source": {
-                "code": 'lcsh'
+              source: {
+                code: 'lcsh'
               }
             }
           ]
@@ -589,8 +607,10 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
           <subject>
             <name type="personal">
               <role>
-                <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/dpc">depicted</roleTerm>
-                <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/dpc">dpc</roleTerm>
+                <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/"
+                  valueURI="http://id.loc.gov/vocabulary/relators/dpc">depicted</roleTerm>
+                <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/"
+                  valueURI="http://id.loc.gov/vocabulary/relators/dpc">dpc</roleTerm>
               </role>
               <namePart type="family">Nole</namePart>
               <namePart type="given">Andneas Colijns de</namePart>
@@ -603,40 +623,40 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "type": 'person',
-              "parallelValue": [
+              type: 'person',
+              parallelValue: [
                 {
-                  "structuredValue": [
+                  structuredValue: [
                     {
-                      "value": 'Nole',
-                      "type": 'surname'
+                      value: 'Nole',
+                      type: 'surname'
                     },
                     {
-                      "value": 'Andneas Colijns de',
-                      "type": 'forename'
+                      value: 'Andneas Colijns de',
+                      type: 'forename'
                     },
                     {
-                      "value": '1590-?',
-                      "type": 'life dates'
+                      value: '1590-?',
+                      type: 'life dates'
                     }
                   ]
                 },
                 {
-                  "value": 'Nole, Andneas Colijns de, 1590-?',
-                  "type": 'display'
+                  value: 'Nole, Andneas Colijns de, 1590-?',
+                  type: 'display'
                 }
               ],
-              "note": [
+              note: [
                 {
-                  "type": 'role',
-                  "value": 'depicted',
-                  "code": 'dpc',
-                  "uri": 'http://id.loc.gov/vocabulary/relators/dpc',
-                  "source": {
-                    "code": 'marcrelator',
-                    "uri": 'http://id.loc.gov/vocabulary/relators/'
+                  type: 'role',
+                  value: 'depicted',
+                  code: 'dpc',
+                  uri: 'http://id.loc.gov/vocabulary/relators/dpc',
+                  source: {
+                    code: 'marcrelator',
+                    uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
                 }
               ]

--- a/spec/services/cocina/mapping/descriptive/mods/subject_occupation_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_occupation_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe 'MODS subject occupation <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "value": 'Typesetters',
-              "type": 'occupation'
+              value: 'Typesetters',
+              type: 'occupation'
             }
           ]
         }

--- a/spec/services/cocina/mapping/descriptive/mods/subject_temporal_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_temporal_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe 'MODS subject temporal <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "value": '1922-05-15',
-              "encoding": {
-                "code": 'w3cdtf'
+              value: '1922-05-15',
+              encoding: {
+                code: 'w3cdtf'
               },
-              "type": 'time'
+              type: 'time'
             }
           ]
         }
@@ -42,22 +42,22 @@ RSpec.describe 'MODS subject temporal <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": '1890-06-11',
-                  "type": 'start'
+                  value: '1890-06-11',
+                  type: 'start'
                 },
                 {
-                  "value": '1894-03-19',
-                  "type": 'end'
+                  value: '1894-03-19',
+                  type: 'end'
                 }
               ],
-              "encoding": {
-                "code": 'w3cdtf'
+              encoding: {
+                code: 'w3cdtf'
               },
-              "type": 'time'
+              type: 'time'
             }
           ]
         }

--- a/spec/services/cocina/mapping/descriptive/mods/subject_topic_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_topic_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "value": 'Cats',
-              "type": 'topic'
+              value: 'Cats',
+              type: 'topic'
             }
           ]
         }
@@ -50,16 +50,16 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": 'Cats',
-                  "type": 'topic'
+                  value: 'Cats',
+                  type: 'topic'
                 },
                 {
-                  "value": '1640',
-                  "type": 'time'
+                  value: '1640',
+                  type: 'time'
                 }
               ]
             }
@@ -73,7 +73,8 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
-          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">
+          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+            valueURI="http://id.loc.gov/authorities/subjects/sh85021262">
             <topic>Cats</topic>
           </subject>
         XML
@@ -82,21 +83,22 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
       let(:roundtrip_mods) do
         <<~XML
           <subject authority="lcsh">
-            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
+            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+              valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
           </subject>
         XML
       end
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "value": 'Cats',
-              "type": 'topic',
-              "uri": 'http://id.loc.gov/authorities/subjects/sh85021262',
-              "source": {
-                "code": 'lcsh',
-                "uri": 'http://id.loc.gov/authorities/subjects/'
+              value: 'Cats',
+              type: 'topic',
+              uri: 'http://id.loc.gov/authorities/subjects/sh85021262',
+              source: {
+                code: 'lcsh',
+                uri: 'http://id.loc.gov/authorities/subjects/'
               }
             }
           ]
@@ -110,7 +112,8 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
       let(:mods) do
         <<~XML
           <subject authority="lcsh">
-            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
+            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+              valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
           </subject>
         XML
       end
@@ -125,14 +128,14 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "value": 'Cats',
-              "type": 'topic',
-              "uri": 'http://id.loc.gov/authorities/subjects/sh85021262',
-              "source": {
-                "code": 'lcsh',
-                "uri": 'http://id.loc.gov/authorities/subjects/'
+              value: 'Cats',
+              type: 'topic',
+              uri: 'http://id.loc.gov/authorities/subjects/sh85021262',
+              source: {
+                code: 'lcsh',
+                uri: 'http://id.loc.gov/authorities/subjects/'
               }
             }
           ]
@@ -145,8 +148,10 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
-          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">
-            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
+          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+            valueURI="http://id.loc.gov/authorities/subjects/sh85021262">
+            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+              valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
           </subject>
         XML
       end
@@ -154,21 +159,22 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
       let(:roundtrip_mods) do
         <<~XML
           <subject authority="lcsh">
-            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
+            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+              valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
           </subject>
         XML
       end
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "value": 'Cats',
-              "type": 'topic',
-              "uri": 'http://id.loc.gov/authorities/subjects/sh85021262',
-              "source": {
-                "code": 'lcsh',
-                "uri": 'http://id.loc.gov/authorities/subjects/'
+              value: 'Cats',
+              type: 'topic',
+              uri: 'http://id.loc.gov/authorities/subjects/sh85021262',
+              source: {
+                code: 'lcsh',
+                uri: 'http://id.loc.gov/authorities/subjects/'
               }
             }
           ]
@@ -181,7 +187,8 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
-          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021263">
+          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+            valueURI="http://id.loc.gov/authorities/subjects/sh85021263">
             <topic>Cats</topic>
             <topic>Anatomy</topic>
           </subject>
@@ -190,22 +197,22 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": 'Cats',
-                  "type": 'topic'
+                  value: 'Cats',
+                  type: 'topic'
                 },
                 {
-                  "value": 'Anatomy',
-                  "type": 'topic'
+                  value: 'Anatomy',
+                  type: 'topic'
                 }
               ],
-              "uri": 'http://id.loc.gov/authorities/subjects/sh85021263',
-              "source": {
-                "code": 'lcsh',
-                "uri": 'http://id.loc.gov/authorities/subjects/'
+              uri: 'http://id.loc.gov/authorities/subjects/sh85021263',
+              source: {
+                code: 'lcsh',
+                uri: 'http://id.loc.gov/authorities/subjects/'
               }
             }
           ]
@@ -227,20 +234,20 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": 'Prices',
-                  "type": 'topic'
+                  value: 'Prices',
+                  type: 'topic'
                 },
                 {
-                  "value": 'Great Britain',
-                  "type": 'place'
+                  value: 'Great Britain',
+                  type: 'place'
                 }
               ],
-              "source": {
-                "code": 'lcsh'
+              source: {
+                code: 'lcsh'
               }
             }
           ]
@@ -253,31 +260,33 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
     let(:mods) do
       <<~XML
         <subject authority="lcsh">
-          <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
-          <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sj96004895">Behavior</topic>
+          <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+            valueURI="http://id.loc.gov/authorities/subjects/sh85021262">Cats</topic>
+          <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+            valueURI="http://id.loc.gov/authorities/subjects/sj96004895">Behavior</topic>
         </subject>
       XML
     end
 
     let(:cocina) do
       {
-        "subject": [
+        subject: [
           {
-            "structuredValue": [
+            structuredValue: [
               {
-                "value": 'Cats',
-                "type": 'topic',
-                "uri": 'http://id.loc.gov/authorities/subjects/sh85021262'
+                value: 'Cats',
+                type: 'topic',
+                uri: 'http://id.loc.gov/authorities/subjects/sh85021262'
               },
               {
-                "value": 'Behavior',
-                "type": 'topic',
-                "uri": 'http://id.loc.gov/authorities/subjects/sj96004895'
+                value: 'Behavior',
+                type: 'topic',
+                uri: 'http://id.loc.gov/authorities/subjects/sj96004895'
               }
             ],
-            "source": {
-              "code": 'lcsh',
-              "uri": 'http://id.loc.gov/authorities/subjects/'
+            source: {
+              code: 'lcsh',
+              uri: 'http://id.loc.gov/authorities/subjects/'
             }
           }
         ]
@@ -291,41 +300,44 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
-          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh12345">
-            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh23456">Horses</topic>
-            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/" valueURI="http://id.loc.gov/authorities/subjects/sh34567">History</topic>
+          <subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+            valueURI="http://id.loc.gov/authorities/subjects/sh12345">
+            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+              valueURI="http://id.loc.gov/authorities/subjects/sh23456">Horses</topic>
+            <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects/"
+              valueURI="http://id.loc.gov/authorities/subjects/sh34567">History</topic>
           </subject>
         XML
       end
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "structuredValue": [
+              structuredValue: [
                 {
-                  "value": 'Horses',
-                  "type": 'topic',
-                  "uri": 'http://id.loc.gov/authorities/subjects/sh23456',
-                  "source": {
-                    "code": 'lcsh',
-                    "uri": 'http://id.loc.gov/authorities/subjects/'
+                  value: 'Horses',
+                  type: 'topic',
+                  uri: 'http://id.loc.gov/authorities/subjects/sh23456',
+                  source: {
+                    code: 'lcsh',
+                    uri: 'http://id.loc.gov/authorities/subjects/'
                   }
                 },
                 {
-                  "value": 'History',
-                  "type": 'topic',
-                  "uri": 'http://id.loc.gov/authorities/subjects/sh34567',
-                  "source": {
-                    "code": 'lcsh',
-                    "uri": 'http://id.loc.gov/authorities/subjects/'
+                  value: 'History',
+                  type: 'topic',
+                  uri: 'http://id.loc.gov/authorities/subjects/sh34567',
+                  source: {
+                    code: 'lcsh',
+                    uri: 'http://id.loc.gov/authorities/subjects/'
                   }
                 }
               ],
-              "uri": 'http://id.loc.gov/authorities/subjects/sh12345',
-              "source": {
-                "code": 'lcsh',
-                "uri": 'http://id.loc.gov/authorities/subjects/'
+              uri: 'http://id.loc.gov/authorities/subjects/sh12345',
+              source: {
+                code: 'lcsh',
+                uri: 'http://id.loc.gov/authorities/subjects/'
               }
             }
           ]
@@ -349,29 +361,29 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "parallelValue": [
+              parallelValue: [
                 {
-                  "value": 'French New Wave',
-                  "valueLanguage": {
-                    "code": 'eng',
-                    "source": {
-                      "code": 'iso639-2b'
+                  value: 'French New Wave',
+                  valueLanguage: {
+                    code: 'eng',
+                    source: {
+                      code: 'iso639-2b'
                     }
                   }
                 },
                 {
-                  "value": 'Nouvelle Vague',
-                  "valueLanguage": {
-                    "code": 'fre',
-                    "source": {
-                      "code": 'iso639-2b'
+                  value: 'Nouvelle Vague',
+                  valueLanguage: {
+                    code: 'fre',
+                    source: {
+                      code: 'iso639-2b'
                     }
                   }
                 }
               ],
-              "type": 'topic'
+              type: 'topic'
             }
           ]
         }
@@ -391,12 +403,12 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "value": 'String quartets',
-              "type": 'topic',
-              "source": {
-                "code": 'lcsh'
+              value: 'String quartets',
+              type: 'topic',
+              source: {
+                code: 'lcsh'
               }
             }
           ]
@@ -417,11 +429,11 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
 
       let(:cocina) do
         {
-          "subject": [
+          subject: [
             {
-              "value": 'Stuff',
-              "type": 'topic',
-              "displayLabel": 'This is about'
+              value: 'Stuff',
+              type: 'topic',
+              displayLabel: 'This is about'
             }
           ]
         }


### PR DESCRIPTION
## Why was this change made?

syntax highlighting in IDE saves lives.  Or time.  Or avoids errors.  Or something.

## How was this change tested?

specs only changed

## Which documentation and/or configurations were updated?



