### PR TITLE
Fix mapping when subject altRepGroups have same types.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -148,7 +148,7 @@ module Cocina
             xml.subject topic_attributes_for(subject_value)
           else
             xml.subject(subject_attributes) do
-              write_topic(subject, subject_value)
+              write_topic(subject, subject_value, type: type)
             end
           end
         end
@@ -181,9 +181,9 @@ module Cocina
           xml.classification value, attrs
         end
 
-        def write_topic(subject, subject_value, is_parallel: false)
+        def write_topic(subject, subject_value, is_parallel: false, type: nil)
           topic_attributes = topic_attributes_for(subject_value, is_parallel: is_parallel)
-          case subject_value.type
+          case type || subject_value.type
           when 'person'
             xml.name topic_attributes.merge(type: 'personal') do
               xml.namePart(subject_value.value) if subject_value.value

--- a/spec/services/cocina/mapping/descriptive/mods/subject_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_spec.rb
@@ -294,4 +294,46 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
       end
     end
   end
+
+  describe 'Parallel subjects' do
+    # Adapted from bc269jd4815
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <subject altRepGroup="1" authority="lcsh">
+            <titleInfo>
+              <title>Chu ci (Ancient Chinese poems)</title>
+            </titleInfo>
+          </subject>
+          <subject altRepGroup="1">
+            <titleInfo>
+              <title>&#x695A;&#x8F9E;(Ancient Chinese poems)</title>
+            </titleInfo>
+          </subject>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          subject: [
+            {
+              parallelValue: [
+                {
+                  source: {
+                    code: 'lcsh'
+                  },
+                  value: 'Chu ci (Ancient Chinese poems)'
+
+                },
+                {
+                  "value": '楚辞(Ancient Chinese poems)'
+                }
+              ],
+              type: 'title'
+            }
+          ]
+        }
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes #2219

## Why was this change made?
Appease the mapping gods.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


