### PR TITLE
Improve reporting of diffs.

### DIFF
--- a/app/services/mods_equivalent_service.rb
+++ b/app/services/mods_equivalent_service.rb
@@ -106,11 +106,19 @@ class ModsEquivalentService
   end
 
   def diff
-    mods_nodes1.map do |mods_node1|
+    element_diff = mods_nodes1.map do |mods_node1|
       next nil if has_equivalent_node?(mods_node1)
 
       Difference.new(mods_node1, find_closest_node(mods_node1))
     end.compact
+
+    attr_diff = mods_ng_xml1.root.keys.map do |attr_key|
+      next if mods_ng_xml1.root[attr_key] == mods_ng_xml2.root[attr_key]
+
+      Difference.new(mods_ng_xml1.root[attr_key], mods_ng_xml2.root[attr_key])
+    end.compact
+
+    element_diff + attr_diff
   end
 
   def mods_nodes1

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -41,7 +41,8 @@ end
 # rubocop:disable Metrics/ParameterLists
 # rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/BlockLength
-def write_result(druid, original_ng_xml, roundtrip_ng_xml, cocina, differences, data_errors, mods_msg)
+# rubocop:disable Metrics/PerceivedComplexity
+def write_result(druid, original_ng_xml, roundtrip_ng_xml, cocina, differences, reverse_differences, data_errors, mods_msg)
   File.open("results/#{druid}.txt", 'w') do |file|
     file.write("Druid: #{druid}\n\n")
 
@@ -76,6 +77,17 @@ def write_result(druid, original_ng_xml, roundtrip_ng_xml, cocina, differences, 
       end
     end
 
+    reverse_differences.each_with_index do |difference, index|
+      file.write("Differences #{index + 1}\n")
+      file.write("Roundtripped node:\n#{difference.mods_node1}\n")
+      if difference.mods_node2
+        file.write("Best guess original node:\n#{difference.mods_node2}\n")
+        file.write("Difference:\n#{Diffy::Diff.new("#{difference.mods_node1}\n", "#{difference.mods_node2}\n")}\n")
+      else
+        file.write("Could not find similar original node.\n")
+      end
+    end
+
     file.write("\nOriginal XML:\n#{original_ng_xml.to_xml}\n")
     file.write("Roundtripped XML:\n#{roundtrip_ng_xml.to_xml}\n")
     file.write("Cocina:\n#{JSON.pretty_generate(cocina)}\n\n")
@@ -84,6 +96,7 @@ end
 # rubocop:enable Metrics/ParameterLists
 # rubocop:enable Metrics/AbcSize
 # rubocop:enable Metrics/BlockLength
+# rubocop:enable Metrics/PerceivedComplexity
 
 def write_error(druid, original_ng_xml, cocina, error)
   File.open("results/#{druid}.txt", 'w') do |file|
@@ -111,6 +124,7 @@ def validate_mods(ng_xml)
   end
 end
 
+# rubocop:disable Metrics/CyclomaticComplexity
 def validate_druid(druid, cache, fast: false)
   begin
     original_ng_xml = cache.descmd_xml(druid)
@@ -151,17 +165,20 @@ def validate_druid(druid, cache, fast: false)
 
   return :success if equiv.success?
 
-  # Validate MODS
+  # If not equivalent, but no diffs reported, then try in reverse.
+  reverse_equiv = ModsEquivalentService.equivalent_with_result?(roundtrip_ng_xml, norm_original_ng_xml) if equiv.failure.empty?
 
   write_result(druid,
                norm_original_ng_xml,
                roundtrip_ng_xml,
                cocina_props,
                equiv.failure,
+               Array(reverse_equiv&.failure),
                notifier.data_errors,
                validate_mods(original_ng_xml))
   :different
 end
+# rubocop:enable Metrics/CyclomaticComplexity
 
 def percentage(raw_num, denom)
   (100 * raw_num.to_f / denom).round(3)

--- a/spec/services/mods_equivalent_service_spec.rb
+++ b/spec/services/mods_equivalent_service_spec.rb
@@ -637,4 +637,34 @@ RSpec.describe ModsEquivalentService do
       expect(bool_result).to be(true)
     end
   end
+
+  context 'when version mismatch node' do
+    let(:mods_ng_xml2) do
+      Nokogiri::XML <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.5"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <titleInfo>
+            <title>journal of stuff</title>
+          </titleInfo>
+          <identifier type="uri">https://www.wikidata.org/wiki/Q146</identifier>
+          <identifier displayLabel="Accession number">1980-12345</identifier>
+        </mods>
+      XML
+    end
+
+    it 'returns failure' do
+      expect(result.failure?).to be(true)
+    end
+
+    it 'returns diff' do
+      expect(result.failure.size).to eq(1)
+      expect(result.failure.first.mods_node1.to_s).to eq('3.6')
+      expect(result.failure.first.mods_node2).to eq('3.5')
+    end
+
+    it 'returns false' do
+      expect(bool_result).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?
Some items report that roundtripping is not equivalent, but don't provide the reasons. This fixes those cases by looking for diffs in reverse (roundtripped to original) and by checking attributes on the MODS element.

For example: druid:gt859cc5891, druid:hj975yc6595, druid:hp978sk7611


## How was this change tested?
Local


## Which documentation and/or configurations were updated?
NA


