### PR TITLE
Changes ModsEquivalentService to consider altRepGroups with same elem…

### DIFF
--- a/app/services/mods_equivalent_service.rb
+++ b/app/services/mods_equivalent_service.rb
@@ -26,7 +26,7 @@ class ModsEquivalentService
   def initialize(mods_ng_xml1, mods_ng_xml2)
     @mods_ng_xml1 = mods_ng_xml1
     @mods_ng_xml2 = mods_ng_xml2
-    # Map of [altRepGroup ids, parent node] from mods_ng_xml1 to mods_ng_xml2
+    # Map of [altRepGroup ids, node_name, parent node] from mods_ng_xml1 to mods_ng_xml2
     # The parent node is necessary because ids are unique for mods/relatedItem not entire document.
     @altrepgroup_ids = {}
     # Map of equivalent nodes with altRepGroup attributes.
@@ -94,7 +94,7 @@ class ModsEquivalentService
     equiv = EquivalentXml.equivalent?(norm_node1, norm_node2)
     if equiv
       if altrepgroup1
-        altrepgroup_ids[[altrepgroup1.value, node1.parent]] = altrepgroup2.value if altrepgroup2
+        altrepgroup_ids[[altrepgroup1.value, node1.name, node1.parent]] = altrepgroup2.value if altrepgroup2
         altrepgroup_nodes[node1] = node2
       end
       if nametitlegroup1
@@ -166,7 +166,7 @@ class ModsEquivalentService
       node1_altrepgroup = node1['altRepGroup']
       node2 = altrepgroup_nodes[node1]
       node2_altrepgroup = node2 ? node2['altRepGroup'] : nil
-      expected_node2_altrepgroup = altrepgroup_ids[[node1_altrepgroup, node1.parent]]
+      expected_node2_altrepgroup = altrepgroup_ids[[node1_altrepgroup, node1.name, node1.parent]]
 
       next nil if expected_node2_altrepgroup && expected_node2_altrepgroup == node2_altrepgroup
 

--- a/spec/services/mods_equivalent_service_spec.rb
+++ b/spec/services/mods_equivalent_service_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe ModsEquivalentService do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <note lang="eng" altRepGroup="1">This is a note.</note>
           <note lang="fre" altRepGroup="1">C'est une note.</note>
+          <titleInfo altRepGroup="1"><title>This is a title</title></titleInfo>
         </mods>
       XML
     end
@@ -153,6 +154,7 @@ RSpec.describe ModsEquivalentService do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <note lang="eng" altRepGroup="2">This is a note.</note>
           <note lang="fre" altRepGroup="2">C'est une note.</note>
+          <titleInfo altRepGroup="3"><title>This is a title</title></titleInfo>
         </mods>
       XML
     end


### PR DESCRIPTION
…ent name.

refs #2216

## Why was this change made?
More equivalence.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


