### PR TITLE
event mapping: edtf date ranges are like other date ranges in cocina

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -390,17 +390,10 @@ module Cocina
         end
 
         # rubocop:disable Metrics/CyclomaticComplexity
-        # rubocop:disable Metrics/PerceivedComplexity
         def build_structured_date(date_nodes)
           return if date_nodes.blank?
 
           common_attribs = common_date_attributes(date_nodes)
-          # FIXME: to be implemented: model edtf date range in cocina like other date ranges;
-          #   put the slash back in when mapping back to MODS
-          if edtf_range?(date_nodes, common_attribs[:encoding])
-            common_attribs[:status] = 'primary' if date_nodes.any? { |node| node['keyDate'] == 'yes' }
-            return common_attribs.merge(value: date_nodes.join('/'))
-          end
 
           remove_dup_key_date_from_end_point(date_nodes)
           dates = date_nodes.map do |node|
@@ -413,7 +406,6 @@ module Cocina
           end
           { structuredValue: dates }.merge(common_attribs).compact
         end
-        # rubocop:enable Metrics/PerceivedComplexity
         # rubocop:enable Metrics/CyclomaticComplexity
 
         # Per Arcadia, keyDate should only appear once in an originInfo.
@@ -425,11 +417,6 @@ module Cocina
 
           end_node = key_date_point_nodes.find { |node| node['point'] == 'end' }
           end_node.delete('keyDate')
-        end
-
-        # @return [Boolean] true if this node set can be expressed as an EDTF range.
-        def edtf_range?(date_nodes, encoding)
-          date_nodes.size == 2 && date_nodes.map { |node| node['point'] } == %w[start end] && encoding == { code: 'edtf' }
         end
 
         def common_date_attributes(date_nodes)

--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -174,7 +174,7 @@ module Cocina
           event[:date] = date_values if date_values.present?
         end
 
-        XPATH_HAS_CONTENT_PREDICATE = '[string-length(normalize-space()) > 1]'
+        XPATH_HAS_CONTENT_PREDICATE = '[string-length(normalize-space()) > 0]'
 
         def build_copyright_notice_event(origin_info_node)
           date_nodes = origin_info_node.xpath("mods:copyrightDate#{XPATH_HAS_CONTENT_PREDICATE}", mods: DESC_METADATA_NS)

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_date_spec.rb
@@ -530,8 +530,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   end
 
   describe 'BCE date range (edtf encoding)' do
-    # it_behaves_like 'MODS cocina mapping' do
-    xit 'FIXME: to be implemented: model edtf date range in cocina like other date range' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <originInfo>
@@ -547,12 +546,21 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
             {
               date: [
                 {
-                  value: '-0599/-0499',
+                  structuredValue: [
+                    {
+                      value: '-0599',
+                      type: 'start',
+                      status: 'primary'
+                    },
+                    {
+                      value: '-0499',
+                      type: 'end'
+                    }
+                  ],
                   type: 'creation',
                   encoding: {
                     code: 'edtf'
-                  },
-                  status: 'primary'
+                  }
                 }
               ]
             }
@@ -594,8 +602,7 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
   end
 
   describe 'CE date range (edtf encoding)' do
-    # it_behaves_like 'MODS cocina mapping' do
-    xit 'FIXME: to be implemented: model edtf date range in cocina like other date range' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <originInfo>
@@ -611,12 +618,21 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
             {
               date: [
                 {
-                  value: '0800/1000',
+                  structuredValue: [
+                    {
+                      value: '0800',
+                      type: 'start',
+                      status: 'primary'
+                    },
+                    {
+                      value: '1000',
+                      type: 'end'
+                    }
+                  ],
                   type: 'creation',
                   encoding: {
                     code: 'edtf'
-                  },
-                  status: 'primary'
+                  }
                 }
               ]
             }
@@ -3110,6 +3126,102 @@ RSpec.describe 'MODS originInfo <--> cocina mappings' do
                   type: 'issuance',
                   source: {
                     value: 'MODS issuance terms'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
+  end
+
+  context 'when edtf with single digit date value' do
+    # based on wf185fz5396
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo>
+            <dateCreated keyDate="yes" encoding="edtf" qualifier="approximate" point="start">0</dateCreated>
+            <dateCreated encoding="edtf" qualifier="approximate" point="end">200</dateCreated>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '0',
+                      status: 'primary',
+                      type: 'start'
+                    },
+                    {
+                      value: '200',
+                      type: 'end'
+                    }
+                  ],
+                  type: 'creation',
+                  qualifier: 'approximate',
+                  encoding: {
+                    code: 'edtf'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
+  end
+
+  describe 'edtf dates should not become dateOther' do
+    # based on wf395pf7684
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <originInfo displayLabel="Place of creation">
+            <dateIssued keyDate="yes" encoding="edtf" point="start">103</dateIssued>
+            <dateIssued encoding="edtf" point="end">111</dateIssued>
+          </originInfo>
+        XML
+      end
+
+      # trailing slash on placeTerm authorityURI
+      let(:roundtrip_mods) do
+        <<~XML
+          <originInfo displayLabel="Place of creation">
+            <dateIssued keyDate="yes" encoding="edtf" point="start">103</dateIssued>
+            <dateIssued encoding="edtf" point="end">111</dateIssued>
+          </originInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          event: [
+            {
+              displayLabel: 'Place of creation',
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '103',
+                      status: 'primary',
+                      type: 'start'
+                    },
+                    {
+                      value: '111',
+                      type: 'end'
+                    }
+                  ],
+                  type: 'publication',
+                  encoding: {
+                    code: 'edtf'
                   }
                 }
               ]


### PR DESCRIPTION
## Why was this change made?

- Arcadia said we could treat edtf date ranges in cocina like other date ranges.  This simplified the mapping code.  
- There was a problem with single digit dates disappearing in mapping.  This was fixed.

Closes #2459 - edtf date ranges are like other date ranges
Closes #2461 - single digit date mapping
Closes #2292 - edtf and keyDate
Closes #2392 - edtf and keyDate

## How was this change tested?

### BEFORE (main branch)

```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99249 (99.867%)
  Different: 131 (0.132%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     1 (0.001%)
  Missing (no descMetadata):     619 (0.619%)
```

### AFTER (this branch)

```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99281 (99.899%)
  Different: 99 (0.1%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     1 (0.001%)
  Missing (no descMetadata):     619 (0.619%)
```

### specific records that all are successful with this branch:

wf395pf7684 (type of date field was changed)  from #2459
```
$ bin/validate-cocina-roundtrip -d 'druid:wf395pf7684'
...
Status (n=1; not using Missing for success/different/error stats):
  Success:   1 (100.0%)
```

- wf185fz5396 (single digit date) from #2461
```
$ bin/validate-cocina-roundtrip -d 'druid:wf185fz5396'
...
Status (n=1; not using Missing for success/different/error stats):
  Success:   1 (100.0%)
```

- my402cp8117 (edtf range with keyDate) from # 2392
```
$ bin/validate-cocina-roundtrip -d 'druid:my402cp8117'
...
Status (n=1; not using Missing for success/different/error stats):
  Success:   1 (100.0%)
``` 

- bf973rp9392 (edtf single date with keyDate ... was already working) from #2292
```
$ bin/validate-cocina-roundtrip -d 'druid:bf973rp9392'
...
Status (n=1; not using Missing for success/different/error stats):
  Success:   1 (100.0%)
```

## Which documentation and/or configurations were updated?



