### PR TITLE
event mapping:  keep adding marcrelator role to MODS when mapping from cocina event contrib without one

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -353,22 +353,22 @@ module Cocina
           return if publisher_nodes.empty?
 
           event[:contributor] ||= []
-          publisher_nodes.each do |publisher|
-            next if publisher.text.blank?
+          publisher_nodes.each do |publisher_node|
+            next if publisher_node.text.blank?
 
             event[:contributor] << {
               name: [
                 {
-                  value: publisher.text,
-                  valueLanguage: LanguageScript.build(node: publisher)
+                  value: publisher_node.text,
+                  valueLanguage: LanguageScript.build(node: publisher_node)
                 }.tap do |attrs|
                   if origin_info_node['transliteration']
                     attrs[:type] = 'transliteration'
                     attrs[:standard] = { value: origin_info_node['transliteration'] }
                   end
-                  if publisher['transliteration']
+                  if publisher_node['transliteration']
                     attrs[:type] = 'transliteration'
-                    attrs[:standard] = { value: publisher['transliteration'] }
+                    attrs[:standard] = { value: publisher_node['transliteration'] }
                   end
                 end.compact
               ],

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_publisher_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_publisher_spec.rb
@@ -613,7 +613,7 @@ RSpec.describe 'MODS originInfo publisher <--> cocina mappings' do
 
   # specs added by devs below
 
-  context 'when publisher is not marcrelator' do
+  context 'when publisher is not marcrelator and has no authority, authorityURI or valueURI' do
     # NOTE: cocina -> MODS
     it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
@@ -641,7 +641,7 @@ RSpec.describe 'MODS originInfo publisher <--> cocina mappings' do
         }
       end
 
-      xit 'FIXME: to be implemented: contrib role should NOT morph to include marcrelator on cocina roundtrip per Arcadia'
+      # marcrelator is added
       let(:roundtrip_cocina) do
         {
           event: [


### PR DESCRIPTION
## Why was this change made?

Closes #2460

Arcadia decided we are going to keep marcrelator role info when mapping from cocina event to MODS, so xit can be removed.

![image](https://user-images.githubusercontent.com/96775/110668363-14d17380-8180-11eb-859f-0454e5b10389.png)


## How was this change tested?

test suite (no mappings were changed so no need to check roundtrip stats)

## Which documentation and/or configurations were updated?



