### PR TITLE
updates cocina model (and openapi.yml) to 0.52.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.50.0'
+gem 'cocina-models', '~> 0.51.0'
 gem 'dor-rights-auth', '>= 1.5.0' # required for new CDL rights
 gem 'dor-services', '~> 9.6'
 gem 'dor-workflow-client', '~> 3.17'

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.51.0'
+gem 'cocina-models', '~> 0.52.0'
 gem 'dor-rights-auth', '>= 1.5.0' # required for new CDL rights
 gem 'dor-services', '~> 9.6'
 gem 'dor-workflow-client', '~> 3.17'

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.49.0'
+gem 'cocina-models', '~> 0.50.0'
 gem 'dor-rights-auth', '>= 1.5.0' # required for new CDL rights
 gem 'dor-services', '~> 9.6'
 gem 'dor-workflow-client', '~> 3.17'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.49.0)
+    cocina-models (0.50.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -521,7 +521,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.49.0)
+  cocina-models (~> 0.50.0)
   committee
   config
   deprecation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.50.0)
+    cocina-models (0.51.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -521,7 +521,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.50.0)
+  cocina-models (~> 0.51.0)
   committee
   config
   deprecation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.51.0)
+    cocina-models (0.52.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -521,7 +521,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.51.0)
+  cocina-models (~> 0.52.0)
   committee
   config
   deprecation

--- a/app/services/cocina/from_fedora/apo.rb
+++ b/app/services/cocina/from_fedora/apo.rb
@@ -34,9 +34,11 @@ module Cocina
 
       def build_apo_administrative
         {}.tap do |admin|
-          registration_workflow = item.administrativeMetadata.ng_xml.xpath('//administrativeMetadata/dissemination/workflow/@id').text
+          registration_workflows = item.administrativeMetadata.ng_xml.xpath('//administrativeMetadata/registration/workflow/@id').map(&:value)
+          dissemination_workflow = item.administrativeMetadata.ng_xml.xpath('//administrativeMetadata/dissemination/workflow/@id').text
           admin[:defaultObjectRights] = item.defaultObjectRights.content
-          admin[:registrationWorkflow] = registration_workflow if registration_workflow.present?
+          admin[:disseminationWorkflow] = dissemination_workflow if dissemination_workflow.present?
+          admin[:registrationWorkflow] = registration_workflows if registration_workflows.present?
           admin[:hasAdminPolicy] = item.admin_policy_object_id
         end
       end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -58,10 +58,7 @@ module Cocina
                                  label: obj.label).tap do |item|
         add_description(item, obj)
 
-        admin_node = item.administrativeMetadata.ng_xml.xpath('//administrativeMetadata').first
-        admin_node.add_child "<dissemination><workflow id=\"#{obj.administrative.registrationWorkflow}\"></dissemination>"
-        item.administrativeMetadata.ng_xml_will_change!
-
+        Cocina::ToFedora::ApoRights.write(item.administrativeMetadata, obj.administrative)
         Cocina::ToFedora::Identity.apply(obj, item, object_type: 'adminPolicy')
       end
     end

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -58,11 +58,7 @@ module Cocina
       # item.source_id = obj.identification.sourceId
       item.label = truncate_label(obj.label)
 
-      admin_node = item.administrativeMetadata.ng_xml.xpath('//administrativeMetadata').first
-      # TODO: need to see if this node already exists
-      admin_node.add_child "<dissemination><workflow id=\"#{obj.administrative.registrationWorkflow}\"></dissemination>"
-      item.administrativeMetadata.ng_xml_will_change!
-
+      Cocina::ToFedora::ApoRights.write(item.administrativeMetadata, obj.administrative)
       Cocina::ToFedora::Identity.apply(obj, item, object_type: 'adminPolicy')
     end
 

--- a/app/services/cocina/to_fedora/apo_rights.rb
+++ b/app/services/cocina/to_fedora/apo_rights.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Cocina
+  module ToFedora
+    # This transforms the AdminPolicyAdministrative schema to the
+    # Fedora 3 data model rights
+    class ApoRights
+      def self.write(administrative_metadata, administrative)
+        admin_node = administrative_metadata.ng_xml.xpath('//administrativeMetadata').first
+        # TODO: need to see if this node already exists
+        admin_node.add_child "<dissemination><workflow id=\"#{administrative.disseminationWorkflow}\" /></dissemination>"
+        registration_workflows = administrative.registrationWorkflow.map { |wf_id| "<workflow id=\"#{wf_id}\" />" }.join
+        admin_node.add_child "<registration>#{registration_workflows}</registration>"
+
+        administrative_metadata.ng_xml_will_change!
+      end
+    end
+  end
+end

--- a/openapi.yml
+++ b/openapi.yml
@@ -1794,6 +1794,7 @@ components:
       additionalProperties: false
       allOf:
         - $ref: "#/components/schemas/DescriptiveStructuredValue"
+        - $ref: "#/components/schemas/DescriptiveValueLanguage"
         - type: object
           additionalProperties: false
           properties:

--- a/openapi.yml
+++ b/openapi.yml
@@ -1167,6 +1167,10 @@ components:
           type: array
           items:
             type: string
+        disseminationWorkflow:
+          description: An additional workflow to start for objects managed by this admin policy once the end-accession workflow step is complete
+          example: wasCrawlPreassemblyWF
+          type: string
         collectionsForRegistration:
           description: When you register an item with this admin policy, these are the collections that are available.
           type: array

--- a/openapi.yml
+++ b/openapi.yml
@@ -1070,6 +1070,48 @@ components:
             - 'art'
             - 'hoover'
             - 'm&m'
+    AccessRole:
+      description: Access role conferred by an AdminPolicy to objects within it. (used by Argo)
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          description: Name of role
+          type: string
+          enum:
+            - 'sdr-administrator'
+            - 'sdr-viewer'
+            - 'dor-apo-manager'
+            - 'hydrus-collection-creator'
+            - 'hydrus-collection-manager'
+            - 'hydrus-collection-depositor'
+            - 'hydrus-collection-item-depositor'
+            - 'hydrus-collection-reviewer'
+            - 'hydrus-collection-viewer'
+        members:
+          description: The users and groups that are members of the role
+          type: array
+          items:
+            $ref: '#/components/schemas/AccessRoleMember'
+      required:
+        - members
+        - name
+    AccessRoleMember:
+      description: Represents a user or group that is a member of an AccessRole
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          description: Name of role
+          type: string
+          enum:
+            - 'sunetid'
+            - 'workgroup'
+        identifier:
+          type: string
+      required:
+        - identifier
+        - type
     Administrative:
       type: object
       additionalProperties: false
@@ -1113,6 +1155,7 @@ components:
         - type
         - version
     AdminPolicyAdministrative:
+      description: Administrative properties for an AdminPolicy
       type: object
       additionalProperties: false
       properties:
@@ -1120,12 +1163,20 @@ components:
           type: string
           default: <?xml version="1.0" encoding="UTF-8"?><rightsMetadata><access type="discover"><machine><world/></machine></access><access type="read"><machine><world/></machine></access><use><human type="useAndReproduction"/><human type="creativeCommons"/><machine type="creativeCommons" uri=""/><human type="openDataCommons"/><machine type="openDataCommons" uri=""/></use><copyright><human/></copyright></rightsMetadata>
         registrationWorkflow:
-          type: string
+          description: When you register an item with this admin policy, these are the workflows that are available.
+          type: array
+          items:
+            type: string
         collectionsForRegistration:
           description: When you register an item with this admin policy, these are the collections that are available.
           type: array
           items:
             type: string
+        roles:
+          description: The access roles conferred by this AdminPolicy (used by Argo)
+          type: array
+          items:
+            $ref: '#/components/schemas/AccessRole'
         hasAdminPolicy:
           type: string
       required:
@@ -1476,6 +1527,47 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DescriptiveValue"
+    DescriptiveParallelEvent:
+      description: Value model for multiple representations of information about the same event (e.g. in different languages).
+      type: object
+      additionalProperties: false
+      allOf:
+        - $ref: "#/components/schemas/DescriptiveValueLanguage"
+        - $ref: "#/components/schemas/DescriptiveStructuredValue"
+        - type: object
+          additionalProperties: false
+          properties:
+            type:
+              description: Description of the event (creation, publication, etc.).
+              type: string
+            displayLabel:
+              description: The preferred display label to use for the event in access systems.
+              type: string
+            date:
+              description: Dates associated with the event.
+              type: array
+              items:
+                $ref: "#/components/schemas/DescriptiveValue"
+            contributor:
+              description: Contributors associated with the event.
+              type: array
+              items:
+                $ref: "#/components/schemas/Contributor"
+            location:
+              description: Locations associated with the event.
+              type: array
+              items:
+                $ref: "#/components/schemas/DescriptiveValue"
+            identifier:
+              description: Identifiers and URIs associated with the event.
+              type: array
+              items:
+                $ref: "#/components/schemas/DescriptiveValue"
+            note:
+              description: Other information about the event.
+              type: array
+              items:
+                $ref: "#/components/schemas/DescriptiveValue"
     DescriptiveParallelValue:
       description: Value model for multiple representations of the same information (e.g. in different languages).
       type: object
@@ -1698,7 +1790,6 @@ components:
       additionalProperties: false
       allOf:
         - $ref: "#/components/schemas/DescriptiveStructuredValue"
-        - $ref: "#/components/schemas/DescriptiveParallelValue"
         - type: object
           additionalProperties: false
           properties:
@@ -1733,6 +1824,11 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/DescriptiveValue"
+            parallelEvent:
+              description: For multiple representations of information about the same event (e.g. in different languages)
+              type: array
+              items:
+                $ref: "#/components/schemas/DescriptiveParallelEvent"
     File:
       description: Binaries that are the basis of what our domain manages. Binaries here do not include metadata files generated for the domain's own management purposes.
       type: object

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -692,7 +692,8 @@ RSpec.describe 'Create object' do
                                       administrative: {
                                         defaultObjectRights: default_object_rights,
                                         hasAdminPolicy: 'druid:dd999df4567',
-                                        registrationWorkflow: 'assemblyWF'
+                                        disseminationWorkflow: 'assemblyWF',
+                                        registrationWorkflow: %w[goobiWF registrationWF]
                                       },
                                       externalIdentifier: druid)
     end
@@ -705,7 +706,8 @@ RSpec.describe 'Create object' do
           "label":"This is my label","version":1,
           "administrative":{
             "defaultObjectRights":#{default_object_rights.to_json},
-            "registrationWorkflow":"assemblyWF",
+            "disseminationWorkflow":"assemblyWF",
+            "registrationWorkflow":["goobiWF","registrationWF"],
             "hasAdminPolicy":"druid:dd999df4567"},
           "description":{"title":[{"value":"This is my title"}],"purl":"http://purl.stanford.edu/gg777gg7777","access":{"digitalRepository":[{"value":"Stanford Digital Repository"}]}}}
       JSON

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -423,6 +423,10 @@ RSpec.describe 'Get the object' do
       before do
         object.administrativeMetadata.content = <<~XML
           <administrativeMetadata>
+            <registration>
+              <workflow id="registrationWF"/>
+              <workflow id="goobiWF"/>
+            </registration>
             <dissemination>
               <workflow id="wasCrawlPreassemblyWF"/>
             </dissemination>
@@ -443,7 +447,8 @@ RSpec.describe 'Get the object' do
         expect(json['label']).to eq 'foo'
         expect(json['version']).to eq 1
         expect(json['administrative']['defaultObjectRights']).to match '<rightsMetadata>'
-        expect(json['administrative']['registrationWorkflow']).to eq 'wasCrawlPreassemblyWF'
+        expect(json['administrative']['registrationWorkflow']).to eq %w[registrationWF goobiWF]
+        expect(json['administrative']['disseminationWorkflow']).to eq 'wasCrawlPreassemblyWF'
       end
     end
   end

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -925,7 +925,8 @@ RSpec.describe 'Update object' do
                                       administrative: {
                                         defaultObjectRights: default_object_rights,
                                         hasAdminPolicy: 'druid:dd999df4567',
-                                        registrationWorkflow: 'assemblyWF'
+                                        disseminationWorkflow: 'assemblyWF',
+                                        registrationWorkflow: %w[goobiWF registrationWF]
                                       },
                                       externalIdentifier: druid)
     end
@@ -940,7 +941,8 @@ RSpec.describe 'Update object' do
           "label":"This is my label","version":1,
           "administrative":{
             "defaultObjectRights":#{default_object_rights.to_json},
-            "registrationWorkflow":"assemblyWF",
+            "disseminationWorkflow":"assemblyWF",
+            "registrationWorkflow":["goobiWF","registrationWF"],
             "hasAdminPolicy":"druid:dd999df4567"},
           "description":{"title":[{"value":"This is my title"}]}}
       JSON


### PR DESCRIPTION
## Why was this change made?

We need cocina model changes:
- admin metadata changes to get roles and workflow updates
- event changes for clean roundtripping of MODS originInfo to cocina and back                                                                                                                                                                                                                                                                                                                                                                                                                                                

## How was this change tested?



## Which documentation and/or configurations were updated?



