### PR TITLE
do not drop authority info on placeTerm in originInfo

### DIFF
--- a/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
@@ -23,6 +23,7 @@ module Cocina
         remove_empty_origin_info # must be after remove_empty_child_elements
         normalize_legacy_mods_event_type
         place_term_type_normalization
+        place_term_authority_normalization # must be after place_term_type_normalization
         normalize_authority_marcountry
         single_key_date
         remove_trailing_period_from_date_values
@@ -44,7 +45,7 @@ module Cocina
         end
       end
 
-      # must be after remove_empty_child_elements
+      # must be called after remove_empty_child_elements
       def remove_empty_origin_info
         ng_xml.root.xpath('//mods:originInfo[not(mods:*) and not(@*)]', mods: ModsNormalizer::MODS_NS).each(&:remove)
         # make sure we remove ones such as <originInfo eventType="publication"/>
@@ -69,6 +70,7 @@ module Cocina
         end
       end
 
+      # must be called before place_term_authority_normalization
       # if the cocina model doesn't have a code, then it will have a value;
       #   this is output as attribute type=text on the roundtripped placeTerm element
       def place_term_type_normalization
@@ -77,6 +79,49 @@ module Cocina
 
           place_term_node['type'] = 'text' if place_term_node.attributes['type'].blank?
         end
+      end
+
+      # must be called after place_term_type_normalization
+      # if the MODS has a single place element with both text and code placeTerm elements, if the text
+      # element has no authority attributes but the code element DOES have authority attributes, then both
+      # the text and the code elements get the authority attributes from the code element.
+      def place_term_authority_normalization
+        ng_xml.root.xpath('//mods:originInfo/mods:place[mods:placeTerm/@type]', mods: ModsNormalizer::MODS_NS).each do |place_node|
+          text_place_term_node = place_node.xpath("mods:placeTerm[not(@type='code')]", mods: ModsNormalizer::MODS_NS).first
+          next unless text_place_term_node
+          next if text_place_term_node.text.blank?
+
+          code_place_term_node = place_node.xpath("mods:placeTerm[@type='code']", mods: ModsNormalizer::MODS_NS).first
+          next unless code_place_term_node
+          next if code_place_term_node.text.blank?
+
+          text_authority_attributes = authority_attributes(text_place_term_node)
+          code_authority_attributes = authority_attributes(code_place_term_node)
+
+          # NOTE: deliberately skipping situation where text node has some authority info and code node
+          #  has other authority info as we may never encounter this
+
+          if text_authority_attributes.present? && code_authority_attributes.blank?
+            text_authority_attributes.each do |key, val|
+              code_place_term_node[key] = val
+            end
+            next
+          end
+
+          next if code_authority_attributes.blank? || text_authority_attributes.present?
+
+          code_authority_attributes.each do |key, val|
+            text_place_term_node[key] = val
+          end
+        end
+      end
+
+      def authority_attributes(ng_node)
+        {
+          valueURI: ng_node['valueURI'],
+          authority: ng_node['authority'],
+          authorityURI: ng_node['authorityURI']
+        }.compact
       end
 
       def normalize_authority_marcountry

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_place_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_place_spec.rb
@@ -473,4 +473,84 @@ RSpec.describe 'MODS originInfo place <--> cocina mappings' do
       end
     end
   end
+
+  describe 'placeTerm code xx with authority marccountry' do
+    context 'when code alone' do
+      # based on cf040mt0946, dm283vh3332, fn474tc0101, gq289jf7762, hm986jh6778, jg916mx8338
+      it_behaves_like 'MODS cocina mapping' do
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <place>
+                <placeTerm type="code" authority="marccountry">xx</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                location: [
+                  {
+                    code: 'xx',
+                    source: {
+                      code: 'marccountry'
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        end
+      end
+    end
+
+    context 'when single place element with code and text' do
+      # based on cf040mt0946, dm283vh3332, fn474tc0101, gq289jf7762, hm986jh6778, jg916mx8338
+      it_behaves_like 'MODS cocina mapping' do
+        let(:mods) do
+          <<~XML
+            <originInfo>
+              <place>
+                <placeTerm type="code" authority="marccountry">xx</placeTerm>
+                <placeTerm type="text">Place of publication not identified]</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        # authority="marccountry" added to text placeTerm
+        let(:roundtrip_mods) do
+          <<~XML
+            <originInfo>
+              <place>
+                <placeTerm type="code" authority="marccountry">xx</placeTerm>
+                <placeTerm type="text" authority="marccountry">Place of publication not identified]</placeTerm>
+              </place>
+            </originInfo>
+          XML
+        end
+
+        let(:cocina) do
+          {
+            event: [
+              {
+                location: [
+                  {
+                    value: 'Place of publication not identified]',
+                    code: 'xx',
+                    source: {
+                      code: 'marccountry'
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        end
+      end
+    end
+  end
 end

--- a/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
@@ -748,7 +748,103 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
     end
   end
 
-  context 'when placeTerm is empty and dateOther has only content and legacy mods displaLabel' do
+  context 'when single place element with placeTerm for code and text' do
+    context 'when authority attribute on code only' do
+      # based on cf040mt0946, dm283vh3332, fn474tc0101, gq289jf7762, hm986jh6778, jg916mx8338
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <place>
+                <placeTerm type="code" authority="marccountry">xx</placeTerm>
+                <placeTerm type="text">Place of publication not identified]</placeTerm>
+              </place>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'adds the authority attributes to both code and text placeTerm elements' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <place>
+                <placeTerm type="code" authority="marccountry">xx</placeTerm>
+                <placeTerm type="text" authority="marccountry">Place of publication not identified]</placeTerm>
+              </place>
+            </originInfo>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when all three authority attributes on code placeTerm only' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <place>
+                <placeTerm type="code" authority="marccountry" authorityURI="http://id.loc.gov/vocabulary/countries/"
+                  valueURI="http://id.loc.gov/vocabulary/countries/cau">cau</placeTerm>
+                <placeTerm type="text">Cornell Adult University (hah!)</placeTerm>
+              </place>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'adds the authority attributes to both code and text placeTerm elements' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <place>
+                <placeTerm type="code" authority="marccountry" authorityURI="http://id.loc.gov/vocabulary/countries/"
+                  valueURI="http://id.loc.gov/vocabulary/countries/cau">cau</placeTerm>
+                <placeTerm type="text" authority="marccountry" authorityURI="http://id.loc.gov/vocabulary/countries/"
+                  valueURI="http://id.loc.gov/vocabulary/countries/cau">Cornell Adult University (hah!)</placeTerm>
+              </place>
+            </originInfo>
+          </mods>
+        XML
+      end
+    end
+
+    context 'when authority attributes on text placeTerm only' do
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <place>
+                <placeTerm type="code">cau</placeTerm>
+                <placeTerm type="text" authorityURI="http://id.loc.gov/vocabulary/countries/"
+                  valueURI="http://id.loc.gov/vocabulary/countries/cau">Cornell Adult University (hah!)</placeTerm>
+              </place>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'adds the authority attributes to both code and text placeTerm elements' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <place>
+                <placeTerm type="code" authorityURI="http://id.loc.gov/vocabulary/countries/"
+                  valueURI="http://id.loc.gov/vocabulary/countries/cau">cau</placeTerm>
+                <placeTerm type="text" authorityURI="http://id.loc.gov/vocabulary/countries/"
+                  valueURI="http://id.loc.gov/vocabulary/countries/cau">Cornell Adult University (hah!)</placeTerm>
+              </place>
+            </originInfo>
+          </mods>
+        XML
+      end
+    end
+
+    # NOTE: deliberately skipping situation where text placeTerm has some authority info and code placeTerm has other authority info
+    #  as we may never encounter this
+  end
+
+  context 'when placeTerm is empty and dateOther has only content and legacy mods displayLabel' do
     # based on wm519yn6490
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML


### PR DESCRIPTION
## Why was this change made?

We've been dropping authority information on placeTerm MODS elements if text and code are both specified in a single place element and the authority attributes are on the code element only. I believe this has been true all along, but now that we've quieted down the errors on originInfo roundtripping, this was noticed.

Fixes #2448

## How was this change tested?

### BEFORE (main branch)

```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99249 (99.867%)
  Different: 131 (0.132%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     1 (0.001%)
  Missing (no descMetadata):     619 (0.619%)
```

### AFTER (this branch)

```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99279 (99.897%)
  Different: 101 (0.102%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     1 (0.001%)
  Missing (no descMetadata):     619 (0.619%)
```



## Which documentation and/or configurations were updated?



