### PR TITLE
Use correct version of MARC21slim2MODS3-7_SDR XSLT.

### DIFF
--- a/app/models/marcxml_resource.rb
+++ b/app/models/marcxml_resource.rb
@@ -22,7 +22,7 @@ class MarcxmlResource
   private
 
   def marc_to_mods_xslt
-    @marc_to_mods_xslt ||= Nokogiri::XSLT(File.open(File.join(Rails.root, 'app', 'xslt', 'MARC21slim2MODS3-7_SDR_v1.xsl')))
+    @marc_to_mods_xslt ||= Nokogiri::XSLT(File.open(File.join(Rails.root, 'app', 'xslt', 'MARC21slim2MODS3-7_SDR_v2.xsl')))
   end
 
   # @raises SymphonyReader::ResponseError


### PR DESCRIPTION
## Why was this change made?
We were using version 1, when we should have been using version 2.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


