### PR TITLE
add metadata/mods endpoint to retrieve source mods

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -14,6 +14,10 @@ class MetadataController < ApplicationController
     render xml: service
   end
 
+  def mods
+    render xml: @item.descMetadata.content
+  end
+
   # This supports the Legacy Fedora 3 data model. This is used by the accessionWF.
   def update_legacy_metadata
     datastream_names = {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
           patch 'legacy', action: :update_legacy_metadata
           get 'dublin_core'
           get 'descriptive'
+          get 'mods'
         end
       end
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -782,6 +782,23 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
+  '/v1/objects/{object_id}/metadata/mods':
+    get:
+      tags:
+        - objects
+      summary: Retrieve the source MODS metadata for the object
+      description: ''
+      operationId: 'metadata#mods'
+      responses:
+        '200':
+          description: OK
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
   '/v1/objects/{object_id}/events':
     get:
       tags:

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -19,8 +19,23 @@ RSpec.describe 'Display metadata' do
     end
   end
 
+  describe 'mods' do
+    it 'returns the source MODS xml' do
+      get '/v1/objects/druid:mk420bs7601/metadata/mods',
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to be_successful
+      expect(response.body).to be_equivalent_to <<~XML
+        <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <titleInfo>
+            <title>Hello</title>
+          </titleInfo>
+        </mods>
+      XML
+    end
+  end
+
   describe 'descriptive' do
-    it 'returns the DC xml' do
+    it 'returns the public xml' do
       get '/v1/objects/druid:mk420bs7601/metadata/descriptive',
           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful


### PR DESCRIPTION
## Why was this change made?

Fixes #1885

Adds an endpoint to retrieve source MODS for a DOR object.

## How was this change tested?

test suite

## Which documentation and/or configurations were updated?



