### PR TITLE
Support partial object update.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,7 @@ Metrics/ClassLength:
     - 'app/services/cocina/mods_normalizers/origin_info_normalizer.rb'
     - 'app/services/cocina/from_fedora/descriptive/access.rb'
     - 'app/services/cocina/to_fedora/descriptive/related_resource.rb'
+    - 'app/services/cocina/object_updater.rb'
 
 RSpec/DescribeClass:
   Exclude:

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -60,7 +60,7 @@ module Cocina
 
         Cocina::ToFedora::ApoRights.write(item.administrativeMetadata, obj.administrative)
         Cocina::ToFedora::Roles.write(item, Array(obj.administrative.roles))
-        Cocina::ToFedora::Identity.apply(obj, item, object_type: 'adminPolicy')
+        Cocina::ToFedora::Identity.apply(item, label: obj.label, object_type: 'adminPolicy')
       end
     end
 
@@ -82,7 +82,7 @@ module Cocina
         Cocina::ToFedora::DROAccess.apply(item, obj.access) if obj.access
 
         item.contentMetadata.content = Cocina::ToFedora::ContentMetadataGenerator.generate(druid: pid, object: obj)
-        Cocina::ToFedora::Identity.apply(obj, item, object_type: 'item', agreement_id: obj.structural&.hasAgreement)
+        Cocina::ToFedora::Identity.apply(item, label: obj.label, object_type: 'item', agreement_id: obj.structural&.hasAgreement)
       end
     end
 
@@ -99,7 +99,7 @@ module Cocina
         add_collection_tags(pid, obj)
         apply_default_access(item)
         Cocina::ToFedora::Access.apply(item, obj.access) if obj.access
-        Cocina::ToFedora::Identity.apply(obj, item, object_type: 'collection')
+        Cocina::ToFedora::Identity.apply(item, label: obj.label, object_type: 'collection')
       end
     end
 

--- a/app/services/cocina/to_fedora/access.rb
+++ b/app/services/cocina/to_fedora/access.rb
@@ -21,6 +21,8 @@ module Cocina
       def apply
         # See https://github.com/sul-dlss/dor-services/blob/main/lib/dor/datastreams/rights_metadata_ds.rb
         Dor::RightsMetadataDS.upd_rights_xml_for_rights_type(item.rightsMetadata.ng_xml, rights_type)
+        # This invalidates the dra_object, which is necessary if re-mapping.
+        item.rightsMetadata.content = item.rightsMetadata.ng_xml.to_s
         item.rightsMetadata.ng_xml_will_change!
       end
 

--- a/app/services/cocina/to_fedora/identity.rb
+++ b/app/services/cocina/to_fedora/identity.rb
@@ -6,11 +6,11 @@ module Cocina
     # Fedora 3 data model identityMetadata
     class Identity
       # @param [String] agreement_id (nil) the identifier for the agreement. Note that only items have an agreement.
-      def self.apply(obj, item, object_type:, agreement_id: nil)
+      def self.apply(item, label:, object_type:, agreement_id: nil)
         item.objectId = item.pid
         item.objectCreator = 'DOR'
         # May have already been set when setting descriptive metadata.
-        item.objectLabel = obj.label if item.objectLabel.empty?
+        item.objectLabel = label if item.objectLabel.empty?
         item.objectType = object_type
         item.identityMetadata.agreementId = agreement_id if agreement_id
       end

--- a/spec/services/cocina/object_updater_spec.rb
+++ b/spec/services/cocina/object_updater_spec.rb
@@ -1,0 +1,510 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Tests whether partial updates are handled correctly.
+# It does not test the updates themselves.
+RSpec.describe Cocina::ObjectUpdater do
+  subject(:update) { described_class.run(item, cocina_object) }
+
+  # For the existing item.
+  let(:orig_cocina_object) do
+    Cocina::Models.build(orig_cocina_attrs.with_indifferent_access)
+  end
+
+  # For the submitted item.
+  let(:cocina_object) do
+    Cocina::Models.build(cocina_attrs.with_indifferent_access)
+  end
+
+  let(:cocina_attrs) { orig_cocina_attrs }
+
+  before do
+    allow(Cocina::Mapper).to receive(:build).and_return(orig_cocina_object)
+    allow(Cocina::ApoExistenceValidator).to receive(:new).and_return(instance_double(Cocina::ApoExistenceValidator, valid?: true))
+    allow(Settings.enabled_features).to receive(:update_descriptive).and_return(true)
+    allow(AdministrativeTags).to receive(:for).and_return([])
+  end
+
+  context 'when an admin policy' do
+    let(:item) do
+      instance_double(Dor::AdminPolicyObject, pid: 'druid:bc123df4567',
+                                              save!: nil,
+                                              administrativeMetadata: double,
+                                              descMetadata: desc_metadata)
+    end
+
+    let(:desc_metadata) { double }
+
+    let(:orig_cocina_attrs) do
+      {
+        type: 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld',
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'orig label',
+        version: 1,
+        administrative: { hasAdminPolicy: 'druid:dd999df4567' },
+        description: { title: [{ value: 'orig title' }] }
+      }
+    end
+
+    context 'when updating label' do
+      before do
+        allow(item).to receive(:label=)
+        allow(Cocina::ToFedora::Identity).to receive(:apply)
+      end
+
+      context 'when label has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:label] = 'new label'
+          end
+        end
+
+        it 'updates label' do
+          update
+          expect(item).to have_received(:label=).with('new label')
+          expect(Cocina::ToFedora::Identity).to have_received(:apply)
+        end
+      end
+
+      context 'when label has not changed' do
+        it 'does not update label' do
+          update
+          expect(item).not_to have_received(:label=)
+          expect(Cocina::ToFedora::Identity).not_to have_received(:apply)
+        end
+      end
+    end
+
+    context 'when updating description' do
+      before do
+        allow(desc_metadata).to receive(:content=)
+        allow(desc_metadata).to receive(:content_will_change!)
+        allow(Cocina::ToFedora::Descriptive).to receive(:transform).and_return(Nokogiri::XML::Document.new)
+      end
+
+      context 'when description has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:description] = { title: [{ value: 'new title' }] }
+          end
+        end
+
+        it 'updates description' do
+          update
+          expect(desc_metadata).to have_received(:content=)
+          expect(desc_metadata).to have_received(:content_will_change!)
+          expect(Cocina::ToFedora::Descriptive).to have_received(:transform)
+        end
+      end
+
+      context 'when description has not changed' do
+        it 'does not update descriptive' do
+          update
+          expect(desc_metadata).not_to have_received(:content=)
+          expect(desc_metadata).not_to have_received(:content_will_change!)
+          expect(Cocina::ToFedora::Descriptive).not_to have_received(:transform)
+        end
+      end
+    end
+
+    context 'when updating administrative' do
+      before do
+        allow(item).to receive(:admin_policy_object_id=)
+        allow(Cocina::ToFedora::ApoRights).to receive(:write)
+        allow(Cocina::ToFedora::Roles).to receive(:write)
+      end
+
+      context 'when administrative has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:administrative][:disseminationWorkflow] = 'assemblyWF'
+          end
+        end
+
+        it 'updates administrative' do
+          update
+          expect(item).to have_received(:admin_policy_object_id=).with('druid:dd999df4567')
+          expect(Cocina::ToFedora::ApoRights).to have_received(:write)
+          expect(Cocina::ToFedora::Roles).to have_received(:write)
+        end
+      end
+
+      context 'when administrative has not changed' do
+        it 'does not update administrative' do
+          update
+          expect(item).not_to have_received(:admin_policy_object_id=)
+          expect(Cocina::ToFedora::ApoRights).not_to have_received(:write)
+          expect(Cocina::ToFedora::Roles).not_to have_received(:write)
+        end
+      end
+    end
+  end
+
+  context 'when a collection' do
+    let(:item) do
+      instance_double(Dor::Collection, pid: 'druid:bc123df4567',
+                                       save!: nil,
+                                       descMetadata: desc_metadata)
+    end
+
+    let(:desc_metadata) { double }
+
+    let(:orig_cocina_attrs) do
+      {
+        type: 'http://cocina.sul.stanford.edu/models/collection.jsonld',
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'orig label',
+        version: 1,
+        access: { access: 'world' }
+      }
+    end
+
+    context 'when updating label' do
+      before do
+        allow(item).to receive(:label=)
+        allow(Cocina::ToFedora::Identity).to receive(:apply)
+      end
+
+      context 'when label has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:label] = 'new label'
+          end
+        end
+
+        it 'updates label' do
+          update
+          expect(item).to have_received(:label=).with('new label')
+          expect(Cocina::ToFedora::Identity).to have_received(:apply)
+        end
+      end
+
+      context 'when label has not changed' do
+        it 'does not update label' do
+          update
+          expect(item).not_to have_received(:label=)
+          expect(Cocina::ToFedora::Identity).not_to have_received(:apply)
+        end
+      end
+    end
+
+    context 'when updating description' do
+      before do
+        allow(desc_metadata).to receive(:content=)
+        allow(desc_metadata).to receive(:content_will_change!)
+        allow(Cocina::ToFedora::Descriptive).to receive(:transform).and_return(Nokogiri::XML::Document.new)
+      end
+
+      context 'when description has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:description] = { title: [{ value: 'new title' }] }
+          end
+        end
+
+        it 'updates description' do
+          update
+          expect(desc_metadata).to have_received(:content=)
+          expect(desc_metadata).to have_received(:content_will_change!)
+          expect(Cocina::ToFedora::Descriptive).to have_received(:transform)
+        end
+      end
+
+      context 'when description has not changed' do
+        it 'does not update descriptive' do
+          update
+          expect(desc_metadata).not_to have_received(:content=)
+          expect(desc_metadata).not_to have_received(:content_will_change!)
+          expect(Cocina::ToFedora::Descriptive).not_to have_received(:transform)
+        end
+      end
+    end
+
+    context 'when updating administrative' do
+      before do
+        allow(item).to receive(:admin_policy_object_id=)
+      end
+
+      context 'when administrative has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:administrative] = { hasAdminPolicy: 'druid:dd999df4567' }
+          end
+        end
+
+        it 'updates administrative' do
+          update
+          expect(item).to have_received(:admin_policy_object_id=).with('druid:dd999df4567')
+        end
+      end
+
+      context 'when administrative has not changed' do
+        it 'does not update administrative' do
+          update
+          expect(item).not_to have_received(:admin_policy_object_id=)
+        end
+      end
+    end
+
+    context 'when updating access' do
+      before do
+        allow(Cocina::ToFedora::Access).to receive(:apply)
+      end
+
+      context 'when access has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:access] = {
+              access: 'stanford'
+            }
+          end
+        end
+
+        it 'updates access' do
+          update
+          expect(Cocina::ToFedora::Access).to have_received(:apply)
+        end
+      end
+
+      context 'when access has not changed' do
+        it 'does not update access' do
+          update
+          expect(Cocina::ToFedora::Access).not_to have_received(:apply)
+        end
+      end
+    end
+  end
+
+  context 'when a DRO' do
+    let(:item) do
+      instance_double(Dor::Item, pid: 'druid:bc123df4567',
+                                 save!: nil,
+                                 label: 'orig label',
+                                 contentMetadata: content_metadata,
+                                 descMetadata: desc_metadata)
+    end
+
+    let(:content_metadata) { double }
+
+    let(:desc_metadata) { double }
+
+    let(:orig_cocina_attrs) do
+      {
+        type: 'http://cocina.sul.stanford.edu/models/media.jsonld',
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'orig label',
+        version: 1,
+        access: { access: 'world' },
+        administrative: { hasAdminPolicy: 'druid:dd999df4567' }
+      }
+    end
+
+    context 'when updating label' do
+      let(:cocina_attrs) do
+        orig_cocina_attrs.tap do |attrs|
+          attrs[:label] = 'new label'
+        end
+      end
+
+      before do
+        allow(item).to receive(:label=)
+        allow(Cocina::ToFedora::Identity).to receive(:apply)
+      end
+
+      it 'updates label' do
+        update
+        expect(item).to have_received(:label=).with('new label')
+        expect(Cocina::ToFedora::Identity).to have_received(:apply)
+      end
+    end
+
+    context 'when updating description' do
+      before do
+        allow(desc_metadata).to receive(:content=)
+        allow(desc_metadata).to receive(:content_will_change!)
+        allow(Cocina::ToFedora::Descriptive).to receive(:transform).and_return(Nokogiri::XML::Document.new)
+      end
+
+      context 'when description has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:description] = { title: [{ value: 'new title' }] }
+          end
+        end
+
+        it 'updates description' do
+          update
+          expect(desc_metadata).to have_received(:content=)
+          expect(desc_metadata).to have_received(:content_will_change!)
+          expect(Cocina::ToFedora::Descriptive).to have_received(:transform)
+        end
+      end
+
+      context 'when description has not changed' do
+        it 'does not update descriptive' do
+          update
+          expect(desc_metadata).not_to have_received(:content=)
+          expect(desc_metadata).not_to have_received(:content_will_change!)
+          expect(Cocina::ToFedora::Descriptive).not_to have_received(:transform)
+        end
+      end
+    end
+
+    context 'when updating administrative' do
+      before do
+        allow(item).to receive(:admin_policy_object_id=)
+        allow(AdministrativeTags).to receive(:create)
+      end
+
+      context 'when administrative has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:administrative] = {
+              hasAdminPolicy: 'druid:ff000df4567',
+              partOfProject: 'Google Books'
+            }
+          end
+        end
+
+        it 'updates administrative' do
+          update
+          expect(item).to have_received(:admin_policy_object_id=).with('druid:ff000df4567')
+          expect(AdministrativeTags).to have_received(:create)
+        end
+      end
+
+      context 'when administrative has not changed' do
+        it 'does not update administrative' do
+          update
+          expect(item).not_to have_received(:admin_policy_object_id=)
+          expect(AdministrativeTags).not_to have_received(:create)
+        end
+      end
+    end
+
+    context 'when updating identification' do
+      before do
+        allow(item).to receive(:source_id=)
+        allow(item).to receive(:catkey=)
+      end
+
+      context 'when identication has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:identification] = {
+              sourceId: 'sul:8.559351',
+              catalogLinks: [{ catalog: 'symphony', catalogRecordId: '10121797' }]
+            }
+          end
+        end
+
+        it 'updates identification' do
+          update
+          expect(item).to have_received(:source_id=)
+          expect(item).to have_received(:catkey=)
+        end
+      end
+
+      context 'when identication has not changed' do
+        it 'does not update identification' do
+          update
+          expect(item).not_to have_received(:source_id=)
+          expect(item).not_to have_received(:catkey=)
+        end
+      end
+    end
+
+    context 'when updating structural' do
+      before do
+        allow(item).to receive(:collection_ids=)
+        allow(content_metadata).to receive(:contentType=)
+        allow(Cocina::ToFedora::Identity).to receive(:apply)
+        allow(AdministrativeTags).to receive(:create)
+      end
+
+      context 'when structural has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:structural] = {
+              isMemberOf: ['druid:bk024qs1809'],
+              hasMemberOrders: [{ viewingDirection: 'right-to-left' }]
+            }
+          end
+        end
+
+        it 'updates structural' do
+          update
+          expect(item).to have_received(:collection_ids=)
+          expect(content_metadata).to have_received(:contentType=)
+          expect(Cocina::ToFedora::Identity).to have_received(:apply)
+          expect(AdministrativeTags).to have_received(:create)
+        end
+      end
+
+      context 'when structural has not changed' do
+        it 'does not update structural' do
+          update
+          expect(item).not_to have_received(:collection_ids=)
+          expect(content_metadata).not_to have_received(:contentType=)
+          expect(Cocina::ToFedora::Identity).not_to have_received(:apply)
+          expect(AdministrativeTags).not_to have_received(:create)
+        end
+      end
+    end
+
+    context 'when updating access' do
+      before do
+        allow(Cocina::ToFedora::DROAccess).to receive(:apply)
+      end
+
+      context 'when access has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:access] = {
+              access: 'stanford'
+            }
+          end
+        end
+
+        it 'updates access' do
+          update
+          expect(Cocina::ToFedora::DROAccess).to have_received(:apply)
+        end
+      end
+
+      context 'when access has not changed' do
+        it 'does not update access' do
+          update
+          expect(Cocina::ToFedora::DROAccess).not_to have_received(:apply)
+        end
+      end
+    end
+
+    context 'when updating type' do
+      before do
+        allow(content_metadata).to receive(:contentType=)
+      end
+
+      context 'when type has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:type] = 'http://cocina.sul.stanford.edu/models/object.jsonld'
+          end
+        end
+
+        it 'updates access' do
+          update
+          expect(content_metadata).to have_received(:contentType=)
+        end
+      end
+
+      context 'when type has not changed' do
+        it 'does not update type' do
+          update
+          expect(content_metadata).not_to have_received(:contentType=)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #2410

## Why was this change made?
Reduce the risk of unrelated mapping errors when performing an object update by only update Fedora from the parts of the cocina object that have changed.

In particular, it avoids changes being accidentally made to descriptive metadata.

## How was this change tested?
Not yet.


## Which documentation and/or configurations were updated?
NA


