### PR TITLE
Handle when modified_date is a String

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -47,7 +47,7 @@ class ObjectsController < ApplicationController
     # This hack overrides that behavior and ensures Etds can be mapped to Cocina.
     models = ActiveFedora::ContentModel.models_asserted_by(@item)
     @item = @item.adapt_to(Etd) if models.include?('info:fedora/afmodel:Etd')
-    headers['Last-Modified'] = @item.modified_date.httpdate
+    headers['Last-Modified'] = @item.modified_date.to_datetime.httpdate
     render json: Cocina::Mapper.build(@item)
   rescue SolrConnectionError => e
     json_api_error(status: :internal_server_error,

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -5,6 +5,9 @@ require 'rails_helper'
 RSpec.describe 'Get the object' do
   before do
     allow(Dor).to receive(:find).and_return(object)
+    # When an AF object comes from persistence, then modified_date is a string.  If it's new it's a date.
+    # So by mocking this as a string it looks like the real use case:
+    allow(object).to receive(:modified_date).and_return('2021-03-04T14:50:08.107Z')
     allow(object).to receive(:admin_policy_object_id).and_return('druid:df123cd4567')
   end
 


### PR DESCRIPTION

## Why was this change made?

When an ActiveFedora object is new, the modified_date returns a DateTime, but when it's persisted it returns a string.  Cast this to a datetime so that we can use it as intended


## How was this change tested?



## Which documentation and/or configurations were updated?



