### PR TITLE
event mapping and normalization filters out valueless data

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/event.rb
+++ b/app/services/cocina/to_fedora/descriptive/event.rb
@@ -194,6 +194,8 @@ module Cocina
 
         # rubocop:disable Metrics/ParameterLists
         def write_event(cocina_event_type, dates, locations, names, notes, attributes, is_parallel: false)
+          return if dates.blank? && locations.blank? && names.blank? && notes.blank?
+
           xml.originInfo attributes do
             Array(dates).each do |date|
               write_basic_date(date, cocina_event_type)

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -1870,4 +1870,134 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
       end
     end
   end
+
+  context 'when originInfo dateOther[@type] matches eventType and dateOther is empty' do
+    # based on #xv158sd4671
+
+    # Temporarily ignoring <originInfo> pending https://github.com/sul-dlss/dor-services-app/issues/2128
+    xit 'need to deal with dateOther type matching eventType and roundtripping' do
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="distribution">
+            <place>
+              <placeTerm type="text">Washington, DC</placeTerm>
+            </place>
+            <publisher>blah</publisher>
+            <dateOther type="distribution"/>
+          </originInfo>
+        XML
+      end
+
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="distribution">
+            <place>
+              <placeTerm type="text">Washington, DC</placeTerm>
+            </place>
+            <publisher>blah</publisher>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'distribution',
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'blah'
+                    }
+                  ],
+                  type: 'organization',
+                  role: [
+                    {
+                      value: 'distributor',
+                      code: 'dst',
+                      uri: 'http://id.loc.gov/vocabulary/relators/dst',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    }
+                  ]
+                }
+              ],
+              location: [
+                {
+                  value: 'Washington, DC'
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
+  end
+
+  context 'when dateIssued with encoding and keyDate but no value' do
+    # based on #vj932ns8042
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo>
+            <dateIssued encoding="w3cdtf" keyDate="yes"/>
+            <publisher>blah</publisher>
+            <issuance>monographic</issuance>
+          </originInfo>
+        XML
+      end
+
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="publication">
+            <publisher>blah</publisher>
+            <issuance>monographic</issuance>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              note: [
+                {
+                  source: {
+                    value: 'MODS issuance terms'
+                  },
+                  type: 'issuance',
+                  value: 'monographic'
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'blah'
+                    }
+                  ],
+                  type: 'organization',
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
+  end
 end

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_logic_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_logic_spec.rb
@@ -2,46 +2,8 @@
 
 require 'rails_helper'
 
-# rubocop:disable RSpec/OverwritingSetup
-# TODO: remove these rubocop exceptions when implementation uncomments spec lines, but keep the one above
-# rubocop:disable Layout/CommentIndentation
-# rubocop:disable Layout/IndentationConsistency
 RSpec.describe 'MODS originInfo <--> cocina mappings LOGIC' do
   describe 'Multiple date types, no event type' do
-    let(:my_roundtrip_mods) do
-      <<~XML
-        <originInfo eventType="publication">
-          <dateIssued>1930</dateIssued>
-        </originInfo>
-        <originInfo eventType="copyright">
-          <copyrightDate>1929</copyrightDate>
-        </originInfo>
-      XML
-    end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            date: [
-              {
-                value: '1930'
-              }
-            ]
-          },
-          {
-            type: 'copyright',
-            date: [
-              {
-                value: '1929'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
@@ -51,51 +13,44 @@ RSpec.describe 'MODS originInfo <--> cocina mappings LOGIC' do
           </originInfo>
         XML
       end
-      let(:roundtrip_mods) { my_roundtrip_mods }
-      let(:cocina) { my_cocina }
-    end
 
-    it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_roundtrip_mods }
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="publication">
+            <dateIssued>1930</dateIssued>
+          </originInfo>
+          <originInfo eventType="copyright">
+            <copyrightDate>1929</copyrightDate>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              date: [
+                {
+                  value: '1930'
+                }
+              ]
+            },
+            {
+              type: 'copyright',
+              date: [
+                {
+                  value: '1929'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'Multiple date types, matching event type' do
-    let(:my_roundtrip_mods) do
-      <<~XML
-        <originInfo eventType="publication">
-          <dateIssued>1930</dateIssued>
-        </originInfo>
-        <originInfo eventType="copyright">
-          <copyrightDate>1929</copyrightDate>
-        </originInfo>
-      XML
-    end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            date: [
-              {
-                value: '1930'
-              }
-            ]
-          },
-          {
-            type: 'copyright',
-            date: [
-              {
-                value: '1929'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
@@ -105,147 +60,99 @@ RSpec.describe 'MODS originInfo <--> cocina mappings LOGIC' do
           </originInfo>
         XML
       end
-      let(:roundtrip_mods) { my_roundtrip_mods }
-      let(:cocina) { my_cocina }
-    end
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="publication">
+            <dateIssued>1930</dateIssued>
+          </originInfo>
+          <originInfo eventType="copyright">
+            <copyrightDate>1929</copyrightDate>
+          </originInfo>
+        XML
+      end
 
-    it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_roundtrip_mods }
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              date: [
+                {
+                  value: '1930'
+                }
+              ]
+            },
+            {
+              type: 'copyright',
+              date: [
+                {
+                  value: '1929'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'Single date type, nonmatching event type' do
-    xit 'to be implemented'
+    xit 'to be implemented: single date type, nonmatching event type' do
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="publication">
+            <copyrightDate>1929</copyrightDate>
+          </originInfo>
+        XML
+      end
 
-    let(:my_mods) do
-      <<~XML
-        <originInfo eventType="publication">
-          <copyrightDate>1929</copyrightDate>
-        </originInfo>
-      XML
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              date: [
+                {
+                  value: '1929',
+                  type: 'copyright'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            date: [
-              {
-                value: '1929',
-                type: 'copyright'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    # it_behaves_like 'MODS cocina mapping' do
-      let(:mods) { my_mods }
-      let(:cocina) { my_cocina }
-    # end
-
-    # it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_mods }
-    # end
   end
 
   describe 'Single dateOther, nonmatching event type' do
-    xit 'to be implemented'
+    xit 'to be implemented: single dateOther, nonmatching event type' do
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="production">
+            <dateOther type="development">1930</dateOther>
+          </originInfo>
+        XML
+      end
 
-    let(:my_mods) do
-      <<~XML
-        <originInfo eventType="production">
-          <dateOther type="development">1930</dateOther>
-        </originInfo>
-      XML
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'production',
+              date: [
+                {
+                  value: '1930',
+                  type: 'development'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'production',
-            date: [
-              {
-                value: '1930',
-                type: 'development'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    # it_behaves_like 'MODS cocina mapping' do
-      let(:mods) { my_mods }
-      let(:cocina) { my_cocina }
-    # end
-
-    # it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_mods }
-    # end
   end
 
   describe 'No date, no event type, publication subelements' do
-    let(:my_roundtrip_mods) do
-      <<~XML
-        <originInfo eventType="publication">
-          <publisher>Virago</publisher>
-          <edition>1st edition</edition>
-          <place>
-            <placeTerm type="text">London</placeTerm>
-          </place>
-        </originInfo>
-      XML
-    end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            contributor: [
-              {
-                name: [
-                  {
-                    value: 'Virago'
-                  }
-                ],
-                type: 'organization',
-                role: [
-                  {
-                    value: 'publisher',
-                    code: 'pbl',
-                    uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                    source: {
-                      code: 'marcrelator',
-                      uri: 'http://id.loc.gov/vocabulary/relators/'
-                    }
-                  }
-                ]
-              }
-            ],
-            location: [
-              {
-                value: 'London'
-              }
-            ],
-            note: [
-              {
-                value: '1st edition',
-                type: 'edition'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
@@ -258,43 +165,65 @@ RSpec.describe 'MODS originInfo <--> cocina mappings LOGIC' do
           </originInfo>
         XML
       end
-      let(:roundtrip_mods) { my_roundtrip_mods }
-      let(:cocina) { my_cocina }
-    end
 
-    it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_roundtrip_mods }
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="publication">
+            <publisher>Virago</publisher>
+            <edition>1st edition</edition>
+            <place>
+              <placeTerm type="text">London</placeTerm>
+            </place>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Virago'
+                    }
+                  ],
+                  type: 'organization',
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    }
+                  ]
+                }
+              ],
+              location: [
+                {
+                  value: 'London'
+                }
+              ],
+              note: [
+                {
+                  value: '1st edition',
+                  type: 'edition'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'dateCreated, no event type' do
-    xit 'to be implemented'
-
-    let(:my_roundtrip_mods) do
-      <<~XML
-        <originInfo eventType="creation">
-          <dateCreated>1930</dateCreated>
-        </originInfo>
-      XML
-    end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'creation',
-            date: [
-              {
-                value: '1930'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    # it_behaves_like 'MODS cocina mapping' do
+    xit 'to be implemented: dateCreated, no event type' do
       let(:mods) do
         <<~XML
           <originInfo>
@@ -302,43 +231,34 @@ RSpec.describe 'MODS originInfo <--> cocina mappings LOGIC' do
           </originInfo>
         XML
       end
-      let(:roundtrip_mods) { my_roundtrip_mods }
-      let(:cocina) { my_cocina }
-    # end
 
-    # it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_roundtrip_mods }
-    # end
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="creation">
+            <dateCreated>1930</dateCreated>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  value: '1930'
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
   end
 
   describe 'dateOther with type, no event type' do
-    xit 'to be implemented: MODS cocina mapping'
-
-    let(:my_roundtrip_mods) do
-      <<~XML
-        <originInfo eventType="acquisition">
-          <dateOther>1930</dateOther>
-        </originInfo>
-      XML
-    end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'acquisition',
-            date: [
-              {
-                value: '1930'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    # it_behaves_like 'MODS cocina mapping' do
+    xit 'to be implemented: MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <originInfo>
@@ -347,106 +267,62 @@ RSpec.describe 'MODS originInfo <--> cocina mappings LOGIC' do
         XML
       end
 
-      let(:roundtrip_mods) { my_roundtrip_mods }
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="acquisition">
+            <dateOther>1930</dateOther>
+          </originInfo>
+        XML
+      end
 
-      let(:cocina) { my_cocina }
-    # end
-
-    it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_roundtrip_mods }
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'acquisition',
+              date: [
+                {
+                  value: '1930'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'Only place subelement, no event type' do
-    xit 'to be implemented'
+    xit 'to be implemented: place subelement no event type' do
+      let(:mods) do
+        <<~XML
+          <originInfo>
+            <place>
+              <placeTerm type="text">San Francisco, Calif.</placeTerm>
+            </place>
+          </originInfo>
+        XML
+      end
 
-    let(:my_mods) do
-      <<~XML
-        <originInfo>
-          <place>
-            <placeTerm type="text">San Francisco, Calif.</placeTerm>
-          </place>
-        </originInfo>
-      XML
-    end
+      let(:cocina) do
+        {
+          event: [
+            {
+              location: [
+                {
+                  value: 'San Francisco, Calif.'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            location: [
-              {
-                value: 'San Francisco, Calif.'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    # it_behaves_like 'MODS cocina mapping' do
-      let(:mods) { my_mods }
-      let(:cocina) { my_cocina }
       let(:warnings) { [Notification.new(msg: 'Undetermined event type')] }
-    # end
-
-    # it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_mods }
-    # end
+    end
   end
 
   describe 'Multiple date types, additional publication subelements' do
-    let(:my_roundtrip_mods) do
-      <<~XML
-        <originInfo eventType="publication">
-          <dateIssued>1930</dateIssued>
-          <place>
-            <placeTerm type="text">London</placeTerm>
-          </place>
-          <edition>1st edition</edition>
-        </originInfo>
-        <originInfo eventType="copyright">
-          <copyrightDate>1929</copyrightDate>
-        </originInfo>
-      XML
-    end
-
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'publication',
-            date: [
-              {
-                value: '1930'
-              }
-            ],
-            location: [
-              {
-                value: 'London'
-              }
-            ],
-            note: [
-              {
-                value: '1st edition',
-                type: 'edition'
-              }
-            ]
-          },
-          {
-            type: 'copyright',
-            date: [
-              {
-                value: '1929'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
@@ -461,92 +337,111 @@ RSpec.describe 'MODS originInfo <--> cocina mappings LOGIC' do
         XML
       end
 
-      let(:roundtrip_mods) { my_roundtrip_mods }
-      let(:cocina) { my_cocina }
-    end
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo eventType="publication">
+            <dateIssued>1930</dateIssued>
+            <place>
+              <placeTerm type="text">London</placeTerm>
+            </place>
+            <edition>1st edition</edition>
+          </originInfo>
+          <originInfo eventType="copyright">
+            <copyrightDate>1929</copyrightDate>
+          </originInfo>
+        XML
+      end
 
-    it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_roundtrip_mods }
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              date: [
+                {
+                  value: '1930'
+                }
+              ],
+              location: [
+                {
+                  value: 'London'
+                }
+              ],
+              note: [
+                {
+                  value: '1st edition',
+                  type: 'edition'
+                }
+              ]
+            },
+            {
+              type: 'copyright',
+              date: [
+                {
+                  value: '1929'
+                }
+              ]
+            }
+          ]
+        }
+      end
     end
   end
 
   describe 'Unmapped event type' do
-    xit 'to be implemented'
+    xit 'to be implemented: unmapped event type' do
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="deaccession">
+            <dateOther>1930</dateOther>
+          </originInfo>
+        XML
+      end
 
-    let(:my_mods) do
-      <<~XML
-        <originInfo eventType="deaccession">
-          <dateOther>1930</dateOther>
-        </originInfo>
-      XML
-    end
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'deaccession',
+              date: [
+                {
+                  value: '1930'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            type: 'deaccession',
-            date: [
-              {
-                value: '1930'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    # it_behaves_like 'MODS cocina mapping' do
-      let(:mods) { my_mods }
-      let(:cocina) { my_cocina }
       let(:warnings) { [Notification.new(msg: 'Unmapped event type')] }
-    # end
-
-    # it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_mods }
-    # end
+    end
   end
 
   describe 'No event type' do
-    xit 'to be implemented: warning message'
+    xit 'to be implemented: warning message' do
+      let(:mods) do
+        <<~XML
+          <originInfo>
+            <dateOther>1930</dateOther>
+          </originInfo>
+        XML
+      end
 
-    let(:my_mods) do
-      <<~XML
-        <originInfo>
-          <dateOther>1930</dateOther>
-        </originInfo>
-      XML
-    end
+      let(:cocina) do
+        {
+          event: [
+            {
+              date: [
+                {
+                  value: '1930'
+                }
+              ]
+            }
+          ]
+        }
+      end
 
-    let(:my_cocina) do
-      {
-        event: [
-          {
-            date: [
-              {
-                value: '1930'
-              }
-            ]
-          }
-        ]
-      }
-    end
-
-    # it_behaves_like 'MODS cocina mapping' do
-      let(:mods) { my_mods }
-      let(:cocina) { my_cocina }
       let(:warnings) { [Notification.new(msg: 'Undetermined event type')] }
-    # end
-
-    # it_behaves_like 'cocina MODS mapping' do
-      let(:cocina) { my_cocina }
-      let(:mods) { my_mods }
-      let(:warnings) { [Notification.new(msg: 'Undetermined event type')] }
-    # end
+    end
   end
 end
-# rubocop:enable RSpec/OverwritingSetup
-# rubocop:enable Layout/CommentIndentation
-# rubocop:enable Layout/IndentationConsistency

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
@@ -2014,7 +2014,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
     context 'when cocina event is array with empty hash' do
       # NOTE: cocina -> MODS
-      xit 'this is implemented in PR #2209' do
+      it_behaves_like 'cocina MODS mapping' do
         let(:cocina) do
           {
             event: [{}]

--- a/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
     end
   end
 
-  context 'when normalizing originInfo dates' do
+  context 'when normalizing originInfo date values' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML
         <mods #{MODS_ATTRIBUTES}>
@@ -668,6 +668,184 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
         expect(normalized_ng_xml).to be_equivalent_to <<~XML
           <mods #{MODS_ATTRIBUTES}>
             <originInfo eventType="publication"/>
+          </mods>
+        XML
+      end
+    end
+  end
+
+  describe 'empty originInfo date elements' do
+    context 'when dateCreated' do
+      # based on jw174hd9042, vy673zb2925
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateCreated></dateCreated>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'removes the empty child' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when dateIssued' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateIssued/>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'removes the empty child' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when dateIssued with encoding and type' do
+      # based on vj932ns8042
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateIssued encoding="w3cdtf" keyDate="yes"/>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'removes the empty child' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when dateCaptured' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateCaptured/>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'removes the empty child' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when dateValid' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateValid></dateValid>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'removes the empty child' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when dateModified' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateModified></dateModified>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'removes the empty child' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when dateOther with no attibutes' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateOther></dateOther>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      # Temporarily ignoring <originInfo> pending https://github.com/sul-dlss/dor-services-app/issues/2128
+      xit 'removes the element' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when dateOther with @type matching eventType' do
+      # based on xv158sd4671, qx562pf7510
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateOther type="distribution"></dateOther>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      # Temporarily ignoring <originInfo> pending https://github.com/sul-dlss/dor-services-app/issues/2128
+      xit 'removes the element' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when copyrightDate' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <copyrightDate></copyrightDate>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'removes the empty child' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
           </mods>
         XML
       end

--- a/spec/support/mods_mapping_spec_helper.rb
+++ b/spec/support/mods_mapping_spec_helper.rb
@@ -120,7 +120,7 @@ RSpec.shared_examples 'MODS cocina mapping' do
       # the starting MODS is normalized to address discrepancies found against MODS roundtripped to data store (Fedora)
       #  and back, per Arcadia's specifications.  E.g., removal of empty nodes and attributes; addition of eventType to
       #  originInfo nodes.
-      expect(actual_xml).to be_equivalent_to Cocina::ModsNormalizer.normalize(mods_ng_xml: orig_mods_ng, druid: local_druid)
+      expect(actual_xml).to be_equivalent_to Cocina::ModsNormalizer.normalize(mods_ng_xml: orig_mods_ng, druid: local_druid).to_xml
     end
   end
 
@@ -264,7 +264,7 @@ RSpec.shared_examples 'cocina MODS mapping' do
 
     it 'roundtrip cocina Description maps to expected MODS, normalized' do
       # the roundtrip cocina is, effectively, the cocina for the normalized MODS - the MODS is normalized before it gets to cocina
-      normalized_mods_xml = Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_xml, druid: local_druid) if defined?(roundtrip_cocina)
+      normalized_mods_xml = Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_xml, druid: local_druid).to_xml if defined?(roundtrip_cocina)
       expect(roundtrip_mods_xml).to be_equivalent_to normalized_mods_xml if defined?(roundtrip_cocina)
     end
 


### PR DESCRIPTION
## Why was this change made?

Improves cocina event mapping and MODS originInfo normalization by filtering out valueless data (empty date values, empty originInfo elements ...)

## How was this change tested?

### This Branch

```
Status (n=25000):
  Success:   24601 (98.404%)
  Different: 220 (0.88%)
  To Cocina error:     1 (0.004%)
  To Fedora error:     0 (0.0%)
  Missing (no descMetadata):     178 (0.712%)
```

#### roundtrip failures only in this branch
- kf303dc5137 - **roundtrip eventType changes (from production to publication)** and no empty dateOther
- qx562pf7510 - **roundtrip eventType changes (from manufacture to publication)** and no empty dateOther
- xv158sd4671 - **roundtrip eventType changes (from distribution to publication)** and no empty dateOther

#### other significant roundtrip differences between the branches for "Different"
(insignificant:  ordering of elements in mods or cocina)
- by352mp6687, fg349td3577, fv195wh3632, gv022qp2544, jk090bg7477, kq586bq1216, yh127sy5622 -- empty dateCreated no longer mapped/created
- nc238hg8745, yt337yg7382 - **roundtrip eventType  production vs publication**, empty dateCreated no longer mapped/created
- jz402xk5530 - **roundtrip eventType changes (from manufacture to publication)** and no empty dateOther;  **main branch loses displayLabel**, but this branch does not.
- vy980tx4948 
    - **roundtrip eventType changes (from manufacture to publication)** and no empty dateOther
    - **has data errors (Related resource has type and otherType)** (prob same across both branches?)
    - **a bunch of other roundtrip errors** (prob same across both branches?)

^^ all available in `ndushay/dor-services-app/results-new` folder on sdr-deploy.  Not sure for how long ...

### Main Branch

```
Status (n=25000):
  Success:   24604 (98.416%)
  Different: 217 (0.868%)
  To Cocina error:     1 (0.004%)
  To Fedora error:     0 (0.0%)
  Missing (no descMetadata):     178 (0.712%)
```

## Which documentation and/or configurations were updated?



