### PR TITLE
Map roleMetadata to and from cocina for APOs

### DIFF
--- a/app/services/cocina/from_fedora/apo.rb
+++ b/app/services/cocina/from_fedora/apo.rb
@@ -40,7 +40,18 @@ module Cocina
           admin[:disseminationWorkflow] = dissemination_workflow if dissemination_workflow.present?
           admin[:registrationWorkflow] = registration_workflows if registration_workflows.present?
           admin[:hasAdminPolicy] = item.admin_policy_object_id
+          admin[:roles] = build_roles
         end
+      end
+
+      # @return [Array<Hash>] the list of name and members
+      def build_roles
+        # rubocop:disable Rails/DynamicFindBy  false positive
+        item.roleMetadata.find_by_xpath('/roleMetadata/role').map do |role|
+          members = role.xpath('group/identifier').map { |ident| { type: ident['type'], identifier: ident.text } }
+          { name: role['type'], members: members }
+        end
+        # rubocop:enable Rails/DynamicFindBy
       end
     end
   end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -59,6 +59,7 @@ module Cocina
         add_description(item, obj)
 
         Cocina::ToFedora::ApoRights.write(item.administrativeMetadata, obj.administrative)
+        Cocina::ToFedora::Roles.write(item, Array(obj.administrative.roles))
         Cocina::ToFedora::Identity.apply(obj, item, object_type: 'adminPolicy')
       end
     end

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -59,6 +59,7 @@ module Cocina
       item.label = truncate_label(obj.label)
 
       Cocina::ToFedora::ApoRights.write(item.administrativeMetadata, obj.administrative)
+      Cocina::ToFedora::Roles.write(item, Array(obj.administrative.roles))
       Cocina::ToFedora::Identity.apply(obj, item, object_type: 'adminPolicy')
     end
 

--- a/app/services/cocina/to_fedora/roles.rb
+++ b/app/services/cocina/to_fedora/roles.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Cocina
+  module ToFedora
+    # This transforms the AdminPolicyAdministrative schema to the
+    # Fedora 3 roles
+    class Roles
+      def self.write(apo, roles)
+        apo.purge_roles
+        roles.each do |role|
+          role.members.each do |member|
+            apo.add_roleplayer(role.name, member.identifier, member.type.to_sym)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -693,7 +693,18 @@ RSpec.describe 'Create object' do
                                         defaultObjectRights: default_object_rights,
                                         hasAdminPolicy: 'druid:dd999df4567',
                                         disseminationWorkflow: 'assemblyWF',
-                                        registrationWorkflow: %w[goobiWF registrationWF]
+                                        registrationWorkflow: %w[goobiWF registrationWF],
+                                        roles: [
+                                          {
+                                            name: 'dor-apo-manager',
+                                            members: [
+                                              {
+                                                type: 'workgroup',
+                                                identifier: 'sdr:psm-staff'
+                                              }
+                                            ]
+                                          }
+                                        ]
                                       },
                                       externalIdentifier: druid)
     end
@@ -708,7 +719,9 @@ RSpec.describe 'Create object' do
             "defaultObjectRights":#{default_object_rights.to_json},
             "disseminationWorkflow":"assemblyWF",
             "registrationWorkflow":["goobiWF","registrationWF"],
-            "hasAdminPolicy":"druid:dd999df4567"},
+            "hasAdminPolicy":"druid:dd999df4567",
+            "roles":[{"name":"dor-apo-manager","members":[{"type":"workgroup","identifier":"sdr:psm-staff"}]}]
+          },
           "description":{"title":[{"value":"This is my title"}],"purl":"http://purl.stanford.edu/gg777gg7777","access":{"digitalRepository":[{"value":"Stanford Digital Repository"}]}}}
       JSON
     end
@@ -747,7 +760,8 @@ RSpec.describe 'Create object' do
                                       },
                                       administrative: {
                                         defaultObjectRights: default_object_rights,
-                                        hasAdminPolicy: 'druid:dd999df4567'
+                                        hasAdminPolicy: 'druid:dd999df4567',
+                                        roles: []
                                       },
                                       externalIdentifier: druid)
     end

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -416,6 +416,7 @@ RSpec.describe 'Get the object' do
         expect(json['administrative']['defaultObjectRights']).to match '<rightsMetadata>'
         expect(json['administrative']['registrationWorkflow']).to be_nil
         expect(json['administrative']['hasAdminPolicy']).to eq 'druid:df123cd4567'
+        expect(json['administrative']['roles']).to eq []
       end
     end
 
@@ -431,6 +432,24 @@ RSpec.describe 'Get the object' do
               <workflow id="wasCrawlPreassemblyWF"/>
             </dissemination>
           </administrativeMetadata>
+        XML
+        object.roleMetadata.content = <<~XML
+          <roleMetadata objectId="druid:bx911tp9024">
+            <role type="dor-apo-manager">
+              <group>
+                <identifier type="workgroup">sdr:psm-staff</identifier>
+              </group>
+              <group>
+                <identifier type="workgroup">sdr:developer</identifier>
+              </group>
+              <group>
+                <identifier type="workgroup">sdr:metadata-staff</identifier>
+              </group>
+              <group>
+                <identifier type="workgroup">sdr:admin-docs</identifier>
+              </group>
+            </role>
+          </roleMetadata>
         XML
         object.descMetadata.title_info.main_title = 'Hello'
         object.label = 'foo'
@@ -449,6 +468,29 @@ RSpec.describe 'Get the object' do
         expect(json['administrative']['defaultObjectRights']).to match '<rightsMetadata>'
         expect(json['administrative']['registrationWorkflow']).to eq %w[registrationWF goobiWF]
         expect(json['administrative']['disseminationWorkflow']).to eq 'wasCrawlPreassemblyWF'
+        expect(json['administrative']['roles']).to eq [
+          {
+            'name' => 'dor-apo-manager',
+            'members' => [
+              {
+                'type' => 'workgroup',
+                'identifier' => 'sdr:psm-staff'
+              },
+              {
+                'type' => 'workgroup',
+                'identifier' => 'sdr:developer'
+              },
+              {
+                'type' => 'workgroup',
+                'identifier' => 'sdr:metadata-staff'
+              },
+              {
+                'type' => 'workgroup',
+                'identifier' => 'sdr:admin-docs'
+              }
+            ]
+          }
+        ]
       end
     end
   end

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -926,7 +926,18 @@ RSpec.describe 'Update object' do
                                         defaultObjectRights: default_object_rights,
                                         hasAdminPolicy: 'druid:dd999df4567',
                                         disseminationWorkflow: 'assemblyWF',
-                                        registrationWorkflow: %w[goobiWF registrationWF]
+                                        registrationWorkflow: %w[goobiWF registrationWF],
+                                        roles: [
+                                          {
+                                            name: 'dor-apo-manager',
+                                            members: [
+                                              {
+                                                type: 'workgroup',
+                                                identifier: 'sdr:psm-staff'
+                                              }
+                                            ]
+                                          }
+                                        ]
                                       },
                                       externalIdentifier: druid)
     end
@@ -943,7 +954,9 @@ RSpec.describe 'Update object' do
             "defaultObjectRights":#{default_object_rights.to_json},
             "disseminationWorkflow":"assemblyWF",
             "registrationWorkflow":["goobiWF","registrationWF"],
-            "hasAdminPolicy":"druid:dd999df4567"},
+            "hasAdminPolicy":"druid:dd999df4567",
+            "roles":[{"name":"dor-apo-manager","members":[{"type":"workgroup","identifier":"sdr:psm-staff"}]}]
+          },
           "description":{"title":[{"value":"This is my title"}]}}
       JSON
     end


### PR DESCRIPTION
## Why was this change made?

Supports https://github.com/sul-dlss/argo/issues/2420 and https://github.com/sul-dlss/dor_indexing_app/issues/511


## How was this change tested?



## Which documentation and/or configurations were updated?



