### PR TITLE
origin_info mapping specs and normalization - a few tweaks

### DIFF
--- a/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
@@ -15,6 +15,7 @@ module Cocina
       end
 
       def normalize
+        normalize_empty_origin_info
         normalize_origin_info_split
         normalize_origin_info_event_types
         normalize_origin_info_date_other_types
@@ -30,6 +31,10 @@ module Cocina
       private
 
       attr_reader :ng_xml
+
+      def normalize_empty_origin_info
+        ng_xml.root.xpath('//mods:originInfo[not(mods:*) and not(@*)]', mods: ModsNormalizer::MODS_NS).each(&:remove)
+      end
 
       def normalize_origin_info_split
         # Split a single originInfo into multiple.

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -1336,7 +1336,9 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
   describe 'Date mapping for presentation event type' do
     context 'event type and date only' do
-      it_behaves_like 'cocina MODS mapping' do
+      xit 'to be implemented: presentation currently maps to MODS dateIssued, not dateCreated - what do we want?'
+
+      # it_behaves_like 'cocina MODS mapping' do
         let(:cocina) do
           {
             event: [
@@ -1359,7 +1361,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
             </originInfo>
           XML
         end
-      end
+      # end
     end
 
     context 'with more complex presentation' do

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -1335,33 +1335,31 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   end
 
   describe 'Date mapping for presentation event type' do
-    context 'event type and date only' do
+    context 'with event type and date only' do
       xit 'to be implemented: presentation currently maps to MODS dateIssued, not dateCreated - what do we want?'
 
-      # it_behaves_like 'cocina MODS mapping' do
-        let(:cocina) do
-          {
-            event: [
-              {
-                type: 'presentation',
-                date: [
-                  {
-                    value: '1990'
-                  }
-                ]
-              }
-            ]
-          }
-        end
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'presentation',
+              date: [
+                {
+                  value: '1990'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-        let(:mods) do
-          <<~XML
-            <originInfo eventType="presentation">
-              <dateCreated>1990</dateCreated>
-            </originInfo>
-          XML
-        end
-      # end
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="presentation">
+            <dateCreated>1990</dateCreated>
+          </originInfo>
+        XML
+      end
     end
 
     context 'with more complex presentation' do

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -1417,12 +1417,12 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         let(:mods) do
           <<~XML
             <originInfo displayLabel="Presented" eventType="presentation">
-               <place>
-                 <placeTerm type="text" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
-               </place>
-               <publisher>Stanford Institute for Theoretical Economics</publisher>
-               <dateIssued keyDate="yes" encoding="w3cdtf">2018</dateIssued>
-             </originInfo>
+              <place>
+                <placeTerm type="text" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+              </place>
+              <publisher>Stanford Institute for Theoretical Economics</publisher>
+              <dateIssued keyDate="yes" encoding="w3cdtf">2018</dateIssued>
+            </originInfo>
           XML
         end
       end

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -1335,29 +1335,162 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   end
 
   describe 'Date mapping for presentation event type' do
-    xit 'not implemented' # or is it?
-
-    let(:cocina) do
-      {
-        event: [
+    context 'event type and date only' do
+      it_behaves_like 'cocina MODS mapping' do
+        let(:cocina) do
           {
-            type: 'presentation',
-            date: [
+            event: [
               {
-                value: '1990'
+                type: 'presentation',
+                date: [
+                  {
+                    value: '1990'
+                  }
+                ]
               }
             ]
           }
-        ]
-      }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="presentation">
+              <dateCreated>1990</dateCreated>
+            </originInfo>
+          XML
+        end
+      end
     end
 
-    let(:mods) do
-      <<~XML
-        <originInfo eventType="presentation">
-          <dateCreated>1990</dateCreated>
-        </originInfo>
-      XML
+    context 'with more complex presentation' do
+      # from druid:ht706sj6651
+
+      # NOTE: cocina -> MODS
+      it_behaves_like 'cocina MODS mapping' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'presentation',
+                date: [
+                  {
+                    value: '2018',
+                    encoding: {
+                      code: 'w3cdtf'
+                    },
+                    status: 'primary'
+                  }
+                ],
+                displayLabel: 'Presented',
+                contributor: [
+                  {
+                    name: [
+                      {
+                        value: 'Stanford Institute for Theoretical Economics'
+                      }
+                    ],
+                    type: 'organization',
+                    role: [
+                      {
+                        value: 'publisher',
+                        code: 'pbl',
+                        uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                        source: {
+                          code: 'marcrelator',
+                          uri: 'http://id.loc.gov/vocabulary/relators/'
+                        }
+                      }
+                    ]
+                  }
+                ],
+                location: [
+                  {
+                    uri: 'http://id.loc.gov/authorities/names/n50046557',
+                    value: 'Stanford (Calif.)'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo displayLabel="Presented" eventType="presentation">
+               <place>
+                 <placeTerm type="text" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+               </place>
+               <publisher>Stanford Institute for Theoretical Economics</publisher>
+               <dateIssued keyDate="yes" encoding="w3cdtf">2018</dateIssued>
+             </originInfo>
+          XML
+        end
+      end
+    end
+
+    context 'with an originInfo that is a presentation' do
+      # from druid:ht706sj6651
+
+      it_behaves_like 'MODS cocina mapping' do
+        let(:mods) do
+          <<~XML
+            <originInfo displayLabel="Presented" eventType="presentation">
+              <place>
+                <placeTerm type="text" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+              </place>
+              <publisher>Stanford Institute for Theoretical Economics</publisher>
+              <dateIssued keyDate="yes" encoding="w3cdtf">2018</dateIssued>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'presentation',
+                date: [
+                  {
+                    value: '2018',
+                    encoding: {
+                      code: 'w3cdtf'
+                    },
+                    status: 'primary'
+                  }
+                ],
+                displayLabel: 'Presented',
+                contributor: [
+                  {
+                    name: [
+                      {
+                        value: 'Stanford Institute for Theoretical Economics'
+                      }
+                    ],
+                    type: 'organization',
+                    role: [
+                      {
+                        value: 'publisher',
+                        code: 'pbl',
+                        uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                        source: {
+                          code: 'marcrelator',
+                          uri: 'http://id.loc.gov/vocabulary/relators/'
+                        }
+                      }
+                    ]
+                  }
+                ],
+                location: [
+                  {
+                    uri: 'http://id.loc.gov/authorities/names/n50046557',
+                    value: 'Stanford (Calif.)'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+      end
     end
   end
 
@@ -1594,71 +1727,6 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
     end
   end
 
-  context 'with an originInfo that is a presentation' do
-    # from druid:ht706sj6651
-
-    it_behaves_like 'MODS cocina mapping' do
-      let(:mods) do
-        <<~XML
-          <originInfo displayLabel="Presented" eventType="presentation">
-            <place>
-              <placeTerm type="text" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
-            </place>
-            <publisher>Stanford Institute for Theoretical Economics</publisher>
-            <dateIssued keyDate="yes" encoding="w3cdtf">2018</dateIssued>
-          </originInfo>
-        XML
-      end
-
-      let(:cocina) do
-        {
-          event: [
-            {
-              type: 'presentation',
-              date: [
-                {
-                  value: '2018',
-                  encoding: {
-                    code: 'w3cdtf'
-                  },
-                  status: 'primary'
-                }
-              ],
-              displayLabel: 'Presented',
-              contributor: [
-                {
-                  name: [
-                    {
-                      value: 'Stanford Institute for Theoretical Economics'
-                    }
-                  ],
-                  type: 'organization',
-                  role: [
-                    {
-                      value: 'publisher',
-                      code: 'pbl',
-                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                      source: {
-                        code: 'marcrelator',
-                        uri: 'http://id.loc.gov/vocabulary/relators/'
-                      }
-                    }
-                  ]
-                }
-              ],
-              location: [
-                {
-                  uri: 'http://id.loc.gov/authorities/names/n50046557',
-                  value: 'Stanford (Calif.)'
-                }
-              ]
-            }
-          ]
-        }
-      end
-    end
-  end
-
   context 'when it has a single dateOther' do
     context 'with eventType="acquisition"' do
       # NOTE: cocina -> MODS
@@ -1812,72 +1880,6 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                     code: 'marccountry'
                   },
                   code: 'enk'
-                }
-              ]
-            }
-          ]
-        }
-      end
-    end
-  end
-
-  context 'with presentation' do
-    # from druid:ht706sj6651
-
-    # NOTE: cocina -> MODS
-    it_behaves_like 'cocina MODS mapping' do
-      let(:mods) do
-        <<~XML
-          <originInfo displayLabel="Presented" eventType="presentation">
-             <place>
-               <placeTerm type="text" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
-             </place>
-             <publisher>Stanford Institute for Theoretical Economics</publisher>
-             <dateIssued keyDate="yes" encoding="w3cdtf">2018</dateIssued>
-           </originInfo>
-        XML
-      end
-
-      let(:cocina) do
-        {
-          event: [
-            {
-              type: 'presentation',
-              date: [
-                {
-                  value: '2018',
-                  encoding: {
-                    code: 'w3cdtf'
-                  },
-                  status: 'primary'
-                }
-              ],
-              displayLabel: 'Presented',
-              contributor: [
-                {
-                  name: [
-                    {
-                      value: 'Stanford Institute for Theoretical Economics'
-                    }
-                  ],
-                  type: 'organization',
-                  role: [
-                    {
-                      value: 'publisher',
-                      code: 'pbl',
-                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                      source: {
-                        code: 'marcrelator',
-                        uri: 'http://id.loc.gov/vocabulary/relators/'
-                      }
-                    }
-                  ]
-                }
-              ],
-              location: [
-                {
-                  uri: 'http://id.loc.gov/authorities/names/n50046557',
-                  value: 'Stanford (Calif.)'
                 }
               ]
             }

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
@@ -2007,20 +2007,76 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
     end
   end
 
-  context 'when events is nil' do
-    it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) do
-        {
-          event: []
-        }
-      end
+  context 'when originInfo / event is various flavors of missing' do
+    context 'when cocina event is empty array' do
+      # NOTE: cocina -> MODS
+      it_behaves_like 'cocina MODS mapping' do
+        let(:cocina) do
+          {
+            event: []
+          }
+        end
 
-      let(:roundtrip_cocina) do
-        {
-        }
-      end
+        let(:roundtrip_cocina) do
+          {
+          }
+        end
 
-      let(:mods) { '' }
+        let(:mods) { '' }
+      end
+    end
+
+    context 'when MODS has no elements' do
+      it_behaves_like 'MODS cocina mapping' do
+        let(:mods) { '' }
+
+        let(:cocina) do
+          {
+          }
+        end
+      end
+    end
+
+    context 'when cocina event is array with empty hash' do
+      # NOTE: cocina -> MODS
+      it_behaves_like 'cocina MODS mapping' do
+        let(:cocina) do
+          {
+            event: [{}]
+          }
+        end
+
+        let(:roundtrip_cocina) do
+          {
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo/>
+          XML
+        end
+      end
+    end
+
+    context 'when MODS is empty originInfo element with no attributes' do
+      it_behaves_like 'MODS cocina mapping' do
+        let(:mods) do
+          <<~XML
+            <originInfo/>
+          XML
+        end
+
+        let(:roundtrip_mods) do
+          <<~XML
+          XML
+        end
+
+        let(:cocina) do
+          {
+          }
+        end
+      end
     end
   end
 end

--- a/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
@@ -562,4 +562,63 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
       XML
     end
   end
+
+  context 'when empty originInfo element' do
+    context 'when no attributes no children' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo/>
+          </mods>
+        XML
+      end
+
+      it 'removes it' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when attributes attribute but no children' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo eventType="publication"/>
+          </mods>
+        XML
+      end
+
+      it 'does not remove it' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo eventType="publication"/>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when no attributes but (empty) child' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <publisher/>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'does not remove it' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo eventType="publication">
+              <publisher/>
+            </originInfo>
+          </mods>
+        XML
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

- beef up mapping specs for originInfo in diff flavors of empty
- mods normalization removes empty originInfo elements
- originInfo mapping specs about event type presentation collated and deduped ... and xit'ed the inconsistent one.

## How was this change tested?

it's all specs except mods normalization, which had a spec written for it.

## Which documentation and/or configurations were updated?



