### PR TITLE
Event date point keydate

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -220,8 +220,8 @@ module Cocina
         def date_values_for_event(date_nodes, default_type)
           dates = date_nodes.reject { |node| node['point'] }.map do |node|
             addl_attributes = {}
-            # NOTE: only dateOther should have type attribute;  not sure if we have dirty data in this respect
-            #   if so, it's invalid MODS, so validating against the MODS schema will catch it
+            # NOTE: only dateOther should have type attribute;  not sure if we have dirty data in this respect.
+            #   If so, it's invalid MODS, so validating against the MODS schema will catch it
             addl_attributes[:type] = node['type'] if node['type'].present?
             build_date(node).merge(addl_attributes)
           end

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -402,6 +402,7 @@ module Cocina
             return common_attribs.merge(value: date_nodes.join('/'))
           end
 
+          remove_dup_key_date_from_end_point(date_nodes)
           dates = date_nodes.map do |node|
             next if node.text.blank? && node.attributes.empty?
 
@@ -414,6 +415,17 @@ module Cocina
         end
         # rubocop:enable Metrics/PerceivedComplexity
         # rubocop:enable Metrics/CyclomaticComplexity
+
+        # Per Arcadia, keyDate should only appear once in an originInfo.
+        # If keyDate is on a date of type point and is on both the start and end points, then
+        # it should be removed from the end point
+        def remove_dup_key_date_from_end_point(date_nodes)
+          key_date_point_nodes = date_nodes.select { |node| node['keyDate'] == 'yes' && node['point'].present? }
+          return unless key_date_point_nodes.size == 2
+
+          end_node = key_date_point_nodes.find { |node| node['point'] == 'end' }
+          end_node.delete('keyDate')
+        end
 
         # @return [Boolean] true if this node set can be expressed as an EDTF range.
         def edtf_range?(date_nodes, encoding)

--- a/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
@@ -24,6 +24,7 @@ module Cocina
         normalize_legacy_mods_event_type
         place_term_type_normalization
         normalize_authority_marcountry
+        single_key_date
         remove_trailing_period_from_date_values
         ng_xml
       end
@@ -81,6 +82,16 @@ module Cocina
       def normalize_authority_marcountry
         ng_xml.root.xpath("//mods:*[@authority='marcountry']", mods: ModsNormalizer::MODS_NS).each do |node|
           node[:authority] = 'marccountry'
+        end
+      end
+
+      def single_key_date
+        DATE_FIELDS.each do |date_field|
+          key_date_nodes = ng_xml.root.xpath("//mods:originInfo/mods:#{date_field}[@point and @keyDate='yes']", mods: ModsNormalizer::MODS_NS)
+          next unless key_date_nodes.size == 2
+
+          end_node = key_date_nodes.find { |node| node['point'] == 'end' }
+          end_node.delete('keyDate')
         end
       end
 

--- a/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
@@ -23,8 +23,8 @@ module Cocina
         remove_empty_origin_info # must be after remove_empty_child_elements
         normalize_legacy_mods_event_type
         place_term_type_normalization
-        remove_trailing_period_from_date_values
         normalize_authority_marcountry
+        remove_trailing_period_from_date_values
         ng_xml
       end
 
@@ -78,31 +78,16 @@ module Cocina
         end
       end
 
+      def normalize_authority_marcountry
+        ng_xml.root.xpath("//mods:*[@authority='marcountry']", mods: ModsNormalizer::MODS_NS).each do |node|
+          node[:authority] = 'marccountry'
+        end
+      end
+
       def remove_trailing_period_from_date_values
         DATE_FIELDS.each do |date_field|
           ng_xml.root.xpath("//mods:originInfo/mods:#{date_field}", mods: ModsNormalizer::MODS_NS)
                 .each { |date_node| date_node.content = date_node.content.delete_suffix('.') }
-        end
-      end
-
-      def publisher_attribs_normalization
-        ng_xml.root.xpath('//mods:publisher[@lang]', mods: ModsNormalizer::MODS_NS).each do |publisher_node|
-          publisher_node.parent['lang'] = publisher_node['lang']
-          publisher_node.delete('lang')
-        end
-        ng_xml.root.xpath('//mods:publisher[@script]', mods: ModsNormalizer::MODS_NS).each do |publisher_node|
-          publisher_node.parent['script'] = publisher_node['script']
-          publisher_node.delete('script')
-        end
-        ng_xml.root.xpath('//mods:publisher[@transliteration]', mods: ModsNormalizer::MODS_NS).each do |publisher_node|
-          publisher_node.parent['transliteration'] = publisher_node['transliteration']
-          publisher_node.delete('transliteration')
-        end
-      end
-
-      def normalize_authority_marcountry
-        ng_xml.root.xpath("//mods:*[@authority='marcountry']", mods: ModsNormalizer::MODS_NS).each do |node|
-          node[:authority] = 'marccountry'
         end
       end
     end

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -3012,6 +3012,45 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
     end
   end
 
+  context 'when end point date only with keyDate=yes' do
+    # based on gd436kk2484, kq971bk2940, mv125bf6089, nz219st6133
+    # xit 'TODO: allow single end point date to have keyDate on to_fedora' do
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo>
+            <dateCreated keyDate="yes" encoding="w3cdtf" qualifier="approximate" point="end">1948</dateCreated>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '1948',
+                      status: 'primary',
+                      type: 'end'
+                    }
+                  ],
+                  encoding: {
+                    code: 'w3cdtf'
+                  },
+                  qualifier: 'approximate',
+                  type: 'creation'
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
+  end
+
   context 'when useless dateIssued' do
     # based on vj932ns8042
 

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -3014,7 +3014,6 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
   context 'when end point date only with keyDate=yes' do
     # based on gd436kk2484, kq971bk2940, mv125bf6089, nz219st6133
-    # xit 'TODO: allow single end point date to have keyDate on to_fedora' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -2968,15 +2968,22 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
 
   context 'when keyDate is on start and end of point' do
     # based on wz774ws7198, fs078fy1458
-
-    # it_behaves_like 'MODS cocina mapping' do
-    # FIXME: also address with normalization - only have keyDate on the start point when both start and end have it
-    xit 'FIXME: to be implemented: if we only have end then it can be keyDate, otherwise it should be start only' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <originInfo>
             <dateCreated encoding="w3cdtf" keyDate="yes" point="start" qualifier="approximate">1175</dateCreated>
             <dateCreated encoding="w3cdtf" keyDate="yes" point="end" qualifier="approximate">1325</dateCreated>
+          </originInfo>
+        XML
+      end
+
+      # keyDate removed from endpoint
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo>
+            <dateCreated encoding="w3cdtf" keyDate="yes" point="start" qualifier="approximate">1175</dateCreated>
+            <dateCreated encoding="w3cdtf" point="end" qualifier="approximate">1325</dateCreated>
           </originInfo>
         XML
       end

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
@@ -1820,45 +1820,6 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
     end
   end
 
-  context 'when end point date only with keyDate=yes' do
-    # based on gd436kk2484, kq971bk2940, mv125bf6089, nz219st6133
-    # xit 'TODO: allow single end point date to have keyDate on to_fedora' do
-    it_behaves_like 'MODS cocina mapping' do
-      let(:mods) do
-        <<~XML
-          <originInfo>
-            <dateCreated keyDate="yes" encoding="w3cdtf" qualifier="approximate" point="end">1948</dateCreated>
-          </originInfo>
-        XML
-      end
-
-      let(:cocina) do
-        {
-          event: [
-            {
-              date: [
-                {
-                  structuredValue: [
-                    {
-                      value: '1948',
-                      status: 'primary',
-                      type: 'end'
-                    }
-                  ],
-                  encoding: {
-                    code: 'w3cdtf'
-                  },
-                  qualifier: 'approximate',
-                  type: 'creation'
-                }
-              ]
-            }
-          ]
-        }
-      end
-    end
-  end
-
   context 'when empty placeTerm and empty date qualifier attribute' do
     # based on gh074sd3455, zp908qm7502
     it_behaves_like 'MODS cocina mapping' do


### PR DESCRIPTION
## Why was this change made?

Fixes #2450, and some tiny refactorings and comment improvements (which I can split out into a separate PR if desired)

We have data like this:

```xml
<originInfo>
  <dateCreated encoding="w3cdtf" keyDate="yes" point="start" qualifier="approximate">1175</dateCreated>
  <dateCreated encoding="w3cdtf" keyDate="yes" point="end" qualifier="approximate">1325</dateCreated>
</originInfo>
```

which should be like this:

```xml
<originInfo>
  <dateCreated encoding="w3cdtf" keyDate="yes" point="start" qualifier="approximate">1175</dateCreated>
  <dateCreated encoding="w3cdtf" point="end" qualifier="approximate">1325</dateCreated>
</originInfo>
```

This PR addresses this by only mapping the start keyDate to cocina in this situation and by having the mods normalization remove the extra keyDate

## How was this change tested?

Note that this problem was NOT flagged as incorrect since it was not addressed in normalization or mapping prior to this PR

### BEFORE (main branch)

```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9919 (99.879%)
  Different: 12 (0.121%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     69 (0.69%)
```

fs078fy1458 is a record with this situation:

```
$ bin/validate-cocina-roundtrip -d 'druid:fs078fy1458'
Status (n=1; not using Missing for success/different/error stats):
  Success:   1 (100.0%)
  Different: 0 (0.0%)
```

### AFTER (this branch)

```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9919 (99.879%)
  Different: 12 (0.121%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     69 (0.69%)
```

```
$ bin/validate-cocina-roundtrip -d 'druid:fs078fy1458'
Status (n=1; not using Missing for success/different/error stats):
  Success:   1 (100.0%)
  Different: 0 (0.0%)
```

## Which documentation and/or configurations were updated?



