### PR TITLE
Normalizes Hydrus titles.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -9,15 +9,17 @@ module Cocina
 
     # @param [Nokogiri::Document] mods_ng_xml MODS to be normalized
     # @param [String] druid
+    # @param [String] label
     # @return [Nokogiri::Document] normalized MODS
-    def self.normalize(mods_ng_xml:, druid:)
-      ModsNormalizer.new(mods_ng_xml: mods_ng_xml, druid: druid).normalize
+    def self.normalize(mods_ng_xml:, druid:, label:)
+      ModsNormalizer.new(mods_ng_xml: mods_ng_xml, druid: druid, label: label).normalize
     end
 
-    def initialize(mods_ng_xml:, druid:)
+    def initialize(mods_ng_xml:, druid:, label:)
       @ng_xml = mods_ng_xml.dup
       @ng_xml.encoding = 'UTF-8' if @ng_xml.respond_to?(:encoding=) # sometimes it's a String (?)
       @druid = druid
+      @label = label
     end
 
     def normalize
@@ -39,7 +41,7 @@ module Cocina
       normalize_location_physical_location
       normalize_purl
       normalize_empty_notes
-      @ng_xml = ModsNormalizers::TitleNormalizer.normalize(mods_ng_xml: ng_xml)
+      @ng_xml = ModsNormalizers::TitleNormalizer.normalize(mods_ng_xml: ng_xml, label: label)
       @ng_xml = ModsNormalizers::GeoExtensionNormalizer.normalize(mods_ng_xml: ng_xml, druid: druid)
       normalize_empty_type_of_resource # Must be after normalize_empty_attributes
       normalize_abstract_summary
@@ -53,7 +55,7 @@ module Cocina
 
     private
 
-    attr_reader :ng_xml, :druid
+    attr_reader :ng_xml, :druid, :label
 
     def normalize_default_namespace
       xml = ng_xml.to_s

--- a/app/services/cocina/mods_normalizers/title_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/title_normalizer.rb
@@ -5,17 +5,20 @@ module Cocina
     # Normalizes a Fedora MODS document for title elements.
     class TitleNormalizer
       # @param [Nokogiri::Document] mods_ng_xml MODS to be normalized
+      # @param [String] label
       # @return [Nokogiri::Document] normalized MODS
-      def self.normalize(mods_ng_xml:)
-        new(mods_ng_xml: mods_ng_xml).normalize
+      def self.normalize(mods_ng_xml:, label:)
+        new(mods_ng_xml: mods_ng_xml, label: label).normalize
       end
 
-      def initialize(mods_ng_xml:)
+      def initialize(mods_ng_xml:, label:)
         @ng_xml = mods_ng_xml.dup
         @ng_xml.encoding = 'UTF-8'
+        @label = label
       end
 
       def normalize
+        normalize_hydrus_title
         normalize_empty_titles
         normalize_title_type
         normalize_title_trailing
@@ -24,7 +27,18 @@ module Cocina
 
       private
 
-      attr_reader :ng_xml
+      attr_reader :ng_xml, :label
+
+      def normalize_hydrus_title
+        titles = ng_xml.root.xpath('mods:titleInfo/mods:title[string-length() > 0]', mods: ModsNormalizer::MODS_NS)
+        return if titles.present? || label != 'Hydrus'
+
+        new_title_info = Nokogiri::XML::Node.new('titleInfo', Nokogiri::XML(nil))
+        new_title = Nokogiri::XML::Node.new('title', Nokogiri::XML(nil))
+        new_title.content = 'Hydrus'
+        new_title_info << new_title
+        ng_xml.root << new_title_info
+      end
 
       def normalize_empty_titles
         ng_xml.root.xpath('//mods:title[not(text())]', mods: ModsNormalizer::MODS_NS).each(&:remove)

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -130,7 +130,7 @@ def validate_druid(druid, cache, fast: false)
 
   begin
     # Changes to support better matching.
-    norm_original_ng_xml = Cocina::ModsNormalizer.normalize(mods_ng_xml: original_ng_xml, druid: druid)
+    norm_original_ng_xml = Cocina::ModsNormalizer.normalize(mods_ng_xml: original_ng_xml, druid: druid, label: label)
   rescue StandardError => e
     write_error(druid, original_ng_xml, cocina_props, e) unless fast
     return :mods_normalizer_error

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::ModsNormalizer do
-  let(:normalized_ng_xml) { described_class.normalize(mods_ng_xml: mods_ng_xml, druid: nil) }
+  let(:normalized_ng_xml) { described_class.normalize(mods_ng_xml: mods_ng_xml, druid: nil, label: nil) }
 
   context 'when normalizing version' do
     context 'when version in recordInfo' do

--- a/spec/services/cocina/mods_normalizers/geo_extension_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/geo_extension_normalizer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::ModsNormalizers::GeoExtensionNormalizer do
-  let(:normalized_ng_xml) { Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_ng_xml, druid: 'druid:pf694bk4862').to_xml }
+  let(:normalized_ng_xml) { Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_ng_xml, druid: 'druid:pf694bk4862', label: nil).to_xml }
 
   context 'when normalizing geo PURL' do
     let(:mods_ng_xml) do

--- a/spec/services/cocina/mods_normalizers/name_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/name_normalizer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::ModsNormalizers::NameNormalizer do
-  let(:normalized_ng_xml) { Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_ng_xml, druid: nil).to_xml }
+  let(:normalized_ng_xml) { Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_ng_xml, druid: nil, label: nil).to_xml }
 
   context 'when the role term has no type' do
     let(:mods_ng_xml) do

--- a/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
-  let(:normalized_ng_xml) { Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_ng_xml, druid: nil).to_xml }
+  let(:normalized_ng_xml) { Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_ng_xml, druid: nil, label: nil).to_xml }
 
   context 'when normalizing originInfo eventTypes' do
     context 'when event type assigning date element present' do

--- a/spec/services/cocina/mods_normalizers/subject_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/subject_normalizer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::ModsNormalizers::SubjectNormalizer do
-  let(:normalized_ng_xml) { Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_ng_xml, druid: nil).to_xml }
+  let(:normalized_ng_xml) { Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_ng_xml, druid: nil, label: nil).to_xml }
 
   context 'when normalizing topic' do
     let(:mods_ng_xml) do

--- a/spec/services/cocina/mods_normalizers/title_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/title_normalizer_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::ModsNormalizers::TitleNormalizer do
-  let(:normalized_ng_xml) { Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_ng_xml, druid: nil).to_xml }
+  let(:normalized_ng_xml) { Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_ng_xml, druid: nil, label: label).to_xml }
+
+  let(:label) { nil }
 
   context 'when normalizing empty title' do
     let(:mods_ng_xml) do
@@ -20,6 +22,30 @@ RSpec.describe Cocina::ModsNormalizers::TitleNormalizer do
     it 'removes titleInfo' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
         <mods #{MODS_ATTRIBUTES}>
+        </mods>
+      XML
+    end
+  end
+
+  context 'when normalizing Hydrus title' do
+    let(:label) { 'Hydrus' }
+
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{MODS_ATTRIBUTES}>
+          <titleInfo>
+            <title />
+          </titleInfo>
+        </mods>
+      XML
+    end
+
+    it 'adds Hydrus titleInfo' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{MODS_ATTRIBUTES}>
+          <titleInfo>
+            <title>Hydrus</title>
+          </titleInfo>
         </mods>
       XML
     end

--- a/spec/support/mods_mapping_spec_helper.rb
+++ b/spec/support/mods_mapping_spec_helper.rb
@@ -33,7 +33,7 @@ end
 # When starting from MODS.
 RSpec.shared_examples 'MODS cocina mapping' do
   # Required: mods, cocina
-  # Optional: druid, roundtrip_mods, warnings, errors, mods_attributes, skip_normalization
+  # Optional: druid, roundtrip_mods, warnings, errors, mods_attributes, skip_normalization, label
 
   # Note that this instantiation of Description does NOT validate against OpenAPI due to title validation issues.
   let(:orig_cocina_description) { Cocina::Models::Description.new(cocina, false, false) }
@@ -51,6 +51,8 @@ RSpec.shared_examples 'MODS cocina mapping' do
   let(:local_errors) { defined?(errors) ? errors : [] }
 
   let(:skip_normalization) { false }
+
+  let(:label) { nil }
 
   context 'when mapping from MODS (to cocina)' do
     let(:notifier) { instance_double(Cocina::FromFedora::DataErrorNotifier) }
@@ -122,7 +124,7 @@ RSpec.shared_examples 'MODS cocina mapping' do
       # the starting MODS is normalized to address discrepancies found against MODS roundtripped to data store (Fedora)
       #  and back, per Arcadia's specifications.  E.g., removal of empty nodes and attributes; addition of eventType to
       #  originInfo nodes.
-      expect(actual_xml).to be_equivalent_to Cocina::ModsNormalizer.normalize(mods_ng_xml: orig_mods_ng, druid: local_druid).to_xml unless skip_normalization
+      expect(actual_xml).to be_equivalent_to Cocina::ModsNormalizer.normalize(mods_ng_xml: orig_mods_ng, druid: local_druid, label: label).to_xml unless skip_normalization
     end
   end
 
@@ -154,7 +156,7 @@ RSpec.shared_examples 'MODS cocina mapping' do
       # the starting MODS is normalized to address discrepancies found against MODS roundtripped to data store (Fedora)
       #  and back, per Arcadia's specifications.  E.g., removal of empty nodes and attributes; addition of eventType to
       #  originInfo nodes.
-      normalized_rt_mods_xml = Cocina::ModsNormalizer.normalize(mods_ng_xml: roundtrip_mods_xml, druid: local_druid).to_xml if defined?(roundtrip_mods)
+      normalized_rt_mods_xml = Cocina::ModsNormalizer.normalize(mods_ng_xml: roundtrip_mods_xml, druid: local_druid, label: label).to_xml if defined?(roundtrip_mods)
       expect(re_roundtrip_mods_xml).to be_equivalent_to normalized_rt_mods_xml if defined?(roundtrip_mods)
     end
   end
@@ -163,7 +165,7 @@ end
 # When starting from cocina, e.g., H2.
 RSpec.shared_examples 'cocina MODS mapping' do
   # Required: mods, cocina
-  # Optional: druid, roundtrip_cocina, warnings, errors, mods_attributes
+  # Optional: druid, roundtrip_cocina, warnings, errors, mods_attributes, label
 
   # Note that this instantiation of Description does NOT validate against OpenAPI due to title validation issues.
   let(:orig_cocina_description) { Cocina::Models::Description.new(cocina, false, false) }
@@ -179,6 +181,8 @@ RSpec.shared_examples 'cocina MODS mapping' do
   let(:local_warnings) { defined?(warnings) ? warnings : [] }
 
   let(:local_errors) { defined?(errors) ? errors : [] }
+
+  let(:label) { nil }
 
   context 'when mapping from cocina (to MODS)' do
     let(:actual_mods_ng) { Cocina::ToFedora::Descriptive.transform(orig_cocina_description, local_druid).doc }
@@ -266,7 +270,7 @@ RSpec.shared_examples 'cocina MODS mapping' do
 
     it 'roundtrip cocina Description maps to expected MODS, normalized' do
       # the roundtrip cocina is, effectively, the cocina for the normalized MODS - the MODS is normalized before it gets to cocina
-      normalized_mods_xml = Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_xml, druid: local_druid).to_xml if defined?(roundtrip_cocina)
+      normalized_mods_xml = Cocina::ModsNormalizer.normalize(mods_ng_xml: mods_xml, druid: local_druid, label: label).to_xml if defined?(roundtrip_cocina)
       expect(roundtrip_mods_xml).to be_equivalent_to normalized_mods_xml if defined?(roundtrip_cocina)
     end
 


### PR DESCRIPTION
closes #2268

## Why was this change made?
Because Hydrus is "special".


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


