### PR TITLE
Adds MODS validation to legacy metadata endpoint.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,23 @@ class ApplicationController < ActionController::API
 
   TOKEN_HEADER = 'Authorization'
 
+  def json_api_error(status:, message:, title: nil, meta: nil)
+    status_code = Rack::Utils.status_code(status)
+    render status: status,
+           content_type: 'application/vnd.api+json',
+           json: {
+             errors: [
+               {
+                 status: status_code.to_s,
+                 title: title || Rack::Utils::HTTP_STATUS_CODES[status_code],
+                 detail: message
+               }.tap do |h|
+                 h[:meta] = meta if meta.present?
+               end
+             ]
+           }
+  end
+
   private
 
   # Ensure a valid token is present, or renders "401: Not Authorized"

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ObjectsController < ApplicationController # rubocop:disable Metrics/ClassLength
+class ObjectsController < ApplicationController
   before_action :load_item, except: [:create]
 
   rescue_from(Cocina::ObjectUpdater::NotImplemented) do |e|
@@ -130,23 +130,6 @@ class ObjectsController < ApplicationController # rubocop:disable Metrics/ClassL
   end
 
   private
-
-  def json_api_error(status:, message:, title: nil, meta: nil)
-    status_code = Rack::Utils.status_code(status)
-    render status: status,
-           content_type: 'application/vnd.api+json',
-           json: {
-             errors: [
-               {
-                 status: status_code.to_s,
-                 title: title || Rack::Utils::HTTP_STATUS_CODES[status_code],
-                 detail: message
-               }.tap do |h|
-                 h[:meta] = meta if meta.present?
-               end
-             ]
-           }
-  end
 
   def workflow_client
     WorkflowClientFactory.build

--- a/app/services/legacy_metadata_service.rb
+++ b/app/services/legacy_metadata_service.rb
@@ -3,14 +3,37 @@
 # Operations on the legacy Fedora 3 metadata.
 # This is used by the accessionWF and the etdSubmitWF
 class LegacyMetadataService
+  # Error indicating a validation error with the datastream.
+  class DatastreamValidationError < StandardError
+    def initialize(message, detail: nil)
+      super(message)
+      @detail = detail
+    end
+
+    attr_reader :detail
+  end
+
   # If the updated value is newer than then createDate of the datastream, then update it.
+  # @raise [DatastreamValidationError] if datastream fails validation
   def self.update_datastream_if_newer(datastream:, updated:, content:, event_factory:)
+    new(datastream: datastream, updated: updated, content: content, event_factory: event_factory).update_datastream_if_newer
+  end
+
+  def initialize(datastream:, updated:, content:, event_factory:)
+    @datastream = datastream
+    @updated = updated
+    @content = content
+    @event_factory = event_factory
+  end
+
+  def update_datastream_if_newer
     if !datastream.createDate || updated > datastream.createDate
       datastream.content = content
       event_factory.create(druid: datastream.pid, event_type: 'legacy_metadata_update', data: { datastream: datastream.dsid })
     end
 
-    validate_desc_metadata(datastream) if datastream.dsid == 'descMetadata'
+    validate_desc_metadata if datastream.dsid == 'descMetadata'
+    validate_rights_metadata if datastream.dsid == 'rightsMetadata'
 
     return if !datastream.createDate || updated > datastream.createDate
 
@@ -19,8 +42,19 @@ class LegacyMetadataService
       'Doing an experiment to see if this ever happens.')
   end
 
-  def self.validate_desc_metadata(datastream)
-    raise "#{datastream.pid} descMetadata missing required fields (<title>)" if datastream.mods_title.blank?
+  private
+
+  attr_reader :datastream, :updated, :content, :event_factory
+
+  def validate_rights_metadata
+    result = Fedora::RightsValidator.valid?(datastream.ng_xml)
+    raise DatastreamValidationError.new('Invalid rightsMetadata', detail: result.failure.join(' ')) if result.failure?
   end
-  private_class_method :validate_desc_metadata
+
+  def validate_desc_metadata
+    result = ModsValidator.valid?(datastream.ng_xml)
+    raise DatastreamValidationError.new('MODS validation failed', detail: result.failure.join(' ')) if result.failure?
+
+    raise DatastreamValidationError, "#{datastream.pid} descMetadata missing required fields (<title>)" if datastream.mods_title.blank?
+  end
 end

--- a/app/validators/fedora/rights_validator.rb
+++ b/app/validators/fedora/rights_validator.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Fedora
+  # Validator for Rights datastream.
+  class RightsValidator
+    include Dry::Monads[:result]
+
+    # @param [Nokogiri::Document] ng_xml
+    # @return [Dry::Monads::Result]
+    def self.valid?(ng_xml)
+      new(ng_xml).valid?
+    end
+
+    def initialize(ng_xml)
+      @ng_xml = ng_xml
+    end
+
+    def valid?
+      dra = Dor::RightsMetadataDS.from_xml(ng_xml.to_xml).dra_object
+      return Failure([dra.index_elements[:errors].to_sentence]) if dra.index_elements[:errors].present?
+
+      Success()
+    end
+
+    private
+
+    attr_reader :ng_xml
+  end
+end

--- a/app/validators/mods_validator.rb
+++ b/app/validators/mods_validator.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Validator for MODS.
+class ModsValidator
+  include Dry::Monads[:result]
+
+  # @param [Nokogiri::Document] ng_xml
+  # @return [Dry::Monads::Result]
+  def self.valid?(ng_xml)
+    new(ng_xml).valid?
+  end
+
+  def initialize(ng_xml)
+    @ng_xml = ng_xml
+  end
+
+  def valid?
+    mods_version = ng_xml.root[:version]
+    return Failure(['MODS version attribute not found.']) if mods_version.nil?
+
+    Dir.chdir('mods') do
+      mods_xsd_filename = "mods-#{mods_version.sub('.', '-')}.xsd"
+      return Failure(['Unknown MODS version.']) unless File.exist?(mods_xsd_filename)
+
+      xsd = Nokogiri::XML::Schema(File.read(mods_xsd_filename))
+      return Success() if xsd.valid?(ng_xml)
+
+      Failure(xsd.validate(ng_xml).map(&:to_s))
+    end
+  end
+
+  private
+
+  attr_reader :ng_xml
+end

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -110,18 +110,9 @@ def write_error(druid, original_ng_xml, cocina, error)
 end
 
 def validate_mods(ng_xml)
-  mods_version = ng_xml.root[:version]
-  return 'MODS version attribute not found' if mods_version.nil?
+  result = ModsValidator.valid?(ng_xml)
 
-  Dir.chdir('mods') do
-    mods_xsd_filename = "mods-#{mods_version.sub('.', '-')}.xsd"
-    return 'Unknown MODS version' unless File.exist?(mods_xsd_filename)
-
-    xsd = Nokogiri::XML::Schema(File.read(mods_xsd_filename))
-    return 'Valid MODS' if xsd.valid?(ng_xml)
-
-    xsd.validate(ng_xml).map(&:to_s)
-  end
+  result.failure? ? result.failure : 'Valid MODS'
 end
 
 # rubocop:disable Metrics/CyclomaticComplexity

--- a/openapi.yml
+++ b/openapi.yml
@@ -734,7 +734,7 @@ paths:
       responses:
         '200':
           description: OK
-        422:
+        '422':
           description: Validation error
           content:
             application/json:

--- a/spec/services/legacy_metadata_service_spec.rb
+++ b/spec/services/legacy_metadata_service_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe LegacyMetadataService do
+  include Dry::Monads[:result]
+
   describe '.update_datastream_if_newer' do
     subject(:update) do
       described_class.update_datastream_if_newer(datastream: datastream,
@@ -23,6 +25,11 @@ RSpec.describe LegacyMetadataService do
                                            mods_title: title)
     end
 
+    before do
+      allow(datastream).to receive(:ng_xml).and_return(Nokogiri::XML(content))
+      allow(ModsValidator).to receive(:valid?).and_return(Success())
+    end
+
     context 'with a new datastream' do
       let(:create_date) { nil }
 
@@ -30,6 +37,7 @@ RSpec.describe LegacyMetadataService do
         update
         expect(datastream).to have_received(:content=).with(content)
         expect(event_factory).to have_received(:create)
+        expect(ModsValidator).to have_received(:valid?)
       end
     end
 

--- a/spec/validators/fedora/rights_validator_spec.rb
+++ b/spec/validators/fedora/rights_validator_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Fedora::RightsValidator do
+  let(:result) { described_class.valid?(Nokogiri.XML(ds)) }
+
+  context 'when valid' do
+    let(:ds) do
+      <<~XML
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <copyright>
+            <human/>
+          </copyright>
+          <use>
+            <human type="useAndReproduction"/>
+          </use>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'returns success' do
+      expect(result.success?).to be true
+    end
+  end
+
+  context 'when invalid' do
+    let(:ds) do
+      <<~XML
+        <rightsMetadata>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'returns failure' do
+      expect(result.failure?).to be true
+      expect(result.failure.first).to start_with('no_discover_access, no_discover_machine')
+    end
+  end
+end

--- a/spec/validators/mods_validator_spec.rb
+++ b/spec/validators/mods_validator_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ModsValidator do
+  let(:result) { described_class.valid?(Nokogiri.XML(mods)) }
+
+  context 'when valid' do
+    let(:mods) do
+      <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.7">
+          <titleInfo>
+            <title>Kayaking the Main Coast</title>
+          </titleInfo>
+        </mods>
+      XML
+    end
+
+    it 'returns success' do
+      expect(result.success?).to be true
+    end
+  end
+
+  context 'when invalid' do
+    let(:mods) do
+      <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.7">
+          <frequency>often</frequency>
+        </mods>
+      XML
+    end
+
+    it 'returns failure' do
+      expect(result.failure?).to be true
+      expect(result.failure.first).to start_with("2:0: ERROR: Element '{http://www.loc.gov/mods/v3}frequency': This element is not expected.")
+    end
+  end
+
+  context 'when missing version' do
+    let(:mods) do
+      <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3">
+          <titleInfo>
+            <title>Kayaking the Main Coast</title>
+          </titleInfo>
+        </mods>
+      XML
+    end
+
+    it 'returns failure' do
+      expect(result.failure?).to be true
+      expect(result.failure.first).to start_with('MODS version attribute not found.')
+    end
+  end
+
+  context 'when unknown version' do
+    let(:mods) do
+      <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="1.0">
+          <titleInfo>
+            <title>Kayaking the Main Coast</title>
+          </titleInfo>
+        </mods>
+      XML
+    end
+
+    it 'returns failure' do
+      expect(result.failure?).to be true
+      expect(result.failure.first).to start_with('Unknown MODS version.')
+    end
+  end
+end


### PR DESCRIPTION
refs #2411

## Why was this change made?
Keep out bad data.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
openapi


