### PR TITLE
Correct name xlink mapping

### DIFF
--- a/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
@@ -1362,7 +1362,11 @@ RSpec.describe 'MODS name <--> cocina mappings' do
       {
         contributor: [
           {
-            uri: 'http://name.org/name'
+            name: [
+              {
+                valueAt: 'http://name.org/name'
+              }
+            ]
           }
         ]
       }


### PR DESCRIPTION
## Why was this change made?
To fix a mapping error


## How was this change tested?
n/a


## Which documentation and/or configurations were updated?
n/a


