### PR TITLE
add a little info to some xit messages in mapping specs

### DIFF
--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -1308,7 +1308,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   end
 
   describe 'Date mapping for recording event type' do
-    xit 'not implemented'
+    xit 'not implemented: recording event type'
 
     let(:cocina) do
       {
@@ -1495,7 +1495,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   end
 
   describe 'Date mapping for performance event type' do
-    xit 'not implemented'
+    xit 'not implemented: performance event type'
 
     let(:cocina) do
       {
@@ -1522,7 +1522,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   end
 
   describe 'Date mapping for release event type' do
-    xit 'not implemented' # also mapped in H2
+    xit 'not implemented: release event reverse of H2 spec - bug!' # also mapped in H2
 
     let(:cocina) do
       {

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_place_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_place_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe 'MODS originInfo place <--> cocina mappings' do
       }
     end
 
-    xit 'not implemented'
+    xit 'not implemented: text and code for diff places from replayable spreadsheet'
   end
 
   describe 'Supplied place name' do


### PR DESCRIPTION
## Why was this change made?

b/c i often "ack" for xit and this helps.

## How was this change tested?



## Which documentation and/or configurations were updated?



