### PR TITLE
Do not remove geographic subjects with valueURIs.

### DIFF
--- a/app/services/cocina/mods_normalizers/subject_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/subject_normalizer.rb
@@ -253,9 +253,9 @@ module Cocina
       end
 
       def normalize_empty_geographic
-        ng_xml.root.xpath('//mods:subject/mods:geographic[not(text())]', mods: ModsNormalizer::MODS_NS).each do |temporal_node|
-          subject_node = temporal_node.parent
-          temporal_node.remove
+        ng_xml.root.xpath('//mods:subject/mods:geographic[not(@valueURI) and not(text())]', mods: ModsNormalizer::MODS_NS).each do |geo_node|
+          subject_node = geo_node.parent
+          geo_node.remove
           subject_node.remove if subject_node.elements.empty? && subject_node.attributes.empty?
         end
       end

--- a/spec/services/cocina/mods_normalizers/subject_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/subject_normalizer_spec.rb
@@ -714,6 +714,9 @@ RSpec.describe Cocina::ModsNormalizers::SubjectNormalizer do
           <subject>
             <geographic/>
           </subject>
+          <subject>
+            <geographic valueURI="http://sws.geonames.org/5391295"/>
+          </subject>
         </mods>
       XML
     end
@@ -722,6 +725,9 @@ RSpec.describe Cocina::ModsNormalizers::SubjectNormalizer do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
         <mods #{MODS_ATTRIBUTES}>
           <subject authority="geonames" authorityURI="http://sws.geonames.org" valueURI="http://sws.geonames.org/2946447/" />
+          <subject>
+            <geographic valueURI="http://sws.geonames.org/5391295"/>
+          </subject>
         </mods>
       XML
     end


### PR DESCRIPTION
closes #2234

## Why was this change made?
Normalization was a bit too greedy.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


