### PR TITLE
Quiet ruby warning in cach-o-matic.

### DIFF
--- a/bin/cache-o-matic.sh
+++ b/bin/cache-o-matic.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Quiet ruby warnings.
+export RUBYOPT='-W:no-deprecated -W:no-experimental'
+
 # Adds/updates cache for recently indexed objects.
 
 YESTERDAY=`date -d "yesterday" --iso-8601`


### PR DESCRIPTION
## Why was this change made?
I need quiet.


## How was this change tested?
sdr-deploy


## Which documentation and/or configurations were updated?
NA


