### PR TITLE
implement typeOfResource mapping when attribute without value

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/form.rb
+++ b/app/services/cocina/from_fedora/descriptive/form.rb
@@ -118,14 +118,16 @@ module Cocina
 
         def add_types(forms)
           type_of_resource.each do |type|
-            forms << {
-              value: type.text,
-              type: 'resource type',
-              source: {
-                value: 'MODS resource types'
-              },
-              displayLabel: type[:displayLabel].presence
-            }.compact
+            if type.text.present?
+              forms << {
+                value: type.text,
+                type: 'resource type',
+                source: {
+                  value: 'MODS resource types'
+                },
+                displayLabel: type[:displayLabel].presence
+              }.compact
+            end
 
             if type[:manuscript] == 'yes'
               forms << {

--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -59,6 +59,7 @@ module Cocina
       normalize_title_trailing
       normalize_gml_id
       normalize_empty_resource
+      normalize_empty_type_of_resource # Must be after normalize_empty_attributes
       normalize_abstract_summary
       # This should be last-ish.
       normalize_empty_related_items
@@ -319,6 +320,10 @@ module Cocina
 
     def normalize_empty_notes
       ng_xml.root.xpath('//mods:note[not(text())]', mods: MODS_NS).each(&:remove)
+    end
+
+    def normalize_empty_type_of_resource
+      ng_xml.root.xpath('//mods:typeOfResource[not(text())][not(@*)]', mods: MODS_NS).each(&:remove)
     end
 
     def normalize_unmatched_altrepgroup

--- a/spec/services/cocina/from_fedora/descriptive/form_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/form_spec.rb
@@ -19,6 +19,21 @@ RSpec.describe Cocina::FromFedora::Descriptive::Form do
     XML
   end
 
+  describe 'typeOfResource' do
+    context 'with empty element' do
+      let(:xml) do
+        <<~XML
+          <typeOfResource></typeOfResource>
+          <typeOfResource/>
+        XML
+      end
+
+      it 'builds the cocina data structure' do
+        expect(build).to eq []
+      end
+    end
+  end
+
   describe 'genre' do
     context 'with authority missing valueURI' do
       let(:xml) do

--- a/spec/services/cocina/mapping/descriptive/mods/type_of_resource_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/type_of_resource_spec.rb
@@ -123,25 +123,25 @@ RSpec.describe 'MODS typeOfResource <--> cocina mappings' do
   end
 
   describe 'Attribute without value' do
-    xit 'not implemented'
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <typeOfResource manuscript="yes" />
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <typeOfResource manuscript="yes" />
-      XML
-    end
-
-    let(:cocina) do
-      {
-        form: [
-          {
-            value: 'manuscript',
-            source: {
-              value: 'MODS resource types'
+      let(:cocina) do
+        {
+          form: [
+            {
+              value: 'manuscript',
+              source: {
+                value: 'MODS resource types'
+              }
             }
-          }
-        ]
-      }
+          ]
+        }
+      end
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #1969 

## How was this change tested?

### This branch

I’m assuming that many of the mappings we’re now implementing occur rarely, and thus our roundtrip validation tests may show exactly the same numbers as main.   Roundtrip did show a difference before I adjusted mods_normalizer.

```
Status (n=50000):
  Success:   49078 (98.156%)
  Different: 595 (1.19%)
  To Cocina error:     16 (0.032%)
  To Fedora error:     0 (0.0%)
  Missing:     311 (0.622%)
```

### main branch

```
Status (n=50000):
  Success:   49078 (98.156%)
  Different: 595 (1.19%)
  To Cocina error:     16 (0.032%)
  To Fedora error:     0 (0.0%)
  Missing:     311 (0.622%)

```

## Which documentation and/or configurations were updated?



