### PR TITLE
Un-xit corporate and family names with authority tests.

### DIFF
--- a/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
@@ -795,68 +795,68 @@ RSpec.describe 'MODS name <--> cocina mappings' do
 
   describe 'Corporate name with authority' do
     # Example adapted from gq991tw6162
-    xit 'not implemented'
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <name type="corporate" usage="primary" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n85809720">
+            <namePart>Monterey Jazz Festival</namePart>
+          </name>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <name type="corporate" usage="primary" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n85809720">
-          <namePart>Monterey Jazz Festival</namePart>
-        </name>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        contributor: [
-          {
-            name: [
-              {
-                value: 'Monterey Jazz Festival',
-                uri: 'http://id.loc.gov/authorities/names/n85809720',
-                source: {
-                  code: 'naf',
-                  uri: 'http://id.loc.gov/authorities/names/'
+      let(:cocina) do
+        {
+          contributor: [
+            {
+              name: [
+                {
+                  value: 'Monterey Jazz Festival',
+                  uri: 'http://id.loc.gov/authorities/names/n85809720',
+                  source: {
+                    code: 'naf',
+                    uri: 'http://id.loc.gov/authorities/names/'
+                  }
                 }
-              }
-            ],
-            type: 'organization',
-            status: 'primary'
-          }
-        ]
-      }
+              ],
+              type: 'organization',
+              status: 'primary'
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'Family name with authority' do
-    xit 'not implemented'
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <name type="family" usage="primary" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n000000">
+            <namePart>Stanford family</namePart>
+          </name>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <name type="family" usage="primary" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n000000">
-          <namePart>Stanford family</namePart>
-        </name>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        contributor: [
-          {
-            name: [
-              {
-                value: 'Stanford family',
-                uri: 'http://id.loc.gov/authorities/names/n000000',
-                source: {
-                  code: 'naf',
-                  uri: 'http://id.loc.gov/authorities/names/'
+      let(:cocina) do
+        {
+          contributor: [
+            {
+              name: [
+                {
+                  value: 'Stanford family',
+                  uri: 'http://id.loc.gov/authorities/names/n000000',
+                  source: {
+                    code: 'naf',
+                    uri: 'http://id.loc.gov/authorities/names/'
+                  }
                 }
-              }
-            ],
-            type: 'family',
-            status: 'primary'
-          }
-        ]
-      }
+              ],
+              type: 'family',
+              status: 'primary'
+            }
+          ]
+        }
+      end
     end
   end
 


### PR DESCRIPTION
closes #2077

## Why was this change made?
Green++


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


