### PR TITLE
Don't publish object created messages for admin policies

### DIFF
--- a/app/services/notifications/object_created.rb
+++ b/app/services/notifications/object_created.rb
@@ -5,6 +5,9 @@ module Notifications
   # The primary use case here is that the requestor may want to know what druid was assigned to the request.
   class ObjectCreated
     def self.publish(model:)
+      # Skipping APOs because they don't (yet) have a partOfProject assertion.
+      return if model.is_a? Cocina::Models::AdminPolicy
+
       Rails.logger.info "Publishing Rabbitmq Message for #{model.externalIdentifier}"
       new(model: model, channel: channel).publish
       Rails.logger.info "Published Rabbitmq Message for #{model.externalIdentifier}"

--- a/spec/services/notifications/object_created_spec.rb
+++ b/spec/services/notifications/object_created_spec.rb
@@ -9,10 +9,7 @@ RSpec.describe Notifications::ObjectCreated do
   let(:administrative) do
     instance_double(Cocina::Models::Administrative, partOfProject: 'h2')
   end
-  let(:model) do
-    instance_double(Cocina::Models::DRO,
-                    externalIdentifier: 'druid:123', administrative: administrative, to_h: data)
-  end
+
   let(:bunny) { instance_double(Bunny::Session, start: true, create_channel: channel) }
   let(:channel) { instance_double(Bunny::Channel, topic: topic) }
   let(:topic) { instance_double(Bunny::Exchange, publish: true) }
@@ -21,8 +18,32 @@ RSpec.describe Notifications::ObjectCreated do
     allow(Bunny).to receive(:new).and_return(bunny)
   end
 
-  it 'is successful' do
-    publish
-    expect(topic).to have_received(:publish).with('{"model":{"data":"455"}}', routing_key: 'h2')
+  context 'when called with a DRO' do
+    let(:model) do
+      instance_double(Cocina::Models::DRO,
+                      externalIdentifier: 'druid:123', administrative: administrative, to_h: data)
+    end
+
+    it 'is successful' do
+      publish
+      expect(topic).to have_received(:publish).with('{"model":{"data":"455"}}', routing_key: 'h2')
+    end
+  end
+
+  context 'when called with an AdminPolicy' do
+    let(:model) do
+      Cocina::Models::AdminPolicy.new(externalIdentifier: 'druid:bc123dg9393',
+                                      administrative: {
+                                        hasAdminPolicy: 'druid:gg123vx9393'
+                                      },
+                                      version: 1,
+                                      label: 'just an apo',
+                                      type: Cocina::Models::Vocab.admin_policy)
+    end
+
+    it 'is successful' do
+      publish
+      expect(topic).not_to have_received(:publish)
+    end
   end
 end


### PR DESCRIPTION


## Why was this change made?

Because they don't have a project so we don't know their routing key

## How was this change tested?



## Which documentation and/or configurations were updated?



