### PR TITLE
Norm empty elements

### DIFF
--- a/app/services/cocina/from_fedora/descriptive.rb
+++ b/app/services/cocina/from_fedora/descriptive.rb
@@ -5,6 +5,7 @@ module Cocina
     # Creates Cocina Descriptive objects from Fedora objects
     class Descriptive
       DESC_METADATA_NS = Dor::DescMetadataDS::MODS_NS
+      XLINK_NS = 'http://www.w3.org/1999/xlink'
 
       # @param [#build] title_builder
       # @param [Nokogiri::XML] mods

--- a/app/services/cocina/from_fedora/descriptive/access.rb
+++ b/app/services/cocina/from_fedora/descriptive/access.rb
@@ -70,13 +70,13 @@ module Cocina
         def url
           url_nodes.map do |url_node|
             {
-              value: url_node.text,
+              value: url_node.text.presence,
               displayLabel: url_node[:displayLabel]
             }.tap do |attrs|
               attrs[:status] = 'primary' if url_node == primary_url_node
               attrs[:note] = [{ value: url_node[:note] }] if url_node[:note]
-            end.compact
-          end
+            end.compact.presence
+          end.compact
         end
 
         def primary_url_node

--- a/app/services/cocina/from_fedora/descriptive/identifier_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/identifier_builder.rb
@@ -30,6 +30,8 @@ module Cocina
         end
 
         def build
+          return if identifier_element.text.blank? && identifier_element.attributes.size.zero?
+
           {
             displayLabel: identifier_element['displayLabel']
           }.tap do |attrs|

--- a/app/services/cocina/from_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/from_fedora/descriptive/related_resource.rb
@@ -24,6 +24,8 @@ module Cocina
         def build
           related_items.map do |related_item|
             check_other_type(related_item)
+            next nil if related_item.elements.empty?
+
             descriptive_builder.build(resource_element: related_item, require_title: false).tap do |item|
               item[:displayLabel] = related_item['displayLabel']
               notes = build_notes(related_item)

--- a/app/services/cocina/mods_normalizers/subject_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/subject_normalizer.rb
@@ -15,6 +15,8 @@ module Cocina
       end
 
       def normalize
+        normalize_empty_geographic
+        normalize_empty_temporal
         normalize_subject
         normalize_subject_children
         normalize_subject_authority
@@ -221,6 +223,22 @@ module Cocina
             subject_node['script'] = child_node['script']
             child_node.delete('script')
           end
+        end
+      end
+
+      def normalize_empty_temporal
+        ng_xml.root.xpath('//mods:subject/mods:temporal[not(text())]', mods: ModsNormalizer::MODS_NS).each do |temporal_node|
+          subject_node = temporal_node.parent
+          temporal_node.remove
+          subject_node.remove if subject_node.elements.empty?
+        end
+      end
+
+      def normalize_empty_geographic
+        ng_xml.root.xpath('//mods:subject/mods:geographic[not(text())]', mods: ModsNormalizer::MODS_NS).each do |temporal_node|
+          subject_node = temporal_node.parent
+          temporal_node.remove
+          subject_node.remove if subject_node.elements.empty? && subject_node.attributes.empty?
         end
       end
     end

--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -143,6 +143,9 @@ module Cocina
             xml.subject(subject_attributes) do
               write_person(subject, subject_value, display_values: display_values)
             end
+          elsif !type && !subject_value.value
+            # For subject only (no children).
+            xml.subject topic_attributes_for(subject_value)
           else
             xml.subject(subject_attributes) do
               write_topic(subject, subject_value, is_parallel: alt_rep_group.present?)

--- a/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_spec.rb
@@ -551,13 +551,21 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
     end
 
     before do
-      allow(notifier).to receive(:error)
+      allow(notifier).to receive(:warn)
     end
 
     it 'builds the cocina data structure and errors' do
-      expect(build).to be_empty
-      expect(notifier).to have_received(:error).with('Subject has no children nodes',
-                                                     { subject: '<subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects" ' \
+      expect(build).to eq [
+        {
+          source: {
+            code: 'lcsh',
+            uri: 'http://id.loc.gov/authorities/subjects/'
+          },
+          uri: 'http://id.loc.gov/authorities/subjects/sh2002009897'
+        }
+      ]
+      expect(notifier).to have_received(:warn).with('Subject has text',
+                                                    { subject: '<subject authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects" ' \
 'valueURI="http://id.loc.gov/authorities/subjects/sh2002009897">authority="" authorityURI="" valueURI=""&gt;Improvisation (Acting)</subject>' })
     end
   end

--- a/spec/services/cocina/mapping/descriptive/mods/identifier_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/identifier_spec.rb
@@ -260,14 +260,8 @@ RSpec.describe 'MODS identifier <--> cocina mappings' do
           }
         end
 
-        # NOTE: not sure this is desirable, but it probably doesn't hurt anything?
         let(:roundtrip_cocina) do
           {
-            identifier: [
-              {
-                value: ''
-              }
-            ]
           }
         end
 
@@ -287,14 +281,13 @@ RSpec.describe 'MODS identifier <--> cocina mappings' do
           XML
         end
 
-        # NOTE: not sure this is desirable, but it probably doesn't hurt anything?
+        let(:roundtrip_mods) do
+          <<~XML
+          XML
+        end
+
         let(:cocina) do
           {
-            identifier: [
-              {
-                value: ''
-              }
-            ]
           }
         end
       end

--- a/spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb
@@ -517,4 +517,45 @@ RSpec.describe 'MODS relatedItem <--> cocina mappings' do
       end
     end
   end
+
+  describe 'Empty related item' do
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <relatedItem>
+            <titleInfo>
+              <title/>
+            </titleInfo>
+            <location>
+              <url/>
+            </location>
+          </relatedItem>
+        XML
+      end
+
+      let(:cocina) { {} }
+
+      let(:roundtrip_mods) { '' }
+
+      let(:warnings) do
+        [
+          Notification.new(msg: 'Empty title node')
+        ]
+      end
+    end
+  end
+
+  describe 'Another empty related item' do
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <relatedItem type="original"/>
+        XML
+      end
+
+      let(:cocina) { {} }
+
+      let(:roundtrip_mods) { '' }
+    end
+  end
 end

--- a/spec/services/cocina/mapping/descriptive/mods/subject_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_spec.rb
@@ -114,4 +114,37 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
       end
     end
   end
+
+  describe 'Authority-only subject' do
+    # Adapted from nv251kt0037
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <subject authority="geonames" authorityURI="http://sws.geonames.org" valueURI="http://sws.geonames.org/2946447/">
+            <geographic/>
+          </subject>
+        XML
+      end
+
+      let(:roundtrip_mods) do
+        <<~XML
+          <subject authority="geonames" authorityURI="http://sws.geonames.org" valueURI="http://sws.geonames.org/2946447/" />
+        XML
+      end
+
+      let(:cocina) do
+        {
+          subject: [
+            {
+              source: {
+                code: 'geonames',
+                uri: 'http://sws.geonames.org'
+              },
+              uri: 'http://sws.geonames.org/2946447/'
+            }
+          ]
+        }
+      end
+    end
+  end
 end

--- a/spec/services/cocina/mapping/descriptive/mods/subject_topic_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_topic_spec.rb
@@ -499,4 +499,20 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
       end
     end
   end
+
+  describe 'Empty topic subject' do
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <subject>
+            <topic></topic>
+          </subject>
+        XML
+      end
+
+      let(:cocina) { {} }
+
+      let(:roundtrip_mods) { '' }
+    end
+  end
 end

--- a/spec/services/cocina/mapping/descriptive/mods/type_of_resource_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/type_of_resource_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'MODS typeOfResource <--> cocina mappings' do
     end
   end
 
-  describe 'Attribute without value' do
+  describe 'Manuscript without value' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
@@ -169,6 +169,30 @@ RSpec.describe 'MODS typeOfResource <--> cocina mappings' do
                 value: 'MODS resource types'
               }
             }
+          ]
+        }
+      end
+    end
+  end
+
+  describe 'Collection without value' do
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <typeOfResource collection="yes" />
+        XML
+      end
+
+      let(:cocina) do
+        {
+          form: [
+            {
+              value: 'collection',
+              source: {
+                value: 'MODS resource types'
+              }
+            }
+
           ]
         }
       end

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -292,20 +292,162 @@ RSpec.describe Cocina::ModsNormalizer do
   end
 
   context 'when normalizing empty attributes' do
-    let(:mods_ng_xml) do
-      Nokogiri::XML <<~XML
-        <mods #{MODS_ATTRIBUTES}>
-          <classification authority="">Y 1.1/2:</mods:classification>
-        </mods>
-      XML
+    context 'when outer element' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <classification authority="">Y 1.1/2:</mods:classification>
+          </mods>
+        XML
+      end
+
+      it 'removes empty attributes' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <classification>Y 1.1/2:</mods:classification>
+          </mods>
+        XML
+      end
     end
 
-    it 'removes unmatched' do
-      expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <mods #{MODS_ATTRIBUTES}>
-          <classification>Y 1.1/2:</mods:classification>
-        </mods>
-      XML
+    context 'when in nested elements - originInfo' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo eventType="production" displayLabel="">
+              <place supplied="">
+                <placeTerm authorityURI=""
+                  valueURI="http://id.loc.gov/authorities/names/n81127564" type="">Selma (Ala.)</placeTerm>
+              </place>
+              <dateCreated keyDate="" encoding="w3cdtf">1965</dateCreated>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'removes empty elements and attributes' do
+        # note that placeTerm type="text" is assigned when type is missing
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo eventType="production">
+              <place>
+                <placeTerm valueURI="http://id.loc.gov/authorities/names/n81127564" type="text">Selma (Ala.)</placeTerm>
+              </place>
+              <dateCreated encoding="w3cdtf">1965</dateCreated>
+            </originInfo>
+          </mods>
+        XML
+      end
+    end
+  end
+
+  context 'when normalizing elements with no content and no attributes' do
+    context 'when nested elements - originInfo' do
+      xit 'not implemented: remove when <originInfo eventType="blah"/> is only attribute / value'
+
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo eventType="" displayLabel="">
+              <place supplied="">
+                <placeTerm authorityURI=""
+                  valueURI="" type=""></placeTerm>
+              </place>
+              <dateCreated keyDate="" encoding=""/>
+              <dateIssued/>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      # Temporarily ignoring <originInfo> pending https://github.com/sul-dlss/dor-services-app/issues/2128
+      xit 'removes empty attributes and attributes' do
+        # note that placeTerm type="text" is assigned when type is missing
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo eventType="publication"/>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when nested elements - name' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <name type="" usage="">
+              <namePart></namePart>
+              <role>
+                <roleTerm type=""></roleTerm>
+                <roleTerm/>
+              </role>
+            </name>
+          </mods>
+        XML
+      end
+
+      it 'removes empty elements and attributes' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when nested elements - language' do
+      xit 'not implemented: remove when <languageTerm type="code"/> is only attribute / value'
+
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <language>
+              <languageTerm type="" authority="" authorityURI="" valueURI=""></languageTerm>
+              <languageTerm type=""></languageTerm>
+              <scriptTerm type="" authority=""></scriptTerm>
+              <scriptTerm/>
+            </language>
+          </mods>
+        XML
+      end
+
+      it 'removes empty elements and attributes' do
+        # note that languageTerm type="code" is assigned when type is missing
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <language>
+              <languageTerm type="code"/>
+              <languageTerm type="code"/>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when nested elements - relatedItem' do
+      # based on nj954ht3332
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <note type="contact" displayLabel="Contact">pwrcourses@stanford.edu</note>
+            <relatedItem>
+              <titleInfo>
+                <title/>
+              </titleInfo>
+              <location>
+                <url/>
+              </location>
+            </relatedItem>
+          </mods>
+        XML
+      end
+
+      it 'removes empty elements and attributes and their empty parents' do
+        # note that languageTerm type="code" is assigned when type is missing
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <note type="contact" displayLabel="Contact">pwrcourses@stanford.edu</note>
+          </mods>
+        XML
+      end
     end
   end
 

--- a/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
@@ -116,15 +116,12 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
       XML
     end
 
-    it 'removes dateOther type attribute if it matches eventType and dateOther is empty' do
+    # Temporarily ignoring <originInfo> pending https://github.com/sul-dlss/dor-services-app/issues/2128
+    xit 'removes dateOther type attribute if it matches eventType and dateOther is empty' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
         <mods #{MODS_ATTRIBUTES}>
-          <originInfo eventType="distribution">
-            <dateOther/>
-          </originInfo>
-          <originInfo eventType="manufacture">
-            <dateOther/>
-          </originInfo>
+          <originInfo eventType="distribution"/>
+          <originInfo eventType="manufacture"/>
           <originInfo eventType="distribution">
             <dateOther type="distribution">1937</dateOther>
           </originInfo>
@@ -637,7 +634,7 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
       end
     end
 
-    context 'when attributes attribute but no children' do
+    context 'when eventType attribute but no children' do
       let(:mods_ng_xml) do
         Nokogiri::XML <<~XML
           <mods #{MODS_ATTRIBUTES}>
@@ -655,7 +652,7 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
       end
     end
 
-    context 'when no attributes but (empty) child' do
+    context 'when eventType attribute and (empty) child' do
       let(:mods_ng_xml) do
         Nokogiri::XML <<~XML
           <mods #{MODS_ATTRIBUTES}>
@@ -666,12 +663,11 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
         XML
       end
 
-      it 'does not remove it' do
+      # Temporarily ignoring <originInfo> pending https://github.com/sul-dlss/dor-services-app/issues/2128
+      xit 'removes the empty child' do
         expect(normalized_ng_xml).to be_equivalent_to <<~XML
           <mods #{MODS_ATTRIBUTES}>
-            <originInfo eventType="publication">
-              <publisher/>
-            </originInfo>
+            <originInfo eventType="publication"/>
           </mods>
         XML
       end

--- a/spec/services/cocina/mods_normalizers/subject_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/subject_normalizer_spec.rb
@@ -627,4 +627,53 @@ RSpec.describe Cocina::ModsNormalizers::SubjectNormalizer do
       XML
     end
   end
+
+  context 'when normalizing temporal' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{MODS_ATTRIBUTES}>
+          <subject>
+            <temporal encoding="iso8601" point="start">[1923?-]</temporal>
+            <temporal encoding="iso8601" point="end"/>
+          </subject>
+          <subject>
+            <temporal />
+          </subject>
+        </mods>
+      XML
+    end
+
+    it 'removes empty' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{MODS_ATTRIBUTES}>
+          <subject>
+            <temporal encoding="iso8601" point="start">[1923?-]</temporal>
+          </subject>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when normalizing empty geographic' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{MODS_ATTRIBUTES}>
+          <subject authority="geonames" authorityURI="http://sws.geonames.org" valueURI="http://sws.geonames.org/2946447/">
+            <geographic/>
+          </subject>
+          <subject>
+            <geographic/>
+          </subject>
+        </mods>
+      XML
+    end
+
+    it 'removes empty' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{MODS_ATTRIBUTES}>
+          <subject authority="geonames" authorityURI="http://sws.geonames.org" valueURI="http://sws.geonames.org/2946447/" />
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
Easiest way to show results of my attempt to normalize removal of empty elements, recursively from #2034.

We appear to have inconsistent rules for mapping empty MODS to cocina --- in some cases, an empty MODS produces no cocina, and in others, it produces cocina but with no useful data in it.


## Why was this change made?



## How was this change tested?

### this branch

```
Status (n=1000):
  Success:   972 (97.2%)
  Different: 16 (1.6%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  Missing:     12 (1.2%)
```

### main branch

```
Status (n=1000):
  Success:   976 (97.6%)
  Different: 12 (1.2%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  Missing:     12 (1.2%)
```

### diff between results of the 2 branches:

```
Only in results-norm-1000: druid:br564zr5425.txt
Only in results-norm-1000: druid:kg623mg8697.txt
Only in results-norm-1000: druid:qx562pf7510.txt
diff results-norm-1000/druid:qy796rh6653.txt results-main-1000/druid:qy796rh6653.txt
5a6,9
>   <place>
>     <placeTerm/>
>   </place>
>   <publisher/>
18,19c22,24
<    <dateOther type="production">September 1990</dateOther>
< +  <place>
---
> +  <dateOther type="production">September 1990</dateOther>
>    <place>
> -    <placeTerm/>
21,22c26,28
< +  </place>
< +  <publisher/>
---
>    </place>
>    <publisher/>
> -  <dateOther type="production">September 1990</dateOther>
56a63,66
>     <place>
>       <placeTerm/>
>     </place>
>     <publisher/>
Only in results-norm-1000: druid:xv158sd4671.txt
```

https://argo.stanford.edu/view/br564zr5425 has:

```xml
<relatedItem>
    <titleInfo>
      <title/>
    </titleInfo>
    <location>
      <url/>
    </location>
  </relatedItem>
```

https://argo.stanford.edu/view/kg623mg8697 has 

empty `<originInfo><dateIssued/>`

```xml
  <originInfo eventType="publication">
    <place>
      <placeTerm type="text">Bucharest</placeTerm>
    </place>
    <publisher>Editura Academiei Rom&#xE2;ne</publisher>
    <dateIssued/>
  </originInfo>
```

https://argo.stanford.edu/view/qx562pf7510 has an empty `<originInfo><dateOther/>`
https://argo.stanford.edu/view/xv158sd4671 has an empty `<originInfo><dateOther/>`

As for the one in both results, but different, qy796rh6653:

```
 <place>
    <placeTerm type="text"/>
  </place>
```
appears in roundtripped ...

## Which documentation and/or configurations were updated?



