### PR TITLE
origin_info_normalizer: fix keyDate error

### DIFF
--- a/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
+++ b/app/services/cocina/mods_normalizers/origin_info_normalizer.rb
@@ -136,7 +136,7 @@ module Cocina
           next unless key_date_nodes.size == 2
 
           end_node = key_date_nodes.find { |node| node['point'] == 'end' }
-          end_node.delete('keyDate')
+          end_node.delete('keyDate') if end_node && end_node['keyDate'].present?
         end
       end
 

--- a/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
+++ b/spec/services/cocina/mods_normalizers/origin_info_normalizer_spec.rb
@@ -746,6 +746,39 @@ RSpec.describe Cocina::ModsNormalizers::OriginInfoNormalizer do
         XML
       end
     end
+
+    context 'when multiple originInfo with keyDates' do
+      # based on kc552wv4693
+      let(:mods_ng_xml) do
+        Nokogiri::XML <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateCreated keyDate="yes" encoding="w3cdtf" point="start">1947</dateCreated>
+              <dateCreated encoding="w3cdtf" point="end">1952</dateCreated>
+            </originInfo>
+            <originInfo displayLabel="Contract date">
+              <dateCreated keyDate="yes" encoding="w3cdtf" point="start">1947</dateCreated>
+              <dateCreated encoding="w3cdtf" point="end">1952</dateCreated>
+            </originInfo>
+          </mods>
+        XML
+      end
+
+      it 'keeps them when correct' do
+        expect(normalized_ng_xml).to be_equivalent_to <<~XML
+          <mods #{MODS_ATTRIBUTES}>
+            <originInfo>
+              <dateCreated keyDate="yes" encoding="w3cdtf" point="start">1947</dateCreated>
+              <dateCreated encoding="w3cdtf" point="end">1952</dateCreated>
+            </originInfo>
+            <originInfo displayLabel="Contract date">
+              <dateCreated keyDate="yes" encoding="w3cdtf" point="start">1947</dateCreated>
+              <dateCreated encoding="w3cdtf" point="end">1952</dateCreated>
+            </originInfo>
+          </mods>
+        XML
+      end
+    end
   end
 
   context 'when single place element with placeTerm for code and text' do


### PR DESCRIPTION
## Why was this change made?

fixes an error being thrown in some mods_normalization cases (when origin_info had a date point)

(fixes 29 out of 29 normalization errors!)

Fixes #2490 

## How was this change tested?

### BEFORE (main branch)

```
$ bin/validate-cocina-roundtrip -d 'druid:kc552wv4693'
...
Status (n=1; not using Missing for success/different/error stats):
  Success:   0 (0.0%)
  Different: 0 (0.0%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     1 (100.0%)
  Missing (no descMetadata):     0 (0.0%)
```

### AFTER (this branch)

```
$ bin/validate-cocina-roundtrip -d 'druid:kc552wv4693'
...
Status (n=1; not using Missing for success/different/error stats):
  Success:   1 (100.0%)
  Different: 0 (0.0%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     0 (0.0%)
```


## Which documentation and/or configurations were updated?



