### PR TITLE
Normalize empty physicalLocation.

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -242,6 +242,8 @@ module Cocina
     def normalize_location_physical_location
       ng_xml.root.xpath('//mods:location', mods: MODS_NS).each do |location_node|
         location_node.xpath('mods:physicalLocation|mods:url|mods:shelfLocator', mods: MODS_NS).each do |node|
+          next unless node.content.present? || node['xlink:href']
+
           new_location = Nokogiri::XML::Node.new('location', ng_xml)
           new_location << node
           location_node.parent << new_location

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -846,4 +846,23 @@ RSpec.describe Cocina::ModsNormalizer do
       XML
     end
   end
+
+  context 'when normalizing empty physicalLocation' do
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{MODS_ATTRIBUTES}>
+          <location>
+            <physicalLocation type="location"/>
+          </location>          
+        </mods>
+      XML
+    end
+
+    it 'removes' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{MODS_ATTRIBUTES}>
+        </mods>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
closes #2273

## Why was this change made?
Remove emptiness.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


