### PR TITLE
originInfo normalizer: ensure all flavors of empty are dealt with

### DIFF
--- a/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
@@ -682,6 +682,8 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
           <mods #{MODS_ATTRIBUTES}>
             <originInfo>
               <dateCreated></dateCreated>
+              <dateCreated/>
+              <dateCreated />
             </originInfo>
           </mods>
         XML


### PR DESCRIPTION
## Why was this change made?

Arcadia raised this issue, which is captured as part of #2240

## How was this change tested?

it's a spec change

## Which documentation and/or configurations were updated?



