### PR TITLE
Do not map empty relatedItem.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/from_fedora/descriptive/related_resource.rb
@@ -37,21 +37,29 @@ module Cocina
             next { valueAt: related_item['xlink:href'] } if related_item['xlink:href']
             next nil if related_item.elements.empty?
 
-            descriptive_builder.build(resource_element: related_item, require_title: false).tap do |item|
-              item[:displayLabel] = related_item['displayLabel']
-              notes = build_notes(related_item)
-              if related_item['type']
-                item[:type] = normalized_type_for(related_item['type'])
-              elsif related_item['otherType']
-                item[:type] = 'related to'
-                notes <<
-                  { type: 'other relation type', value: related_item['otherType'] }.tap do |note|
-                    note[:uri] = related_item['otherTypeURI'] if related_item['otherTypeURI']
-                    note[:source] = { value: related_item['otherTypeAuth'] } if related_item['otherTypeAuth']
-                  end
-              end
-              item[:note] = notes unless notes.empty?
-            end.compact.presence
+            related_item = build_related_item(related_item)
+            # Skip if type only.
+            next nil if related_item.keys == [:type]
+
+            related_item.presence
+          end.compact
+        end
+
+        def build_related_item(related_item)
+          descriptive_builder.build(resource_element: related_item, require_title: false).tap do |item|
+            item[:displayLabel] = related_item['displayLabel']
+            notes = build_notes(related_item)
+            if related_item['type']
+              item[:type] = normalized_type_for(related_item['type'])
+            elsif related_item['otherType']
+              item[:type] = 'related to'
+              notes <<
+                { type: 'other relation type', value: related_item['otherType'] }.tap do |note|
+                  note[:uri] = related_item['otherTypeURI'] if related_item['otherTypeURI']
+                  note[:source] = { value: related_item['otherTypeAuth'] } if related_item['otherTypeAuth']
+                end
+            end
+            item[:note] = notes unless notes.empty?
           end.compact
         end
 

--- a/spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb
@@ -536,7 +536,7 @@ RSpec.describe 'MODS relatedItem <--> cocina mappings' do
     end
   end
 
-  describe 'Empty related item' do
+  describe 'Empty related item - A' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
@@ -563,7 +563,7 @@ RSpec.describe 'MODS relatedItem <--> cocina mappings' do
     end
   end
 
-  describe 'Another empty related item' do
+  describe 'Empty related item - B' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
@@ -574,6 +574,30 @@ RSpec.describe 'MODS relatedItem <--> cocina mappings' do
       let(:cocina) { {} }
 
       let(:roundtrip_mods) { '' }
+    end
+  end
+
+  describe 'Empty related item - C' do
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <relatedItem type="constituent">
+            <titleInfo>
+              <title/>
+            </titleInfo>
+          </relatedItem>
+        XML
+      end
+
+      let(:cocina) { {} }
+
+      let(:roundtrip_mods) { '' }
+
+      let(:warnings) do
+        [
+          Notification.new(msg: 'Empty title node')
+        ]
+      end
     end
   end
 

--- a/spec/services/cocina/mods_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizer_spec.rb
@@ -699,6 +699,11 @@ RSpec.describe Cocina::ModsNormalizer do
       Nokogiri::XML <<~XML
         <mods #{MODS_ATTRIBUTES}>
           <relatedItem />
+          <relatedItem type="constituent">
+            <titleInfo>
+              <title/>
+            </titleInfo>
+          </relatedItem>
         </mods>
       XML
     end


### PR DESCRIPTION
closes #2274

## Why was this change made?
Who would've thought relatedItem could be empty in so many ways?


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


