### PR TITLE
Un-xit H2 mapping for non-FAST term spec.

### DIFF
--- a/spec/services/cocina/mapping/descriptive/h2/subject_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/subject_spec.rb
@@ -281,25 +281,25 @@ RSpec.describe 'Cocina --> MODS mappings for FAST subjects' do
   end
 
   describe 'Non-FAST term' do
-    xit 'not implemented'
+    it_behaves_like 'cocina MODS mapping' do
+      let(:mods) do
+        <<~XML
+          <subject>
+            <topic>Brooding sea stars</topic>
+          </subject>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <subject>
-          <topic>Brooding sea-stars</topic>
-        </subject>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        subject: [
-          {
-            value: 'Brooding sea stars',
-            type: 'topic'
-          }
-        ]
-      }
+      let(:cocina) do
+        {
+          subject: [
+            {
+              value: 'Brooding sea stars',
+              type: 'topic'
+            }
+          ]
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
closes #2058

## Why was this change made?
More tests.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


