### PR TITLE
beef up mapping specs to ensure roundtripping is super stable 

### DIFF
--- a/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
@@ -132,6 +132,8 @@ module Cocina
 
       def normalize_origin_info_developed_date
         ng_xml.root.xpath('//mods:originInfo/mods:dateOther[@type="developed"]', mods: ModsNormalizer::MODS_NS).each do |date_other|
+          next if date_other.parent['eventType'] == 'development'
+
           # Move to own originInfo
           new_origin_info = Nokogiri::XML::Node.new('originInfo', Nokogiri::XML(nil))
           new_origin_info[:eventType] = 'development'

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -165,21 +165,40 @@ RSpec.describe Cocina::ModsNormalizer do
   end
 
   context 'when normalizing empty notes' do
-    let(:mods_ng_xml) do
-      Nokogiri::XML <<~XML
-        <mods #{MODS_ATTRIBUTES}>
-          <note type="statement of responsibility" altRepGroup="00" script="Latn"/>
-          <note>Includes various issues of some sheets.</note>
-        </mods>
-      XML
+    context 'without attributes' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <note/>
+            <note></note>
+          </mods>
+        XML
+      end
+
+      it 'removes' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}/>
+        XML
+      end
     end
 
-    it 'removes' do
-      expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <mods #{MODS_ATTRIBUTES}>
-          <note>Includes various issues of some sheets.</note>
-        </mods>
-      XML
+    context 'with attributes' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <note type="statement of responsibility" altRepGroup="00" script="Latn"/>
+            <note>Includes various issues of some sheets.</note>
+          </mods>
+        XML
+      end
+
+      it 'removes' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <note>Includes various issues of some sheets.</note>
+          </mods>
+        XML
+      end
     end
   end
 

--- a/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
@@ -232,34 +232,90 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
   end
 
   context 'when normalizing originInfo with developed date' do
-    let(:mods_ng_xml) do
-      Nokogiri::XML <<~XML
-        <mods #{MODS_ATTRIBUTES}>
-          <originInfo displayLabel="Place of Creation" eventType="production">
-            <place>
-              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
-            </place>
-            <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
-            <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
-          </originInfo>
-        </mods>
-      XML
+    context 'with unmatching eventType' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo displayLabel="Place of Creation" eventType="production">
+              <place>
+                <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+              </place>
+              <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
+              <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'moves to own originInfo' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo displayLabel="Place of Creation" eventType="production">
+              <place>
+                <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+              </place>
+              <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
+            </originInfo>
+            <originInfo eventType="development">
+              <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
+            </originInfo>
+          </mods>
+        XML
+      end
     end
 
-    it 'moves to own originInfo' do
-      expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <mods #{MODS_ATTRIBUTES}>
-          <originInfo displayLabel="Place of Creation" eventType="production">
-            <place>
-              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
-            </place>
-            <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
-          </originInfo>
-          <originInfo eventType="development">
-            <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
-          </originInfo>
-        </mods>
-      XML
+    context 'with matching eventType' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo displayLabel="Place of Creation" eventType="production">
+              <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
+            </originInfo>
+            <originInfo eventType="development">
+              <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'stays the same' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo displayLabel="Place of Creation" eventType="production">
+              <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
+            </originInfo>
+            <originInfo eventType="development">
+              <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
+            </originInfo>
+          </mods>
+        XML
+      end
+    end
+
+    context 'with no eventType' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo displayLabel="Place of Creation">
+              <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
+              <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'moves to own originInfo' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo displayLabel="Place of Creation" eventType="production">
+              <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
+            </originInfo>
+            <originInfo eventType="development">
+              <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
+            </originInfo>
+          </mods>
+        XML
+      end
     end
   end
 
@@ -619,6 +675,34 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
           </mods>
         XML
       end
+    end
+  end
+
+  context 'when originInfo production followed by originInfo development' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{MODS_ATTRIBUTES}>
+          <originInfo displayLabel="Place of Creation" eventType="production">
+            <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
+          </originInfo>
+          <originInfo eventType="development">
+            <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
+          </originInfo>
+        </mods>
+      XML
+    end
+
+    it 'stays the same' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{MODS_ATTRIBUTES}>
+          <originInfo displayLabel="Place of Creation" eventType="production">
+            <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
+          </originInfo>
+          <originInfo eventType="development">
+            <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
+          </originInfo>
+        </mods>
+      XML
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

for fun and profit.

## How was this change tested?

### Main branch

```
Status (n=10000):
  Success:   9830 (98.3%)
  Different: 102 (1.02%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  Missing:     68 (0.68%)
```

### this branch

```
Status (n=10000):
  Success:   9830 (98.3%)
  Different: 102 (1.02%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  Missing:     68 (0.68%)
```


## Which documentation and/or configurations were updated?



