### PR TITLE
upgrade super_diff to version that works w/ CI build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :test, :development do
   gem 'rubocop-rails'
   gem 'rubocop-rspec', '~> 1.32.0'
   gem 'simplecov', '~> 0.17.1' # https://github.com/codeclimate/test-reporter/issues/413
-  gem 'super_diff', '~> 0.5.3' # 0.6.0 breaks CircleCI build (but not local), see https://github.com/sul-dlss/dor-services-app/issues/2131
+  gem 'super_diff'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -472,7 +472,7 @@ GEM
     stanford-mods-normalizer (0.1.0)
       nokogiri (~> 1.8)
     stomp (1.4.10)
-    super_diff (0.5.3)
+    super_diff (0.6.1)
       attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff
@@ -557,7 +557,7 @@ DEPENDENCIES
   simplecov (~> 0.17.1)
   spring
   spring-watcher-listen (~> 2.0.0)
-  super_diff (~> 0.5.3)
+  super_diff
   uuidtools (~> 2.1.4)
   webmock
   whenever


### PR DESCRIPTION
## Why was this change made?

fix #2131 (allow us to unpin super_diff gem)

see https://github.com/mcmire/super_diff/issues/120#issuecomment-776414070

~~will update and take out of draft once there's an official release~~ ready for review, upgraded to [0.6.1](https://github.com/mcmire/super_diff/issues/120#issuecomment-777185023)

## How was this change tested?

* ran test suite on local dev instance
* CI run for this PR

## Which documentation and/or configurations were updated?

unpinned a gem