### PR TITLE
Add legacy MARC2MODS output mappings to originInfo eventType

### DIFF
--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -13,22 +13,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="production">
-            <dateCreated>1980</dateCreated>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
-                  value: '1980'
+                  value: '1980',
+                  type: 'creation'
                 }
               ]
             }
@@ -48,22 +40,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="publication">
-            <dateIssued encoding="w3cdtf">1928</dateIssued>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'publication',
               date: [
                 {
                   value: '1928',
+                  type: 'publication',
                   encoding: {
                     code: 'w3cdtf'
                   }
@@ -86,22 +70,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="copyright">
-            <copyrightDate>1930</copyrightDate>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'copyright',
               date: [
                 {
-                  value: '1930'
+                  value: '1930',
+                  type: 'copyright'
                 }
               ]
             }
@@ -121,22 +97,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="capture">
-            <dateCaptured keyDate="yes" encoding="iso8601">20131012231249</dateCaptured>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'capture',
               date: [
                 {
                   value: '20131012231249',
+                  type: 'capture',
                   encoding: {
                     code: 'iso8601'
                   },
@@ -168,12 +136,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
               date: [
                 {
                   value: '1441 AH',
-                  note: [
-                    {
-                      value: 'Islamic',
-                      type: 'date type'
-                    }
-                  ]
+                  type: 'Islamic'
                 }
               ]
             }
@@ -225,20 +188,10 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="production">
-            <dateCreated keyDate="yes" point="start">1920</dateCreated>
-            <dateCreated point="end">1925</dateCreated>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
                   structuredValue: [
@@ -251,7 +204,8 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                       value: '1925',
                       type: 'end'
                     }
-                  ]
+                  ],
+                  type: 'creation'
                 }
               ]
             }
@@ -271,22 +225,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="production">
-            <dateCreated qualifier="approximate">1940</dateCreated>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
                   value: '1940',
+                  type: 'creation',
                   qualifier: 'approximate'
                 }
               ]
@@ -308,20 +254,10 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="production">
-            <dateCreated keyDate="yes" point="start" qualifier="approximate">1940</dateCreated>
-            <dateCreated point="end" qualifier="approximate">1945</dateCreated>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
                   structuredValue: [
@@ -335,6 +271,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                       type: 'end'
                     }
                   ],
+                  type: 'creation',
                   qualifier: 'approximate'
                 }
               ]
@@ -356,20 +293,10 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="production">
-            <dateCreated keyDate="yes" point="start" qualifier="approximate">1940</dateCreated>
-            <dateCreated point="end">1945</dateCreated>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
                   structuredValue: [
@@ -383,7 +310,8 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                       value: '1945',
                       type: 'end'
                     }
-                  ]
+                  ],
+                  type: 'creation'
                 }
               ]
             }
@@ -404,20 +332,10 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="production">
-            <dateCreated keyDate="yes" point="start">1940</dateCreated>
-            <dateCreated point="end" qualifier="approximate">1945</dateCreated>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
                   structuredValue: [
@@ -431,7 +349,8 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                       type: 'end',
                       qualifier: 'approximate'
                     }
-                  ]
+                  ],
+                  type: 'creation'
                 }
               ]
             }
@@ -451,22 +370,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="production">
-            <dateCreated qualifier="inferred">1940</dateCreated>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
                   value: '1940',
+                  type: 'creation',
                   qualifier: 'inferred'
                 }
               ]
@@ -487,22 +398,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="production">
-            <dateCreated qualifier="questionable">1940</dateCreated>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
                   value: '1940',
+                  type: 'creation',
                   qualifier: 'questionable'
                 }
               ]
@@ -525,25 +428,11 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="publication">
-            <dateIssued keyDate="yes" point="start">1940</dateIssued>
-            <dateIssued point="end">1945</dateIssued>
-            <dateIssued>1948</dateIssued>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'publication',
               date: [
-                {
-                  value: '1948'
-                },
                 {
                   structuredValue: [
                     {
@@ -555,7 +444,12 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                       value: '1945',
                       type: 'end'
                     }
-                  ]
+                  ],
+                  type: 'publication'
+                },
+                {
+                  value: '1948',
+                  type: 'publication'
                 }
               ]
             }
@@ -576,27 +470,19 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="publication">
-            <dateIssued keyDate="yes">1940</dateIssued>
-            <dateIssued>1942</dateIssued>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'publication',
               date: [
                 {
                   value: '1940',
+                  type: 'publication',
                   status: 'primary'
                 },
                 {
-                  value: '1942'
+                  value: '1942',
+                  type: 'publication'
                 }
               ]
             }
@@ -616,22 +502,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="production">
-            <dateCreated keyDate="yes" encoding="edtf">-0499</dateCreated>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
                   value: '-0499',
+                  type: 'creation',
                   encoding: {
                     code: 'edtf'
                   },
@@ -650,16 +528,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
       let(:mods) do
         <<~XML
           <originInfo>
-            <dateCreated encoding="edtf" point="start">-0599</dateCreated>
-            <dateCreated encoding="edtf" point="end">-0499</dateCreated>
-          </originInfo>
-        XML
-      end
-
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="production">
-            <dateCreated encoding="edtf" point="start">-0599</dateCreated>
+            <dateCreated keyDate="yes" encoding="edtf" point="start">-0599</dateCreated>
             <dateCreated encoding="edtf" point="end">-0499</dateCreated>
           </originInfo>
         XML
@@ -669,13 +538,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
                   value: '-0599/-0499',
+                  type: 'creation',
                   encoding: {
                     code: 'edtf'
-                  }
+                  },
+                  status: 'primary'
                 }
               ]
             }
@@ -690,15 +560,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
       let(:mods) do
         <<~XML
           <originInfo>
-            <dateCreated encoding="edtf">0800</dateCreated>
-          </originInfo>
-        XML
-      end
-
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="production">
-            <dateCreated encoding="edtf">0800</dateCreated>
+            <dateCreated keyDate="yes" encoding="edtf">0800</dateCreated>
           </originInfo>
         XML
       end
@@ -707,10 +569,10 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
                   value: '0800',
+                  status: 'primary',
                   encoding: {
                     code: 'edtf'
                   }
@@ -728,16 +590,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
       let(:mods) do
         <<~XML
           <originInfo>
-            <dateCreated encoding="edtf" point="start">0800</dateCreated>
-            <dateCreated encoding="edtf" point="end">1000</dateCreated>
-          </originInfo>
-        XML
-      end
-
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="production">
-            <dateCreated encoding="edtf" point="start">0800</dateCreated>
+            <dateCreated keyDate="yes" encoding="edtf" point="start">0800</dateCreated>
             <dateCreated encoding="edtf" point="end">1000</dateCreated>
           </originInfo>
         XML
@@ -747,13 +600,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
                   value: '0800/1000',
+                  type: 'creation',
                   encoding: {
                     code: 'edtf'
-                  }
+                  },
+                  status: 'primary'
                 }
               ]
             }
@@ -768,18 +622,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
       let(:mods) do
         <<~XML
           <originInfo>
-            <dateIssued>1955</dateIssued>
-            <copyrightDate>1940</copyrightDate>
-          </originInfo>
-        XML
-      end
-
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="publication">
-            <dateIssued>1955</dateIssued>
-          </originInfo>
-          <originInfo eventType="copyright">
+            <dateIssued keyDate="yes">1955</dateIssued>
             <copyrightDate>1940</copyrightDate>
           </originInfo>
         XML
@@ -789,18 +632,15 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         {
           event: [
             {
-              type: 'publication',
               date: [
                 {
-                  value: '1955'
-                }
-              ]
-            },
-            {
-              type: 'copyright',
-              date: [
+                  value: '1955',
+                  type: 'publication',
+                  status: 'primary'
+                },
                 {
-                  value: '1940'
+                  value: '1940',
+                  type: 'copyright'
                 }
               ]
             }
@@ -824,16 +664,11 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         {
           event: [
             {
-              type: 'creation',
+              type: 'production',
               date: [
                 {
                   value: '1544-02-02',
-                  note: [
-                    {
-                      value: 'Julian',
-                      type: 'date type'
-                    }
-                  ]
+                  type: 'Julian'
                 }
               ]
             }
@@ -857,14 +692,15 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         {
           event: [
             {
-              type: 'creation',
+              type: 'production',
               date: [
                 {
                   value: '1544-02-02',
+                  type: 'creation',
                   note: [
                     {
                       value: 'Julian',
-                      type: 'date type'
+                      type: 'calendar'
                     }
                   ]
                 }
@@ -886,23 +722,19 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="publication">
-            <dateIssued point="end">1980</dateIssued>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'publication',
               date: [
                 {
-                  value: '1980',
-                  type: 'end'
+                  structuredValue: [
+                    {
+                      value: '1980',
+                      type: 'end'
+                    }
+                  ],
+                  type: 'publication'
                 }
               ]
             }
@@ -922,23 +754,19 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="publication">
-            <dateIssued point="start">1975</dateIssued>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'publication',
               date: [
                 {
-                  value: '1975',
-                  type: 'start'
+                  structuredValue: [
+                    {
+                      value: '1975',
+                      type: 'start'
+                    }
+                  ],
+                  type: 'publication'
                 }
               ]
             }
@@ -958,22 +786,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="production">
-            <dateCreated encoding="marc">19uu</dateCreated>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
                   value: '19uu',
+                  type: 'creation',
                   encoding: {
                     code: 'marc'
                   }
@@ -996,22 +816,14 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="production">
-            <dateCreated>11th century</dateCreated>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
-                  value: '11th century'
+                  value: '11th century',
+                  type: 'creation'
                 }
               ]
             }
@@ -1036,26 +848,11 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         XML
       end
 
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo displayLabel="Place of Creation" eventType="production">
-            <place>
-              <placeTerm type="text" authority="naf" authorityURI="http://id.loc.gov/authorities/names/"
-                valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
-            </place>
-            <dateCreated keyDate="yes" encoding="w3cdtf">2003-11-29</dateCreated>
-          </originInfo>
-          <originInfo displayLabel="Place of Creation" eventType="development">
-            <dateOther type="developed" encoding="w3cdtf">2003-12-01</dateOther>
-          </originInfo>
-        XML
-      end
-
       let(:cocina) do
         {
           event: [
             {
-              type: 'creation',
+              type: 'production',
               displayLabel: 'Place of Creation',
               location: [
                 {
@@ -1070,19 +867,15 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
               date: [
                 {
                   value: '2003-11-29',
+                  type: 'creation',
                   status: 'primary',
                   encoding: {
                     code: 'w3cdtf'
                   }
-                }
-              ]
-            },
-            {
-              type: 'development',
-              displayLabel: 'Place of Creation',
-              date: [
+                },
                 {
                   value: '2003-12-01',
+                  type: 'development',
                   encoding: {
                     code: 'w3cdtf'
                   }
@@ -1095,103 +888,1739 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
     end
   end
 
-  describe 'dateValid' do
-    # Adapted from druid:gx929mp5413
+  describe 'MODS date types' do
+    describe 'dateCreated' do
+      xit 'not implemented' do
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateCreated>1928</dateCreated>
+            </originInfo>
+          XML
+        end
 
-    it_behaves_like 'MODS cocina mapping' do
-      let(:mods) do
-        <<~XML
-          <originInfo eventType="publication">
-            <publisher>Articque informatique</publisher>
-            <place>
-              <placeTerm type="text">Fondettes, FR</placeTerm>
-            </place>
-            <dateIssued encoding="w3cdtf" keyDate="yes">2010</dateIssued>
-            <dateValid encoding="w3cdtf">2010</dateValid>
-            <edition>1</edition>
-          </originInfo>
-        XML
-      end
-
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="publication">
-            <publisher>Articque informatique</publisher>
-            <place>
-              <placeTerm type="text">Fondettes, FR</placeTerm>
-            </place>
-            <dateIssued encoding="w3cdtf" keyDate="yes">2010</dateIssued>
-            <edition>1</edition>
-          </originInfo>
-          <originInfo eventType="validity">
-            <dateValid encoding="w3cdtf">2010</dateValid>
-          </originInfo>
-        XML
-      end
-
-      let(:cocina) do
-        {
-          event: [
-            {
-              type: 'publication',
-              contributor: [
-                {
-                  name: [
-                    {
-                      value: 'Articque informatique'
-                    }
-                  ],
-                  type: 'organization',
-                  role: [
-                    {
-                      value: 'publisher',
-                      code: 'pbl',
-                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                      source: {
-                        code: 'marcrelator',
-                        uri: 'http://id.loc.gov/vocabulary/relators/'
-                      }
-                    }
-                  ]
-                }
-              ],
-              location: [
-                {
-                  value: 'Fondettes, FR'
-                }
-              ],
-              date: [
-                {
-                  value: '2010',
-                  encoding: {
-                    code: 'w3cdtf'
-                  },
-                  status: 'primary'
-                }
-              ],
-              note: [
-                {
-                  type: 'edition',
-                  value: '1'
-                }
-              ]
-            },
-            {
-              type: 'validity',
-              date: [
-                {
-                  value: '2010',
-                  encoding: {
-                    code: 'w3cdtf'
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928',
+                    type: 'creation'
                   }
-                }
-              ]
-            }
-          ]
-        }
+                ]
+              }
+            ]
+          }
+        end
+      end
+    end
+
+    describe 'dateIssued' do
+      xit 'not implemented' do
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateIssued>1928</dateIssued>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928',
+                    type: 'publication'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+      end
+    end
+
+    describe 'copyrightDate' do
+      xit 'not implemented' do
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <copyrightDate>1928</copyrightDate>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928',
+                    type: 'copyright'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+      end
+    end
+
+    describe 'dateCaptured' do
+      xit 'not implemented' do
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateCaptured>1928</dateCaptured>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928',
+                    type: 'capture'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+      end
+    end
+
+    describe 'dateValid' do
+      xit 'not implemented' do
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateValid>1928</dateValid>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928',
+                    type: 'validity'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+      end
+    end
+
+    describe 'dateModified' do
+      xit 'not implemented' do
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateModified>1928</dateModified>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928',
+                    type: 'modification'
+                  }
+                ]
+              }
+            ]
+          }
+        end
       end
     end
   end
+
+  # describe 'dateValid' do
+  #   # Adapted from druid:gx929mp5413
+  #
+  #   it_behaves_like 'MODS cocina mapping' do
+  #     let(:mods) do
+  #       <<~XML
+  #         <originInfo eventType="publication">
+  #           <publisher>Articque informatique</publisher>
+  #           <place>
+  #             <placeTerm type="text">Fondettes, FR</placeTerm>
+  #           </place>
+  #           <dateIssued encoding="w3cdtf" keyDate="yes">2010</dateIssued>
+  #           <dateValid encoding="w3cdtf">2010</dateValid>
+  #           <edition>1</edition>
+  #         </originInfo>
+  #       XML
+  #     end
+  #
+  #     let(:cocina) do
+  #       {
+  #         event: [
+  #           {
+  #             type: 'publication',
+  #             contributor: [
+  #               {
+  #                 name: [
+  #                   {
+  #                     value: 'Articque informatique'
+  #                   }
+  #                 ],
+  #                 type: 'organization',
+  #                 role: [
+  #                   {
+  #                     value: 'publisher',
+  #                     code: 'pbl',
+  #                     uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+  #                     source: {
+  #                       code: 'marcrelator',
+  #                       uri: 'http://id.loc.gov/vocabulary/relators/'
+  #                     }
+  #                   }
+  #                 ]
+  #               }
+  #             ],
+  #             location: [
+  #               {
+  #                 value: 'Fondettes, FR'
+  #               }
+  #             ],
+  #             date: [
+  #               {
+  #                 value: '2010',
+  #                 type: 'publication',
+  #                 encoding: {
+  #                   code: 'w3cdtf'
+  #                 },
+  #                 status: 'primary'
+  #               },
+  #               {
+  #                 value: '2010',
+  #                 type: 'validity',
+  #                 encoding: {
+  #                   code: 'w3cdtf'
+  #                 }
+  #               }
+  #             ],
+  #             note: [
+  #               {
+  #                 type: 'edition',
+  #                 value: '1'
+  #               }
+  #             ]
+  #           }
+  #         ]
+  #       }
+  #     end
+  #   end
+  # end
+
+  describe 'Cocina event type > MODS event/date type' do
+    # Cocina date type takes precedent over event type in determining
+    # which MODS date element to use
+    describe 'acquisition' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'acquisition',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="acquisition">
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'capture' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'capture',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:roundtrip_cocina) do
+          {
+            event: [
+              {
+                type: 'capture',
+                date: [
+                  {
+                    value: '1928',
+                    type: 'capture'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="capture">
+              <dateCaptured>1928</dateCaptured>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'collection' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'collection',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="collection">
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'copyright' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'copyright',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:roundtrip_cocina) do
+          {
+            event: [
+              {
+                type: 'copyright',
+                date: [
+                  {
+                    value: '1928',
+                    type: 'copyright'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="copyright">
+              <copyrightDate>1928</copyrightDate>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'creation' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'creation',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="creation">
+              <dateCreated>1928</dateCreated>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'degree conferral' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'degree conferral',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="date conferral">
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'development' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'development',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="development">
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'distribution' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'distribution',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="distribution">
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'generation' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'generation',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="generation">
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'manufacture' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'manufacture',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="manufacture">
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'modification' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'modification',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:roundtrip_cocina) do
+          {
+            event: [
+              {
+                type: 'modification',
+                date: [
+                  {
+                    value: '1928',
+                    type: 'modification'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="modification">
+              <dateModified>1928</dateModified>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'performance' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'performance',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="performance">
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'presentation' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'presentation',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="presentation">
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'production' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'production',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo evenType="production">
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'publication' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'publication',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:roundtrip_cocina) do
+          {
+            event: [
+              {
+                type: 'publication',
+                date: [
+                  {
+                    value: '1928',
+                    type: 'publication'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="publication">
+              <dateIssued>1928</dateIssued>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'recording' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'recording',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="recording">
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'release' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'release',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="release">
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'submission' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'submission',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="submission">
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'validity' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'validity',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:roundtrip_cocina) do
+          {
+            event: [
+              {
+                type: 'validity',
+                date: [
+                  {
+                    value: '1928',
+                    type: 'validity'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="validity">
+              <dateValid>1928</dateValid>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'withdrawal' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'withdrawal',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="withdrawal">
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'other event type not listed above' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'deaccession',
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="deaccession">
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+
+        let(:warnings) { [Notification.new(msg: 'Unrecognized event type')] }
+      end
+    end
+  end
+
+  describe 'Cocina date type > MODS date type' do
+    describe 'acquisition' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'acquisition'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther type="acquisition">1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'capture' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'capture'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateCaptured>1928</dateCaptured>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'collection' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'collection'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther type="collection">1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'copyright' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'copyright'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <copyrightDate>1928</copyrightDate>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'creation' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'creation'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateCreated>1928</dateCreated>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'degree conferral' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'degree conferral'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther type="date conferral">1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'development' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'development'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther type="development">1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'distribution' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'distribution'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther type="distribution">1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'generation' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'generation'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther type="generation">1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'manufacture' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'manufacture'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther type="manufacture">1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'modification' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'modification'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateModified>1928</dateModified>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'performance' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'performance'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther type="performance">1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'presentation' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'presentation'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther type="presentation">1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'production' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'production'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther type="production">1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'publication' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'publication'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateIssued>1928</dateIssued>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'recording' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'recording'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther type="recording">1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'release' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'release'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther type="release">1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'submission' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'submission'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther type="submission">1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'validity' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'validity'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateValid>1928</dateValid>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'withdrawal' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'withdrawal'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther type="withdrawal">1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+
+    describe 'other date type not listed above' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ],
+                type: 'deaccession'
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther type="deaccession">1928</dateOther>
+            </originInfo>
+          XML
+        end
+
+        let(:warnings) { [Notification.new(msg: 'Unrecognized date type')] }
+      end
+    end
+
+    describe 'no event type, no date type' do
+      xit 'not implemented' do
+        let(:cocina) do
+          {
+            event: [
+              {
+                date: [
+                  {
+                    value: '1928'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <dateOther>1928</dateOther>
+            </originInfo>
+          XML
+        end
+      end
+    end
+  end
+
+  # describe 'Date mapping for recording event type' do
+  #   xit 'not implemented: recording event type' do
+  #     let(:cocina) do
+  #       {
+  #         event: [
+  #           {
+  #             type: 'recording',
+  #             date: [
+  #               {
+  #                 value: '1990'
+  #               }
+  #             ]
+  #           }
+  #         ]
+  #       }
+  #     end
+  #
+  #     let(:mods) do
+  #       <<~XML
+  #         <originInfo eventType="recording">
+  #           <dateCreated>1990</dateCreated>
+  #         </originInfo>
+  #       XML
+  #     end
+  #   end
+  # end
+  #
+  # describe 'Date mapping for presentation event type' do
+  #   context 'with event type and date only' do
+  #     xit 'to be implemented: presentation currently maps to MODS dateIssued, not dateCreated - what do we want?' do
+  #       let(:cocina) do
+  #         {
+  #           event: [
+  #             {
+  #               type: 'presentation',
+  #               date: [
+  #                 {
+  #                   value: '1990'
+  #                 }
+  #               ]
+  #             }
+  #           ]
+  #         }
+  #       end
+  #
+  #       let(:mods) do
+  #         <<~XML
+  #           <originInfo eventType="presentation">
+  #             <dateCreated>1990</dateCreated>
+  #           </originInfo>
+  #         XML
+  #       end
+  #     end
+  #   end
+  #
+  #   context 'with more complex presentation' do
+  #     # from druid:ht706sj6651
+  #
+  #     # NOTE: cocina -> MODS
+  #     it_behaves_like 'cocina MODS mapping' do
+  #       let(:cocina) do
+  #         {
+  #           event: [
+  #             {
+  #               type: 'presentation',
+  #               date: [
+  #                 {
+  #                   value: '2018',
+  #                   encoding: {
+  #                     code: 'w3cdtf'
+  #                   },
+  #                   status: 'primary'
+  #                 }
+  #               ],
+  #               displayLabel: 'Presented',
+  #               contributor: [
+  #                 {
+  #                   name: [
+  #                     {
+  #                       value: 'Stanford Institute for Theoretical Economics'
+  #                     }
+  #                   ],
+  #                   type: 'organization',
+  #                   role: [
+  #                     {
+  #                       value: 'publisher',
+  #                       code: 'pbl',
+  #                       uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+  #                       source: {
+  #                         code: 'marcrelator',
+  #                         uri: 'http://id.loc.gov/vocabulary/relators/'
+  #                       }
+  #                     }
+  #                   ]
+  #                 }
+  #               ],
+  #               location: [
+  #                 {
+  #                   uri: 'http://id.loc.gov/authorities/names/n50046557',
+  #                   value: 'Stanford (Calif.)'
+  #                 }
+  #               ]
+  #             }
+  #           ]
+  #         }
+  #       end
+  #
+  #       let(:mods) do
+  #         <<~XML
+  #           <originInfo displayLabel="Presented" eventType="presentation">
+  #             <place>
+  #               <placeTerm type="text" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+  #             </place>
+  #             <publisher>Stanford Institute for Theoretical Economics</publisher>
+  #             <dateIssued keyDate="yes" encoding="w3cdtf">2018</dateIssued>
+  #           </originInfo>
+  #         XML
+  #       end
+  #     end
+  #   end
+  #
+  #   context 'with an originInfo that is a presentation' do
+  #     # from druid:ht706sj6651
+  #
+  #     it_behaves_like 'MODS cocina mapping' do
+  #       let(:mods) do
+  #         <<~XML
+  #           <originInfo displayLabel="Presented" eventType="presentation">
+  #             <place>
+  #               <placeTerm type="text" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
+  #             </place>
+  #             <publisher>Stanford Institute for Theoretical Economics</publisher>
+  #             <dateIssued keyDate="yes" encoding="w3cdtf">2018</dateIssued>
+  #           </originInfo>
+  #         XML
+  #       end
+  #
+  #       let(:cocina) do
+  #         {
+  #           event: [
+  #             {
+  #               type: 'presentation',
+  #               date: [
+  #                 {
+  #                   value: '2018',
+  #                   encoding: {
+  #                     code: 'w3cdtf'
+  #                   },
+  #                   status: 'primary'
+  #                 }
+  #               ],
+  #               displayLabel: 'Presented',
+  #               contributor: [
+  #                 {
+  #                   name: [
+  #                     {
+  #                       value: 'Stanford Institute for Theoretical Economics'
+  #                     }
+  #                   ],
+  #                   type: 'organization',
+  #                   role: [
+  #                     {
+  #                       value: 'publisher',
+  #                       code: 'pbl',
+  #                       uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+  #                       source: {
+  #                         code: 'marcrelator',
+  #                         uri: 'http://id.loc.gov/vocabulary/relators/'
+  #                       }
+  #                     }
+  #                   ]
+  #                 }
+  #               ],
+  #               location: [
+  #                 {
+  #                   uri: 'http://id.loc.gov/authorities/names/n50046557',
+  #                   value: 'Stanford (Calif.)'
+  #                 }
+  #               ]
+  #             }
+  #           ]
+  #         }
+  #       end
+  #     end
+  #   end
+  # end
+  #
+  # describe 'Date mapping for performance event type' do
+  #   xit 'not implemented: performance event type' do
+  #     let(:cocina) do
+  #       {
+  #         event: [
+  #           {
+  #             type: 'performance',
+  #             date: [
+  #               {
+  #                 value: '1990'
+  #               }
+  #             ]
+  #           }
+  #         ]
+  #       }
+  #     end
+  #
+  #     let(:mods) do
+  #       <<~XML
+  #         <originInfo eventType="performance">
+  #           <dateCreated>1990</dateCreated>
+  #         </originInfo>
+  #       XML
+  #     end
+  #   end
+  # end
+  #
+  # describe 'Date mapping for release event type' do
+  #   xit 'not implemented: release event bug! (also has reverse mapped in H2 spec)' do
+  #     let(:cocina) do
+  #       {
+  #         event: [
+  #           {
+  #             type: 'release',
+  #             date: [
+  #               {
+  #                 value: '1990'
+  #               }
+  #             ]
+  #           }
+  #         ]
+  #       }
+  #     end
+  #
+  #     let(:mods) do
+  #       <<~XML
+  #         <originInfo eventType="release">
+  #           <dateIssued>1990</dateIssued>
+  #         </originInfo>
+  #       XML
+  #     end
+  #   end
+  # end
 
   # Bad data handling
 
@@ -1209,7 +2638,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
       # remove empty qualifier attribute
       let(:roundtrip_mods) do
         <<~XML
-          <originInfo eventType="production">
+          <originInfo>
             <dateCreated keyDate="yes" point="start">1920</dateCreated>
             <dateCreated point="end">1925</dateCreated>
           </originInfo>
@@ -1220,7 +2649,6 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
                   structuredValue: [
@@ -1233,7 +2661,8 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                       value: '1925',
                       type: 'end'
                     }
-                  ]
+                  ],
+                  type: 'creation'
                 }
               ]
             }
@@ -1257,7 +2686,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
       # remove empty encoding attribute
       let(:roundtrip_mods) do
         <<~XML
-          <originInfo eventType="production">
+          <originInfo>
             <dateCreated keyDate="yes" point="start">1920</dateCreated>
             <dateCreated point="end">1925</dateCreated>
           </originInfo>
@@ -1268,7 +2697,6 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         {
           event: [
             {
-              type: 'creation',
               date: [
                 {
                   structuredValue: [
@@ -1281,7 +2709,8 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                       value: '1925',
                       type: 'end'
                     }
-                  ]
+                  ],
+                  type: 'creation'
                 }
               ]
             }
@@ -1290,249 +2719,6 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
       end
     end
   end
-
-  describe 'Date mapping for recording event type' do
-    xit 'not implemented: recording event type' do
-      let(:cocina) do
-        {
-          event: [
-            {
-              type: 'recording',
-              date: [
-                {
-                  value: '1990'
-                }
-              ]
-            }
-          ]
-        }
-      end
-
-      let(:mods) do
-        <<~XML
-          <originInfo eventType="recording">
-            <dateCreated>1990</dateCreated>
-          </originInfo>
-        XML
-      end
-    end
-  end
-
-  describe 'Date mapping for presentation event type' do
-    context 'with event type and date only' do
-      xit 'to be implemented: presentation currently maps to MODS dateIssued, not dateCreated - what do we want?' do
-        let(:cocina) do
-          {
-            event: [
-              {
-                type: 'presentation',
-                date: [
-                  {
-                    value: '1990'
-                  }
-                ]
-              }
-            ]
-          }
-        end
-
-        let(:mods) do
-          <<~XML
-            <originInfo eventType="presentation">
-              <dateCreated>1990</dateCreated>
-            </originInfo>
-          XML
-        end
-      end
-    end
-
-    context 'with more complex presentation' do
-      # from druid:ht706sj6651
-
-      # NOTE: cocina -> MODS
-      it_behaves_like 'cocina MODS mapping' do
-        let(:cocina) do
-          {
-            event: [
-              {
-                type: 'presentation',
-                date: [
-                  {
-                    value: '2018',
-                    encoding: {
-                      code: 'w3cdtf'
-                    },
-                    status: 'primary'
-                  }
-                ],
-                displayLabel: 'Presented',
-                contributor: [
-                  {
-                    name: [
-                      {
-                        value: 'Stanford Institute for Theoretical Economics'
-                      }
-                    ],
-                    type: 'organization',
-                    role: [
-                      {
-                        value: 'publisher',
-                        code: 'pbl',
-                        uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                        source: {
-                          code: 'marcrelator',
-                          uri: 'http://id.loc.gov/vocabulary/relators/'
-                        }
-                      }
-                    ]
-                  }
-                ],
-                location: [
-                  {
-                    uri: 'http://id.loc.gov/authorities/names/n50046557',
-                    value: 'Stanford (Calif.)'
-                  }
-                ]
-              }
-            ]
-          }
-        end
-
-        let(:mods) do
-          <<~XML
-            <originInfo displayLabel="Presented" eventType="presentation">
-              <place>
-                <placeTerm type="text" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
-              </place>
-              <publisher>Stanford Institute for Theoretical Economics</publisher>
-              <dateIssued keyDate="yes" encoding="w3cdtf">2018</dateIssued>
-            </originInfo>
-          XML
-        end
-      end
-    end
-
-    context 'with an originInfo that is a presentation' do
-      # from druid:ht706sj6651
-
-      it_behaves_like 'MODS cocina mapping' do
-        let(:mods) do
-          <<~XML
-            <originInfo displayLabel="Presented" eventType="presentation">
-              <place>
-                <placeTerm type="text" valueURI="http://id.loc.gov/authorities/names/n50046557">Stanford (Calif.)</placeTerm>
-              </place>
-              <publisher>Stanford Institute for Theoretical Economics</publisher>
-              <dateIssued keyDate="yes" encoding="w3cdtf">2018</dateIssued>
-            </originInfo>
-          XML
-        end
-
-        let(:cocina) do
-          {
-            event: [
-              {
-                type: 'presentation',
-                date: [
-                  {
-                    value: '2018',
-                    encoding: {
-                      code: 'w3cdtf'
-                    },
-                    status: 'primary'
-                  }
-                ],
-                displayLabel: 'Presented',
-                contributor: [
-                  {
-                    name: [
-                      {
-                        value: 'Stanford Institute for Theoretical Economics'
-                      }
-                    ],
-                    type: 'organization',
-                    role: [
-                      {
-                        value: 'publisher',
-                        code: 'pbl',
-                        uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                        source: {
-                          code: 'marcrelator',
-                          uri: 'http://id.loc.gov/vocabulary/relators/'
-                        }
-                      }
-                    ]
-                  }
-                ],
-                location: [
-                  {
-                    uri: 'http://id.loc.gov/authorities/names/n50046557',
-                    value: 'Stanford (Calif.)'
-                  }
-                ]
-              }
-            ]
-          }
-        end
-      end
-    end
-  end
-
-  describe 'Date mapping for performance event type' do
-    xit 'not implemented: performance event type' do
-      let(:cocina) do
-        {
-          event: [
-            {
-              type: 'performance',
-              date: [
-                {
-                  value: '1990'
-                }
-              ]
-            }
-          ]
-        }
-      end
-
-      let(:mods) do
-        <<~XML
-          <originInfo eventType="performance">
-            <dateCreated>1990</dateCreated>
-          </originInfo>
-        XML
-      end
-    end
-  end
-
-  describe 'Date mapping for release event type' do
-    xit 'not implemented: release event bug! (also has reverse mapped in H2 spec)' do
-      let(:cocina) do
-        {
-          event: [
-            {
-              type: 'release',
-              date: [
-                {
-                  value: '1990'
-                }
-              ]
-            }
-          ]
-        }
-      end
-
-      let(:mods) do
-        <<~XML
-          <originInfo eventType="release">
-            <dateIssued>1990</dateIssued>
-          </originInfo>
-        XML
-      end
-    end
-  end
-
-  # specs added by devs below
 
   context 'with a simple dateCreated with a trailing period' do
     it_behaves_like 'MODS cocina mapping' do
@@ -1570,375 +2756,6 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
     end
   end
 
-  context 'with a single dateOther' do
-    describe 'with type attribute on the dateOther element' do
-      it_behaves_like 'MODS cocina mapping' do
-        let(:mods) do
-          <<~XML
-            <originInfo>
-              <dateOther type="Islamic">1441 AH</dateOther>
-            </originInfo>
-          XML
-        end
-
-        let(:cocina) do
-          {
-            event: [
-              {
-                date: [
-                  {
-                    value: '1441 AH',
-                    note: [
-                      {
-                        value: 'Islamic',
-                        type: 'date type'
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        end
-
-        let(:warnings) { [Notification.new(msg: 'originInfo/dateOther missing eventType')] }
-      end
-    end
-
-    describe 'with eventType attribute at the originInfo level' do
-      it_behaves_like 'MODS cocina mapping' do
-        let(:mods) do
-          <<~XML
-            <originInfo eventType="acquisition" displayLabel="Acquisition date">
-              <dateOther encoding="w3cdtf">1992</dateOther>
-            </originInfo>
-          XML
-        end
-
-        let(:cocina) do
-          {
-            event: [
-              {
-                type: 'acquisition',
-                displayLabel: 'Acquisition date',
-                date: [
-                  {
-                    value: '1992',
-                    encoding: {
-                      code: 'w3cdtf'
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        end
-      end
-    end
-
-    describe 'without any type attribute, with displayLabel' do
-      it_behaves_like 'MODS cocina mapping' do
-        let(:mods) do
-          <<~XML
-            <originInfo displayLabel="Acquisition date">
-              <dateOther keyDate="yes" encoding="w3cdtf">1970-11-23</dateOther>
-            </originInfo>
-          XML
-        end
-
-        let(:cocina) do
-          {
-            event: [
-              {
-                displayLabel: 'Acquisition date',
-                date: [
-                  {
-                    value: '1970-11-23',
-                    encoding: {
-                      code: 'w3cdtf'
-                    },
-                    status: 'primary'
-                  }
-                ]
-              }
-            ]
-          }
-        end
-
-        let(:warnings) { [Notification.new(msg: 'originInfo/dateOther missing eventType')] }
-      end
-    end
-  end
-
-  context 'with issuance for a creation event' do
-    it_behaves_like 'MODS cocina mapping' do
-      let(:mods) do
-        <<~XML
-          <originInfo eventType="production">
-            <dateCreated encoding="w3cdtf" keyDate="yes">1988-08-03</dateCreated>
-            <issuance>monographic</issuance>
-          </originInfo>
-        XML
-      end
-
-      let(:cocina) do
-        {
-          event: [
-            {
-              type: 'creation',
-              date: [
-                {
-                  value: '1988-08-03',
-                  status: 'primary',
-                  encoding: {
-                    code: 'w3cdtf'
-                  }
-                }
-              ],
-              note: [
-                {
-                  value: 'monographic',
-                  type: 'issuance',
-                  source: {
-                    value: 'MODS issuance terms'
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      end
-    end
-  end
-
-  context 'when it has a single dateOther' do
-    context 'with eventType="acquisition"' do
-      # NOTE: cocina -> MODS
-      it_behaves_like 'cocina MODS mapping' do
-        let(:mods) do
-          <<~XML
-            <originInfo eventType="acquisition">
-              <dateOther keyDate="yes" encoding="w3cdtf">1970-11-23</dateOther>
-            </originInfo>
-          XML
-        end
-
-        let(:cocina) do
-          {
-            event: [
-              {
-                type: 'acquisition',
-                date: [
-                  {
-                    value: '1970-11-23',
-                    status: 'primary',
-                    encoding:
-                      {
-                        code: 'w3cdtf'
-                      }
-                  }
-                ]
-              }
-            ]
-          }
-        end
-      end
-    end
-
-    context 'without note, with displayLabel' do
-      # NOTE: cocina -> MODS
-      it_behaves_like 'cocina MODS mapping' do
-        let(:mods) do
-          <<~XML
-            <originInfo displayLabel="Acquisition date">
-              <dateOther keyDate="yes" encoding="w3cdtf">1970-11-23</dateOther>
-            </originInfo>
-          XML
-        end
-
-        let(:cocina) do
-          {
-            event: [
-              {
-                displayLabel: 'Acquisition date',
-                date: [
-                  {
-                    value: '1970-11-23',
-                    encoding: {
-                      code: 'w3cdtf'
-                    },
-                    status: 'primary'
-                  }
-                ]
-              }
-            ]
-          }
-        end
-
-        # for MODS -> cocina
-        let(:warnings) { [Notification.new(msg: 'originInfo/dateOther missing eventType')] }
-      end
-    end
-  end
-
-  context 'with originInfo with dateIssued with single point' do
-    # from druid:bm971cx9348
-
-    # NOTE: cocina -> MODS
-    it_behaves_like 'cocina MODS mapping' do
-      let(:mods) do
-        <<~XML
-          <originInfo eventType="publication">
-            <dateIssued>[192-?]-[193-?]</dateIssued>
-            <dateIssued encoding="marc" point="start">1920</dateIssued>
-            <place>
-              <placeTerm type="text">London</placeTerm>
-            </place>
-            <place>
-              <placeTerm type="code" authority="marccountry">enk</placeTerm>
-            </place>
-            <publisher>H.M. Stationery Off</publisher>
-            <edition>2nd ed.</edition>
-            <issuance>monographic</issuance>
-          </originInfo>
-        XML
-      end
-
-      let(:cocina) do
-        {
-          event: [
-            {
-              type: 'publication',
-              date: [
-                {
-                  value: '[192-?]-[193-?]'
-                },
-                {
-                  value: '1920',
-                  encoding: {
-                    code: 'marc'
-                  },
-                  type: 'start'
-                }
-              ],
-              note: [
-                {
-                  type: 'edition',
-                  value: '2nd ed.'
-                },
-                {
-                  source: {
-                    value: 'MODS issuance terms'
-                  },
-                  type: 'issuance',
-                  value: 'monographic'
-                }
-              ],
-              contributor: [
-                {
-                  name: [
-                    {
-                      value: 'H.M. Stationery Off'
-                    }
-                  ],
-                  type: 'organization',
-                  role: [
-                    {
-                      value: 'publisher',
-                      code: 'pbl',
-                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
-                      source: {
-                        code: 'marcrelator',
-                        uri: 'http://id.loc.gov/vocabulary/relators/'
-                      }
-                    }
-                  ]
-                }
-              ],
-              location: [
-                {
-                  value: 'London'
-                },
-                {
-                  source: {
-                    code: 'marccountry'
-                  },
-                  code: 'enk'
-                }
-              ]
-            }
-          ]
-        }
-      end
-    end
-  end
-
-  context 'when originInfo dateOther[@type] matches eventType and dateOther is empty' do
-    # based on #xv158sd4671
-
-    # Temporarily ignoring <originInfo> pending https://github.com/sul-dlss/dor-services-app/issues/2128
-    xit 'need to deal with dateOther type matching eventType and roundtripping' do
-      let(:mods) do
-        <<~XML
-          <originInfo eventType="distribution">
-            <place>
-              <placeTerm type="text">Washington, DC</placeTerm>
-            </place>
-            <publisher>blah</publisher>
-            <dateOther type="distribution"/>
-          </originInfo>
-        XML
-      end
-
-      let(:roundtrip_mods) do
-        <<~XML
-          <originInfo eventType="distribution">
-            <place>
-              <placeTerm type="text">Washington, DC</placeTerm>
-            </place>
-            <publisher>blah</publisher>
-          </originInfo>
-        XML
-      end
-
-      let(:cocina) do
-        {
-          event: [
-            {
-              type: 'distribution',
-              contributor: [
-                {
-                  name: [
-                    {
-                      value: 'blah'
-                    }
-                  ],
-                  type: 'organization',
-                  role: [
-                    {
-                      value: 'distributor',
-                      code: 'dst',
-                      uri: 'http://id.loc.gov/vocabulary/relators/dst',
-                      source: {
-                        code: 'marcrelator',
-                        uri: 'http://id.loc.gov/vocabulary/relators/'
-                      }
-                    }
-                  ]
-                }
-              ],
-              location: [
-                {
-                  value: 'Washington, DC'
-                }
-              ]
-            }
-          ]
-        }
-      end
-    end
-  end
-
   context 'when dateIssued with encoding and keyDate but no value' do
     # based on #vj932ns8042
     it_behaves_like 'MODS cocina mapping' do
@@ -1954,7 +2771,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
       let(:roundtrip_mods) do
         <<~XML
-          <originInfo eventType="publication">
+          <originInfo>
             <publisher>blah</publisher>
             <issuance>monographic</issuance>
           </originInfo>
@@ -1965,7 +2782,6 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         {
           event: [
             {
-              type: 'publication',
               note: [
                 {
                   source: {
@@ -1982,7 +2798,6 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                       value: 'blah'
                     }
                   ],
-                  type: 'organization',
                   role: [
                     {
                       value: 'publisher',
@@ -2002,4 +2817,373 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
       end
     end
   end
+
+  # context 'with a single dateOther' do
+  #   describe 'with type attribute on the dateOther element' do
+  #     it_behaves_like 'MODS cocina mapping' do
+  #       let(:mods) do
+  #         <<~XML
+  #           <originInfo>
+  #             <dateOther type="Islamic">1441 AH</dateOther>
+  #           </originInfo>
+  #         XML
+  #       end
+  #
+  #       let(:cocina) do
+  #         {
+  #           event: [
+  #             {
+  #               date: [
+  #                 {
+  #                   value: '1441 AH',
+  #                   note: [
+  #                     {
+  #                       value: 'Islamic',
+  #                       type: 'date type'
+  #                     }
+  #                   ]
+  #                 }
+  #               ]
+  #             }
+  #           ]
+  #         }
+  #       end
+  #
+  #       let(:warnings) { [Notification.new(msg: 'originInfo/dateOther missing eventType')] }
+  #     end
+  #   end
+  #
+  #   describe 'with eventType attribute at the originInfo level' do
+  #     it_behaves_like 'MODS cocina mapping' do
+  #       let(:mods) do
+  #         <<~XML
+  #           <originInfo eventType="acquisition" displayLabel="Acquisition date">
+  #             <dateOther encoding="w3cdtf">1992</dateOther>
+  #           </originInfo>
+  #         XML
+  #       end
+  #
+  #       let(:cocina) do
+  #         {
+  #           event: [
+  #             {
+  #               type: 'acquisition',
+  #               displayLabel: 'Acquisition date',
+  #               date: [
+  #                 {
+  #                   value: '1992',
+  #                   encoding: {
+  #                     code: 'w3cdtf'
+  #                   }
+  #                 }
+  #               ]
+  #             }
+  #           ]
+  #         }
+  #       end
+  #     end
+  #   end
+  #
+  #   describe 'without any type attribute, with displayLabel' do
+  #     it_behaves_like 'MODS cocina mapping' do
+  #       let(:mods) do
+  #         <<~XML
+  #           <originInfo displayLabel="Acquisition date">
+  #             <dateOther keyDate="yes" encoding="w3cdtf">1970-11-23</dateOther>
+  #           </originInfo>
+  #         XML
+  #       end
+  #
+  #       let(:cocina) do
+  #         {
+  #           event: [
+  #             {
+  #               displayLabel: 'Acquisition date',
+  #               date: [
+  #                 {
+  #                   value: '1970-11-23',
+  #                   encoding: {
+  #                     code: 'w3cdtf'
+  #                   },
+  #                   status: 'primary'
+  #                 }
+  #               ]
+  #             }
+  #           ]
+  #         }
+  #       end
+  #
+  #       let(:warnings) { [Notification.new(msg: 'originInfo/dateOther missing eventType')] }
+  #     end
+  #   end
+  # end
+
+  # context 'with issuance for a creation event' do
+  #   it_behaves_like 'MODS cocina mapping' do
+  #     let(:mods) do
+  #       <<~XML
+  #         <originInfo eventType="production">
+  #           <dateCreated encoding="w3cdtf" keyDate="yes">1988-08-03</dateCreated>
+  #           <issuance>monographic</issuance>
+  #         </originInfo>
+  #       XML
+  #     end
+  #
+  #     let(:cocina) do
+  #       {
+  #         event: [
+  #           {
+  #             type: 'creation',
+  #             date: [
+  #               {
+  #                 value: '1988-08-03',
+  #                 status: 'primary',
+  #                 encoding: {
+  #                   code: 'w3cdtf'
+  #                 }
+  #               }
+  #             ],
+  #             note: [
+  #               {
+  #                 value: 'monographic',
+  #                 type: 'issuance',
+  #                 source: {
+  #                   value: 'MODS issuance terms'
+  #                 }
+  #               }
+  #             ]
+  #           }
+  #         ]
+  #       }
+  #     end
+  #   end
+  # end
+
+  # context 'when it has a single dateOther' do
+  #   context 'with eventType="acquisition"' do
+  #     # NOTE: cocina -> MODS
+  #     it_behaves_like 'cocina MODS mapping' do
+  #       let(:mods) do
+  #         <<~XML
+  #           <originInfo eventType="acquisition">
+  #             <dateOther keyDate="yes" encoding="w3cdtf">1970-11-23</dateOther>
+  #           </originInfo>
+  #         XML
+  #       end
+  #
+  #       let(:cocina) do
+  #         {
+  #           event: [
+  #             {
+  #               type: 'acquisition',
+  #               date: [
+  #                 {
+  #                   value: '1970-11-23',
+  #                   status: 'primary',
+  #                   encoding:
+  #                     {
+  #                       code: 'w3cdtf'
+  #                     }
+  #                 }
+  #               ]
+  #             }
+  #           ]
+  #         }
+  #       end
+  #     end
+  #   end
+  #
+  #   context 'without note, with displayLabel' do
+  #     # NOTE: cocina -> MODS
+  #     it_behaves_like 'cocina MODS mapping' do
+  #       let(:mods) do
+  #         <<~XML
+  #           <originInfo displayLabel="Acquisition date">
+  #             <dateOther keyDate="yes" encoding="w3cdtf">1970-11-23</dateOther>
+  #           </originInfo>
+  #         XML
+  #       end
+  #
+  #       let(:cocina) do
+  #         {
+  #           event: [
+  #             {
+  #               displayLabel: 'Acquisition date',
+  #               date: [
+  #                 {
+  #                   value: '1970-11-23',
+  #                   encoding: {
+  #                     code: 'w3cdtf'
+  #                   },
+  #                   status: 'primary'
+  #                 }
+  #               ]
+  #             }
+  #           ]
+  #         }
+  #       end
+  #
+  #       # for MODS -> cocina
+  #       let(:warnings) { [Notification.new(msg: 'originInfo/dateOther missing eventType')] }
+  #     end
+  #   end
+  # end
+
+  # context 'with originInfo with dateIssued with single point' do
+  #   # from druid:bm971cx9348
+  #
+  #   # NOTE: cocina -> MODS
+  #   it_behaves_like 'cocina MODS mapping' do
+  #     let(:mods) do
+  #       <<~XML
+  #         <originInfo eventType="publication">
+  #           <dateIssued>[192-?]-[193-?]</dateIssued>
+  #           <dateIssued encoding="marc" point="start">1920</dateIssued>
+  #           <place>
+  #             <placeTerm type="text">London</placeTerm>
+  #           </place>
+  #           <place>
+  #             <placeTerm type="code" authority="marccountry">enk</placeTerm>
+  #           </place>
+  #           <publisher>H.M. Stationery Off</publisher>
+  #           <edition>2nd ed.</edition>
+  #           <issuance>monographic</issuance>
+  #         </originInfo>
+  #       XML
+  #     end
+  #
+  #     let(:cocina) do
+  #       {
+  #         event: [
+  #           {
+  #             type: 'publication',
+  #             date: [
+  #               {
+  #                 value: '[192-?]-[193-?]'
+  #               },
+  #               {
+  #                 value: '1920',
+  #                 encoding: {
+  #                   code: 'marc'
+  #                 },
+  #                 type: 'start'
+  #               }
+  #             ],
+  #             note: [
+  #               {
+  #                 type: 'edition',
+  #                 value: '2nd ed.'
+  #               },
+  #               {
+  #                 source: {
+  #                   value: 'MODS issuance terms'
+  #                 },
+  #                 type: 'issuance',
+  #                 value: 'monographic'
+  #               }
+  #             ],
+  #             contributor: [
+  #               {
+  #                 name: [
+  #                   {
+  #                     value: 'H.M. Stationery Off'
+  #                   }
+  #                 ],
+  #                 type: 'organization',
+  #                 role: [
+  #                   {
+  #                     value: 'publisher',
+  #                     code: 'pbl',
+  #                     uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+  #                     source: {
+  #                       code: 'marcrelator',
+  #                       uri: 'http://id.loc.gov/vocabulary/relators/'
+  #                     }
+  #                   }
+  #                 ]
+  #               }
+  #             ],
+  #             location: [
+  #               {
+  #                 value: 'London'
+  #               },
+  #               {
+  #                 source: {
+  #                   code: 'marccountry'
+  #                 },
+  #                 code: 'enk'
+  #               }
+  #             ]
+  #           }
+  #         ]
+  #       }
+  #     end
+  #   end
+  # end
+
+  # context 'when originInfo dateOther[@type] matches eventType and dateOther is empty' do
+  #   # based on #xv158sd4671
+  #
+  #   # Temporarily ignoring <originInfo> pending https://github.com/sul-dlss/dor-services-app/issues/2128
+  #   xit 'need to deal with dateOther type matching eventType and roundtripping' do
+  #     let(:mods) do
+  #       <<~XML
+  #         <originInfo eventType="distribution">
+  #           <place>
+  #             <placeTerm type="text">Washington, DC</placeTerm>
+  #           </place>
+  #           <publisher>blah</publisher>
+  #           <dateOther type="distribution"/>
+  #         </originInfo>
+  #       XML
+  #     end
+  #
+  #     let(:roundtrip_mods) do
+  #       <<~XML
+  #         <originInfo eventType="distribution">
+  #           <place>
+  #             <placeTerm type="text">Washington, DC</placeTerm>
+  #           </place>
+  #           <publisher>blah</publisher>
+  #         </originInfo>
+  #       XML
+  #     end
+  #
+  #     let(:cocina) do
+  #       {
+  #         event: [
+  #           {
+  #             type: 'distribution',
+  #             contributor: [
+  #               {
+  #                 name: [
+  #                   {
+  #                     value: 'blah'
+  #                   }
+  #                 ],
+  #                 type: 'organization',
+  #                 role: [
+  #                   {
+  #                     value: 'distributor',
+  #                     code: 'dst',
+  #                     uri: 'http://id.loc.gov/vocabulary/relators/dst',
+  #                     source: {
+  #                       code: 'marcrelator',
+  #                       uri: 'http://id.loc.gov/vocabulary/relators/'
+  #                     }
+  #                   }
+  #                 ]
+  #               }
+  #             ],
+  #             location: [
+  #               {
+  #                 value: 'Washington, DC'
+  #               }
+  #             ]
+  #           }
+  #         ]
+  #       }
+  #     end
+  #   end
+  # end
 end

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_event_type_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_event_type_spec.rb
@@ -633,4 +633,32 @@ RSpec.describe 'MODS originInfo <--> cocina mappings TEST' do
       end
     end
   end
+
+  describe 'copyright notice eventType' do
+    xit 'not implemented' do
+      let(:mods) do
+        <<~XML
+          <originInfo eventType="copyright notice">
+             <copyrightDate>©2018</copyrightDate>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'copyright notice',
+              note: [
+                {
+                  value: '©2018',
+                  type: 'copyright statement'
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
+  end
 end

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_event_type_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_event_type_spec.rb
@@ -661,4 +661,304 @@ RSpec.describe 'MODS originInfo <--> cocina mappings TEST' do
       end
     end
   end
+
+  context 'legacy MARC2MODS 264 mappings' do
+    xit 'not implemented' do
+      describe 'producer eventType' do
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="producer">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:roundtrip_mods) do
+          <<~XML
+            <originInfo eventType="production">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'production',
+                location: [
+                  {
+                    value: 'London'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+      end
+
+      describe 'publisher eventType' do
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="publisher">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:roundtrip_mods) do
+          <<~XML
+            <originInfo eventType="publication">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'publication',
+                location: [
+                  {
+                    value: 'London'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+      end
+
+      describe 'distributor eventType' do
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="distributor">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:roundtrip_mods) do
+          <<~XML
+            <originInfo eventType="distribution">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'distribution',
+                location: [
+                  {
+                    value: 'London'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+      end
+
+      describe 'producer eventType' do
+        let(:mods) do
+          <<~XML
+            <originInfo eventType="manufacturer">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:roundtrip_mods) do
+          <<~XML
+            <originInfo eventType="manufacture">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'manufacture',
+                location: [
+                  {
+                    value: 'London'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+      end
+
+      describe 'producer displayLabel' do
+        let(:mods) do
+          <<~XML
+            <originInfo displayLabel="producer">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:roundtrip_mods) do
+          <<~XML
+            <originInfo eventType="production">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'production',
+                location: [
+                  {
+                    value: 'London'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+      end
+
+      describe 'publisher displayLabel' do
+        let(:mods) do
+          <<~XML
+            <originInfo displayLabel="publisher">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:roundtrip_mods) do
+          <<~XML
+            <originInfo eventType="publication">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'publication',
+                location: [
+                  {
+                    value: 'London'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+      end
+
+      describe 'distributor displayLabel' do
+        let(:mods) do
+          <<~XML
+            <originInfo displayLabel="distributor">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:roundtrip_mods) do
+          <<~XML
+            <originInfo eventType="distribution">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'distribution',
+                location: [
+                  {
+                    value: 'London'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+      end
+
+      describe 'producer displayLabel' do
+        let(:mods) do
+          <<~XML
+            <originInfo displayLabel="manufacturer">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:roundtrip_mods) do
+          <<~XML
+            <originInfo eventType="manufacture">
+              <place>
+                <placeTerm type="text">London</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                type: 'manufacture',
+                location: [
+                  {
+                    value: 'London'
+                  }
+                ]
+              }
+            ]
+          }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?
More mappings


## How was this change tested?
n/a


## Which documentation and/or configurations were updated?
n/a


Implementation ticket #2392 