### PR TITLE
Support partial object update.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,7 @@ Metrics/ClassLength:
     - 'app/services/cocina/mods_normalizers/origin_info_normalizer.rb'
     - 'app/services/cocina/from_fedora/descriptive/access.rb'
     - 'app/services/cocina/to_fedora/descriptive/related_resource.rb'
+    - 'app/services/cocina/object_updater.rb'
 
 RSpec/DescribeClass:
   Exclude:

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -34,8 +34,8 @@ class ObjectsController < ApplicationController
 
   def update
     obj = Dor.find(params[:id])
-    update_request = Cocina::Models.build(params.except(:action, :controller, :id).to_unsafe_h)
-    cocina_object = Cocina::ObjectUpdater.run(obj, update_request)
+    update_request = Cocina::Models.build(params.except(:action, :controller, :id, :only).to_unsafe_h)
+    cocina_object = Cocina::ObjectUpdater.run(obj, update_request, only: params[:only])
 
     render json: cocina_object
   rescue Cocina::ValidationError => e

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -59,7 +59,7 @@ module Cocina
         add_description(item, obj)
 
         Cocina::ToFedora::ApoRights.write(item.administrativeMetadata, obj.administrative)
-        Cocina::ToFedora::Identity.apply(obj, item, object_type: 'adminPolicy')
+        Cocina::ToFedora::Identity.apply(item, label: obj.label, object_type: 'adminPolicy')
       end
     end
 
@@ -81,7 +81,7 @@ module Cocina
         Cocina::ToFedora::DROAccess.apply(item, obj.access) if obj.access
 
         item.contentMetadata.content = Cocina::ToFedora::ContentMetadataGenerator.generate(druid: pid, object: obj)
-        Cocina::ToFedora::Identity.apply(obj, item, object_type: 'item', agreement_id: obj.structural&.hasAgreement)
+        Cocina::ToFedora::Identity.apply(item, label: obj.label, object_type: 'item', agreement_id: obj.structural&.hasAgreement)
       end
     end
 
@@ -98,7 +98,7 @@ module Cocina
         add_collection_tags(pid, obj)
         apply_default_access(item)
         Cocina::ToFedora::Access.apply(item, obj.access) if obj.access
-        Cocina::ToFedora::Identity.apply(obj, item, object_type: 'collection')
+        Cocina::ToFedora::Identity.apply(item, label: obj.label, object_type: 'collection')
       end
     end
 

--- a/app/services/cocina/to_fedora/identity.rb
+++ b/app/services/cocina/to_fedora/identity.rb
@@ -6,11 +6,11 @@ module Cocina
     # Fedora 3 data model identityMetadata
     class Identity
       # @param [String] agreement_id (nil) the identifier for the agreement. Note that only items have an agreement.
-      def self.apply(obj, item, object_type:, agreement_id: nil)
+      def self.apply(item, label:, object_type:, agreement_id: nil)
         item.objectId = item.pid
         item.objectCreator = 'DOR'
         # May have already been set when setting descriptive metadata.
-        item.objectLabel = obj.label if item.objectLabel.empty?
+        item.objectLabel = label if item.objectLabel.empty?
         item.objectType = object_type
         item.identityMetadata.agreementId = agreement_id if agreement_id
       end

--- a/openapi.yml
+++ b/openapi.yml
@@ -983,6 +983,16 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
+        - name: only
+          in: query
+          description: Limit update to the provided keys.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [type, label, version, access, administrative, description, identification, structural, geographic]
+            minItems: 1
       requestBody:
         required: true
         content:


### PR DESCRIPTION
closes #2410

## Why was this change made?
Avoid unintended update to other parts of an item when using update API.


## How was this change tested?
Not yet.


## Which documentation and/or configurations were updated?
openapi


