### PR TITLE
Do not supply Hydrus title for relatedItems.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/hydrus_default_title_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/hydrus_default_title_builder.rb
@@ -10,7 +10,7 @@ module Cocina
         # @return [Hash] a hash that can be mapped to a cocina model
         def self.build(resource_element:, notifier:, require_title: nil)
           titles = resource_element.xpath('mods:titleInfo/mods:title[string-length() > 0]', mods: DESC_METADATA_NS)
-          return [{ value: 'Hydrus' }] if titles.empty?
+          return [{ value: 'Hydrus' }] if titles.empty? && resource_element.name != 'relatedItem'
 
           Titles.build(resource_element: resource_element, notifier: notifier)
         end

--- a/spec/services/cocina/from_fedora/descriptive/hydrus_default_title_builder_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/hydrus_default_title_builder_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::FromFedora::Descriptive::HydrusDefaultTitleBuilder do
+  let(:object) { Dor::Item.new }
+
+  describe '.build' do
+    subject(:build) { described_class.build(resource_element: ng_xml.root, require_title: true, notifier: notifier) }
+
+    let(:notifier) { instance_double(Cocina::FromFedora::DataErrorNotifier) }
+
+    context 'when no title' do
+      let(:ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <titleInfo>
+              <title />
+            </titleInfo>
+          </mods>
+        XML
+      end
+
+      it 'returns Hydrus as title' do
+        expect(build).to eq([{ value: 'Hydrus' }])
+      end
+    end
+
+    context 'when relatedItem with no title' do
+      let(:ng_xml) do
+        Nokogiri::XML <<~XML
+          <relatedItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.loc.gov/mods/v3" version="3.6"
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+            <titleInfo>
+              <title />
+            </titleInfo>
+          </mods>
+        XML
+      end
+
+      before do
+        allow(notifier).to receive(:error)
+        allow(notifier).to receive(:warn)
+      end
+
+      it 'returns empty' do
+        expect(build).to be_empty
+        expect(notifier).to have_received(:warn).with('Empty title node')
+        expect(notifier).to have_received(:error).with('Missing title')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?
Hydrus creates mess data.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


