### PR TITLE
origin_info mapping specs - turn some back on, reversing PR #2130

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -161,17 +161,18 @@ module Cocina
         def build_events_for_origin_info(origin_info, language_script)
           [].tap do |events|
             orig_info_type = origin_info['eventType']
+            has_content_predicate = '[string-length(normalize-space()) > 1]'
 
-            date_created = origin_info.xpath('mods:dateCreated[text()]', mods: DESC_METADATA_NS)
+            date_created = origin_info.xpath("mods:dateCreated#{has_content_predicate}", mods: DESC_METADATA_NS)
             events << build_event('creation', date_created, language_script) if date_created.present?
 
-            date_issued = origin_info.xpath('mods:dateIssued', mods: DESC_METADATA_NS)
+            date_issued = origin_info.xpath("mods:dateIssued#{has_content_predicate}", mods: DESC_METADATA_NS)
             if date_issued.present?
               event_type = event_type_or_default(orig_info_type, 'publication')
               events << build_event(event_type, date_issued, language_script)
             end
 
-            copyright_date = origin_info.xpath('mods:copyrightDate[text()]', mods: DESC_METADATA_NS)
+            copyright_date = origin_info.xpath("mods:copyrightDate#{has_content_predicate}", mods: DESC_METADATA_NS)
             if copyright_date.present?
               events << if origin_info['eventType'] == 'copyright notice'
                           build_copyright_note(copyright_date.first)
@@ -180,13 +181,13 @@ module Cocina
                         end
             end
 
-            date_captured = origin_info.xpath('mods:dateCaptured[text()]', mods: DESC_METADATA_NS)
+            date_captured = origin_info.xpath("mods:dateCaptured#{has_content_predicate}", mods: DESC_METADATA_NS)
             events << build_event('capture', date_captured, language_script) if date_captured.present?
 
-            date_validity = origin_info.xpath('mods:dateValid[text()]', mods: DESC_METADATA_NS)
+            date_validity = origin_info.xpath("mods:dateValid#{has_content_predicate}", mods: DESC_METADATA_NS)
             events << build_event('validity', date_validity, language_script) if date_validity.present?
 
-            date_other = origin_info.xpath('mods:dateOther[text()]', mods: DESC_METADATA_NS)
+            date_other = origin_info.xpath("mods:dateOther#{has_content_predicate}", mods: DESC_METADATA_NS)
             events << build_event(date_other_event_type(origin_info, date_other.first), date_other, language_script) if date_other.present?
 
             # set eventType to 'production' in MODS if no date present

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -366,7 +366,6 @@ module Cocina
         def build_event(type, node_set, language_script = nil)
           dates = node_set.reject { |node| node['point'] }.map do |node|
             next if node.text.blank? # && node.attributes.size.zero?
-            # next if node.text.blank? && node.attributes.size == 1 && node.attributes.
 
             addl_attributes = node['encoding'].nil? && language_script ? { valueLanguage: language_script } : {}
             build_date(type, node).merge(addl_attributes)

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -366,7 +366,7 @@ module Cocina
         # rubocop:disable Metrics/CyclomaticComplexity
         def build_event(type, node_set, language_script = nil)
           dates = node_set.reject { |node| node['point'] }.map do |node|
-            next if node.text.blank? && node.attributes.size.zero?
+            next if node.text.blank? #&& node.attributes.size.zero?
 
             addl_attributes = node['encoding'].nil? && language_script ? { valueLanguage: language_script } : {}
             build_date(type, node).merge(addl_attributes)

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -162,7 +162,7 @@ module Cocina
           [].tap do |events|
             orig_info_type = origin_info['eventType']
 
-            date_created = origin_info.xpath('mods:dateCreated', mods: DESC_METADATA_NS)
+            date_created = origin_info.xpath('mods:dateCreated[text()]', mods: DESC_METADATA_NS)
             events << build_event('creation', date_created, language_script) if date_created.present?
 
             date_issued = origin_info.xpath('mods:dateIssued', mods: DESC_METADATA_NS)
@@ -171,7 +171,7 @@ module Cocina
               events << build_event(event_type, date_issued, language_script)
             end
 
-            copyright_date = origin_info.xpath('mods:copyrightDate', mods: DESC_METADATA_NS)
+            copyright_date = origin_info.xpath('mods:copyrightDate[text()]', mods: DESC_METADATA_NS)
             if copyright_date.present?
               events << if origin_info['eventType'] == 'copyright notice'
                           build_copyright_note(copyright_date.first)
@@ -180,13 +180,13 @@ module Cocina
                         end
             end
 
-            date_captured = origin_info.xpath('mods:dateCaptured', mods: DESC_METADATA_NS)
+            date_captured = origin_info.xpath('mods:dateCaptured[text()]', mods: DESC_METADATA_NS)
             events << build_event('capture', date_captured, language_script) if date_captured.present?
 
-            date_validity = origin_info.xpath('mods:dateValid', mods: DESC_METADATA_NS)
+            date_validity = origin_info.xpath('mods:dateValid[text()]', mods: DESC_METADATA_NS)
             events << build_event('validity', date_validity, language_script) if date_validity.present?
 
-            date_other = origin_info.xpath('mods:dateOther', mods: DESC_METADATA_NS)
+            date_other = origin_info.xpath('mods:dateOther[text()]', mods: DESC_METADATA_NS)
             events << build_event(date_other_event_type(origin_info, date_other.first), date_other, language_script) if date_other.present?
 
             # set eventType to 'production' in MODS if no date present
@@ -365,7 +365,7 @@ module Cocina
 
         def build_event(type, node_set, language_script = nil)
           dates = node_set.reject { |node| node['point'] }.map do |node|
-            next if node.text.blank? # && node.attributes.size.zero?
+            # next if node.text.blank? # && node.attributes.size.zero?
 
             addl_attributes = node['encoding'].nil? && language_script ? { valueLanguage: language_script } : {}
             build_date(type, node).merge(addl_attributes)

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -363,10 +363,9 @@ module Cocina
           end
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
         def build_event(type, node_set, language_script = nil)
           dates = node_set.reject { |node| node['point'] }.map do |node|
-            next if node.text.blank? #&& node.attributes.size.zero?
+            next if node.text.blank? # && node.attributes.size.zero?
 
             addl_attributes = node['encoding'].nil? && language_script ? { valueLanguage: language_script } : {}
             build_date(type, node).merge(addl_attributes)
@@ -384,7 +383,6 @@ module Cocina
           result[:date] = dates.compact if dates.present? && !dates.compact.empty? # deals with [nil]
           result
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
 
         # rubocop:disable Metrics/CyclomaticComplexity
         def build_structured_date(type, node_set)

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -366,6 +366,7 @@ module Cocina
         def build_event(type, node_set, language_script = nil)
           dates = node_set.reject { |node| node['point'] }.map do |node|
             next if node.text.blank? # && node.attributes.size.zero?
+            # next if node.text.blank? && node.attributes.size == 1 && node.attributes.
 
             addl_attributes = node['encoding'].nil? && language_script ? { valueLanguage: language_script } : {}
             build_date(type, node).merge(addl_attributes)

--- a/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
@@ -44,6 +44,11 @@ module Cocina
             date_node.remove if date_node.content.squish.blank?
           end
         end
+
+        # we can also remove dateOther if it has no type attribute
+        ng_xml.root.xpath('//mods:originInfo/mods:dateOther[not(@type)]', mods: ModsNormalizer::MODS_NS).each do |date_node|
+          date_node.remove if date_node.content.squish.blank?
+        end
       end
 
       # must be after remove_empty_origin_info_dates
@@ -131,7 +136,7 @@ module Cocina
 
             date_other_node.remove_attribute('type') if origin_info_event_type.match?(date_other_node['type'])
             # Temporarily ignoring pending https://github.com/sul-dlss/dor-services-app/issues/2128
-            # date_node.remove if date_node.content.squish.blank?
+            # date_other_node.remove if date_other_node.content.squish.blank?
           end
         end
       end

--- a/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
@@ -5,6 +5,8 @@ module Cocina
     # Normalizes a Fedora MODS document for originInfo elements.
     # Must be called after authorityURI attribs are normalized
     class OriginInfoNormalizer
+      DATE_FIELDS = %w[dateIssued copyrightDate dateCreated dateCaptured dateValid dateOther dateModified].freeze
+
       # @param [Nokogiri::Document] mods_ng_xml MODS to be normalized
       # @return [Nokogiri::Document] normalized MODS
       def self.normalize(mods_ng_xml:)
@@ -16,10 +18,11 @@ module Cocina
       end
 
       def normalize
-        normalize_empty_origin_info
+        remove_empty_origin_info_dates
+        remove_empty_origin_info # must be after remove_empty_origin_info_dates
         normalize_origin_info_split
         normalize_origin_info_event_types
-        normalize_origin_info_date_other_types
+        normalize_origin_info_date_other_types # must be after normalize_origin_info_event_types
         normalize_origin_info_place_term_type
         normalize_origin_info_developed_date
         normalize_origin_info_date
@@ -33,7 +36,18 @@ module Cocina
 
       attr_reader :ng_xml
 
-      def normalize_empty_origin_info
+      # must be called before remove_empty_origin_info
+      def remove_empty_origin_info_dates
+        # dateOther is removed by normalize_origin_info_date_other_types
+        DATE_FIELDS.without('dateOther').each do |date_field|
+          ng_xml.root.xpath("//mods:originInfo/mods:#{date_field}", mods: ModsNormalizer::MODS_NS).each do |date_node|
+            date_node.remove if date_node.content.squish.blank?
+          end
+        end
+      end
+
+      # must be after remove_empty_origin_info_dates
+      def remove_empty_origin_info
         ng_xml.root.xpath('//mods:originInfo[not(mods:*) and not(@*)]', mods: ModsNormalizer::MODS_NS).each(&:remove)
       end
 
@@ -116,6 +130,8 @@ module Cocina
             next if date_other_node.content.present?
 
             date_other_node.remove_attribute('type') if origin_info_event_type.match?(date_other_node['type'])
+            # Temporarily ignoring pending https://github.com/sul-dlss/dor-services-app/issues/2128
+            # date_node.remove if date_node.content.squish.blank?
           end
         end
       end
@@ -144,8 +160,8 @@ module Cocina
       end
 
       def normalize_origin_info_date
-        %w[dateIssued copyrightDate dateCreated dateCaptured dateValid dateOther].each do |date_type|
-          ng_xml.root.xpath("//mods:originInfo/mods:#{date_type}", mods: ModsNormalizer::MODS_NS)
+        DATE_FIELDS.each do |date_field|
+          ng_xml.root.xpath("//mods:originInfo/mods:#{date_field}", mods: ModsNormalizer::MODS_NS)
                 .each { |date_node| date_node.content = date_node.content.delete_suffix('.') }
         end
       end

--- a/app/services/cocina/to_fedora/descriptive/event.rb
+++ b/app/services/cocina/to_fedora/descriptive/event.rb
@@ -194,6 +194,8 @@ module Cocina
 
         # rubocop:disable Metrics/ParameterLists
         def write_event(cocina_event_type, dates, locations, names, notes, attributes, is_parallel: false)
+          return if dates.blank? && locations.blank? && names.blank? && notes.blank?
+
           xml.originInfo attributes do
             Array(dates).each do |date|
               write_basic_date(date, cocina_event_type)

--- a/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
@@ -362,41 +362,42 @@ RSpec.describe 'MODS name <--> cocina mappings' do
   end
 
   describe 'Name with ordinal' do
-    xit('not implemented: ordinal type (determined from source data)')
     # Use "term of address" for "ordinal" if type of term cannot be determined from source data.
 
-    let(:mods) do
-      <<~XML
-        <name type="personal" usage="primary">
-          <namePart type="given">Elizabeth</namePart>
-          <namePart type="termsOfAddress">II</namePart>
-        </name>
-      XML
-    end
+    xit('not implemented: ordinal type (determined from source data)') do
+      let(:mods) do
+        <<~XML
+          <name type="personal" usage="primary">
+            <namePart type="given">Elizabeth</namePart>
+            <namePart type="termsOfAddress">II</namePart>
+          </name>
+        XML
+      end
 
-    let(:cocina) do
-      {
-        contributor: [
-          {
-            name: [
-              {
-                structuredValue: [
-                  {
-                    value: 'Elizabeth',
-                    type: 'forename'
-                  },
-                  {
-                    value: 'II',
-                    type: 'ordinal'
-                  }
-                ]
-              }
-            ],
-            type: 'person',
-            status: 'primary'
-          }
-        ]
-      }
+      let(:cocina) do
+        {
+          contributor: [
+            {
+              name: [
+                {
+                  structuredValue: [
+                    {
+                      value: 'Elizabeth',
+                      type: 'forename'
+                    },
+                    {
+                      value: 'II',
+                      type: 'ordinal'
+                    }
+                  ]
+                }
+              ],
+              type: 'person',
+              status: 'primary'
+            }
+          ]
+        }
+      end
     end
   end
 
@@ -1447,40 +1448,40 @@ RSpec.describe 'MODS name <--> cocina mappings' do
   end
 
   describe 'Name with nameIdentifier only (RWO URI)' do
-    xit 'not implemented: mapping to contributor with nameIdentifier only'
+    xit 'not implemented: mapping to contributor with nameIdentifier only' do
+      let(:mods) do
+        <<~XML
+          <name>
+            <nameIdentifier type="orcid">0000-0000-0000</nameIdentifier>
+            <role>
+              <roleTerm type="code" authority="marcrelator">aut</roleTerm>
+            </role>
+          </name>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <name>
-          <nameIdentifier type="orcid">0000-0000-0000</nameIdentifier>
-          <role>
-            <roleTerm type="code" authority="marcrelator">aut</roleTerm>
-          </role>
-        </name>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        contributor: [
-          {
-            name: [
-              {
-                value: '0000-0000-0000',
-                type: 'ORCID'
-              }
-            ],
-            role: [
-              {
-                code: 'aut',
-                source: {
-                  code: 'marcrelator'
+      let(:cocina) do
+        {
+          contributor: [
+            {
+              name: [
+                {
+                  value: '0000-0000-0000',
+                  type: 'ORCID'
                 }
-              }
-            ]
-          }
-        ]
-      }
+              ],
+              role: [
+                {
+                  code: 'aut',
+                  source: {
+                    code: 'marcrelator'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
@@ -1625,68 +1626,70 @@ RSpec.describe 'MODS name <--> cocina mappings' do
   end
 
   describe 'Name with active date - year' do
-    xit 'not implemented: type activity dates'
-
     # If date starts with "active," use type "activity dates" and drop "active" from date value
-    let(:mods) do
-      <<~XML
-        <name type="personal">
-          <namePart>Yao, Zongyi</namePart>
-          <namePart type="date">Active 1618</namePart>
-        </name>
-      XML
-    end
 
-    let(:cocina) do
-      {
-        contributor: [
-          {
-            name: [
-              {
-                value: 'Yao, Zongyi',
-                type: 'name'
-              },
-              {
-                value: '1618',
-                type: 'activity dates'
-              }
-            ]
-          }
-        ]
-      }
+    xit 'not implemented: type activity dates' do
+      let(:mods) do
+        <<~XML
+          <name type="personal">
+            <namePart>Yao, Zongyi</namePart>
+            <namePart type="date">Active 1618</namePart>
+          </name>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          contributor: [
+            {
+              name: [
+                {
+                  value: 'Yao, Zongyi',
+                  type: 'name'
+                },
+                {
+                  value: '1618',
+                  type: 'activity dates'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'Name with active date - century' do
-    xit 'not implemented: type activity dates'
-
     # If date starts with "active," use type "activity dates" and drop "active" from date value
-    let(:mods) do
-      <<~XML
-        <name type="personal">
-          <namePart>Inoue, Kaian</namePart>
-          <namePart type="date">Active 18th century</namePart>
-        </name>
-      XML
-    end
 
-    let(:cocina) do
-      {
-        contributor: [
-          {
-            name: [
-              {
-                value: 'Inoue, Kaian',
-                type: 'name'
-              },
-              {
-                value: '18th century',
-                type: 'activity dates'
-              }
-            ]
-          }
-        ]
-      }
+    xit 'not implemented: type activity dates' do
+      let(:mods) do
+        <<~XML
+          <name type="personal">
+            <namePart>Inoue, Kaian</namePart>
+            <namePart type="date">Active 18th century</namePart>
+          </name>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          contributor: [
+            {
+              name: [
+                {
+                  value: 'Inoue, Kaian',
+                  type: 'name'
+                },
+                {
+                  value: '18th century',
+                  type: 'activity dates'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -861,36 +861,36 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   end
 
   describe 'Julian calendar - MODS 3.7' do
-    let(:mods) do
-      <<~XML
-        <originInfo eventType="production">
-          <dateCreated calendar="Julian">1544-02-02</dateCreated>
-        </originInfo>
-      XML
-    end
+    xit 'not implemented: roundtripping loses calendar Julian note / attrib' do
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="production">
+            <dateCreated calendar="Julian">1544-02-02</dateCreated>
+          </originInfo>
+        XML
+      end
 
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'creation',
-            date: [
-              {
-                value: '1544-02-02',
-                note: [
-                  {
-                    value: 'Julian',
-                    type: 'date type'
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  value: '1544-02-02',
+                  note: [
+                    {
+                      value: 'Julian',
+                      type: 'date type'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
-
-    xit 'not implemented: roundtripping loses calendar Julian note / attrib'
   end
 
   describe 'Date range, no start point' do
@@ -1308,41 +1308,12 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   end
 
   describe 'Date mapping for recording event type' do
-    xit 'not implemented: recording event type'
-
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'recording',
-            date: [
-              {
-                value: '1990'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    let(:mods) do
-      <<~XML
-        <originInfo eventType="recording">
-          <dateCreated>1990</dateCreated>
-        </originInfo>
-      XML
-    end
-  end
-
-  describe 'Date mapping for presentation event type' do
-    context 'with event type and date only' do
-      xit 'to be implemented: presentation currently maps to MODS dateIssued, not dateCreated - what do we want?'
-
+    xit 'not implemented: recording event type' do
       let(:cocina) do
         {
           event: [
             {
-              type: 'presentation',
+              type: 'recording',
               date: [
                 {
                   value: '1990'
@@ -1355,10 +1326,39 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:mods) do
         <<~XML
-          <originInfo eventType="presentation">
+          <originInfo eventType="recording">
             <dateCreated>1990</dateCreated>
           </originInfo>
         XML
+      end
+    end
+  end
+
+  describe 'Date mapping for presentation event type' do
+    context 'with event type and date only' do
+      xit 'to be implemented: presentation currently maps to MODS dateIssued, not dateCreated - what do we want?' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'presentation',
+                date: [
+                  {
+                    value: '1990'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="presentation">
+              <dateCreated>1990</dateCreated>
+            </originInfo>
+          XML
+        end
       end
     end
 
@@ -1495,56 +1495,56 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   end
 
   describe 'Date mapping for performance event type' do
-    xit 'not implemented: performance event type'
+    xit 'not implemented: performance event type' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'performance',
+              date: [
+                {
+                  value: '1990'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'performance',
-            date: [
-              {
-                value: '1990'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    let(:mods) do
-      <<~XML
-        <originInfo eventType="performance">
-          <dateCreated>1990</dateCreated>
-        </originInfo>
-      XML
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="performance">
+            <dateCreated>1990</dateCreated>
+          </originInfo>
+        XML
+      end
     end
   end
 
   describe 'Date mapping for release event type' do
-    xit 'not implemented: release event reverse of H2 spec - bug!' # also mapped in H2
+    xit 'not implemented: release event reverse of H2 spec - bug!' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'release',
+              date: [
+                {
+                  value: '1990'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'release',
-            date: [
-              {
-                value: '1990'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    let(:mods) do
-      <<~XML
-        <originInfo eventType="release">
-          <dateIssued>1990</dateIssued>
-        </originInfo>
-      XML
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="release">
+            <dateIssued>1990</dateIssued>
+          </originInfo>
+        XML
+      end
     end
   end
 

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -1894,6 +1894,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
     # Temporarily ignoring <originInfo> pending https://github.com/sul-dlss/dor-services-app/issues/2128
     xit 'need to deal with dateOther type matching eventType and roundtripping' do
+    # it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <originInfo eventType="distribution">

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -1894,7 +1894,6 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
     # Temporarily ignoring <originInfo> pending https://github.com/sul-dlss/dor-services-app/issues/2128
     xit 'need to deal with dateOther type matching eventType and roundtripping' do
-    # it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <originInfo eventType="distribution">

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -1888,4 +1888,70 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
       end
     end
   end
+
+  context 'when originInfo dateOther[@type] matches eventType and dateOther is empty' do
+    # based on #xv158sd4671
+
+    # Temporarily ignoring <originInfo> pending https://github.com/sul-dlss/dor-services-app/issues/2128
+    xit 'need to deal with dateOther type matching eventType and roundtripping' do
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="distribution">
+            <place>
+              <placeTerm type="text">Washington, DC</placeTerm>
+            </place>
+            <publisher>blah</publisher>
+            <dateOther type="distribution"/>
+          </originInfo>
+        XML
+      end
+
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="distribution">
+            <place>
+              <placeTerm type="text">Washington, DC</placeTerm>
+            </place>
+            <publisher>blah</publisher>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'distribution',
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'blah'
+                    }
+                  ],
+                  type: 'organization',
+                  role: [
+                    {
+                      value: 'distributor',
+                      code: 'dst',
+                      uri: 'http://id.loc.gov/vocabulary/relators/dst',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    }
+                  ]
+                }
+              ],
+              location: [
+                {
+                  value: 'Washington, DC'
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
+  end
 end

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -1954,4 +1954,68 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
       end
     end
   end
+
+  context 'when dateIssued with encoding and keyDate but no value' do
+    # based on #vj932ns8042
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo>
+            <dateIssued encoding="w3cdtf" keyDate="yes"/>
+            <publisher>blah</publisher>
+            <issuance>monographic</issuance>
+          </originInfo>
+        XML
+      end
+
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="publication">
+            <publisher>blah</publisher>
+            <issuance>monographic</issuance>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              note: [
+                {
+                  source: {
+                    value: 'MODS issuance terms'
+                  },
+                  type: 'issuance',
+                  value: 'monographic'
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'blah'
+                    }
+                  ],
+                  type: 'organization',
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
+  end
 end

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_logic_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_logic_spec.rb
@@ -2,46 +2,8 @@
 
 require 'rails_helper'
 
-# rubocop:disable RSpec/OverwritingSetup
-# TODO: remove these rubocop exceptions when implementation uncomments spec lines, but keep the one above
-# rubocop:disable Layout/CommentIndentation
-# rubocop:disable Layout/IndentationConsistency
 RSpec.describe 'MODS originInfo <--> cocina mappings LOGIC' do
   describe 'Multiple date types, no event type' do
-    let(:my_roundtrip_mods) do
-      <<~XML
-        <originInfo eventType="publication">
-          <dateIssued>1930</dateIssued>
-        </originInfo>
-        <originInfo eventType="copyright">
-          <copyrightDate>1929</copyrightDate>
-        </originInfo>
-      XML
-    end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            date: [
-              {
-                value: '1930'
-              }
-            ]
-          },
-          {
-            type: 'copyright',
-            date: [
-              {
-                value: '1929'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
@@ -51,51 +13,44 @@ RSpec.describe 'MODS originInfo <--> cocina mappings LOGIC' do
           </originInfo>
         XML
       end
-      let(:roundtrip_mods) { my_roundtrip_mods }
-      let(:cocina) { my_cocina }
-    end
 
-    it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_roundtrip_mods }
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="publication">
+            <dateIssued>1930</dateIssued>
+          </originInfo>
+          <originInfo eventType="copyright">
+            <copyrightDate>1929</copyrightDate>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              date: [
+                {
+                  value: '1930'
+                }
+              ]
+            },
+            {
+              type: 'copyright',
+              date: [
+                {
+                  value: '1929'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'Multiple date types, matching event type' do
-    let(:my_roundtrip_mods) do
-      <<~XML
-        <originInfo eventType="publication">
-          <dateIssued>1930</dateIssued>
-        </originInfo>
-        <originInfo eventType="copyright">
-          <copyrightDate>1929</copyrightDate>
-        </originInfo>
-      XML
-    end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            date: [
-              {
-                value: '1930'
-              }
-            ]
-          },
-          {
-            type: 'copyright',
-            date: [
-              {
-                value: '1929'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
@@ -105,147 +60,99 @@ RSpec.describe 'MODS originInfo <--> cocina mappings LOGIC' do
           </originInfo>
         XML
       end
-      let(:roundtrip_mods) { my_roundtrip_mods }
-      let(:cocina) { my_cocina }
-    end
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="publication">
+            <dateIssued>1930</dateIssued>
+          </originInfo>
+          <originInfo eventType="copyright">
+            <copyrightDate>1929</copyrightDate>
+          </originInfo>
+        XML
+      end
 
-    it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_roundtrip_mods }
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              date: [
+                {
+                  value: '1930'
+                }
+              ]
+            },
+            {
+              type: 'copyright',
+              date: [
+                {
+                  value: '1929'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'Single date type, nonmatching event type' do
-    xit 'to be implemented'
+    xit 'to be implemented: single date type, nonmatching event type' do
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="publication">
+            <copyrightDate>1929</copyrightDate>
+          </originInfo>
+        XML
+      end
 
-    let(:my_mods) do
-      <<~XML
-        <originInfo eventType="publication">
-          <copyrightDate>1929</copyrightDate>
-        </originInfo>
-      XML
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              date: [
+                {
+                  value: '1929',
+                  type: 'copyright'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            date: [
-              {
-                value: '1929',
-                type: 'copyright'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    # it_behaves_like 'MODS cocina mapping' do
-      let(:mods) { my_mods }
-      let(:cocina) { my_cocina }
-    # end
-
-    # it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_mods }
-    # end
   end
 
   describe 'Single dateOther, nonmatching event type' do
-    xit 'to be implemented'
+    xit 'to be implemented: single dateOther, nonmatching event type' do
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="production">
+            <dateOther type="development">1930</dateOther>
+          </originInfo>
+        XML
+      end
 
-    let(:my_mods) do
-      <<~XML
-        <originInfo eventType="production">
-          <dateOther type="development">1930</dateOther>
-        </originInfo>
-      XML
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'production',
+              date: [
+                {
+                  value: '1930',
+                  type: 'development'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'production',
-            date: [
-              {
-                value: '1930',
-                type: 'development'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    # it_behaves_like 'MODS cocina mapping' do
-      let(:mods) { my_mods }
-      let(:cocina) { my_cocina }
-    # end
-
-    # it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_mods }
-    # end
   end
 
   describe 'No date, no event type, publication subelements' do
-    let(:my_roundtrip_mods) do
-      <<~XML
-        <originInfo eventType="publication">
-          <publisher>Virago</publisher>
-          <edition>1st edition</edition>
-          <place>
-            <placeTerm type="text">London</placeTerm>
-          </place>
-        </originInfo>
-      XML
-    end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            contributor: [
-              {
-                name: [
-                  {
-                    value: 'Virago'
-                  }
-                ],
-                type: 'organization',
-                role: [
-                  {
-                    value: 'publisher',
-                    code: 'pbl',
-                    uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                    source: {
-                      code: 'marcrelator',
-                      uri: 'http://id.loc.gov/vocabulary/relators/'
-                    }
-                  }
-                ]
-              }
-            ],
-            location: [
-              {
-                value: 'London'
-              }
-            ],
-            note: [
-              {
-                value: '1st edition',
-                type: 'edition'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
@@ -258,43 +165,65 @@ RSpec.describe 'MODS originInfo <--> cocina mappings LOGIC' do
           </originInfo>
         XML
       end
-      let(:roundtrip_mods) { my_roundtrip_mods }
-      let(:cocina) { my_cocina }
-    end
 
-    it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_roundtrip_mods }
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="publication">
+            <publisher>Virago</publisher>
+            <edition>1st edition</edition>
+            <place>
+              <placeTerm type="text">London</placeTerm>
+            </place>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Virago'
+                    }
+                  ],
+                  type: 'organization',
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    }
+                  ]
+                }
+              ],
+              location: [
+                {
+                  value: 'London'
+                }
+              ],
+              note: [
+                {
+                  value: '1st edition',
+                  type: 'edition'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'dateCreated, no event type' do
-    xit 'to be implemented'
-
-    let(:my_roundtrip_mods) do
-      <<~XML
-        <originInfo eventType="creation">
-          <dateCreated>1930</dateCreated>
-        </originInfo>
-      XML
-    end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'creation',
-            date: [
-              {
-                value: '1930'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    # it_behaves_like 'MODS cocina mapping' do
+    xit 'to be implemented: dateCreated, no event type' do
       let(:mods) do
         <<~XML
           <originInfo>
@@ -302,43 +231,34 @@ RSpec.describe 'MODS originInfo <--> cocina mappings LOGIC' do
           </originInfo>
         XML
       end
-      let(:roundtrip_mods) { my_roundtrip_mods }
-      let(:cocina) { my_cocina }
-    # end
 
-    # it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_roundtrip_mods }
-    # end
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="creation">
+            <dateCreated>1930</dateCreated>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  value: '1930'
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
   end
 
   describe 'dateOther with type, no event type' do
-    xit 'to be implemented: MODS cocina mapping'
-
-    let(:my_roundtrip_mods) do
-      <<~XML
-        <originInfo eventType="acquisition">
-          <dateOther>1930</dateOther>
-        </originInfo>
-      XML
-    end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'acquisition',
-            date: [
-              {
-                value: '1930'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    # it_behaves_like 'MODS cocina mapping' do
+    xit 'to be implemented: MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <originInfo>
@@ -347,106 +267,62 @@ RSpec.describe 'MODS originInfo <--> cocina mappings LOGIC' do
         XML
       end
 
-      let(:roundtrip_mods) { my_roundtrip_mods }
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="acquisition">
+            <dateOther>1930</dateOther>
+          </originInfo>
+        XML
+      end
 
-      let(:cocina) { my_cocina }
-    # end
-
-    it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_roundtrip_mods }
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'acquisition',
+              date: [
+                {
+                  value: '1930'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'Only place subelement, no event type' do
-    xit 'to be implemented'
+    xit 'to be implemented: place subelement no event type' do
+      let(:mods) do
+        <<~XML
+          <originInfo>
+            <place>
+              <placeTerm type="text">San Francisco, Calif.</placeTerm>
+            </place>
+          </originInfo>
+        XML
+      end
 
-    let(:my_mods) do
-      <<~XML
-        <originInfo>
-          <place>
-            <placeTerm type="text">San Francisco, Calif.</placeTerm>
-          </place>
-        </originInfo>
-      XML
-    end
+      let(:cocina) do
+        {
+          event: [
+            {
+              location: [
+                {
+                  value: 'San Francisco, Calif.'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            location: [
-              {
-                value: 'San Francisco, Calif.'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    # it_behaves_like 'MODS cocina mapping' do
-      let(:mods) { my_mods }
-      let(:cocina) { my_cocina }
       let(:warnings) { [Notification.new(msg: 'Undetermined event type')] }
-    # end
-
-    # it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_mods }
-    # end
+    end
   end
 
   describe 'Multiple date types, additional publication subelements' do
-    let(:my_roundtrip_mods) do
-      <<~XML
-        <originInfo eventType="publication">
-          <dateIssued>1930</dateIssued>
-          <place>
-            <placeTerm type="text">London</placeTerm>
-          </place>
-          <edition>1st edition</edition>
-        </originInfo>
-        <originInfo eventType="copyright">
-          <copyrightDate>1929</copyrightDate>
-        </originInfo>
-      XML
-    end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            date: [
-              {
-                value: '1930'
-              }
-            ],
-            location: [
-              {
-                value: 'London'
-              }
-            ],
-            note: [
-              {
-                value: '1st edition',
-                type: 'edition'
-              }
-            ]
-          },
-          {
-            type: 'copyright',
-            date: [
-              {
-                value: '1929'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
@@ -461,92 +337,111 @@ RSpec.describe 'MODS originInfo <--> cocina mappings LOGIC' do
         XML
       end
 
-      let(:roundtrip_mods) { my_roundtrip_mods }
-      let(:cocina) { my_cocina }
-    end
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="publication">
+            <dateIssued>1930</dateIssued>
+            <place>
+              <placeTerm type="text">London</placeTerm>
+            </place>
+            <edition>1st edition</edition>
+          </originInfo>
+          <originInfo eventType="copyright">
+            <copyrightDate>1929</copyrightDate>
+          </originInfo>
+        XML
+      end
 
-    it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_roundtrip_mods }
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              date: [
+                {
+                  value: '1930'
+                }
+              ],
+              location: [
+                {
+                  value: 'London'
+                }
+              ],
+              note: [
+                {
+                  value: '1st edition',
+                  type: 'edition'
+                }
+              ]
+            },
+            {
+              type: 'copyright',
+              date: [
+                {
+                  value: '1929'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'Unmapped event type' do
-    xit 'to be implemented'
+    xit 'to be implemented: unmapped event type' do
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="deaccession">
+            <dateOther>1930</dateOther>
+          </originInfo>
+        XML
+      end
 
-    let(:my_mods) do
-      <<~XML
-        <originInfo eventType="deaccession">
-          <dateOther>1930</dateOther>
-        </originInfo>
-      XML
-    end
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'deaccession',
+              date: [
+                {
+                  value: '1930'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'deaccession',
-            date: [
-              {
-                value: '1930'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    # it_behaves_like 'MODS cocina mapping' do
-      let(:mods) { my_mods }
-      let(:cocina) { my_cocina }
       let(:warnings) { [Notification.new(msg: 'Unmapped event type')] }
-    # end
-
-    # it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_mods }
-    # end
+    end
   end
 
   describe 'No event type' do
-    xit 'to be implemented: warning message'
+    xit 'to be implemented: warning message' do
+      let(:mods) do
+        <<~XML
+          <originInfo>
+            <dateOther>1930</dateOther>
+          </originInfo>
+        XML
+      end
 
-    let(:my_mods) do
-      <<~XML
-        <originInfo>
-          <dateOther>1930</dateOther>
-        </originInfo>
-      XML
-    end
+      let(:cocina) do
+        {
+          event: [
+            {
+              date: [
+                {
+                  value: '1930'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            date: [
-              {
-                value: '1930'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    # it_behaves_like 'MODS cocina mapping' do
-      let(:mods) { my_mods }
-      let(:cocina) { my_cocina }
       let(:warnings) { [Notification.new(msg: 'Undetermined event type')] }
-    # end
-
-    # it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_mods }
-      let(:warnings) { [Notification.new(msg: 'Undetermined event type')] }
-    # end
+    end
   end
 end
-# rubocop:enable RSpec/OverwritingSetup
-# rubocop:enable Layout/CommentIndentation
-# rubocop:enable Layout/IndentationConsistency

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_place_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_place_spec.rb
@@ -160,45 +160,46 @@ RSpec.describe 'MODS originInfo place <--> cocina mappings' do
 
   describe 'Place - text and code for different places - Version B (from replayable spreadsheet, incorrect MODS)' do
     # The authority value goes with the code term and the authorityURI and valueURI values go with the text term.
-    let(:mods) do
-      <<~XML
-        <originInfo eventType="publication">
-          <place>
-            <placeTerm type="code" authority="marccountry" authorityURI="http://id.loc.gov/authorities/names/"
-              valueURI="http://id.loc.gov/authorities/names/n50046557">cau</placeTerm>
-            <placeTerm type="text" authority="marccountry" authorityURI="http://id.loc.gov/authorities/names/"
-              valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
-          </place>
-        </originInfo>
-      XML
-    end
 
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            location: [
-              {
-                code: 'cau',
-                source: {
-                  code: 'marccountry'
-                }
-              },
-              {
-                value: 'Stanford (Calif.)',
-                uri: 'http://id.loc.gov/authorities/names/n50046557',
-                source: {
-                  uri: 'http://id.loc.gov/authorities/names/'
-                }
-              }
-            ]
-          }
-        ]
-      }
-    end
+    xit 'not implemented: text and code for diff places from replayable spreadsheet' do
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="publication">
+            <place>
+              <placeTerm type="code" authority="marccountry" authorityURI="http://id.loc.gov/authorities/names/"
+                valueURI="http://id.loc.gov/authorities/names/n50046557">cau</placeTerm>
+              <placeTerm type="text" authority="marccountry" authorityURI="http://id.loc.gov/authorities/names/"
+                valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+            </place>
+          </originInfo>
+        XML
+      end
 
-    xit 'not implemented: text and code for diff places from replayable spreadsheet'
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              location: [
+                {
+                  code: 'cau',
+                  source: {
+                    code: 'marccountry'
+                  }
+                },
+                {
+                  value: 'Stanford (Calif.)',
+                  uri: 'http://id.loc.gov/authorities/names/n50046557',
+                  source: {
+                    uri: 'http://id.loc.gov/authorities/names/'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
   end
 
   describe 'Supplied place name' do

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
@@ -31,172 +31,179 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   end
 
   describe 'originInfo eventType differs from date type' do
-    xit 'to be implemented: updated spec'
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="publication">
+            <copyrightDate>1980</copyrightDate>
+          </originInfo>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <originInfo eventType="publication">
-          <copyrightDate>1980</copyrightDate>
-        </originInfo>
-      XML
-    end
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="copyright">
+            <copyrightDate>1980</copyrightDate>
+          </originInfo>
+        XML
+      end
 
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            date: [
-              {
-                value: '1980',
-                type: 'copyright'
-              }
-            ]
-          }
-        ]
-      }
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'copyright',
+              date: [
+                {
+                  value: '1980'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'originInfo eventType differs from date type, copyright and copyright notice events, converted from MARC record with multiple 264s' do
-    xit 'to be implemented: updated spec'
+    it_behaves_like 'MODS cocina mapping' do
+      # eventType="copyright" maps to event.date, "copyright notice" maps to event.note
+      let(:mods) do
+        <<~XML
+          <originInfo>
+             <place>
+                <placeTerm type="code" authority="marccountry">ru</placeTerm>
+             </place>
+             <dateIssued encoding="marc">2019</dateIssued>
+             <copyrightDate encoding="marc">2018</copyrightDate>
+             <issuance>monographic</issuance>
+          </originInfo>
+          <originInfo eventType="publication">
+             <place>
+                <placeTerm type="text">Moskva</placeTerm>
+             </place>
+             <publisher>Izdatelʹstvo "Vesʹ Mir"</publisher>
+             <dateIssued>2019</dateIssued>
+          </originInfo>
+          <originInfo eventType="copyright notice">
+             <copyrightDate>©2018</copyrightDate>
+          </originInfo>
+        XML
+      end
 
-    # eventType="copyright" maps to event.date, "copyright notice" maps to event.note
-    let(:mods) do
-      <<~XML
-        <originInfo>
-           <place>
-              <placeTerm type="code" authority="marccountry">ru</placeTerm>
-           </place>
-           <dateIssued encoding="marc">2019</dateIssued>
-           <copyrightDate encoding="marc">2018</copyrightDate>
-           <issuance>monographic</issuance>
-        </originInfo>
-        <originInfo eventType="publication">
-           <place>
-              <placeTerm type="text">Moskva</placeTerm>
-           </place>
-           <publisher>Izdatelʹstvo "Vesʹ Mir"</publisher>
-           <dateIssued>2019</dateIssued>
-        </originInfo>
-        <originInfo eventType="copyright notice">
-           <copyrightDate>©2018</copyrightDate>
-        </originInfo>
-      XML
-    end
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="publication">
+             <place>
+                <placeTerm type="code" authority="marccountry">ru</placeTerm>
+             </place>
+             <dateIssued encoding="marc">2019</dateIssued>
+             <issuance>monographic</issuance>
+          </originInfo>
+          <originInfo eventType="copyright">
+            <copyrightDate encoding="marc">2018</copyrightDate>
+          </originInfo>
+          <originInfo eventType="publication">
+             <place>
+                <placeTerm type="text">Moskva</placeTerm>
+             </place>
+             <publisher>Izdatelʹstvo "Vesʹ Mir"</publisher>
+             <dateIssued>2019</dateIssued>
+          </originInfo>
+          <originInfo eventType="copyright notice">
+             <copyrightDate>©2018</copyrightDate>
+          </originInfo>
+        XML
+      end
 
-    let(:roundtrip_mods) do
-      <<~XML
-        <originInfo eventType="publication">
-           <place>
-              <placeTerm type="code" authority="marccountry">ru</placeTerm>
-           </place>
-           <dateIssued encoding="marc">2019</dateIssued>
-           <issuance>monographic</issuance>
-        </originInfo>
-        <originInfo eventType="copyright">
-          <copyrightDate encoding="marc">2018</copyrightDate>
-        </originInfo>
-        <originInfo eventType="publication">
-           <place>
-              <placeTerm type="text">Moskva</placeTerm>
-           </place>
-           <publisher>Izdatelʹstvo "Vesʹ Mir"</publisher>
-           <dateIssued>2019</dateIssued>
-        </originInfo>
-        <originInfo eventType="copyright notice">
-           <copyrightDate>©2018</copyrightDate>
-        </originInfo>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            location: [
-              {
-                code: 'ru',
-                source: {
-                  code: 'marccountry'
-                }
-              }
-            ],
-            date: [
-              {
-                value: '2019',
-                encoding: {
-                  code: 'marc'
-                }
-              }
-            ],
-            note: [
-              {
-                value: 'monographic',
-                type: 'issuance',
-                source: {
-                  value: 'MODS issuance terms'
-                }
-              }
-            ]
-          },
-          {
-            type: 'copyright',
-            date: [
-              {
-                value: '2018',
-                encoding: {
-                  code: 'marc'
-                }
-              }
-            ]
-          },
-          {
-            type: 'publication',
-            location: [
-              {
-                value: 'Moskva'
-              }
-            ],
-            contributor: [
-              {
-                name: [
-                  {
-                    value: 'Izdatelʹstvo "Vesʹ Mir"'
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              location: [
+                {
+                  code: 'ru',
+                  source: {
+                    code: 'marccountry'
                   }
-                ],
-                type: 'organization',
-                role: [
-                  {
-                    value: 'publisher',
-                    code: 'pbl',
-                    uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                    source: {
-                      code: 'marcrelator',
-                      uri: 'http://id.loc.gov/vocabulary/relators/'
+                }
+              ],
+              date: [
+                {
+                  value: '2019',
+                  encoding: {
+                    code: 'marc'
+                  }
+                }
+              ],
+              note: [
+                {
+                  value: 'monographic',
+                  type: 'issuance',
+                  source: {
+                    value: 'MODS issuance terms'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'copyright',
+              date: [
+                {
+                  value: '2018',
+                  encoding: {
+                    code: 'marc'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'publication',
+              location: [
+                {
+                  value: 'Moskva'
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Izdatelʹstvo "Vesʹ Mir"'
                     }
-                  }
-                ]
-              }
-            ],
-            date: [
-              {
-                value: '2019'
-              }
-            ]
-          },
-          {
-            type: 'copyright notice',
-            note: [
-              {
-                value: '©2018',
-                type: 'copyright statement'
-              }
-            ]
-          }
-        ]
-      }
+                  ],
+                  type: 'organization',
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    }
+                  ]
+                }
+              ],
+              date: [
+                {
+                  value: '2019'
+                }
+              ]
+            },
+            {
+              type: 'copyright',
+              note: [
+                {
+                  value: '©2018',
+                  type: 'copyright statement'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
@@ -330,56 +337,56 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   end
 
   describe 'Multiple originInfo elements for different events' do
-    xit 'to be implemented: updated spec'
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="production">
+            <dateCreated>1899</dateCreated>
+            <place>
+              <placeTerm type="text">York</placeTerm>
+            </place>
+          </originInfo>
+          <originInfo eventType="publication">
+            <dateIssued>1901</dateIssued>
+            <place>
+              <placeTerm type="text">London</placeTerm>
+            </place>
+          </originInfo>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <originInfo eventType="production">
-          <dateCreated>1899</dateCreated>
-          <place>
-            <placeTerm type="text">York</placeTerm>
-          </place>
-        </originInfo>
-        <originInfo eventType="publication">
-          <dateIssued>1901</dateIssued>
-          <place>
-            <placeTerm type="text">London</placeTerm>
-          </place>
-        </originInfo>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'production',
-            date: [
-              {
-                value: '1899'
-              }
-            ],
-            location: [
-              {
-                value: 'York'
-              }
-            ]
-          },
-          {
-            type: 'publication',
-            date: [
-              {
-                value: '1901'
-              }
-            ],
-            location: [
-              {
-                value: 'London'
-              }
-            ]
-          }
-        ]
-      }
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  value: '1899'
+                }
+              ],
+              location: [
+                {
+                  value: 'York'
+                }
+              ]
+            },
+            {
+              type: 'publication',
+              date: [
+                {
+                  value: '1901'
+                }
+              ],
+              location: [
+                {
+                  value: 'London'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
@@ -571,130 +578,130 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   end
 
   describe 'originInfo with displayLabel' do
-    xit 'to be implemented: updated spec'
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo displayLabel="Origin" eventType="production">
+            <place>
+              <placeTerm type="text">Stanford (Calif.)</placeTerm>
+            </place>
+          </originInfo>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <originInfo displayLabel="Origin" eventType="production">
-          <place>
-            <placeTerm type="text">Stanford (Calif.)</placeTerm>
-          </place>
-        </originInfo>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'production',
-            displayLabel: 'Origin',
-            location: [
-              {
-                value: 'Stanford (Calif.)'
-              }
-            ]
-          }
-        ]
-      }
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              displayLabel: 'Origin',
+              location: [
+                {
+                  value: 'Stanford (Calif.)'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'Multiscript originInfo with eventType production' do
-    xit 'to be implemented: updated spec'
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="production" lang="eng" script="Latn" altRepGroup="1">
+            <dateCreated keyDate="yes" encoding="w3cdtf">1999-09-09</dateCreated>
+            <place>
+              <placeTerm authorityURI="http://id.loc.gov/authorities/names/"
+                valueURI="http://id.loc.gov/authorities/names/n79076156">Moscow</placeTerm>
+            </place>
+          </originInfo>
+          <originInfo eventType="production" lang="rus" script="Cyrl" altRepGroup="1">
+            <place>
+              <placeTerm>Москва</placeTerm>
+            </place>
+          </originInfo>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <originInfo eventType="production" lang="eng" script="Latn" altRepGroup="1">
-          <dateCreated keyDate="yes" encoding="w3cdtf">1999-09-09</dateCreated>
-          <place>
-            <placeTerm authorityURI="http://id.loc.gov/authorities/names/"
-              valueURI="http://id.loc.gov/authorities/names/n79076156">Moscow</placeTerm>
-          </place>
-        </originInfo>
-        <originInfo eventType="production" lang="rus" script="Cyrl" altRepGroup="1">
-          <place>
-            <placeTerm>Москва</placeTerm>
-          </place>
-        </originInfo>
-      XML
-    end
+      let(:roundtrip_mods) do
+        # Same except placeTerm gets type "text"
+        <<~XML
+           <originInfo script="Latn" lang="eng" altRepGroup="1" eventType="production">
+            <dateCreated encoding="w3cdtf" keyDate="yes">1999-09-09</dateCreated>
+            <place>
+              <placeTerm type="text" authorityURI="http://id.loc.gov/authorities/names/"
+                valueURI="http://id.loc.gov/authorities/names/n79076156">Moscow</placeTerm>
+            </place>
+          </originInfo>
+          <originInfo script="Cyrl" lang="rus" altRepGroup="1" eventType="production">
+            <place>
+              <placeTerm type="text">Москва</placeTerm>
+            </place>
+          </originInfo>
+        XML
+      end
 
-    let(:roundtrip_mods) do
-      # Same except placeTerm gets type "text"
-      <<~XML
-         <originInfo script="Latn" lang="eng" altRepGroup="1" eventType="production">
-          <dateCreated encoding="w3cdtf" keyDate="yes">1999-09-09</dateCreated>
-          <place>
-            <placeTerm type="text" authorityURI="http://id.loc.gov/authorities/names/"
-              valueURI="http://id.loc.gov/authorities/names/n79076156">Moscow</placeTerm>
-          </place>
-        </originInfo>
-        <originInfo script="Cyrl" lang="rus" altRepGroup="1" eventType="production">
-          <place>
-            <placeTerm type="text">Москва</placeTerm>
-          </place>
-        </originInfo>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'production',
-            date: [
-              {
-                value: '1999-09-09',
-                status: 'primary',
-                encoding: {
-                  code: 'w3cdtf'
-                }
-              }
-            ],
-            location: [
-              {
-                parallelValue: [
-                  {
-                    value: 'Moscow',
-                    uri: 'http://id.loc.gov/authorities/names/n79076156',
-                    source: {
-                      uri: 'http://id.loc.gov/authorities/names/'
-                    },
-                    valueLanguage: {
-                      code: 'eng',
-                      source: {
-                        code: 'iso639-2b'
-                      },
-                      valueScript: {
-                        code: 'Latn',
-                        source: {
-                          code: 'iso15924'
-                        }
-                      }
-                    }
-                  },
-                  {
-                    value: 'Москва',
-                    valueLanguage: {
-                      code: 'rus',
-                      source: {
-                        code: 'iso639-2b'
-                      },
-                      valueScript: {
-                        code: 'Cyrl',
-                        source: {
-                          code: 'iso15924'
-                        }
-                      }
-                    }
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  value: '1999-09-09',
+                  status: 'primary',
+                  encoding: {
+                    code: 'w3cdtf'
                   }
-                ]
-              }
-            ]
-          }
-        ]
-      }
+                }
+              ],
+              location: [
+                {
+                  parallelValue: [
+                    {
+                      value: 'Moscow',
+                      uri: 'http://id.loc.gov/authorities/names/n79076156',
+                      source: {
+                        uri: 'http://id.loc.gov/authorities/names/'
+                      },
+                      valueLanguage: {
+                        code: 'eng',
+                        source: {
+                          code: 'iso639-2b'
+                        },
+                        valueScript: {
+                          code: 'Latn',
+                          source: {
+                            code: 'iso15924'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      value: 'Москва',
+                      valueLanguage: {
+                        code: 'rus',
+                        source: {
+                          code: 'iso639-2b'
+                        },
+                        valueScript: {
+                          code: 'Cyrl',
+                          source: {
+                            code: 'iso15924'
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
@@ -763,593 +770,596 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   describe 'Parallel value with no script given in MODS - A' do
     # Example adapted from druid:hn285fy7937
 
+    xit 'to be mapped: if it helps, you can add a "cocina MODS mapping: block as we can have both'
+
     # First <place> not included in parallelValue because it's type="code"
-    xit 'to be implemented: removed warning'
-    let(:mods) do
-      <<~XML
-        <originInfo altRepGroup="1">
-          <place>
-            <placeTerm type="code" authority="marccountry">cc</placeTerm>
-          </place>
-          <place>
-            <placeTerm type="text">Chengdu</placeTerm>
-          </place>
-          <publisher>Sichuan chu ban ji tuan, Sichuan wen yi chu ban she</publisher>
-          <dateIssued>2005</dateIssued>
-          <edition>Di 1 ban.</edition>
-          <issuance>monographic</issuance>
-        </originInfo>
-        <originInfo altRepGroup="1">
-          <place>
-            <placeTerm type="text">[Chengdu in Chinese]</placeTerm>
-          </place>
-          <publisher>[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]</publisher>
-          <dateIssued>2005.</dateIssued>
-          <edition>[Di 1 ban in Chinese]</edition>
-        </originInfo>
-      XML
-    end
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo altRepGroup="1">
+            <place>
+              <placeTerm type="code" authority="marccountry">cc</placeTerm>
+            </place>
+            <place>
+              <placeTerm type="text">Chengdu</placeTerm>
+            </place>
+            <publisher>Sichuan chu ban ji tuan, Sichuan wen yi chu ban she</publisher>
+            <dateIssued>2005</dateIssued>
+            <edition>Di 1 ban.</edition>
+            <issuance>monographic</issuance>
+          </originInfo>
+          <originInfo altRepGroup="1">
+            <place>
+              <placeTerm type="text">[Chengdu in Chinese]</placeTerm>
+            </place>
+            <publisher>[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]</publisher>
+            <dateIssued>2005.</dateIssued>
+            <edition>[Di 1 ban in Chinese]</edition>
+          </originInfo>
+        XML
+      end
 
-    # We don't know which originInfo is eng/Latn, so we don't know where to put the unpaired values.
-    # Instead, put all values that are not parallel values in both originInfo elements.
-    # Parallel values are grouped by index (i.e. the first of each pair is in the first originInfo, the second in the second one).
-    let(:roundtrip_mods) do
-      <<~XML
-        <originInfo altRepGroup="1" eventType="publication">
-          <place>
-            <placeTerm type="code" authority="marccountry">cc</placeTerm>
-          </place>
-          <place>
-            <placeTerm type="text">Chengdu</placeTerm>
-          </place>
-          <publisher>Sichuan chu ban ji tuan, Sichuan wen yi chu ban she</publisher>
-          <dateIssued>2005</dateIssued>
-          <edition>Di 1 ban.</edition>
-          <issuance>monographic</issuance>
-        </originInfo>
-        <originInfo altRepGroup="1" eventType="publication">
-          <place>
-            <placeTerm type="code" authority="marccountry">cc</placeTerm>
-          </place>
-          <place>
-            <placeTerm type="text">[Chengdu in Chinese]</placeTerm>
-          </place>
-          <publisher>[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]</publisher>
-          <dateIssued>2005</dateIssued>
-          <edition>[Di 1 ban in Chinese]</edition>
-          <issuance>monographic</issuance>
-        </originInfo>
-      XML
-    end
-    # When converting back to COCINA, duplicate values across the originInfos should be collapsed into one to generate the same record as above.
+      # We don't know which originInfo is eng/Latn, so we don't know where to put the unpaired values.
+      # Instead, put all values that are not parallel values in both originInfo elements.
+      # Parallel values are grouped by index (i.e. the first of each pair is in the first originInfo, the second in the second one).
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo altRepGroup="1" eventType="publication">
+            <place>
+              <placeTerm type="code" authority="marccountry">cc</placeTerm>
+            </place>
+            <place>
+              <placeTerm type="text">Chengdu</placeTerm>
+            </place>
+            <publisher>Sichuan chu ban ji tuan, Sichuan wen yi chu ban she</publisher>
+            <dateIssued>2005</dateIssued>
+            <edition>Di 1 ban.</edition>
+            <issuance>monographic</issuance>
+          </originInfo>
+          <originInfo altRepGroup="1" eventType="publication">
+            <place>
+              <placeTerm type="code" authority="marccountry">cc</placeTerm>
+            </place>
+            <place>
+              <placeTerm type="text">[Chengdu in Chinese]</placeTerm>
+            </place>
+            <publisher>[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]</publisher>
+            <dateIssued>2005</dateIssued>
+            <edition>[Di 1 ban in Chinese]</edition>
+            <issuance>monographic</issuance>
+          </originInfo>
+        XML
+      end
+      # When converting back to COCINA, duplicate values across the originInfos should be collapsed into one to generate the same record as above.
 
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            location: [
-              {
-                parallelValue: [
-                  {
-                    value: 'Chengdu'
-                  },
-                  {
-                    value: '[Chengdu in Chinese]'
-                  }
-                ]
-              },
-              {
-                code: 'cc',
-                source: {
-                  code: 'marccountry'
-                }
-              }
-            ],
-            contributor: [
-              {
-                type: 'organization',
-                name: [
-                  {
-                    parallelValue: [
-                      {
-                        value: 'Sichuan chu ban ji tuan, Sichuan wen yi chu ban she'
-                      },
-                      {
-                        value: '[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]'
-                      }
-                    ]
-                  }
-                ],
-                role: [
-                  {
-                    value: 'publisher',
-                    code: 'pbl',
-                    uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                    source: {
-                      code: 'marcrelator',
-                      uri: 'http://id.loc.gov/vocabulary/relators/'
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              location: [
+                {
+                  parallelValue: [
+                    {
+                      value: 'Chengdu'
+                    },
+                    {
+                      value: '[Chengdu in Chinese]'
                     }
+                  ]
+                },
+                {
+                  code: 'cc',
+                  source: {
+                    code: 'marccountry'
                   }
-                ]
-              }
-            ],
-            date: [
-              {
-                value: '2005'
-              }
-            ],
-            note: [
-              {
-                type: 'edition',
-                parallelValue: [
-                  {
-                    value: 'Di 1 ban.'
-                  },
-                  {
-                    value: '[Di 1 ban in Chinese]'
-                  }
-                ]
-              },
-              {
-                type: 'issuance',
-                value: 'monographic',
-                source: {
-                  value: 'MODS issuance terms'
                 }
+              ],
+              contributor: [
+                {
+                  type: 'organization',
+                  name: [
+                    {
+                      parallelValue: [
+                        {
+                          value: 'Sichuan chu ban ji tuan, Sichuan wen yi chu ban she'
+                        },
+                        {
+                          value: '[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]'
+                        }
+                      ]
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    }
+                  ]
+                }
+              ],
+              date: [
+                {
+                  value: '2005'
+                }
+              ],
+              note: [
+                {
+                  type: 'edition',
+                  parallelValue: [
+                    {
+                      value: 'Di 1 ban.'
+                    },
+                    {
+                      value: '[Di 1 ban in Chinese]'
+                    }
+                  ]
+                },
+                {
+                  type: 'issuance',
+                  value: 'monographic',
+                  source: {
+                    value: 'MODS issuance terms'
+                  }
 
-              }
-            ]
-          }
-        ]
-      }
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'Parallel value with no script given in MODS - B' do
     # Example adapted from druid:yc052ns4738
-    xit 'to be implemented: removed warning'
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo altRepGroup="1">
+             <place>
+                <placeTerm type="code" authority="marccountry">cc</placeTerm>
+             </place>
+             <dateIssued encoding="marc" point="start">1933</dateIssued>
+             <dateIssued encoding="marc" point="end">uuuu</dateIssued>
+             <issuance>serial</issuance>
+             <frequency>Irregular</frequency>
+             <place>
+                <placeTerm type="text">[Ruijin]</placeTerm>
+             </place>
+             <publisher>Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu</publisher>
+          </originInfo>
+          <originInfo altRepGroup="1">
+             <place>
+                <placeTerm type="code" authority="marccountry">cc</placeTerm>
+             </place>
+             <dateIssued encoding="marc" point="start">1933</dateIssued>
+             <dateIssued encoding="marc" point="end">uuuu</dateIssued>
+             <issuance>serial</issuance>
+             <frequency>Irregular</frequency>
+             <place>
+                <placeTerm type="text">[Ruijin] in Chinese</placeTerm>
+             </place>
+             <publisher>Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu in Chinese</publisher>
+          </originInfo>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <originInfo altRepGroup="1">
-           <place>
-              <placeTerm type="code" authority="marccountry">cc</placeTerm>
-           </place>
-           <dateIssued encoding="marc" point="start">1933</dateIssued>
-           <dateIssued encoding="marc" point="end">uuuu</dateIssued>
-           <issuance>serial</issuance>
-           <frequency>Irregular</frequency>
-           <place>
-              <placeTerm type="text">[Ruijin]</placeTerm>
-           </place>
-           <publisher>Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu</publisher>
-        </originInfo>
-        <originInfo altRepGroup="1">
-           <place>
-              <placeTerm type="code" authority="marccountry">cc</placeTerm>
-           </place>
-           <dateIssued encoding="marc" point="start">1933</dateIssued>
-           <dateIssued encoding="marc" point="end">uuuu</dateIssued>
-           <issuance>serial</issuance>
-           <frequency>Irregular</frequency>
-           <place>
-              <placeTerm type="text">[Ruijin] in Chinese</placeTerm>
-           </place>
-           <publisher>Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu in Chinese</publisher>
-        </originInfo>
-      XML
-    end
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo altRepGroup="1" eventType="publication">
+             <place>
+                <placeTerm type="code" authority="marccountry">cc</placeTerm>
+             </place>
+             <dateIssued encoding="marc" point="start">1933</dateIssued>
+             <dateIssued encoding="marc" point="end">uuuu</dateIssued>
+             <issuance>serial</issuance>
+             <place>
+                <placeTerm type="text">[Ruijin]</placeTerm>
+             </place>
+             <publisher>Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu</publisher>
+             <frequency>Irregular</frequency>
+          </originInfo>
+          <originInfo altRepGroup="1" eventType="publication">
+             <place>
+                <placeTerm type="code" authority="marccountry">cc</placeTerm>
+             </place>
+             <dateIssued encoding="marc" point="start">1933</dateIssued>
+             <dateIssued encoding="marc" point="end">uuuu</dateIssued>
+             <issuance>serial</issuance>
+             <place>
+                <placeTerm type="text">[Ruijin] in Chinese</placeTerm>
+             </place>
+             <publisher>Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu in Chinese</publisher>
+             <frequency>Irregular</frequency>
+          </originInfo>
+        XML
+      end
 
-    let(:roundtrip_mods) do
-      <<~XML
-        <originInfo altRepGroup="1" eventType="publication">
-           <place>
-              <placeTerm type="code" authority="marccountry">cc</placeTerm>
-           </place>
-           <dateIssued encoding="marc" point="start">1933</dateIssued>
-           <dateIssued encoding="marc" point="end">uuuu</dateIssued>
-           <issuance>serial</issuance>
-           <place>
-              <placeTerm type="text">[Ruijin]</placeTerm>
-           </place>
-           <publisher>Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu</publisher>
-           <frequency>Irregular</frequency>
-        </originInfo>
-        <originInfo altRepGroup="1" eventType="publication">
-           <place>
-              <placeTerm type="code" authority="marccountry">cc</placeTerm>
-           </place>
-           <dateIssued encoding="marc" point="start">1933</dateIssued>
-           <dateIssued encoding="marc" point="end">uuuu</dateIssued>
-           <issuance>serial</issuance>
-           <place>
-              <placeTerm type="text">[Ruijin] in Chinese</placeTerm>
-           </place>
-           <publisher>Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu in Chinese</publisher>
-           <frequency>Irregular</frequency>
-        </originInfo>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            location: [
-              {
-                parallelValue: [
-                  {
-                    value: '[Ruijin]'
-                  },
-                  {
-                    value: '[Ruijin] in Chinese'
-                  }
-                ]
-              },
-              {
-                code: 'cc',
-                source: {
-                  code: 'marccountry'
-                }
-              }
-            ],
-            date: [
-              {
-                structuredValue: [
-                  {
-                    value: '1933',
-                    type: 'start'
-                  },
-                  {
-                    value: 'uuuu',
-                    type: 'end'
-                  }
-                ],
-                encoding: {
-                  code: 'marc'
-                }
-              }
-            ],
-            contributor: [
-              {
-                type: 'organization',
-                name: [
-                  {
-                    parallelValue: [
-                      {
-                        value: 'Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu'
-                      },
-                      {
-                        value: 'Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu in Chinese'
-                      }
-                    ]
-                  }
-                ],
-                role: [
-                  {
-                    value: 'publisher',
-                    code: 'pbl',
-                    uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                    source: {
-                      code: 'marcrelator',
-                      uri: 'http://id.loc.gov/vocabulary/relators/'
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              location: [
+                {
+                  parallelValue: [
+                    {
+                      value: '[Ruijin]'
+                    },
+                    {
+                      value: '[Ruijin] in Chinese'
                     }
+                  ]
+                },
+                {
+                  code: 'cc',
+                  source: {
+                    code: 'marccountry'
                   }
-                ]
-              }
-            ],
-            note: [
-              {
-                type: 'issuance',
-                value: 'serial',
-                source: {
-                  value: 'MODS issuance terms'
                 }
-              },
-              {
-                type: 'frequency',
-                value: 'Irregular'
-              }
-            ]
-          }
-        ]
-      }
+              ],
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '1933',
+                      type: 'start'
+                    },
+                    {
+                      value: 'uuuu',
+                      type: 'end'
+                    }
+                  ],
+                  encoding: {
+                    code: 'marc'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  type: 'organization',
+                  name: [
+                    {
+                      parallelValue: [
+                        {
+                          value: 'Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu'
+                        },
+                        {
+                          value: 'Zhong yang ge ming jun shi wei yuan hui zong wei sheng bu in Chinese'
+                        }
+                      ]
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    }
+                  ]
+                }
+              ],
+              note: [
+                {
+                  type: 'issuance',
+                  value: 'serial',
+                  source: {
+                    value: 'MODS issuance terms'
+                  }
+                },
+                {
+                  type: 'frequency',
+                  value: 'Irregular'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'Parallel value with no script given in MODS - C' do
     # Example adapted from druid:bh212vz9239
-    xit 'to be implemented: removed warning'
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo altRepGroup="1">
+            <place>
+              <placeTerm type="code" authority="marccountry">cc</placeTerm>
+            </place>
+            <place>
+              <placeTerm type="text">Guangdong</placeTerm>
+            </place>
+            <publisher>Guangdong lu jun ce liang ju</publisher>
+            <dateIssued>Minguo 11-18 [1922-1929]</dateIssued>
+            <dateIssued encoding="marc" point="start">1922</dateIssued>
+            <dateIssued encoding="marc" point="end">1929</dateIssued>
+            <issuance>monographic</issuance>
+          </originInfo>
+          <originInfo altRepGroup="1">
+            <place>
+              <placeTerm type="text">Guangdong in Chinese</placeTerm>
+            </place>
+            <publisher>Guangdong lu jun ce liang ju in Chinese</publisher>
+            <dateIssued>Minguo 11-18 [1922-1929] in Chinese</dateIssued>
+          </originInfo>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <originInfo altRepGroup="1">
-          <place>
-            <placeTerm type="code" authority="marccountry">cc</placeTerm>
-          </place>
-          <place>
-            <placeTerm type="text">Guangdong</placeTerm>
-          </place>
-          <publisher>Guangdong lu jun ce liang ju</publisher>
-          <dateIssued>Minguo 11-18 [1922-1929]</dateIssued>
-          <dateIssued encoding="marc" point="start">1922</dateIssued>
-          <dateIssued encoding="marc" point="end">1929</dateIssued>
-          <issuance>monographic</issuance>
-        </originInfo>
-        <originInfo altRepGroup="1">
-          <place>
-            <placeTerm type="text">Guangdong in Chinese</placeTerm>
-          </place>
-          <publisher>Guangdong lu jun ce liang ju in Chinese</publisher>
-          <dateIssued>Minguo 11-18 [1922-1929] in Chinese</dateIssued>
-        </originInfo>
-      XML
-    end
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="publication" altRepGroup="1">
+            <place>
+              <placeTerm type="code" authority="marccountry">cc</placeTerm>
+            </place>
+            <place>
+              <placeTerm type="text">Guangdong</placeTerm>
+            </place>
+            <publisher>Guangdong lu jun ce liang ju</publisher>
+            <dateIssued>Minguo 11-18 [1922-1929]</dateIssued>
+            <dateIssued encoding="marc" point="start">1922</dateIssued>
+            <dateIssued encoding="marc" point="end">1929</dateIssued>
+            <issuance>monographic</issuance>
+          </originInfo>
+          <originInfo eventType="publication" altRepGroup="1">
+            <place>
+              <placeTerm type="code" authority="marccountry">cc</placeTerm>
+            </place>
+            <place>
+              <placeTerm type="text">Guangdong in Chinese</placeTerm>
+            </place>
+            <publisher>Guangdong lu jun ce liang ju in Chinese</publisher>
+            <dateIssued>Minguo 11-18 [1922-1929] in Chinese</dateIssued>
+            <dateIssued encoding="marc" point="start">1922</dateIssued>
+            <dateIssued encoding="marc" point="end">1929</dateIssued>
+            <issuance>monographic</issuance>
+          </originInfo>
+        XML
+      end
 
-    let(:roundtrip_mods) do
-      <<~XML
-        <originInfo eventType="publication" altRepGroup="1">
-          <place>
-            <placeTerm type="code" authority="marccountry">cc</placeTerm>
-          </place>
-          <place>
-            <placeTerm type="text">Guangdong</placeTerm>
-          </place>
-          <publisher>Guangdong lu jun ce liang ju</publisher>
-          <dateIssued>Minguo 11-18 [1922-1929]</dateIssued>
-          <dateIssued encoding="marc" point="start">1922</dateIssued>
-          <dateIssued encoding="marc" point="end">1929</dateIssued>
-          <issuance>monographic</issuance>
-        </originInfo>
-        <originInfo eventType="publication" altRepGroup="1">
-          <place>
-            <placeTerm type="code" authority="marccountry">cc</placeTerm>
-          </place>
-          <place>
-            <placeTerm type="text">Guangdong in Chinese</placeTerm>
-          </place>
-          <publisher>Guangdong lu jun ce liang ju in Chinese</publisher>
-          <dateIssued>Minguo 11-18 [1922-1929] in Chinese</dateIssued>
-          <dateIssued encoding="marc" point="start">1922</dateIssued>
-          <dateIssued encoding="marc" point="end">1929</dateIssued>
-          <issuance>monographic</issuance>
-        </originInfo>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            location: [
-              {
-                parallelValue: [
-                  {
-                    value: 'Guangdong'
-                  },
-                  {
-                    value: 'Guangdong in Chinese'
-                  }
-                ]
-              },
-              {
-                code: 'cc',
-                source: {
-                  code: 'marccountry'
-                }
-              }
-            ],
-            contributor: [
-              {
-                type: 'organization',
-                name: [
-                  {
-                    parallelValue: [
-                      {
-                        value: 'Guangdong lu jun ce liang ju'
-                      },
-                      {
-                        value: 'Guangdong lu jun ce liang ju in Chinese'
-                      }
-                    ]
-                  }
-                ],
-                role: [
-                  {
-                    value: 'publisher',
-                    code: 'pbl',
-                    uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                    source: {
-                      code: 'marcrelator',
-                      uri: 'http://id.loc.gov/vocabulary/relators/'
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              location: [
+                {
+                  parallelValue: [
+                    {
+                      value: 'Guangdong'
+                    },
+                    {
+                      value: 'Guangdong in Chinese'
                     }
+                  ]
+                },
+                {
+                  code: 'cc',
+                  source: {
+                    code: 'marccountry'
                   }
-                ]
-              }
-            ],
-            date: [
-              {
-                parallelValue: [
-                  {
-                    value: 'Minguo 11-18 [1922-1929]'
-                  },
-                  {
-                    value: 'Minguo 11-18 [1922-1929] in Chinese'
-                  }
-                ]
-              },
-              {
-                structuredValue: [
-                  {
-                    value: '1922',
-                    type: 'start'
-                  },
-                  {
-                    value: '1929',
-                    type: 'end'
-                  }
-                ],
-                encoding: {
-                  code: 'marc'
                 }
-              }
-            ],
-            note: [
-              {
-                type: 'issuance',
-                value: 'monographic',
-                source: {
-                  value: 'MODS issuance terms'
+              ],
+              contributor: [
+                {
+                  type: 'organization',
+                  name: [
+                    {
+                      parallelValue: [
+                        {
+                          value: 'Guangdong lu jun ce liang ju'
+                        },
+                        {
+                          value: 'Guangdong lu jun ce liang ju in Chinese'
+                        }
+                      ]
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    }
+                  ]
                 }
-              }
-            ]
-          }
-        ]
-      }
+              ],
+              date: [
+                {
+                  parallelValue: [
+                    {
+                      value: 'Minguo 11-18 [1922-1929]'
+                    },
+                    {
+                      value: 'Minguo 11-18 [1922-1929] in Chinese'
+                    }
+                  ]
+                },
+                {
+                  structuredValue: [
+                    {
+                      value: '1922',
+                      type: 'start'
+                    },
+                    {
+                      value: '1929',
+                      type: 'end'
+                    }
+                  ],
+                  encoding: {
+                    code: 'marc'
+                  }
+                }
+              ],
+              note: [
+                {
+                  type: 'issuance',
+                  value: 'monographic',
+                  source: {
+                    value: 'MODS issuance terms'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'Multiple originInfo elements with and without eventTypes' do
-    xit 'to be implemented: updated spec'
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo>
+            <place>
+              <placeTerm type="code" authority="marccountry">cau</placeTerm>
+            </place>
+            <dateIssued encoding="marc">2020</dateIssued>
+            <copyrightDate encoding="marc">2020</copyrightDate>
+            <issuance>monographic</issuance>
+          </originInfo>
+          <originInfo eventType="publication">
+            <place>
+              <placeTerm type="text">[Stanford, Calif.]</placeTerm>
+            </place>
+            <publisher>[Stanford University]</publisher>
+            <dateIssued>2020</dateIssued>
+          </originInfo>
+          <originInfo eventType="copyright notice">
+            <copyrightDate>©2020</copyrightDate>
+          </originInfo>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <originInfo>
-          <place>
-            <placeTerm type="code" authority="marccountry">cau</placeTerm>
-          </place>
-          <dateIssued encoding="marc">2020</dateIssued>
-          <copyrightDate encoding="marc">2020</copyrightDate>
-          <issuance>monographic</issuance>
-        </originInfo>
-        <originInfo eventType="publication">
-          <place>
-            <placeTerm type="text">[Stanford, Calif.]</placeTerm>
-          </place>
-          <publisher>[Stanford University]</publisher>
-          <dateIssued>2020</dateIssued>
-        </originInfo>
-        <originInfo eventType="copyright notice">
-          <copyrightDate>©2020</copyrightDate>
-        </originInfo>
-      XML
-    end
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="publication">
+            <place>
+              <placeTerm type="code" authority="marccountry">cau</placeTerm>
+            </place>
+            <dateIssued encoding="marc">2020</dateIssued>
+            <issuance>monographic</issuance>
+          </originInfo>
+          <originInfo eventType="publication">
+            <place>
+              <placeTerm type="text">[Stanford, Calif.]</placeTerm>
+            </place>
+            <publisher>[Stanford University]</publisher>
+            <dateIssued>2020</dateIssued>
+          </originInfo>
+          <originInfo eventType="copyright">
+            <copyrightDate encoding="marc">2020</copyrightDate>
+          </originInfo>
+          <originInfo eventType="copyright notice">
+            <copyrightDate>©2020</copyrightDate>
+          </originInfo>
+        XML
+      end
 
-    let(:roundtrip_mods) do
-      <<~XML
-        <originInfo eventType="publication">
-          <place>
-            <placeTerm type="code" authority="marccountry">cau</placeTerm>
-          </place>
-          <dateIssued encoding="marc">2020</dateIssued>
-          <issuance>monographic</issuance>
-        </originInfo>
-        <originInfo eventType="publication">
-          <place>
-            <placeTerm type="text">[Stanford, Calif.]</placeTerm>
-          </place>
-          <publisher>[Stanford University]</publisher>
-          <dateIssued>2020</dateIssued>
-        </originInfo>
-        <originInfo eventType="copyright">
-          <copyrightDate encoding="marc">2020</copyrightDate>
-        </originInfo>
-        <originInfo eventType="copyright notice">
-          <copyrightDate>©2020</copyrightDate>
-        </originInfo>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            location: [
-              {
-                code: 'cau',
-                source: {
-                  code: 'marccountry'
-                }
-              }
-            ],
-            date: [
-              {
-                value: '2020',
-                encoding: {
-                  code: 'marc'
-                }
-              }
-            ],
-            note: [
-              {
-                type: 'issuance',
-                value: 'monographic',
-                source: {
-                  value: 'MODS issuance terms'
-                }
-              }
-            ]
-          },
-          {
-            type: 'copyright',
-            date: [
-              {
-                value: '2020',
-                encoding: {
-                  code: 'marc'
-                }
-              }
-            ]
-          },
-          {
-            type: 'publication',
-            location: [
-              {
-                value: '[Stanford, Calif.]'
-              }
-            ],
-            contributor: [
-              {
-                name: [
-                  {
-                    value: '[Stanford University]'
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              location: [
+                {
+                  code: 'cau',
+                  source: {
+                    code: 'marccountry'
                   }
-                ],
-                type: 'organization',
-                role: [
-                  {
-                    value: 'publisher',
-                    code: 'pbl',
-                    uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                    source: {
-                      code: 'marcrelator',
-                      uri: 'http://id.loc.gov/vocabulary/relators/'
+                }
+              ],
+              date: [
+                {
+                  value: '2020',
+                  encoding: {
+                    code: 'marc'
+                  }
+                }
+              ],
+              note: [
+                {
+                  type: 'issuance',
+                  value: 'monographic',
+                  source: {
+                    value: 'MODS issuance terms'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'copyright',
+              date: [
+                {
+                  value: '2020',
+                  encoding: {
+                    code: 'marc'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'publication',
+              location: [
+                {
+                  value: '[Stanford, Calif.]'
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: '[Stanford University]'
                     }
-                  }
-                ]
-              }
-            ],
-            date: [
-              {
-                value: '2020'
-              }
-            ]
-          },
-          {
-            type: 'copyright notice',
-            note: [
-              {
-                value: '©2020',
-                type: 'copyright statement'
-              }
-            ]
-          }
-        ]
-      }
+                  ],
+                  type: 'organization',
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    }
+                  ]
+                }
+              ],
+              date: [
+                {
+                  value: '2020'
+                }
+              ]
+            },
+            {
+              type: 'copyright',
+              note: [
+                {
+                  value: '©2020',
+                  type: 'copyright statement'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
@@ -1357,276 +1367,277 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
   describe 'parallel values with example adapted from hn285fy7937' do
     # example adapted from hn285fy7937 after normalization
+    xit 'to be implemented:  warning when altRepGroup is missing lang/script'
 
-    xit 'to be implemented: updated warning message'
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo altRepGroup="1" eventType="publication">
+            <place>
+              <placeTerm type="code" authority="marccountry">cc</placeTerm>
+            </place>
+            <place>
+              <placeTerm type="text">Chengdu</placeTerm>
+            </place>
+            <publisher>Sichuan chu ban ji tuan, Sichuan wen yi chu ban she</publisher>
+            <dateIssued>2005</dateIssued>
+            <edition>Di 1 ban.</edition>
+            <issuance>monographic</issuance>
+          </originInfo>
+          <originInfo altRepGroup="1" eventType="publication">
+            <place>
+              <placeTerm type="code" authority="marccountry">cc</placeTerm>
+            </place>
+            <place>
+              <placeTerm type="text">[Chengdu in Chinese]</placeTerm>
+            </place>
+            <publisher>[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]</publisher>
+            <dateIssued>2005</dateIssued>
+            <edition>[Di 1 ban in Chinese]</edition>
+            <issuance>monographic</issuance>
+          </originInfo>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <originInfo altRepGroup="1" eventType="publication">
-          <place>
-            <placeTerm type="code" authority="marccountry">cc</placeTerm>
-          </place>
-          <place>
-            <placeTerm type="text">Chengdu</placeTerm>
-          </place>
-          <publisher>Sichuan chu ban ji tuan, Sichuan wen yi chu ban she</publisher>
-          <dateIssued>2005</dateIssued>
-          <edition>Di 1 ban.</edition>
-          <issuance>monographic</issuance>
-        </originInfo>
-        <originInfo altRepGroup="1" eventType="publication">
-          <place>
-            <placeTerm type="code" authority="marccountry">cc</placeTerm>
-          </place>
-          <place>
-            <placeTerm type="text">[Chengdu in Chinese]</placeTerm>
-          </place>
-          <publisher>[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]</publisher>
-          <dateIssued>2005</dateIssued>
-          <edition>[Di 1 ban in Chinese]</edition>
-          <issuance>monographic</issuance>
-        </originInfo>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            location: [
-              {
-                parallelValue: [
-                  {
-                    value: 'Chengdu'
-                  },
-                  {
-                    value: '[Chengdu in Chinese]'
-                  }
-                ]
-              },
-              {
-                code: 'cc',
-                source: {
-                  code: 'marccountry'
-                }
-              }
-            ],
-            contributor: [
-              {
-                type: 'organization',
-                name: [
-                  {
-                    parallelValue: [
-                      {
-                        value: 'Sichuan chu ban ji tuan, Sichuan wen yi chu ban she'
-                      },
-                      {
-                        value: '[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]'
-                      }
-                    ]
-                  }
-                ],
-                role: [
-                  {
-                    value: 'publisher',
-                    code: 'pbl',
-                    uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                    source: {
-                      code: 'marcrelator',
-                      uri: 'http://id.loc.gov/vocabulary/relators/'
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              location: [
+                {
+                  parallelValue: [
+                    {
+                      value: 'Chengdu'
+                    },
+                    {
+                      value: '[Chengdu in Chinese]'
                     }
+                  ]
+                },
+                {
+                  code: 'cc',
+                  source: {
+                    code: 'marccountry'
                   }
-                ]
-              }
-            ],
-            date: [
-              {
-                value: '2005'
-              }
-            ],
-            note: [
-              {
-                type: 'edition',
-                parallelValue: [
-                  {
-                    value: 'Di 1 ban.'
-                  },
-                  {
-                    value: '[Di 1 ban in Chinese]'
+                }
+              ],
+              contributor: [
+                {
+                  type: 'organization',
+                  name: [
+                    {
+                      parallelValue: [
+                        {
+                          value: 'Sichuan chu ban ji tuan, Sichuan wen yi chu ban she'
+                        },
+                        {
+                          value: '[Sichuan chu ban ji tuan, Sichuan wen yi chu ban she in Chinese]'
+                        }
+                      ]
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    }
+                  ]
+                }
+              ],
+              date: [
+                {
+                  value: '2005'
+                }
+              ],
+              note: [
+                {
+                  type: 'edition',
+                  parallelValue: [
+                    {
+                      value: 'Di 1 ban.'
+                    },
+                    {
+                      value: '[Di 1 ban in Chinese]'
+                    }
+                  ]
+                },
+                {
+                  type: 'issuance',
+                  value: 'monographic',
+                  source: {
+                    value: 'MODS issuance terms'
                   }
-                ]
-              },
-              {
-                type: 'issuance',
-                value: 'monographic',
-                source: {
-                  value: 'MODS issuance terms'
+
                 }
 
-              }
+              ]
+            }
+          ]
+        }
+      end
 
-            ]
-          }
-        ]
-      }
+      # let(:warnings) { [Notification.new(msg: 'altRepGroup missing lang/script')] }
     end
-
-    let(:warnings) { [Notification.new(msg: 'altRepGroup missing lang/script')] }
   end
 
   describe 'parallel values - originInfo with additional elements in the second position' do
     # example adapted from bh212vz9239 in different order
 
-    xit 'to be implemented: removed warning'
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo altRepGroup="1">
+            <place>
+              <placeTerm type="text">Guangdong in Chinese</placeTerm>
+            </place>
+            <publisher>Guangdong lu jun ce liang ju in Chinese</publisher>
+            <dateIssued>Minguo 11-18 [1922-1929] in Chinese</dateIssued>
+          </originInfo>
+          <originInfo altRepGroup="1">
+            <place>
+              <placeTerm type="code" authority="marccountry">cc</placeTerm>
+            </place>
+            <place>
+              <placeTerm type="text">Guangdong</placeTerm>
+            </place>
+            <publisher>Guangdong lu jun ce liang ju</publisher>
+            <dateIssued>Minguo 11-18 [1922-1929]</dateIssued>
+            <dateIssued encoding="marc" point="start">1922</dateIssued>
+            <dateIssued encoding="marc" point="end">1929</dateIssued>
+            <issuance>monographic</issuance>
+          </originInfo>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <originInfo altRepGroup="1">
-          <place>
-            <placeTerm type="text">Guangdong in Chinese</placeTerm>
-          </place>
-          <publisher>Guangdong lu jun ce liang ju in Chinese</publisher>
-          <dateIssued>Minguo 11-18 [1922-1929] in Chinese</dateIssued>
-        </originInfo>
-        <originInfo altRepGroup="1">
-          <place>
-            <placeTerm type="code" authority="marccountry">cc</placeTerm>
-          </place>
-          <place>
-            <placeTerm type="text">Guangdong</placeTerm>
-          </place>
-          <publisher>Guangdong lu jun ce liang ju</publisher>
-          <dateIssued>Minguo 11-18 [1922-1929]</dateIssued>
-          <dateIssued encoding="marc" point="start">1922</dateIssued>
-          <dateIssued encoding="marc" point="end">1929</dateIssued>
-          <issuance>monographic</issuance>
-        </originInfo>
-      XML
-    end
+      # all parallel elements in both originInfo elements + eventType
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo altRepGroup="1" eventType="publication">
+            <place>
+              <placeTerm type="code" authority="marccountry">cc</placeTerm>
+            </place>
+            <place>
+              <placeTerm type="text">Guangdong in Chinese</placeTerm>
+            </place>
+            <publisher>Guangdong lu jun ce liang ju in Chinese</publisher>
+            <dateIssued>Minguo 11-18 [1922-1929] in Chinese</dateIssued>
+            <dateIssued encoding="marc" point="start">1922</dateIssued>
+            <dateIssued encoding="marc" point="end">1929</dateIssued>
+            <issuance>monographic</issuance>
+          </originInfo>
+          <originInfo altRepGroup="1" eventType="publication">
+            <place>
+              <placeTerm type="code" authority="marccountry">cc</placeTerm>
+            </place>
+            <place>
+              <placeTerm type="text">Guangdong</placeTerm>
+            </place>
+            <publisher>Guangdong lu jun ce liang ju</publisher>
+            <dateIssued>Minguo 11-18 [1922-1929]</dateIssued>
+            <dateIssued encoding="marc" point="start">1922</dateIssued>
+            <dateIssued encoding="marc" point="end">1929</dateIssued>
+            <issuance>monographic</issuance>
+          </originInfo>
+        XML
+      end
 
-    # all parallel elements in both originInfo elements + eventType
-    let(:roundtrip_mods) do
-      <<~XML
-        <originInfo altRepGroup="1" eventType="publication">
-          <place>
-            <placeTerm type="code" authority="marccountry">cc</placeTerm>
-          </place>
-          <place>
-            <placeTerm type="text">Guangdong in Chinese</placeTerm>
-          </place>
-          <publisher>Guangdong lu jun ce liang ju in Chinese</publisher>
-          <dateIssued>Minguo 11-18 [1922-1929] in Chinese</dateIssued>
-          <dateIssued encoding="marc" point="start">1922</dateIssued>
-          <dateIssued encoding="marc" point="end">1929</dateIssued>
-          <issuance>monographic</issuance>
-        </originInfo>
-        <originInfo altRepGroup="1" eventType="publication">
-          <place>
-            <placeTerm type="code" authority="marccountry">cc</placeTerm>
-          </place>
-          <place>
-            <placeTerm type="text">Guangdong</placeTerm>
-          </place>
-          <publisher>Guangdong lu jun ce liang ju</publisher>
-          <dateIssued>Minguo 11-18 [1922-1929]</dateIssued>
-          <dateIssued encoding="marc" point="start">1922</dateIssued>
-          <dateIssued encoding="marc" point="end">1929</dateIssued>
-          <issuance>monographic</issuance>
-        </originInfo>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            location: [
-              {
-                parallelValue: [
-                  {
-                    value: 'Guangdong in Chinese'
-                  },
-                  {
-                    value: 'Guangdong'
-                  }
-                ]
-              },
-              {
-                code: 'cc',
-                source: {
-                  code: 'marccountry'
-                }
-              }
-            ],
-            contributor: [
-              {
-                type: 'organization',
-                name: [
-                  {
-                    parallelValue: [
-                      {
-                        value: 'Guangdong lu jun ce liang ju in Chinese'
-                      },
-                      {
-                        value: 'Guangdong lu jun ce liang ju'
-                      }
-                    ]
-                  }
-                ],
-                role: [
-                  {
-                    value: 'publisher',
-                    code: 'pbl',
-                    uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                    source: {
-                      code: 'marcrelator',
-                      uri: 'http://id.loc.gov/vocabulary/relators/'
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              location: [
+                {
+                  parallelValue: [
+                    {
+                      value: 'Guangdong in Chinese'
+                    },
+                    {
+                      value: 'Guangdong'
                     }
+                  ]
+                },
+                {
+                  code: 'cc',
+                  source: {
+                    code: 'marccountry'
                   }
-                ]
-              }
-            ],
-            date: [
-              {
-                parallelValue: [
-                  {
-                    value: 'Minguo 11-18 [1922-1929] in Chinese'
-                  },
-                  {
-                    value: 'Minguo 11-18 [1922-1929]'
-                  }
-                ]
-              },
-              {
-                structuredValue: [
-                  {
-                    value: '1922',
-                    type: 'start'
-                  },
-                  {
-                    value: '1929',
-                    type: 'end'
-                  }
-                ],
-                encoding: {
-                  code: 'marc'
                 }
-              }
-            ],
-            note: [
-              {
-                type: 'issuance',
-                value: 'monographic',
-                source: {
-                  value: 'MODS issuance terms'
+              ],
+              contributor: [
+                {
+                  type: 'organization',
+                  name: [
+                    {
+                      parallelValue: [
+                        {
+                          value: 'Guangdong lu jun ce liang ju in Chinese'
+                        },
+                        {
+                          value: 'Guangdong lu jun ce liang ju'
+                        }
+                      ]
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    }
+                  ]
                 }
-              }
-            ]
-          }
-        ]
-      }
+              ],
+              date: [
+                {
+                  parallelValue: [
+                    {
+                      value: 'Minguo 11-18 [1922-1929] in Chinese'
+                    },
+                    {
+                      value: 'Minguo 11-18 [1922-1929]'
+                    }
+                  ]
+                },
+                {
+                  structuredValue: [
+                    {
+                      value: '1922',
+                      type: 'start'
+                    },
+                    {
+                      value: '1929',
+                      type: 'end'
+                    }
+                  ],
+                  encoding: {
+                    code: 'marc'
+                  }
+                }
+              ],
+              note: [
+                {
+                  type: 'issuance',
+                  value: 'monographic',
+                  source: {
+                    value: 'MODS issuance terms'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
@@ -1758,54 +1769,54 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   context 'when eventType matches date type "distribution"' do
     # bad data mapping (?)
     # NOTE: cocina -> MODS mapping
-    xit 'to be implemented: updated spec'
-    let(:mods) do
-      <<~XML
-        <originInfo eventType="distribution">
-          <place>
-            <placeTerm type="text">Washington, DC</placeTerm>
-          </place>
-          <publisher>For sale by the Superintendent of Documents, U.S. Government Publishing Office</publisher>
-          <dateOther/>
-        </originInfo>
-      XML
-    end
-
-    # NOTE: contributor role is distributor, not publisher
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'distribution',
-            contributor: [
-              {
-                name: [
-                  {
-                    value: 'For sale by the Superintendent of Documents, U.S. Government Publishing Office'
-                  }
-                ],
-                type: 'organization',
-                role: [
-                  {
-                    value: 'distributor',
-                    code: 'dst',
-                    uri: 'http://id.loc.gov/vocabulary/relators/dst',
-                    source: {
-                      code: 'marcrelator',
-                      uri: 'http://id.loc.gov/vocabulary/relators/'
+    xit 'to be mapped?:  MODS maps back to event type publication' do
+      # NOTE: contributor role is distributor, not publisher
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'distribution',
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'For sale by the Superintendent of Documents, U.S. Government Publishing Office'
                     }
-                  }
-                ]
-              }
-            ],
-            location: [
-              {
-                value: 'Washington, DC'
-              }
-            ]
-          }
-        ]
-      }
+                  ],
+                  type: 'organization',
+                  role: [
+                    {
+                      value: 'distributor',
+                      code: 'dst',
+                      uri: 'http://id.loc.gov/vocabulary/relators/dst',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    }
+                  ]
+                }
+              ],
+              location: [
+                {
+                  value: 'Washington, DC'
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="distribution">
+            <place>
+              <placeTerm type="text">Washington, DC</placeTerm>
+            </place>
+            <publisher>For sale by the Superintendent of Documents, U.S. Government Publishing Office</publisher>
+          </originInfo>
+        XML
+      end
     end
   end
 
@@ -1881,93 +1892,96 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   end
 
   context 'with multiple events and missing event type' do
-    xit 'to be implemented: note that MODS is not correctly mapping to cocina'
-
     # NOTE: cocina -> MODS mapping
-    let(:cocina) do
-      {
-        event: [
-          {
-            type: 'production',
-            date: [
-              {
-                value: '1899'
-              }
-            ],
-            location: [
-              {
-                value: 'York'
-              }
-            ]
-          },
-          {
-            date: [
-              {
-                value: '1901'
-              }
-            ],
-            location: [
-              {
-                value: 'London'
-              }
-            ]
-          }
-        ]
-      }
-    end
+    # it_behaves_like 'cocina MODS mapping' do
+    xit 'to be mapped: MODS is not correctly mapping to cocina and re-roundtripping mess' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'production',
+              date: [
+                {
+                  value: '1899'
+                }
+              ],
+              location: [
+                {
+                  value: 'York'
+                }
+              ]
+            },
+            {
+              date: [
+                {
+                  value: '1901'
+                }
+              ],
+              location: [
+                {
+                  value: 'London'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-    # FIXME:  3 events - the second date splits to event without type, and location gets type publication
-    # Updated by Arcadia to match current model, replaces above specification
-    let(:roundtrip_cocina) do
-      {
-        event: [
-          {
-            type: 'production',
-            date: [
-              {
-                value: '1899'
-              }
-            ],
-            location: [
-              {
-                value: 'York'
-              }
-            ]
-          },
-          {
-            location: [
-              {
-                value: 'London'
-              }
-            ],
-            date: [
-              {
-                value: '1901'
-              }
-            ]
-          }
-        ]
-      }
-    end
+      # FIXME: 3 events - the second date splits to event without type, and location gets type publication
+      # Updated by Arcadia to match current model, replaces above specification
+      # Naomi notes the roundtrip_cocina here is exactly the same as above
+      # let(:roundtrip_cocina) do
+      #   {
+      #     event: [
+      #       {
+      #         type: 'production',
+      #         date: [
+      #           {
+      #             value: '1899'
+      #           }
+      #         ],
+      #         location: [
+      #           {
+      #             value: 'York'
+      #           }
+      #         ]
+      #       },
+      #       {
+      #         location: [
+      #           {
+      #             value: 'London'
+      #           }
+      #         ],
+      #         date: [
+      #           {
+      #             value: '1901'
+      #           }
+      #         ]
+      #       }
+      #     ]
+      #   }
+      # end
+      #
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="production">
+            <dateCreated>1899</dateCreated>
+            <place>
+              <placeTerm type="text">York</placeTerm>
+            </place>
+          </originInfo>
+          <originInfo>
+            <dateOther>1901</dateOther>
+            <place>
+              <placeTerm type="text">London</placeTerm>
+            </place>
+          </originInfo>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <originInfo eventType="production">
-          <dateCreated>1899</dateCreated>
-          <place>
-            <placeTerm type="text">York</placeTerm>
-          </place>
-        </originInfo>
-        <originInfo>
-          <dateOther>1901</dateOther>
-          <place>
-            <placeTerm type="text">London</placeTerm>
-          </place>
-        </originInfo>
-      XML
+      # let(:warnings) { [Notification.new(msg: 'originInfo/dateOther missing eventType')] } # old
+      let(:warnings) { [Notification.new(msg: 'Undetermined event type')] }
     end
-
-    let(:warnings) { [Notification.new(msg: 'Undetermined event type')] }
   end
 
   context 'when originInfo / event is various flavors of missing' do
@@ -2002,35 +2016,36 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
     context 'when cocina event is array with empty hash' do
       # NOTE: cocina -> MODS
-      xit 'updated spec'
-      let(:cocina) do
-        {
-          event: [{}]
-        }
-      end
+      it_behaves_like 'cocina MODS mapping' do
+        let(:cocina) do
+          {
+            event: [{}]
+          }
+        end
 
-      let(:roundtrip_cocina) do
-        {
-        }
-      end
+        let(:roundtrip_cocina) do
+          {
+          }
+        end
 
-      let(:mods) { '' }
+        let(:mods) { '' }
+      end
     end
 
     context 'when MODS is empty originInfo element with no attributes' do
-      xit 'to be implemented: updated spec'
+      it_behaves_like 'MODS cocina mapping' do
+        let(:mods) do
+          <<~XML
+            <originInfo/>
+          XML
+        end
 
-      let(:mods) do
-        <<~XML
-          <originInfo/>
-        XML
-      end
+        let(:roundtrip_mods) { '' }
 
-      let(:roundtrip_mods) { '' }
-
-      let(:cocina) do
-        {
-        }
+        let(:cocina) do
+          {
+          }
+        end
       end
     end
   end

--- a/spec/services/cocina/mapping/descriptive/mods/record_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/record_info_spec.rb
@@ -308,54 +308,54 @@ RSpec.describe 'MODS recordInfo <--> cocina mappings' do
   end
 
   describe 'Converted from ISO 19139' do
-    xit 'not implemented: recordContentSource is a value, not a code ...'
+    xit 'not implemented: recordContentSource is a value, not a code ...' do
+      let(:mods) do
+        <<~XML
+          <recordInfo>
+            <recordContentSource>Stanford</recordContentSource>
+            <recordIdentifier>edu.stanford.purl:ft445st6184</recordIdentifier>
+            <recordOrigin>This record was translated from ISO 19139 to MODS v.3 using an xsl transformation.</recordOrigin>
+            <languageOfCataloging>
+              <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+            </languageOfCataloging>
+          </recordInfo>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <recordInfo>
-          <recordContentSource>Stanford</recordContentSource>
-          <recordIdentifier>edu.stanford.purl:ft445st6184</recordIdentifier>
-          <recordOrigin>This record was translated from ISO 19139 to MODS v.3 using an xsl transformation.</recordOrigin>
-          <languageOfCataloging>
-            <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
-          </languageOfCataloging>
-        </recordInfo>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        adminMetadata: {
-          contributor: [
-            {
-              name: [
-                {
-                  value: 'Stanford'
-                }
-              ]
-            }
-          ],
-          identifier: [
-            {
-              value: 'edu.stanford.purl:ft445st6184'
-            }
-          ],
-          note: [
-            {
-              type: 'record origin',
-              value: 'This record was translated from ISO 19139 to MODS v.3 using an xsl transformation.'
-            }
-          ],
-          language: [
-            {
-              code: 'eng',
-              source: {
-                code: 'iso639-2b'
+      let(:cocina) do
+        {
+          adminMetadata: {
+            contributor: [
+              {
+                name: [
+                  {
+                    value: 'Stanford'
+                  }
+                ]
               }
-            }
-          ]
+            ],
+            identifier: [
+              {
+                value: 'edu.stanford.purl:ft445st6184'
+              }
+            ],
+            note: [
+              {
+                type: 'record origin',
+                value: 'This record was translated from ISO 19139 to MODS v.3 using an xsl transformation.'
+              }
+            ],
+            language: [
+              {
+                code: 'eng',
+                source: {
+                  code: 'iso639-2b'
+                }
+              }
+            ]
+          }
         }
-      }
+      end
     end
   end
 

--- a/spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb
@@ -470,6 +470,7 @@ RSpec.describe 'MODS relatedItem <--> cocina mappings' do
     # Certain related items mapped from MARC don't indicate name type in source data
     # Do not warn for untyped names in relatedItem
     it_behaves_like 'MODS cocina mapping' do
+      # let(:druid) { 'kv699vs9767' } # including this adds location/url with the purl
       let(:mods) do
         <<~XML
           <relatedItem type="otherFormat" displayLabel="Online version:">

--- a/spec/services/cocina/mapping/descriptive/mods/subject_cartographic_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_cartographic_spec.rb
@@ -115,39 +115,39 @@ RSpec.describe 'MODS subject cartographic <--> cocina mappings' do
   end
 
   describe 'Multiple cartographic subjects with altRepGroup' do
-    let(:mods) do
-      <<~XML
-        <subject altRepGroup="1">
-          <cartographics>
-            <scale>Scale 1:650,000.</scale>
-          </cartographics>
-        </subject>
-        <subject altRepGroup="1">
-          <cartographics>
-            <scale>&#x6BD4;&#x4F8B;&#x5C3A; 1:650,000.</scale>
-          </cartographics>
-        </subject>
-      XML
-    end
+    xit 'not implemented: multiple cartographic subjects with altRepGroup' do
+      let(:mods) do
+        <<~XML
+          <subject altRepGroup="1">
+            <cartographics>
+              <scale>Scale 1:650,000.</scale>
+            </cartographics>
+          </subject>
+          <subject altRepGroup="1">
+            <cartographics>
+              <scale>&#x6BD4;&#x4F8B;&#x5C3A; 1:650,000.</scale>
+            </cartographics>
+          </subject>
+        XML
+      end
 
-    let(:cocina) do
-      {
-        form: [
-          parallelValue: [
-            {
-              value: 'Scale 1:650,000.',
-              type: 'map scale'
-            },
-            {
-              value: '比例尺 1:650,000.',
-              type: 'map scale'
-            }
+      let(:cocina) do
+        {
+          form: [
+            parallelValue: [
+              {
+                value: 'Scale 1:650,000.',
+                type: 'map scale'
+              },
+              {
+                value: '比例尺 1:650,000.',
+                type: 'map scale'
+              }
+            ]
           ]
-        ]
-      }
+        }
+      end
     end
-
-    xit 'not implemented'
   end
 
   describe 'Cartographic subject with multiple coordinate representations' do

--- a/spec/services/cocina/mapping/descriptive/mods/title_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/title_info_spec.rb
@@ -550,59 +550,59 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
   describe 'Parallel titles' do
     # How to ID: edge case requiring manual review of records with multiple titleInfo type="translated" instances
 
-    xit 'not implemented: multiple type="translated" edge case'
+    xit 'not implemented: multiple type="translated" edge case' do
+      let(:mods) do
+        <<~XML
+          <titleInfo type="translated" lang="ger" altRepGroup="1">
+            <title>Berliner Mauer Kunst</title>
+          </titleInfo>
+          <titleInfo type="translated" lang="eng" altRepGroup="1">
+            <title>Berlin's wall art</title>
+          </titleInfo>
+          <titleInfo type="translated" lang="spa" altRepGroup="1">
+            <title>Arte en el muro de Berlin</title>
+          </titleInfo>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <titleInfo type="translated" lang="ger" altRepGroup="1">
-          <title>Berliner Mauer Kunst</title>
-        </titleInfo>
-        <titleInfo type="translated" lang="eng" altRepGroup="1">
-          <title>Berlin's wall art</title>
-        </titleInfo>
-        <titleInfo type="translated" lang="spa" altRepGroup="1">
-          <title>Arte en el muro de Berlin</title>
-        </titleInfo>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        title: [
-          {
-            parallelValue: [
-              {
-                value: 'Berliner Mauer Kunst',
-                valueLanguage: {
-                  code: 'ger',
-                  source: {
-                    code: 'iso639-2b'
+      let(:cocina) do
+        {
+          title: [
+            {
+              parallelValue: [
+                {
+                  value: 'Berliner Mauer Kunst',
+                  valueLanguage: {
+                    code: 'ger',
+                    source: {
+                      code: 'iso639-2b'
+                    }
+                  }
+                },
+                {
+                  value: "Berlin's wall art",
+                  valueLanguage: {
+                    code: 'eng',
+                    source: {
+                      code: 'iso639-2b'
+                    }
+                  }
+                },
+                {
+                  value: 'Arte en el muro de Berlin',
+                  valueLanguage: {
+                    code: 'spa',
+                    source: {
+                      code: 'iso639-2b'
+                    }
                   }
                 }
-              },
-              {
-                value: "Berlin's wall art",
-                valueLanguage: {
-                  code: 'eng',
-                  source: {
-                    code: 'iso639-2b'
-                  }
-                }
-              },
-              {
-                value: 'Arte en el muro de Berlin',
-                valueLanguage: {
-                  code: 'spa',
-                  source: {
-                    code: 'iso639-2b'
-                  }
-                }
-              }
-            ],
-            type: 'parallel'
-          }
-        ]
-      }
+              ],
+              type: 'parallel'
+            }
+          ]
+        }
+      end
     end
   end
 

--- a/spec/services/cocina/mapping/descriptive/mods/type_of_resource_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/type_of_resource_spec.rb
@@ -60,35 +60,35 @@ RSpec.describe 'MODS typeOfResource <--> cocina mappings' do
   end
 
   describe 'Multiple types and one predominant' do
-    xit 'not implemented: status primary for typeOfResource'
+    xit 'not implemented: status primary for typeOfResource' do
+      let(:mods) do
+        <<~XML
+          <typeOfResource usage="primary">text</typeOfResource>
+          <typeOfResource>still image</typeOfResource>
+        XML
+      end
 
-    let(:mods) do
-      <<~XML
-        <typeOfResource usage="primary">text</typeOfResource>
-        <typeOfResource>still image</typeOfResource>
-      XML
-    end
-
-    let(:cocina) do
-      {
-        form: [
-          {
-            value: 'text',
-            status: 'primary',
-            type: 'resource type',
-            source: {
-              value: 'MODS resource types'
+      let(:cocina) do
+        {
+          form: [
+            {
+              value: 'text',
+              status: 'primary',
+              type: 'resource type',
+              source: {
+                value: 'MODS resource types'
+              }
+            },
+            {
+              value: 'still image',
+              type: 'resource type',
+              source: {
+                value: 'MODS resource types'
+              }
             }
-          },
-          {
-            value: 'still image',
-            type: 'resource type',
-            source: {
-              value: 'MODS resource types'
-            }
-          }
-        ]
-      }
+          ]
+        }
+      end
     end
   end
 

--- a/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
@@ -100,37 +100,39 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
   end
 
   context 'when normalizing originInfo dateOther[@type]' do
-    let(:mods_ng_xml) do
-      Nokogiri::XML <<~XML
-        <mods #{MODS_ATTRIBUTES}>
-          <originInfo eventType="distribution">
-            <dateOther type="distribution"/>
-          </originInfo>
-          <originInfo eventType="manufacture">
-            <dateOther type="manufacture"/>
-          </originInfo>
-          <originInfo eventType="distribution">
-            <dateOther type="distribution">1937</dateOther>
-          </originInfo>
-        </mods>
-      XML
-    end
+    context 'when matches eventType and dateOther is empty' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo eventType="distribution">
+              <dateOther type="distribution"/>
+            </originInfo>
+            <originInfo eventType="manufacture">
+              <dateOther type="manufacture"/>
+            </originInfo>
+            <originInfo eventType="distribution">
+              <dateOther type="distribution">1937</dateOther>
+            </originInfo>
+          </mods>
+        XML
+      end
 
-    # Temporarily ignoring <originInfo> pending https://github.com/sul-dlss/dor-services-app/issues/2128
-    xit 'removes dateOther type attribute if it matches eventType and dateOther is empty' do
-      expect(normalized_ng_xml).to be_equivalent_to <<~XML
-        <mods #{MODS_ATTRIBUTES}>
-          <originInfo eventType="distribution"/>
-          <originInfo eventType="manufacture"/>
-          <originInfo eventType="distribution">
-            <dateOther type="distribution">1937</dateOther>
-          </originInfo>
-        </mods>
-      XML
+      # Temporarily ignoring <originInfo> pending https://github.com/sul-dlss/dor-services-app/issues/2128
+      xit 'removes dateOther' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo eventType="distribution"/>
+            <originInfo eventType="manufacture"/>
+            <originInfo eventType="distribution">
+              <dateOther type="distribution">1937</dateOther>
+            </originInfo>
+          </mods>
+        XML
+      end
     end
   end
 
-  context 'when normalizing originInfo dates' do
+  context 'when normalizing originInfo date values' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
         <mods #{MODS_ATTRIBUTES}>
@@ -668,6 +670,184 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
         expect(normalized_ng_xml).to be_equivalent_to <<~XML
           <mods #{MODS_ATTRIBUTES}>
             <originInfo eventType="publication"/>
+          </mods>
+        XML
+      end
+    end
+  end
+
+  describe 'empty originInfo date elements' do
+    context 'when dateCreated' do
+      # based on jw174hd9042, vy673zb2925
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateCreated></dateCreated>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'removes the empty child' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when dateIssued' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateIssued/>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'removes the empty child' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when dateIssued with encoding and type' do
+      # based on vj932ns8042
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateIssued encoding="w3cdtf" keyDate="yes"/>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'removes the empty child' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when dateCaptured' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateCaptured/>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'removes the empty child' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when dateValid' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateValid></dateValid>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'removes the empty child' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when dateModified' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateModified></dateModified>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'removes the empty child' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when dateOther with no attibutes' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateOther></dateOther>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      # Temporarily ignoring <originInfo> pending https://github.com/sul-dlss/dor-services-app/issues/2128
+      xit 'removes the element' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when dateOther with @type matching eventType' do
+      # based on xv158sd4671, qx562pf7510
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateOther type="distribution"></dateOther>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      # Temporarily ignoring <originInfo> pending https://github.com/sul-dlss/dor-services-app/issues/2128
+      xit 'removes the element' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when copyrightDate' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <copyrightDate></copyrightDate>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'removes the empty child' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
           </mods>
         XML
       end

--- a/spec/support/mods_mapping_spec_helper.rb
+++ b/spec/support/mods_mapping_spec_helper.rb
@@ -120,7 +120,7 @@ RSpec.shared_examples 'MODS cocina mapping' do
       # the starting MODS is normalized to address discrepancies found against MODS roundtripped to data store (Fedora)
       #  and back, per Arcadia's specifications.  E.g., removal of empty nodes and attributes; addition of eventType to
       #  originInfo nodes.
-      expect(actual_xml).to be_equivalent_to Cocina::ModsNormalizer.normalize(mods_ng_xml: orig_mods_ng, druid: local_druid)
+      expect(actual_xml).to be_equivalent_to Cocina::ModsNormalizer.normalize(mods_ng_xml: orig_mods_ng, druid: local_druid).to_xml
     end
   end
 
@@ -264,7 +264,7 @@ RSpec.shared_examples 'cocina MODS mapping' do
 
     it 'roundtrip cocina Description maps to expected MODS, normalized' do
       # the roundtrip cocina is, effectively, the cocina for the normalized MODS - the MODS is normalized before it gets to cocina
-      normalized_mods_xml = Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_xml, druid: local_druid) if defined?(roundtrip_cocina)
+      normalized_mods_xml = Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_xml, druid: local_druid).to_xml if defined?(roundtrip_cocina)
       expect(roundtrip_mods_xml).to be_equivalent_to normalized_mods_xml if defined?(roundtrip_cocina)
     end
 


### PR DESCRIPTION
NOTE:  do not squash commits!!!!!

## Why was this change made?

After #2173 (beefing up originInfo mapping specs to ensure roundtrip mapping stability), it seemed prudent to turn on as many originInfo specs as possible to trap for errors.   Thus

- this PR is a partial reversion of PR #2130.   Please keep commits separate!!!  (do not squash)

The reversal didn't need to be 100%, and I was able to increase passing origin_info specs by doing a bit more normalization of cocina created from MODS and MODS created from cocina - fewer empty elements (yay!)

## How was this change tested?

### this branch

```
Status (n=10000):
  Success:   9829 (98.29%)
  Different: 103 (1.03%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  Missing (no descMetadata):     68 (0.68%)
```

only in this branch (when keeping date fields with any attributes): 
- dateIssued with encoding and type and no value pops up in roundtrip xml (ends up in cocina) - vj932ns8042

only in this branch (when removing all date fields with no value)
- qx562pf7510
- xv158sd4671

- nc238hg8745 gets diff originInfo b/c dateOther with a type attr was removed ...



diffs in roundtrip xml or cocina between branches:

- fg349td3577, jk090bg7477 , kq586bq1216, nc238hg8745- this branch removed empty dateCreated under event with only type

- dateOther with type manufacturer gets no type in round trip;  this branch removed empty value in cocina  but no xml diff between branches - jz402xk5530

### main branch

```
Status (n=10000):
  Success:   9831 (98.31%)
  Different: 101 (1.01%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  Missing (no descMetadata):     68 (0.68%)
```


## Which documentation and/or configurations were updated?



