### PR TITLE
altRegGroup pairings allowed to have same script

### DIFF
--- a/app/services/cocina/from_fedora/descriptive.rb
+++ b/app/services/cocina/from_fedora/descriptive.rb
@@ -66,6 +66,9 @@ module Cocina
         # No scripts or langs
         return false if scripts.compact.empty? && langs.compact.empty?
 
+        # altRepGroups can have the same script, e.g. Latn for English and French
+        return false if scripts.size == 1
+
         true
       end
       # rubocop:enable Metrics/CyclomaticComplexity

--- a/spec/services/cocina/from_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive_spec.rb
@@ -482,9 +482,9 @@ RSpec.describe Cocina::FromFedora::Descriptive do
       allow(notifier).to receive(:warn)
     end
 
-    it 'warns' do
+    it 'does NOT warn as this is a valid pairing of altRepGroup' do
       descriptive
-      expect(notifier).to have_received(:warn).with('Unpaired altRepGroup')
+      expect(notifier).not_to have_received(:warn)
     end
   end
 

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_spec.rb
@@ -1330,8 +1330,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
         }
       end
 
-      xit 'FIXME: to be implemented: warning should NOT be given for matching script value'
-      let(:warnings) { [Notification.new(msg: 'Unpaired altRepGroup')] }
+      # NOTE: it does NOT warn as this is a valid pairing of altRepGroup
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #2457

## How was this change tested?

it only changes whether or not a warning is given, so ... no roundtrip number changes expected

### BEFORE (main branch)

```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9919 (99.879%)
  Different: 12 (0.121%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     69 (0.69%)
```

### AFTER (this branch)

```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9919 (99.879%)
  Different: 12 (0.121%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     69 (0.69%)
```

## Which documentation and/or configurations were updated?



