### PR TITLE
Allow relatedItems to have notes.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/from_fedora/descriptive/related_resource.rb
@@ -59,7 +59,10 @@ module Cocina
                   note[:source] = { value: related_item['otherTypeAuth'] } if related_item['otherTypeAuth']
                 end
             end
-            item[:note] = notes unless notes.empty?
+            if notes.present?
+              item[:note] ||= []
+              item[:note].concat(notes)
+            end
           end.compact
         end
 

--- a/spec/services/cocina/mapping/descriptive/mods/part_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/part_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'MODS part <--> cocina mappings' do
             <titleInfo>
               <title>Alden, J.E. European Americana,</title>
             </titleInfo>
+            <note>Not recorded at Monterey Jazz Festival</note>
             <part>
               <detail type="part">
                 <number>635/94</number>
@@ -27,6 +28,7 @@ RSpec.describe 'MODS part <--> cocina mappings' do
             <titleInfo>
               <title>Alden, J.E. European Americana</title>
             </titleInfo>
+            <note>Not recorded at Monterey Jazz Festival</note>
             <part>
               <detail type="part">
                 <number>635/94</number>
@@ -49,6 +51,9 @@ RSpec.describe 'MODS part <--> cocina mappings' do
                 }
               ],
               note: [
+                {
+                  value: 'Not recorded at Monterey Jazz Festival'
+                },
                 {
                   type: 'part',
                   groupedValue: [


### PR DESCRIPTION
closes #2363

## Why was this change made?
Notes aren't supposed to disappear.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


