### PR TITLE
Adds reports for elements and attributes that start with spaces.

### DIFF
--- a/bin/report
+++ b/bin/report
@@ -35,6 +35,20 @@ def metadata_toolkit?(ng_xml)
   ng_xml.root.xpath('//mods:recordContentSource[contains(text(), "Metadata ToolKit")]', mods: MODS_NS).present?
 end
 
+def elements_start_with_spaces?(ng_xml)
+  bad_elements = ng_xml.root.xpath('//mods:*[name() != "mods:identifier" and not(*) and text() and (starts-with(text(), " "))]', mods: MODS_NS)
+  return false if bad_elements.empty?
+
+  bad_elements.map(&:to_s).join('; ')
+end
+
+def attributes_start_with_spaces?(ng_xml)
+  bad_elements = ng_xml.root.xpath('//*[(starts-with(@*, " "))]')
+  return false if bad_elements.empty?
+
+  bad_elements.map(&:to_s).join('; ')
+end
+
 # rubocop:disable Layout/LineLength
 MODS_ELEMENTS = %w[abstract accessCondition affiliation alternativeName area caption cartographicExtension cartographics city citySection classification continent coordinates copyInformation copyrightDate country county date dateCaptured dateCreated dateIssued dateModified dateOther dateValid description descriptionStandard detail digitalOrigin displayForm edition electronicLocator end enumerationAndChronology etal extension extent extraTerrestrialArea form frequency genre geographic geographicCode hierarchicalGeographic holdingExternal holdingSimple identifier internetMediaType island issuance itemIdentifier language languageOfCataloging languageTerm list location mods modsCollection name nameIdentifier namePart nonSort note number occupation originInfo part partName partNumber physicalDescription physicalLocation place placeTerm projection province publisher recordChangeDate recordContentSource recordCreationDate recordIdentifier recordInfo recordInfoNote recordOrigin reformattingQuality region relatedItem role roleTerm scale scriptTerm shelfLocator start state subLocation subTitle subject tableOfContents targetAudience temporal territory text title titleInfo topic total typeOfResource url].freeze
 # rubocop:enable Layout/LineLength
@@ -79,7 +93,9 @@ REPORTS = {
   frequency: method(:has_frequency?),
   bad_event_type: method(:bad_event_type?),
   bad_value_uri: method(:elements_with_bad_value_uri),
-  metadata_toolkit: method(:metadata_toolkit?)
+  metadata_toolkit: method(:metadata_toolkit?),
+  element_spaces: method(:elements_start_with_spaces?),
+  attribute_spaces: method(:attributes_start_with_spaces?)
 }.with_indifferent_access
 
 options = { local: false, reports: REPORTS.keys }


### PR DESCRIPTION
closes #2199

## Why was this change made?
Route out the bad datas.


## How was this change tested?
Local, sdr-deploy


## Which documentation and/or configurations were updated?
NA


