### PR TITLE
add event type release

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/event.rb
+++ b/app/services/cocina/to_fedora/descriptive/event.rb
@@ -6,11 +6,12 @@ module Cocina
       # Maps events from cocina to MODS XML
       class Event
         TAG_NAME = {
-          'creation' => :dateCreated,
-          'publication' => :dateIssued,
-          'copyright' => :copyrightDate,
           'capture' => :dateCaptured,
+          'copyright' => :copyrightDate,
+          'creation' => :dateCreated,
           'presentation' => :dateIssued,
+          'publication' => :dateIssued,
+          'release' => :dateIssued,
           'validity' => :dateValid
         }.freeze
 
@@ -22,16 +23,17 @@ module Cocina
         }.freeze
 
         EVENT_TYPE = {
+          'acquisition' => 'acquisition',
           'capture' => 'capture',
           'copyright' => 'copyright',
           'creation' => 'production',
+          'development' => 'development',
           'distribution' => 'distribution',
           'manufacture' => 'manufacture',
-          'publication' => 'publication',
-          'acquisition' => 'acquisition',
-          'development' => 'development',
           'presentation' => 'presentation',
           'production' => 'production',
+          'publication' => 'publication',
+          'release' => 'release',
           'validity' => 'validity'
         }.freeze
 

--- a/spec/services/cocina/mapping/descriptive/h2/event_h2_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/event_h2_spec.rb
@@ -149,38 +149,32 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'Release date: 2022-01-01' do
-    xit 'not implemented: release type nor appliesTo'
-    # Ask Arcadia if she wants to add release to types or if she meant something else
-
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'release',
-            date: [
-              {
-                value: '2022-01-01',
-                encoding: {
-                  code: 'w3cdtf'
-                },
-                appliesTo: [
-                  {
-                    value: 'SDR resource'
+    it_behaves_like 'cocina MODS mapping' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'release',
+              date: [
+                {
+                  value: '2022-01-01',
+                  encoding: {
+                    code: 'w3cdtf'
                   }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    end
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-    let(:mods) do
-      <<~XML
-        <originInfo eventType="release">
-          <dateIssued encoding="w3cdtf">2022-01-01</dateIssued>
-        </originInfo>
-      XML
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="release">
+            <dateIssued encoding="w3cdtf">2022-01-01</dateIssued>
+          </originInfo>
+        XML
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #1995.   "release" eventType is presumably a new one from H2 work.

## How was this change tested?

### main branch

```
Status (n=10000):
  Success:   9830 (98.3%)
  Different: 102 (1.02%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  Missing:     68 (0.68%)
```

### this branch

```
Status (n=10000):
  Success:   9830 (98.3%)
  Different: 102 (1.02%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  Missing:     68 (0.68%)
```

## Which documentation and/or configurations were updated?



