### PR TITLE
don't count objects without descMetadata in roundtrip stats

### DIFF
--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -182,10 +182,12 @@ end
 counts = { different: 0, success: 0, to_cocina_error: 0, to_fedora_error: 0, missing: 0, mods_normalizer_error: 0 }
 results.each { |result| counts[result] += 1 }
 
-puts "Status (n=#{druids.size}):"
-puts "  Success:   #{counts[:success]} (#{100 * counts[:success].to_f / druids.size}%)"
-puts "  Different: #{counts[:different]} (#{100 * counts[:different].to_f / druids.size}%)"
-puts "  To Cocina error:     #{counts[:to_cocina_error]} (#{100 * counts[:to_cocina_error].to_f / druids.size}%)"
-puts "  To Fedora error:     #{counts[:to_fedora_error]} (#{100 * counts[:to_fedora_error].to_f / druids.size}%)"
-puts "  MODS normalizer error:     #{counts[:mods_normalizer_error]} (#{100 * counts[:mods_normalizer_error].to_f / druids.size}%)"
+denom = druids.size - counts[:missing]
+
+puts "Status (n=#{druids.size}; not using Missing for success/different/error stats):"
+puts "  Success:   #{counts[:success]} (#{100 * counts[:success].to_f / denom}%)"
+puts "  Different: #{counts[:different]} (#{100 * counts[:different].to_f / denom}%)"
+puts "  To Cocina error:     #{counts[:to_cocina_error]} (#{100 * counts[:to_cocina_error].to_f / denom}%)"
+puts "  To Fedora error:     #{counts[:to_fedora_error]} (#{100 * counts[:to_fedora_error].to_f / denom}%)"
+puts "  MODS normalizer error:     #{counts[:mods_normalizer_error]} (#{100 * counts[:mods_normalizer_error].to_f / denom}%)"
 puts "  Missing (no descMetadata):     #{counts[:missing]} (#{100 * counts[:missing].to_f / druids.size}%)"


### PR DESCRIPTION
## Why was this change made?

Because the stats were misleading - we were never going to get to 100% roundtrip success if we included objects with no descriptiveMetadata in the stats.

## How was this change tested?

### Before (main branch)

```
Status (n=25000):
  Success:   24712 (98.848%)
  Different: 108 (0.432%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     180 (0.72%)
```

### After (this branch)

```
Status (n=25000; not using Missing for success/different/error stats):
  Success:   24712 (99.56486704270749%)
  Different: 108 (0.43513295729250606%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     180 (0.72%)
```

## Which documentation and/or configurations were updated?



