### PR TITLE
validation: better label for 'Missing (no descMetadata)'

### DIFF
--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -146,4 +146,4 @@ puts "  Success:   #{counts[:success]} (#{100 * counts[:success].to_f / druids.s
 puts "  Different: #{counts[:different]} (#{100 * counts[:different].to_f / druids.size}%)"
 puts "  To Cocina error:     #{counts[:to_cocina_error]} (#{100 * counts[:to_cocina_error].to_f / druids.size}%)"
 puts "  To Fedora error:     #{counts[:to_fedora_error]} (#{100 * counts[:to_fedora_error].to_f / druids.size}%)"
-puts "  Missing:     #{counts[:missing]} (#{100 * counts[:missing].to_f / druids.size}%)"
+puts "  Missing (no descMetadata):     #{counts[:missing]} (#{100 * counts[:missing].to_f / druids.size}%)"

--- a/bin/validate-to-cocina
+++ b/bin/validate-to-cocina
@@ -100,7 +100,7 @@ results.each { |result| counts[result.error_type] += 1 }
 
 puts summary_line_for('To Cocina error', counts[:to_cocina_error])
 puts summary_line_for('Data error', counts[:data_error])
-puts summary_line_for('Missing', counts[:missing])
+puts summary_line_for('Missing (no descMetadata)', counts[:missing])
 puts "\n"
 
 results_by_error = results_by(error_results)

--- a/bin/validate-to-fedora
+++ b/bin/validate-to-fedora
@@ -107,7 +107,7 @@ results.each { |result| counts[result.error_type] += 1 }
 puts summary_line_for('To Fedora error', counts[:to_fedora_error])
 puts summary_line_for('To Cocina error', counts[:to_cocina_error])
 puts summary_line_for('Data error', counts[:data_error])
-puts summary_line_for('Missing', counts[:missing])
+puts summary_line_for('Missing (no descMetadata)', counts[:missing])
 puts "\n"
 
 error_results = results.select { |result| result.error_type == :to_fedora_error }
@@ -120,7 +120,7 @@ File.open(results_file_name(options[:unique_filename]), 'w') do |file|
   file.write(summary_line_for('To Fedora error', counts[:to_fedora_error]))
   file.write(summary_line_for('To Cocina error', counts[:to_cocina_error]))
   file.write(summary_line_for('Data error', counts[:data_error]))
-  file.write(summary_line_for('Missing', counts[:missing]))
+  file.write(summary_line_for('Missing (no descMetadata)', counts[:missing]))
   file.write("\n")
   write_results(file, aggregated_error_results, 'To Fedora error')
 end


### PR DESCRIPTION
## Why was this change made?

Because most of us can't remember what "Missing" means in the validation stats.

## How was this change tested?

n/a

## Which documentation and/or configurations were updated?



