### PR TITLE
mods normalization: split originInfo when eventType production and dateCreated and dateOther

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -376,10 +376,13 @@ module Cocina
 
           notifier.warn('originInfo/dateOther missing eventType') unless type
 
+          display_label = node_set.first.parent['displayLabel'] if node_set&.first&.parent.present?
+
           result = {
             type: type
           }.compact
           result[:date] = dates.compact if dates.compact.present?
+          result[:displayLabel] = display_label if display_label.present?
           result
         end
 

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -364,6 +364,8 @@ module Cocina
           end
         end
 
+        # rubocop:disable  Metrics/CyclomaticComplexity
+        # rubocop:disable  Metrics/PerceivedComplexity
         def build_event(type, node_set, language_script = nil)
           dates = node_set.reject { |node| node['point'] }.map do |node|
             addl_attributes = node['encoding'].nil? && language_script ? { valueLanguage: language_script } : {}
@@ -385,6 +387,8 @@ module Cocina
           result[:displayLabel] = display_label if display_label.present?
           result
         end
+        # rubocop:enable  Metrics/CyclomaticComplexity
+        # rubocop:enable  Metrics/PerceivedComplexity
 
         # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/PerceivedComplexity

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
@@ -2285,12 +2285,9 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
       end
     end
 
-    context 'when dateCreated and dateOther' do
+    context 'when dateCreated and dateOther and eventType production' do
       # based on dg875gq3366
       it_behaves_like 'MODS cocina mapping' do
-        xit 'to be implemented: originInfo normalization needs to split up originInfo'
-        let(:skip_normalization) { true }
-
         let(:mods) do
           <<~XML
             <originInfo displayLabel="something" eventType="production">

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
@@ -630,7 +630,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
       let(:roundtrip_mods) do
         # Same except placeTerm gets type "text"
         <<~XML
-           <originInfo script="Latn" lang="eng" altRepGroup="1" eventType="production">
+          <originInfo script="Latn" lang="eng" altRepGroup="1" eventType="production">
             <dateCreated encoding="w3cdtf" keyDate="yes">1999-09-09</dateCreated>
             <place>
               <placeTerm type="text" authorityURI="http://id.loc.gov/authorities/names/"
@@ -2297,7 +2297,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
           XML
         end
 
-        # splits dateCreated into separate originInfo;  dateOther becomes dateCreated
+        # splits dateCreated into separate originInfo; dateOther becomes dateCreated
         let(:roundtrip_mods) do
           <<~XML
             <originInfo displayLabel="something" eventType="production">

--- a/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
@@ -1017,13 +1017,13 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
       XML
     end
 
-    xit 'splits dateCreated into separate originInfo;  dateOther becomes dateCreated' do
+    it 'splits dateCreated into separate originInfo;  dateOther becomes dateCreated' do
       expect(normalized_ng_xml).to be_equivalent_to <<~XML
         <mods #{MODS_ATTRIBUTES}>
           <originInfo displayLabel="something" eventType="production">
             <dateCreated keyDate="yes" encoding="w3cdtf">1905</dateCreated>
           </originInfo>
-          <originInfo eventType="production">
+          <originInfo displayLabel="something" eventType="production">
             <dateCreated qualifier="approximate" point="end">1925</dateCreated>
           </originInfo>
         </mods>
@@ -1228,7 +1228,7 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
     end
   end
 
-  context 'when  altRepGroup subelements are missing from one of the elements' do
+  context 'when altRepGroup subelements are missing from one of the elements' do
     # based on xj114vt0439
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML


### PR DESCRIPTION
## Why was this change made?

mods normalization needs to split mods originInfo elements just like mapping code does

(un-xit 2 mapping / normalization specs)

## How was this change tested?

### Before (main branch)

```
Status (n=25000; not using Missing for success/different/error stats):
  Success:   24722 (99.60515713134569%)
  Different: 98 (0.39484286865431106%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     180 (0.72%)
```

### After (this branch)

```
Status (n=25000; not using Missing for success/different/error stats):
  Success:   24723 (99.6091861402095%)
  Different: 97 (0.39081385979049155%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     180 (0.72%)
```

## Which documentation and/or configurations were updated?



