### PR TITLE
Support sourceId for collections

### DIFF
--- a/app/services/cocina/from_fedora/identification.rb
+++ b/app/services/cocina/from_fedora/identification.rb
@@ -4,7 +4,7 @@ module Cocina
   module FromFedora
     # Creates Cocina Identification objects from Fedora objects
     class Identification
-      # @param [Dor::Item,Dor::Etd] item
+      # @param [Dor::Item,Dor::Collection,Dor::Etd] item
       # @return [Hash] a hash that can be mapped to a cocina administrative model
       # @raises [Mapper::MissingSourceID]
       def self.props(item)
@@ -16,9 +16,9 @@ module Cocina
       end
 
       def props
-        return {} if item.is_a? Dor::Collection
-
         return { sourceId: item.source_id } if item.source_id
+
+        return {} if item.is_a? Dor::Collection
 
         # ETDs post Summer 2020 have a source id, but legacy ones don't.  In that case look for a dissertation_id.
         dissertation = item.otherId.find { |id| id.start_with?('dissertationid:') }

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -94,6 +94,7 @@ module Cocina
       pid = Dor::SuriService.mint_id
       Dor::Collection.new(pid: pid,
                           admin_policy_object_id: obj.administrative.hasAdminPolicy,
+                          source_id: obj.identification&.sourceId,
                           catkey: catkey_for(obj),
                           label: truncate_label(obj.label)).tap do |item|
         add_description(item, obj)

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe 'Create object' do
                                          ]
                                        }
                                      },
+                                     identification: {
+                                       sourceId: 'hydrus:collection-456'
+                                     },
                                      administrative: {
                                        hasAdminPolicy: 'druid:dd999df4567',
                                        partOfProject: 'Hydrus'
@@ -43,6 +46,7 @@ RSpec.describe 'Create object' do
         {"type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
           "label":"#{label}","version":1,"access":{},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567","partOfProject":"Hydrus"},
+          "identification":{"sourceId":"hydrus:collection-456"},
           "description":{"title":[{"value":"#{title}"}],"purl":"http://purl.stanford.edu/gg777gg7777","access":{"digitalRepository":[{"value":"Stanford Digital Repository"}]}}}
       JSON
     end


### PR DESCRIPTION

## Why was this change made?

This allows us to asynchronously find out when a druid is assigned for our collection by monitoring rabbitMQ and looking for the sourceId we provided


## How was this change tested?



## Which documentation and/or configurations were updated?



