### PR TITLE
mods normalization has encoding set to UTF-8

### DIFF
--- a/app/services/cocina/mods_normalizer.rb
+++ b/app/services/cocina/mods_normalizer.rb
@@ -16,6 +16,7 @@ module Cocina
 
     def initialize(mods_ng_xml:, druid:)
       @ng_xml = mods_ng_xml.dup
+      @ng_xml.encoding = 'UTF-8' if @ng_xml.respond_to?(:encoding=) # sometimes it's a String (?)
       @druid = druid
     end
 

--- a/app/services/cocina/mods_normalizers/geo_extension_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/geo_extension_normalizer.rb
@@ -13,6 +13,7 @@ module Cocina
 
       def initialize(mods_ng_xml:, druid:)
         @ng_xml = mods_ng_xml.dup
+        @ng_xml.encoding = 'UTF-8'
         @druid = druid
       end
 

--- a/app/services/cocina/mods_normalizers/name_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/name_normalizer.rb
@@ -12,6 +12,7 @@ module Cocina
 
       def initialize(mods_ng_xml:)
         @ng_xml = mods_ng_xml.dup
+        @ng_xml.encoding = 'UTF-8'
       end
 
       def normalize

--- a/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
@@ -15,6 +15,7 @@ module Cocina
 
       def initialize(mods_ng_xml:)
         @ng_xml = mods_ng_xml.dup
+        @ng_xml.encoding = 'UTF-8'
       end
 
       def normalize

--- a/app/services/cocina/mods_normalizers/subject_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/subject_normalizer.rb
@@ -12,6 +12,7 @@ module Cocina
 
       def initialize(mods_ng_xml:)
         @ng_xml = mods_ng_xml.dup
+        @ng_xml.encoding = 'UTF-8'
       end
 
       def normalize

--- a/app/services/cocina/mods_normalizers/title_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/title_normalizer.rb
@@ -12,6 +12,7 @@ module Cocina
 
       def initialize(mods_ng_xml:)
         @ng_xml = mods_ng_xml.dup
+        @ng_xml.encoding = 'UTF-8'
       end
 
       def normalize


### PR DESCRIPTION
## Why was this change made?

It helps with spec writing to see actual characters instead of `&Ex58A6;` -- our eyes don't do those sorts of comparisons well.

## How was this change tested?

roundtrip test stats comparison

### Before (main)

```
Status (n=10000):
  Success:   9890 (98.9%)
  Different: 41 (0.41%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     69 (0.69%)
```

### After (this branch)

```
Status (n=10000):
  Success:   9890 (98.9%)
  Different: 41 (0.41%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     69 (0.69%)
```

## Which documentation and/or configurations were updated?



