### PR TITLE
Un-xit name with approximate date spec.

### DIFF
--- a/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
@@ -1474,39 +1474,39 @@ RSpec.describe 'MODS name <--> cocina mappings' do
   end
 
   describe 'Name with approximate date' do
-    xit 'not implemented: needs cocina name type personal, structuredVaue type name'
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <name type="personal">
+            <namePart>Lassus, Rudolph de</namePart>
+            <namePart type="date">approximately 1563-1625</namePart>
+          </name>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <name type="personal">
-          <namePart>Lassus, Rudolph de</namePart>
-          <namePart type="date">approximately 1563-1625</namePart>
-        </name>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        contributor: [
-          {
-            name: [
-              {
-                structuredValue: [
-                  {
-                    value: 'Lassus, Rudolph de',
-                    type: 'name'
-                  },
-                  {
-                    value: 'approximately 1563-1625',
-                    type: 'life dates'
-                  }
-                ]
-              }
-            ],
-            type: 'person'
-          }
-        ]
-      }
+      let(:cocina) do
+        {
+          contributor: [
+            {
+              name: [
+                {
+                  structuredValue: [
+                    {
+                      value: 'Lassus, Rudolph de',
+                      type: 'name'
+                    },
+                    {
+                      value: 'approximately 1563-1625',
+                      type: 'life dates'
+                    }
+                  ]
+                }
+              ],
+              type: 'person'
+            }
+          ]
+        }
+      end
     end
   end
 


### PR DESCRIPTION
closes #2006

## Why was this change made?
Turns out the test works ...


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


