### PR TITLE
Validate rights metadata writes over the legacy API

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -37,6 +37,7 @@ class MetadataController < ApplicationController
       values = params[section]
       next unless values
 
+      validate_rights(values[:content]) if datastream_name == 'rightsMetadata'
       LegacyMetadataService.update_datastream_if_newer(datastream: @item.datastreams[datastream_name],
                                                        updated: Time.zone.parse(values[:updated]),
                                                        content: values[:content],
@@ -44,8 +45,36 @@ class MetadataController < ApplicationController
     end
 
     @item.save!
+  rescue InvalidRights => e
+    render build_error('Invalid rightsMetadata', e)
   rescue Rubydora::FedoraInvalidRequest
     render json: { error: 'Invalid Fedora request possibly due to concurrent requests' },
            status: :service_unavailable
+  end
+
+  class InvalidRights < StandardError; end
+
+  private
+
+  # JSON-API error response
+  def build_error(msg, err)
+    {
+      json: {
+        errors: [
+          {
+            status: '422',
+            title: msg,
+            detail: err.message
+          }
+        ]
+      },
+      content_type: 'application/vnd.api+json',
+      status: :unprocessable_entity
+    }
+  end
+
+  def validate_rights(xml)
+    dra = Dor::RightsMetadataDS.from_xml(xml).dra_object
+    raise InvalidRights, dra.index_elements[:errors].to_sentence if dra.index_elements[:errors].present?
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -734,6 +734,12 @@ paths:
       responses:
         '200':
           description: OK
+        422:
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '503':
           description: Service unavailable when an error occurs saving to Fedora
       parameters:


### PR DESCRIPTION
## Why was this change made?
Fixes #2502


## How was this change tested?



## Which documentation and/or configurations were updated?



