### PR TITLE
Check round trip before doing cocina update or create

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -28,6 +28,9 @@ class ObjectsController < ApplicationController
     render status: :created, location: object_path(cocina_object.externalIdentifier), json: cocina_object
   rescue SymphonyReader::ResponseError
     json_api_error(status: :bad_gateway, title: 'Catalog connection error', message: 'Unable to read descriptive metadata from the catalog')
+  rescue Cocina::RoundtripValidationError => e
+    Honeybadger.notify(e)
+    json_api_error(status: e.status, message: e.message)
   rescue Cocina::ValidationError => e
     json_api_error(status: e.status, message: e.message)
   end
@@ -38,6 +41,9 @@ class ObjectsController < ApplicationController
     cocina_object = Cocina::ObjectUpdater.run(obj, update_request)
 
     render json: cocina_object
+  rescue Cocina::RoundtripValidationError => e
+    Honeybadger.notify(e)
+    json_api_error(status: e.status, message: e.message)
   rescue Cocina::ValidationError => e
     json_api_error(status: e.status, message: e.message)
   end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -11,8 +11,7 @@ module Cocina
     # @param [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAdminPolicy] obj
     # @raises SymphonyReader::ResponseError if symphony connection failed
     def create(obj, event_factory:, persister:)
-      # Validate will raise an error if not valid.
-      ObjectValidator.validate(obj)
+      validate(obj)
 
       af_model = create_from_model(obj, persister: persister)
 
@@ -154,6 +153,16 @@ module Cocina
 
     def truncate_label(label)
       label.length > 254 ? label[0, 254] : label
+    end
+
+    def validate(obj)
+      if Settings.enabled_features.validate_descriptive_roundtrip.create
+        validator = DescriptionRoundtripValidator.new(obj)
+        raise RoundtripValidationError, validator.error unless validator.valid?
+      end
+
+      # Validate will raise an error if not valid.
+      ObjectValidator.validate(obj)
     end
   end
 end

--- a/app/validators/cocina/description_roundtrip_validator.rb
+++ b/app/validators/cocina/description_roundtrip_validator.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Cocina
+  # Validates that descriptive metadata roundtrips.
+  class DescriptionRoundtripValidator
+    # @param [RequestAdminPolicy, RequestDRO, RequestCollection, AdminPolicy, DRO, Collection]
+    def initialize(cocina_object)
+      @cocina_object = cocina_object
+    end
+
+    attr_reader :error
+
+    def valid?
+      return true if cocina_object.description.nil?
+
+      descriptive_ng_xml = ToFedora::Descriptive.transform(cocina_object.description, druid).doc
+      # Map MODS back to Cocina.
+      title_builder = FromFedora::Descriptive::TitleBuilderStrategy.find(label: cocina_object.label)
+      roundtrip_description = FromFedora::Descriptive.props(title_builder: title_builder, mods: descriptive_ng_xml, druid: druid)
+
+      # Compare original description against roundtripped Cocina.
+      unless DeepEqual.match?(roundtrip_description, cocina_object.description.to_h)
+        @error = "Roundtripping of descriptive metadata unsuccessful. Expected #{cocina_object.description.to_h} but received #{roundtrip_description}."
+        return false
+      end
+
+      true
+    end
+
+    private
+
+    attr_reader :cocina_object
+
+    def druid
+      # Requests do not have druids.
+      @druid ||= cocina_object.respond_to?(:externalIdentifier) ? cocina_object.externalIdentifier : nil
+    end
+  end
+end

--- a/app/validators/cocina/roundtrip_validation_error.rb
+++ b/app/validators/cocina/roundtrip_validation_error.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Cocina
+  # Raised when a roundtrip validation fails
+  class RoundtripValidationError < ValidationError
+    def initialize(message)
+      super(message, status: :conflict)
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,9 @@
 enabled_features:
   registration: true
   update_descriptive: false
+  validate_descriptive_roundtrip:
+    update: true
+    create: true
 
 content:
   base_dir: '/dor/workspace'

--- a/openapi.yml
+++ b/openapi.yml
@@ -965,7 +965,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '409':
-          description: Object with that sourceId already exists
+          description: Object with that sourceId already exists or roundtrip validation failed
           content:
             application/json:
               schema:
@@ -1024,7 +1024,11 @@ paths:
         '404':
           description: Object not found in DOR
         '409':
-          description: Object with that sourceId already exists
+          description: Object with that sourceId already exists or roundtrip validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Server error
     get:

--- a/spec/services/cocina/object_updater_spec.rb
+++ b/spec/services/cocina/object_updater_spec.rb
@@ -82,10 +82,13 @@ RSpec.describe Cocina::ObjectUpdater do
     end
 
     context 'when updating description' do
+      let(:description_roundtrip_validator) { instance_double(Cocina::DescriptionRoundtripValidator, 'valid?' => true) }
+
       before do
         allow(desc_metadata).to receive(:content=)
         allow(desc_metadata).to receive(:content_will_change!)
-        allow(Cocina::ToFedora::Descriptive).to receive(:transform).and_return(Nokogiri::XML::Document.new)
+        allow(Cocina::ToFedora::Descriptive).to receive(:transform).and_return(Nokogiri::XML::Builder.new)
+        allow(Cocina::DescriptionRoundtripValidator).to receive(:new).and_return(description_roundtrip_validator)
       end
 
       context 'when description has changed' do
@@ -195,10 +198,13 @@ RSpec.describe Cocina::ObjectUpdater do
     end
 
     context 'when updating description' do
+      let(:description_roundtrip_validator) { instance_double(Cocina::DescriptionRoundtripValidator, 'valid?' => true) }
+
       before do
         allow(desc_metadata).to receive(:content=)
         allow(desc_metadata).to receive(:content_will_change!)
-        allow(Cocina::ToFedora::Descriptive).to receive(:transform).and_return(Nokogiri::XML::Document.new)
+        allow(Cocina::ToFedora::Descriptive).to receive(:transform).and_return(Nokogiri::XML::Builder.new)
+        allow(Cocina::DescriptionRoundtripValidator).to receive(:new).and_return(description_roundtrip_validator)
       end
 
       context 'when description has changed' do
@@ -325,10 +331,13 @@ RSpec.describe Cocina::ObjectUpdater do
     end
 
     context 'when updating description' do
+      let(:description_roundtrip_validator) { instance_double(Cocina::DescriptionRoundtripValidator, 'valid?' => true) }
+
       before do
         allow(desc_metadata).to receive(:content=)
         allow(desc_metadata).to receive(:content_will_change!)
-        allow(Cocina::ToFedora::Descriptive).to receive(:transform).and_return(Nokogiri::XML::Document.new)
+        allow(Cocina::ToFedora::Descriptive).to receive(:transform).and_return(Nokogiri::XML::Builder.new)
+        allow(Cocina::DescriptionRoundtripValidator).to receive(:new).and_return(description_roundtrip_validator)
       end
 
       context 'when description has changed' do
@@ -552,7 +561,7 @@ RSpec.describe Cocina::ObjectUpdater do
       allow(Cocina::ToFedora::Identity).to receive(:apply)
       allow(desc_metadata).to receive(:content=)
       allow(desc_metadata).to receive(:content_will_change!)
-      allow(Cocina::ToFedora::Descriptive).to receive(:transform).and_return(Nokogiri::XML::Document.new)
+      allow(Cocina::ToFedora::Descriptive).to receive(:transform).and_return(Nokogiri::XML::Builder.new)
       allow(AdministrativeTags).to receive(:create)
       allow(content_metadata).to receive(:contentType=)
       allow(Cocina::ToFedora::Identity).to receive(:apply)

--- a/spec/support/matchers/deep_ignore_order_matcher.rb
+++ b/spec/support/matchers/deep_ignore_order_matcher.rb
@@ -2,7 +2,7 @@
 
 # Based on https://github.com/amogil/rspec-deep-ignore-order-matcher/blob/master/lib/rspec_deep_ignore_order_matcher.rb
 RSpec::Matchers.define :be_deep_equal do |expected|
-  match { |actual| match? actual, expected }
+  match { |actual| DeepEqual.match?(actual, expected) }
 
   # Added diffable because it is helpful for troubleshooting, even if it mistakingly diffs order differences.
   diffable
@@ -17,30 +17,5 @@ RSpec::Matchers.define :be_deep_equal do |expected|
 
   description do
     "be deep equal with #{expected}"
-  end
-
-  def match?(actual, expected)
-    return arrays_match?(actual, expected) if expected.is_a?(Array) && actual.is_a?(Array)
-    return hashes_match?(actual, expected) if expected.is_a?(Hash) && actual.is_a?(Hash)
-
-    expected == actual
-  end
-
-  def arrays_match?(actual, expected)
-    exp = expected.clone
-    actual.each do |a|
-      index = exp.find_index { |e| match? a, e }
-      return false if index.nil?
-
-      exp.delete_at(index)
-    end
-    exp.empty?
-  end
-
-  def hashes_match?(actual, expected)
-    return false unless actual.keys.sort == expected.keys.sort
-
-    actual.each { |key, value| return false unless match? value, expected[key] }
-    true
   end
 end


### PR DESCRIPTION
## Why was this change made?
To make sure that only changes that can be roundtripped are accepted for create or update. This ensures the integrity of data that is submitted via cocina update or create endpoints.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


