### PR TITLE
mods normalization: split originInfo when dateIssued and dateCreated

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -134,7 +134,7 @@ module Cocina
 
             events = [{}] if events.empty?
             display_label = origin_info[:displayLabel].presence
-            events.first[:displayLabel] = display_label if display_label
+            events.each { |evnt| evnt[:displayLabel] = display_label } if display_label
 
             events.reject(&:blank?)
           end

--- a/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
@@ -160,6 +160,7 @@ module Cocina
           # Move to own originInfo
           new_origin_info = Nokogiri::XML::Node.new('originInfo', Nokogiri::XML(nil))
           new_origin_info[:eventType] = 'development'
+          new_origin_info[:displayLabel] = date_other.parent['displayLabel'] if date_other.parent['displayLabel']
           new_origin_info << date_other.dup
           date_other.parent.parent << new_origin_info
           date_other.remove

--- a/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
@@ -58,6 +58,7 @@ module Cocina
 
       def normalize_origin_info_split
         # Split a single originInfo into multiple.
+        split_origin_info('dateIssued', 'dateCreated', 'production')
         split_origin_info('dateIssued', 'copyrightDate', 'copyright')
         split_origin_info('dateIssued', 'dateCaptured', 'capture')
         split_origin_info('dateIssued', 'dateValid', 'validity')

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -1044,7 +1044,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
             </place>
             <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
           </originInfo>
-          <originInfo eventType="development">
+          <originInfo displayLabel="Place of Creation" eventType="development">
             <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
           </originInfo>
         XML
@@ -1078,6 +1078,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
             },
             {
               type: 'development',
+              displayLabel: 'Place of Creation',
               date: [
                 {
                   value: '2003-12-01',

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
@@ -2124,9 +2124,6 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
     context 'when dateCreated as point with 2 elements in same originInfo as dateIssued, dateIssued splits' do
       # based on nn349sf6895, rx731vv3403
       it_behaves_like 'MODS cocina mapping' do
-        xit 'to be implemented: plain MODS maps to cocina publication event without displayLabel; normalized mods maps to cocina publication event with displayLabel'
-        let(:skip_normalization) { true }
-
         let(:mods) do
           <<~XML
             <originInfo displayLabel="Place of creation" eventType="publication">
@@ -2140,7 +2137,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         # split into separate originInfo
         let(:roundtrip_mods) do
           <<~XML
-            <originInfo eventType="publication">
+            <originInfo displayLabel="Place of creation" eventType="publication">
               <dateIssued>1887</dateIssued>
             </originInfo>
             <originInfo displayLabel="Place of creation" eventType="production">
@@ -2181,7 +2178,8 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                   {
                     value: '1887'
                   }
-                ]
+                ],
+                displayLabel: 'Place of creation'
               }
             ]
           }
@@ -2308,7 +2306,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
             <originInfo displayLabel="something" eventType="production">
               <dateCreated keyDate="yes" encoding="w3cdtf">1905</dateCreated>
             </originInfo>
-            <originInfo eventType="production">
+            <originInfo displayLabel="something" eventType="production">
               <dateCreated qualifier="approximate" point="end">1925</dateCreated>
             </originInfo>
           XML
@@ -2338,7 +2336,8 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                     type: 'end',
                     value: '1925'
                   }
-                ]
+                ],
+                displayLabel: 'something'
               }
             ]
           }
@@ -2706,7 +2705,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
               <copyrightDate keyDate="yes" encoding="w3cdtf" qualifier="approximate" point="start">1970</copyrightDate>
               <copyrightDate encoding="w3cdtf" qualifier="approximate" point="end">1974</copyrightDate>
             </originInfo>
-            <originInfo eventType="publication">
+            <originInfo displayLabel="Place of creation" eventType="publication">
               <place>
                 <placeTerm type="text">San Francisco (Calif.)</placeTerm>
               </place>
@@ -2746,7 +2745,8 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                   {
                     value: 'San Francisco (Calif.)'
                   }
-                ]
+                ],
+                displayLabel: 'Place of creation'
               }
             ]
           }
@@ -2779,7 +2779,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
               <copyrightDate keyDate="yes" encoding="w3cdtf" qualifier="approximate" point="start">1970</copyrightDate>
               <copyrightDate encoding="w3cdtf" qualifier="approximate" point="end">1974</copyrightDate>
             </originInfo>
-            <originInfo eventType="publication">
+            <originInfo displayLabel="Place of creation" eventType="publication">
               <place>
                 <placeTerm type="text">San Francisco (Calif.)</placeTerm>
               </place>
@@ -2819,7 +2819,8 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                   {
                     value: 'San Francisco (Calif.)'
                   }
-                ]
+                ],
+                displayLabel: 'Place of creation'
               }
             ]
           }

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
@@ -2052,9 +2052,6 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
     context 'when dateCreated and dateIssued in eventType publication it splits' do
       # based on kq506ht3416
       it_behaves_like 'MODS cocina mapping' do
-        xit 'to be implemented: originInfo normalization needs to split up originInfo'
-        let(:skip_normalization) { true }
-
         let(:mods) do
           <<~XML
             <originInfo eventType="publication">
@@ -2127,7 +2124,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
     context 'when dateCreated as point with 2 elements in same originInfo as dateIssued, dateIssued splits' do
       # based on nn349sf6895, rx731vv3403
       it_behaves_like 'MODS cocina mapping' do
-        xit 'to be implemented: originInfo normalization needs to split up originInfo'
+        xit 'to be implemented: plain MODS maps to cocina publication event without displayLabel; normalized mods maps to cocina publication event with displayLabel'
         let(:skip_normalization) { true }
 
         let(:mods) do

--- a/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
@@ -922,7 +922,7 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
       XML
     end
 
-    xit 'moves dateCreated into its own originInfo' do
+    it 'moves dateCreated into its own originInfo' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
         <mods #{MODS_ATTRIBUTES}>
           <originInfo eventType="publication">
@@ -951,10 +951,10 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
       XML
     end
 
-    xit 'splits dateCreated and dateIssued into separate originInfo elements' do
+    it 'splits dateCreated and dateIssued into separate originInfo elements and has displayLabel on both' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
         <mods #{MODS_ATTRIBUTES}>
-          <originInfo eventType="publication">
+          <originInfo displayLabel="Place of creation" eventType="publication">
             <dateIssued>1887</dateIssued>
           </originInfo>
           <originInfo displayLabel="Place of creation" eventType="production">
@@ -985,7 +985,7 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
       XML
     end
 
-    xit 'moves dateCreated into its own originInfo' do
+    xit 'moves dateCreated into its own originInfo and removes exact duplicates' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
         <mods #{MODS_ATTRIBUTES}>
           <originInfo eventType="production">

--- a/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
               </place>
               <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
             </originInfo>
-            <originInfo eventType="development">
+            <originInfo displayLabel="Place of Creation" eventType="development">
               <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
             </originInfo>
           </mods>
@@ -307,7 +307,7 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
             <originInfo displayLabel="Place of Creation" eventType="production">
               <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
             </originInfo>
-            <originInfo eventType="development">
+            <originInfo displayLabel="Place of Creation" eventType="development">
               <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
             </originInfo>
           </mods>


### PR DESCRIPTION
## Why was this change made?

To improve our roundtripping 

short version:   un-xits some mapping and normalization specs

longer version: 
- when mods mapping splits originInfo into multiple events due to date processing, the displayLabel needs to be on each of split events (per Arcadia via slack)
- mods normalization needs to split mods originInfo elements with both dateCreated and dateIssued, just like the mapping code does
- mods normalization needs to include the displayLabel on both originInfo when split due to eventType developed and dateOther


## How was this change tested?

### Before (main)

```
Status (n=25000):
  Success:   24712 (98.848%)
  Different: 108 (0.432%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     180 (0.72%)

```

### After (this branch)

```
Status (n=25000):
  Success:   24721 (98.884%)
  Different: 99 (0.396%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     180 (0.72%)
```

^^ even better after rebasing this branch ... (oops)

## Which documentation and/or configurations were updated?



