### PR TITLE
Do not map empty shelfLocator.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/access.rb
+++ b/app/services/cocina/from_fedora/descriptive/access.rb
@@ -70,11 +70,13 @@ module Cocina
 
         def shelf_location
           resource_element.xpath('mods:location/mods:shelfLocator', mods: DESC_METADATA_NS).map do |shelf_locator_elem|
+            next nil if shelf_locator_elem.content.blank?
+
             {
-              value: shelf_locator_elem.text,
+              value: shelf_locator_elem.content,
               type: 'shelf locator'
             }
-          end
+          end.compact
         end
 
         def url

--- a/spec/services/cocina/mapping/descriptive/mods/location_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/location_spec.rb
@@ -297,6 +297,40 @@ RSpec.describe 'MODS location <--> cocina mappings' do
     end
   end
 
+  describe 'Blank shelf locator' do
+    # Adapted from qy779rm2737
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <location>
+            <physicalLocation>MiU-C WLCL</physicalLocation>
+            <shelfLocator/>
+          </location>
+        XML
+      end
+
+      let(:roundtrip_mods) do
+        <<~XML
+          <location>
+            <physicalLocation>MiU-C WLCL</physicalLocation>
+          </location>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          access: {
+            physicalLocation: [
+              {
+                value: 'MiU-C WLCL'
+              }
+            ]
+          }
+        }
+      end
+    end
+  end
+
   describe 'URL with note' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do


### PR DESCRIPTION
closes #2373

## Why was this change made?
No empty shelves.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


