### PR TITLE
Catch MODS normalizer errors when roundtripping.

### DIFF
--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -128,8 +128,13 @@ def validate_druid(druid, cache, fast: false)
     return :to_cocina_error
   end
 
-  # Changes to support better matching.
-  norm_original_ng_xml = Cocina::ModsNormalizer.normalize(mods_ng_xml: original_ng_xml, druid: druid)
+  begin
+    # Changes to support better matching.
+    norm_original_ng_xml = Cocina::ModsNormalizer.normalize(mods_ng_xml: original_ng_xml, druid: druid)
+  rescue StandardError => e
+    write_error(druid, original_ng_xml, cocina_props, e) unless fast
+    return :mods_normalizer_error
+  end
 
   begin
     roundtrip_ng_xml = round_tripped_ng_xml(cocina, druid)
@@ -174,7 +179,7 @@ end
 results = Parallel.map(druids, progress: 'Testing') do |druid|
   validate_druid(druid, cache, fast: options[:fast])
 end
-counts = { different: 0, success: 0, to_cocina_error: 0, to_fedora_error: 0, missing: 0 }
+counts = { different: 0, success: 0, to_cocina_error: 0, to_fedora_error: 0, missing: 0, mods_normalizer_error: 0 }
 results.each { |result| counts[result] += 1 }
 
 puts "Status (n=#{druids.size}):"
@@ -182,4 +187,5 @@ puts "  Success:   #{counts[:success]} (#{100 * counts[:success].to_f / druids.s
 puts "  Different: #{counts[:different]} (#{100 * counts[:different].to_f / druids.size}%)"
 puts "  To Cocina error:     #{counts[:to_cocina_error]} (#{100 * counts[:to_cocina_error].to_f / druids.size}%)"
 puts "  To Fedora error:     #{counts[:to_fedora_error]} (#{100 * counts[:to_fedora_error].to_f / druids.size}%)"
+puts "  MODS normalizer error:     #{counts[:mods_normalizer_error]} (#{100 * counts[:mods_normalizer_error].to_f / druids.size}%)"
 puts "  Missing (no descMetadata):     #{counts[:missing]} (#{100 * counts[:missing].to_f / druids.size}%)"


### PR DESCRIPTION
## Why was this change made?
A MODS normalizer stops roundtrip testing.


## How was this change tested?
sdr-deploy


## Which documentation and/or configurations were updated?
NA


