### PR TITLE
Event encoding, qualifier cocina attribs at outermost level to which they apply

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -372,8 +372,8 @@ module Cocina
 
           dates = node_set.map do |node|
             new_node = node.deep_dup
-            new_node.remove_attribute('encoding') if common_attribs[:encoding].present?
-            new_node.remove_attribute('qualifier') if common_attribs[:qualifier].present?
+            new_node.remove_attribute('encoding') if common_attribs[:encoding].present? || node[:encoding]&.size&.zero?
+            new_node.remove_attribute('qualifier') if common_attribs[:qualifier].present? || node[:qualifier]&.size&.zero?
             build_date(type, new_node)
           end
           { structuredValue: dates }.merge(common_attribs).compact
@@ -382,12 +382,12 @@ module Cocina
         def common_date_attributes(node_set)
           first_encoding = node_set.first['encoding']
           first_qualifier = node_set.first['qualifier']
-          encoding_is_common = node_set.all? { |node| node['encoding'] == first_encoding } if first_encoding.present?
-          qualifier_is_common = node_set.all? { |node| node['qualifier'] == first_qualifier } if first_qualifier.present?
-          {
-            qualifier: (first_qualifier if qualifier_is_common),
-            encoding: ({ code: first_encoding } if encoding_is_common)
-          }.compact
+          encoding_is_common = node_set.all? { |node| node['encoding'] == first_encoding }
+          qualifier_is_common = node_set.all? { |node| node['qualifier'] == first_qualifier }
+          attribs = {}
+          attribs[:qualifier] = first_qualifier if qualifier_is_common && first_qualifier.present?
+          attribs[:encoding] = { code: first_encoding } if encoding_is_common && first_encoding.present?
+          attribs
         end
 
         def build_date(event_type, node)

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -368,8 +368,26 @@ module Cocina
         def build_structured_date(type, node_set)
           return nil if node_set.blank?
 
-          dates = node_set.map { |node| build_date(type, node) }
-          { structuredValue: dates }
+          common_attribs = common_date_attributes(node_set)
+
+          dates = node_set.map do |node|
+            new_node = node.deep_dup
+            new_node.remove_attribute('encoding') if common_attribs[:encoding].present?
+            new_node.remove_attribute('qualifier') if common_attribs[:qualifier].present?
+            build_date(type, new_node)
+          end
+          { structuredValue: dates }.merge(common_attribs).compact
+        end
+
+        def common_date_attributes(node_set)
+          first_encoding = node_set.first['encoding']
+          first_qualifier = node_set.first['qualifier']
+          encoding_is_common = node_set.all? { |node| node['encoding'] == first_encoding } if first_encoding.present?
+          qualifier_is_common = node_set.all? { |node| node['qualifier'] == first_qualifier } if first_qualifier.present?
+          {
+            qualifier: (first_qualifier if qualifier_is_common),
+            encoding: ({ code: first_encoding } if encoding_is_common)
+          }.compact
         end
 
         def build_date(event_type, node)

--- a/app/services/cocina/to_fedora/descriptive/event.rb
+++ b/app/services/cocina/to_fedora/descriptive/event.rb
@@ -242,18 +242,24 @@ module Cocina
 
         def write_basic_date(date, cocina_event_type)
           if date.structuredValue
-            date_range(date.structuredValue, cocina_event_type)
+            structured_val_attribs = {
+              encoding: date.encoding,
+              qualifier: date.qualifier
+            }
+            date_range(date.structuredValue, cocina_event_type, structured_val_attribs)
           else
             date_tag(date, cocina_event_type)
           end
         end
 
-        def date_tag(date, cocina_event_type)
+        # @param [Hash] structured_val_attribs - populated when structuredValue parent has attributes for individual date elements
+        def date_tag(date, cocina_event_type, structured_val_attribs = {})
           value = date.value
           tag = date_type_value_for(date) ? :dateOther : TAG_NAME.fetch(cocina_event_type, :dateOther)
+
           attributes = {
-            encoding: date.encoding&.code,
-            qualifier: date.qualifier
+            encoding: (date.encoding&.code || structured_val_attribs[:encoding]&.code),
+            qualifier: date.qualifier || structured_val_attribs[:qualifier]
           }.tap do |attrs|
             attrs[:keyDate] = 'yes' if date.status == 'primary'
             attrs[:type] = date_type_for(date, cocina_event_type) if value.present?
@@ -273,9 +279,9 @@ module Cocina
           DATE_OTHER_TYPE[cocina_event_type]
         end
 
-        def date_range(dates, cocina_event_type)
+        def date_range(dates, cocina_event_type, structured_val_attribs)
           dates.each do |date|
-            date_tag(date, cocina_event_type)
+            date_tag(date, cocina_event_type, structured_val_attribs)
           end
         end
 

--- a/spec/services/cocina/from_fedora/descriptive/event_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/event_spec.rb
@@ -436,19 +436,16 @@ RSpec.describe Cocina::FromFedora::Descriptive::Event do
               "structuredValue": [
                 {
                   "value": '1922',
-                  "type": 'start',
-                  "encoding": {
-                    "code": 'marc'
-                  }
+                  "type": 'start'
                 },
                 {
                   "value": '1929',
-                  "type": 'end',
-                  "encoding": {
-                    "code": 'marc'
-                  }
+                  "type": 'end'
                 }
-              ]
+              ],
+              "encoding": {
+                "code": 'marc'
+              }
             }
           ],
           "note": [

--- a/spec/services/cocina/mapping/descriptive/h2/event_h2_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/event_h2_spec.rb
@@ -64,86 +64,87 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'Creation date range: 2020-01-01 to 2021-01-01' do
-    xit 'not implemented: date encoding is in wrong place for structuredValue'
-    # date encoding is in wrong place for structuredValue.
     # Per Arcadia: "the pattern is for properties to be at the highest level to which they apply"
 
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'creation',
-            date: [
-              {
-                structuredValue: [
-                  {
-                    value: '2020-01-01',
-                    type: 'start'
-                  },
-                  {
-                    value: '2021-01-01',
-                    type: 'end'
+    it_behaves_like 'cocina MODS mapping' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '2020-01-01',
+                      type: 'start'
+                    },
+                    {
+                      value: '2021-01-01',
+                      type: 'end'
+                    }
+                  ],
+                  encoding: {
+                    code: 'w3cdtf'
                   }
-                ],
-                encoding: {
-                  code: 'w3cdtf'
                 }
-              }
-            ]
-          }
-        ]
-      }
-    end
+              ]
+            }
+          ]
+        }
+      end
 
-    let(:mods) do
-      <<~XML
-        <originInfo eventType="production">
-          <dateCreated point="start" encoding="w3cdtf">2020-01-01</dateCreated>
-          <dateCreated point="end" encoding="w3cdtf">2021-01-01</dateCreated>
-        </originInfo>
-      XML
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="production">
+            <dateCreated point="start" encoding="w3cdtf">2020-01-01</dateCreated>
+            <dateCreated point="end" encoding="w3cdtf">2021-01-01</dateCreated>
+          </originInfo>
+        XML
+      end
     end
   end
 
   describe 'Approximate creation date: approx. 1900' do
-    xit 'not implemented: date encoding and qualifier in wrong place for structuredValue'
     # Per Arcadia: "the pattern is for properties to be at the highest level to which they apply"
 
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'creation',
-            date: [
-              {
-                structuredValue: [
-                  {
-                    value: '1900',
-                    type: 'start'
-                  },
-                  {
-                    value: '1910',
-                    type: 'end'
+    it_behaves_like 'cocina MODS mapping' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '1900',
+                      type: 'start'
+                    },
+                    {
+                      value: '1910',
+                      type: 'end'
+                    }
+                  ],
+                  qualifier: 'approximate',
+                  encoding: {
+                    code: 'w3cdtf'
                   }
-                ],
-                qualifier: 'approximate',
-                encoding: {
-                  code: 'w3cdtf'
                 }
-              }
-            ]
-          }
-        ]
-      }
-    end
+              ]
+            }
+          ]
+        }
+      end
 
-    let(:mods) do
-      <<~XML
-        <originInfo eventType="production">
-          <dateCreated qualifier="approximate" point="start" encoding="w3cdtf">1900</dateCreated>
-          <dateCreated qualifier="approximate" point="end" encoding="w3cdtf">1910</dateCreated>
-        </originInfo>
-      XML
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="production">
+            <dateCreated qualifier="approximate" point="start" encoding="w3cdtf">1900</dateCreated>
+            <dateCreated qualifier="approximate" point="end" encoding="w3cdtf">1910</dateCreated>
+          </originInfo>
+        XML
+      end
     end
   end
 

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
@@ -328,15 +328,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                     {
                       value: '1940',
                       type: 'start',
-                      status: 'primary',
-                      qualifier: 'approximate'
+                      status: 'primary'
                     },
                     {
                       value: '1945',
-                      type: 'end',
-                      qualifier: 'approximate'
+                      type: 'end'
                     }
-                  ]
+                  ],
+                  qualifier: 'approximate'
                 }
               ]
             }
@@ -675,19 +674,16 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                   structuredValue: [
                     {
                       value: '-0499',
-                      type: 'start',
-                      encoding: {
-                        code: 'edtf'
-                      }
+                      type: 'start'
                     },
                     {
                       value: '-0599',
-                      type: 'end',
-                      encoding: {
-                        code: 'edtf'
-                      }
+                      type: 'end'
                     }
-                  ]
+                  ],
+                  encoding: {
+                    code: 'edtf'
+                  }
                 }
               ]
             }
@@ -765,19 +761,16 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                   structuredValue: [
                     {
                       value: '0800',
-                      type: 'start',
-                      encoding: {
-                        code: 'edtf'
-                      }
+                      type: 'start'
                     },
                     {
                       value: '1000',
-                      type: 'end',
-                      encoding: {
-                        code: 'edtf'
-                      }
+                      type: 'end'
                     }
-                  ]
+                  ],
+                  encoding: {
+                    code: 'edtf'
+                  }
                 }
               ]
             }
@@ -2055,19 +2048,16 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                   structuredValue: [
                     {
                       value: '1933',
-                      type: 'start',
-                      encoding: {
-                        code: 'marc'
-                      }
+                      type: 'start'
                     },
                     {
                       value: 'uuuu',
-                      type: 'end',
-                      encoding: {
-                        code: 'marc'
-                      }
+                      type: 'end'
                     }
-                  ]
+                  ],
+                  encoding: {
+                    code: 'marc'
+                  }
                 }
               ],
               contributor: [
@@ -2249,19 +2239,16 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                   structuredValue: [
                     {
                       value: '1922',
-                      type: 'start',
-                      encoding: {
-                        code: 'marc'
-                      }
+                      type: 'start'
                     },
                     {
                       value: '1929',
-                      type: 'end',
-                      encoding: {
-                        code: 'marc'
-                      }
+                      type: 'end'
                     }
-                  ]
+                  ],
+                  encoding: {
+                    code: 'marc'
+                  }
                 }
               ],
               note: [

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
@@ -261,6 +261,102 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
     end
   end
 
+  describe 'Date range, empty qualifier attribute' do
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo>
+            <dateCreated keyDate="yes" point="start" qualifier="">1920</dateCreated>
+            <dateCreated point="end">1925</dateCreated>
+          </originInfo>
+        XML
+      end
+
+      # remove empty qualifier attribute
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="production">
+            <dateCreated keyDate="yes" point="start">1920</dateCreated>
+            <dateCreated point="end">1925</dateCreated>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '1920',
+                      type: 'start',
+                      status: 'primary'
+                    },
+                    {
+                      value: '1925',
+                      type: 'end'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
+  end
+
+  describe 'Date range, empty encoding attribute' do
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo>
+            <dateCreated keyDate="yes" point="start" encoding="">1920</dateCreated>
+            <dateCreated point="end">1925</dateCreated>
+          </originInfo>
+        XML
+      end
+
+      # remove empty encoding attribute
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="production">
+            <dateCreated keyDate="yes" point="start">1920</dateCreated>
+            <dateCreated point="end">1925</dateCreated>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '1920',
+                      type: 'start',
+                      status: 'primary'
+                    },
+                    {
+                      value: '1925',
+                      type: 'end'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
+  end
+
   describe 'Approximate date' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do


### PR DESCRIPTION
## Why was this change made?

fixes event mapping for `encoding` and `qualifier` attributes -- Arcadia says 

> "the pattern is for properties to be at the highest [outermost] level to which they apply"

Also required fixing existing originInfo/event mapping specs to be consistent with this newly implemented rule.

Fixes #1971 
Fixes #1972

## How was this change tested?

specs updated plus roundtrip validation:

### this branch

```
Status (n=50000):
  Success:   49078 (98.156%)
  Different: 595 (1.19%)
  To Cocina error:     16 (0.032%)
  To Fedora error:     0 (0.0%)
  Missing:     311 (0.622%)
```

### main branch

```
Status (n=50000):
  Success:   49078 (98.156%)
  Different: 595 (1.19%)
  To Cocina error:     16 (0.032%)
  To Fedora error:     0 (0.0%)
  Missing:     311 (0.622%)
```


## Which documentation and/or configurations were updated?



