### PR TITLE
Adds script for roundtripping full cocina objects.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,9 @@ gem 'rails', '~> 5.2.0'
 gem 'puma', '~> 3.12'
 
 group :development do
+  gem 'dor-services-client' # used by bin/validate-cocina-roundtrip
   gem 'listen', '~> 3.0.5'
+  gem 'rubyzip', '>= 1.0.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,13 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
+    dor-services-client (6.26.0)
+      activesupport (>= 4.2, < 7)
+      cocina-models (~> 0.54.0)
+      deprecation
+      faraday (>= 0.15, < 2)
+      moab-versioning (~> 4.0)
+      zeitwerk (~> 2.1)
     dor-workflow-client (3.23.1)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
@@ -441,6 +448,7 @@ GEM
       mime-types
       nokogiri
       rest-client
+    rubyzip (2.3.0)
     scrub_rb (1.0.1)
     sidekiq (6.1.3)
       connection_pool (>= 2.2.2)
@@ -529,6 +537,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.6)
   dor-rights-auth (>= 1.5.0)
   dor-services (~> 9.6)
+  dor-services-client
   dor-workflow-client (~> 3.17)
   dry-monads
   dry-schema (~> 1.4)
@@ -561,6 +570,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   ruby-cache (~> 0.3.0)
+  rubyzip (>= 1.0.0)
   sidekiq (~> 6.0)
   sidekiq-statistic
   simplecov (~> 0.17.1)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ These tools are best run on a server within the network. (Currently installed on
 
         solr:
           url: 'https://sul-solr.stanford.edu/solr/argo3_prod'
+
+        dor_services:
+          url: 'https://dor-services-prod.stanford.edu'
+          token: '<create a token>'
+    
 2. Copy certificates locally:
 
         scp -r <user from puppet>@<dor serices production host>:/etc/pki/tls .
@@ -164,13 +169,34 @@ This script can be run from a cron job to keep the cache up to date.
 
 ### Validate mapping to Cocina from Fedora
 ```
-$ bin/validate-to-cocina -h
+$ bin/validate-cocina-roundtrip -h
+Usage: bin/validate-cocina-roundtrip [options]
+    -s, --sample SAMPLE              Sample size, otherwise all druids.
+    -r, --random                     Select random druids.
+    -d, --druids DRUIDS              List of druids (instead of druids.txt).
+    -h, --help                       Displays help.
+    
+$ bin/validate-cocina-roundtrip -s 100
+Testing |Time: 00:00:21 | ============================================================================ | Time: 00:00:21
+Status (n=100; not using Missing for success/different/error stats):
+  Success:   8 (8.0%)
+  Different: 56 (56.0%)
+  Mapping error:     36 (36.0%)
+  Update error:     0 (0.0%)
+  Missing:     0 (0.0%) 
+```
+
+Using the druids from `druids.txt` and the cache, this will create a Fedora item, map the Fedora item to the Cocina model, update the Fedora item from the Cocina object, map the changed Fedora item to the Cocina model, and compare the original Cocina object against the changed Cocina object and the original Fedora item against the changed Fedora item.
+
+### Validate mapping to Cocina from MODS (descriptive metadata only)
+```
+$ bin/validate-to-desc-cocina -h
 Usage: bin/validate-to-cocina [options]
     -s, --sample SAMPLE              Sample size, otherwise all druids.
     -u, --unique-filename            Result file named for branch and runtime
     -h, --help                       Displays help.
 
-$ bin/validate-to-cocina -s 10
+$ bin/validate-to-desc-cocina -s 10
 Testing |Time: 00:00:00 | ===================================================================== | Time: 00:00:00
 
 Error: 0 of 10 (0.0%)%)
@@ -193,15 +219,15 @@ A complete set of results will be written to `results.txt`.
 
 Note that the location of the cache can be set with `FEDORA_CACHE` environment variable.
 
-### Validate mapping to Fedora from Cocina
+### Validate mapping to MODS from Cocina (descriptive metadata only)
 ```
-$ bin/validate-to-fedora -h
-Usage: bin/validate-to-fedora [options]
+$ bin/validate-to-mods -h
+Usage: bin/validate-to-mods [options]
     -s, --sample SAMPLE              Sample size, otherwise all druids.
     -u, --unique-filename            Result file named for branch and runtime
     -h, --help                       Displays help.
 
-$ bin/validate-to-fedora
+$ bin/validate-to-mods
 Testing |Time: 00:00:06 | ============================================================= | Time: 00:00:06
 To Fedora error: 21 of 7500 (0.28%)
 To Cocina error: 0 of 7500 (0.0%)
@@ -209,28 +235,28 @@ Data error: 4 of 7500 (0.05333333333333334%)
 Missing: 26 of 7500 (0.3466666666666667%)
 ```
 
-This is similar to `bin/validate-to-cocina` but reports errors raised when mapping to Fedora.
+This is similar to `bin/validate-to-desc-cocina` but reports errors raised when mapping to Fedora.
 
 Note that the location of the cache can be set with `FEDORA_CACHE` environment variable.
 
-### Validate roundtrip mapping (to Cocina from Fedora then to Fedora from Cocina)
+### Validate roundtrip mapping (to Cocina from MODS then to Fedora from MODS -- descriptive metadata only)
 ```
-$ bin/validate-cocina-roundtrip -h
-Usage: bin/validate-cocina-roundtrip [options]
+$ bin/validate-desc-cocina-roundtrip -h
+Usage: bin/validate-desc-cocina-roundtrip [options]
     -s, --sample SAMPLE              Sample size, otherwise all druids.
     -r, --random                     Select random druids.
     -f, --fast                       Do not write results files.
     -d, --druids DRUIDS              List of druids (instead of druids.txt).
     -h, --help                       Displays help.
 
-$ bin/validate-cocina-roundtrip -s 10 -r
+$ bin/validate-desc-cocina-roundtrip -s 10 -r
 ```
 
 Using the druids from `druids.txt` and the cache, this will compare the differences between the original MODS (Fedora descriptive metadata) and the roundtripped MODS.
 
 Alternatively, to map a single druid:
 ```
-$ bin/validate-cocina-roundtrip -d druid:bh164hd2167
+$ bin/validate-desc-cocina-roundtrip -d druid:bh164hd2167
 ```
 
 Errors totals are summarized. For example:
@@ -290,12 +316,12 @@ Test with `bin/validate-cocina-roundtrip`, comparing results from main against y
 ```
 $ git checkout main
 $ git pull
-$ bin/validate-cocina-roundtrip -s 350000 -f
+$ bin/validate-desc-cocina-roundtrip -s 350000 -f
 $ git checkout YOUR_BRANCH_NAME
-$ bin/validate-cocina-roundtrip -s 350000 -f
+$ bin/validate-desc-cocina-roundtrip -s 350000 -f
 ```
 
-When running `bin/validate-to-cocina` or `bin/validate-to-feodora`, you may want to fetch the `results.txt` to your local drive (it is written to the root folder of dor-services-app)
+When running `bin/validate-to-desc-cocina` or `bin/validate-to-mods`, you may want to fetch the `results.txt` to your local drive (it is written to the root folder of dor-services-app)
 and look for errors.
 
 ```

--- a/app/services/cocina/from_fedora/apo.rb
+++ b/app/services/cocina/from_fedora/apo.rb
@@ -5,13 +5,15 @@ module Cocina
     # Creates Cocina APO objects from Fedora objects
     class APO
       # @param [Dor::Item,Dor::Etd] item
+      # @param [Cocina::FromFedora::DataErrorNotifier] notifier
       # @return [Hash] a hash that can be mapped to a cocina model
-      def self.props(item)
-        new(item).props
+      def self.props(item, notifier: nil)
+        new(item, notifier: notifier).props
       end
 
-      def initialize(item)
+      def initialize(item, notifier: nil)
         @item = item
+        @notifier = notifier
       end
 
       def props
@@ -23,14 +25,14 @@ module Cocina
           administrative: build_apo_administrative
         }.tap do |props|
           title_builder = FromFedora::Descriptive::TitleBuilderStrategy.find(label: item.label)
-          description = FromFedora::Descriptive.props(title_builder: title_builder, mods: item.descMetadata.ng_xml, druid: item.pid)
+          description = FromFedora::Descriptive.props(title_builder: title_builder, mods: item.descMetadata.ng_xml, druid: item.pid, notifier: notifier)
           props[:description] = description unless description.nil?
         end
       end
 
       private
 
-      attr_reader :item
+      attr_reader :item, :notifier
 
       def build_apo_administrative
         {}.tap do |admin|

--- a/app/services/cocina/from_fedora/collection.rb
+++ b/app/services/cocina/from_fedora/collection.rb
@@ -5,13 +5,15 @@ module Cocina
     # Creates Cocina Collection objects from Fedora objects
     class Collection
       # @param [Dor::Item,Dor::Etd] item
+      # @param [Cocina::FromFedora::DataErrorNotifier] notifier
       # @return [Hash] a hash that can be mapped to a cocina model
-      def self.props(item)
-        new(item).props
+      def self.props(item, notifier: nil)
+        new(item, notifier: notifier).props
       end
 
-      def initialize(item)
+      def initialize(item, notifier: nil)
         @item = item
+        @notifier = notifier
       end
 
       def props
@@ -24,7 +26,7 @@ module Cocina
           access: Access.collection_props(item)
         }.tap do |props|
           title_builder = FromFedora::Descriptive::TitleBuilderStrategy.find(label: item.label)
-          description = FromFedora::Descriptive.props(title_builder: title_builder, mods: item.descMetadata.ng_xml, druid: item.pid)
+          description = FromFedora::Descriptive.props(title_builder: title_builder, mods: item.descMetadata.ng_xml, druid: item.pid, notifier: notifier)
           props[:description] = description unless description.nil?
           identification = FromFedora::Identification.props(item)
           identification[:catalogLinks] = [{ catalog: 'symphony', catalogRecordId: item.catkey }] if item.catkey
@@ -34,7 +36,7 @@ module Cocina
 
       private
 
-      attr_reader :item
+      attr_reader :item, :notifier
     end
   end
 end

--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -22,14 +22,16 @@ module Cocina
 
     # @param [Dor::Abstract] item the Fedora object to convert to a cocina object
     # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]
+    # @param [Cocina::FromFedora::DataErrorNotifier] notifier
     # @raises [SolrConnectionError,UnsupportedObjectType,MissingSourceID]
-    def self.build(item)
-      new(item).build
+    def self.build(item, notifier: nil)
+      new(item, notifier: notifier).build
     end
 
     # @param [Dor::Abstract] item the Fedora object to convert to a cocina object
-    def initialize(item)
+    def initialize(item, notifier: nil)
       @item = item
+      @notifier = notifier
     end
 
     # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]
@@ -37,11 +39,11 @@ module Cocina
     def build
       klass = cocina_klass
       props = if klass == Cocina::Models::DRO
-                FromFedora::DRO.props(item)
+                FromFedora::DRO.props(item, notifier: notifier)
               elsif klass == Cocina::Models::Collection
-                FromFedora::Collection.props(item)
+                FromFedora::Collection.props(item, notifier: notifier)
               elsif klass == Cocina::Models::AdminPolicy
-                FromFedora::APO.props(item)
+                FromFedora::APO.props(item, notifier: notifier)
               else
                 raise "unable to build '#{klass}'"
               end
@@ -53,7 +55,7 @@ module Cocina
 
     private
 
-    attr_reader :item
+    attr_reader :item, :notifier
 
     # @todo This should have more specific type such as found in identityMetadata.objectType
     def cocina_klass

--- a/app/services/deep_equal.rb
+++ b/app/services/deep_equal.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Deeply compares two objects, ignoring array order.
+# Based on https://github.com/amogil/rspec-deep-ignore-order-matcher/blob/master/lib/rspec_deep_ignore_order_matcher.rb
+class DeepEqual
+  def self.match?(actual, expected)
+    new(actual, expected).match?
+  end
+
+  def initialize(actual, expected)
+    @actual = actual
+    @expected = expected
+  end
+
+  def match?
+    objects_match?(actual, expected)
+  end
+
+  private
+
+  attr_reader :actual, :expected
+
+  def objects_match?(actual_obj, expected_obj)
+    return arrays_match?(actual_obj, expected_obj) if expected_obj.is_a?(Array) && actual_obj.is_a?(Array)
+    return hashes_match?(actual_obj, expected_obj) if expected_obj.is_a?(Hash) && actual_obj.is_a?(Hash)
+
+    expected_obj == actual_obj
+  end
+
+  def arrays_match?(actual_array, expected_array)
+    exp = expected_array.clone
+    actual_array.each do |a|
+      index = exp.find_index { |e| objects_match? a, e }
+      return false if index.nil?
+
+      exp.delete_at(index)
+    end
+    exp.empty?
+  end
+
+  def hashes_match?(actual_hash, expected_hash)
+    return false unless actual_hash.keys.sort == expected_hash.keys.sort
+
+    actual_hash.each { |key, value| return false unless objects_match? value, expected_hash[key] }
+    true
+  end
+end

--- a/bin/generate-cache
+++ b/bin/generate-cache
@@ -43,6 +43,5 @@ end
 
 druids.each_with_index do |druid, index|
   puts "#{druid} (#{index + 1})\n" unless options[:quiet]
-  cache.cache_object(druid)
-  cache.cache_descmd(druid)
+  cache.cache(druid)
 end

--- a/bin/report
+++ b/bin/report
@@ -166,7 +166,11 @@ Result = Struct.new(:druid, :apo, :collections, :catkey, :reports)
 
 run_reports = options[:reports].select { |name| REPORTS.key?(name) }
 results = Parallel.map(druids, progress: 'Testing') do |druid|
-  ng_xml = cache.descmd_xml(druid)
+  result = cache.datastream(druid, 'descMetadata')
+  next if result.failure?
+
+  ng_xml = Nokogiri::XML(result.value!)
+
   report_results = {}
   run_reports.each do |name|
     report_result = REPORTS[name].call(ng_xml)
@@ -184,10 +188,6 @@ rescue Errno::EBUSY
   retry
 rescue ActiveFedora::ObjectNotFoundError
   # noop
-rescue StandardError => e
-  raise if e.message != 'Missing item'
-
-  nil
 end.compact
 
 run_reports.each do |name|

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -7,6 +7,8 @@ require_relative '../lib/data_error_notifier'
 require 'set'
 require 'optparse'
 require 'diffy'
+require 'dor/services/client'
+require 'equivalent-xml'
 
 options = { random: false, druids: [], fast: false }
 parser = OptionParser.new do |option_parser|
@@ -14,7 +16,6 @@ parser = OptionParser.new do |option_parser|
 
   option_parser.on('-sSAMPLE', '--sample SAMPLE', Integer, 'Sample size, otherwise all druids.')
   option_parser.on('-r', '--random', 'Select random druids.')
-  option_parser.on('-f', '--fast', 'Do not write results files.')
   option_parser.on('-dDRUIDS', '--druids DRUIDS', Array, 'List of druids (instead of druids.txt).')
   option_parser.on('-h', '--help', 'Displays help.') do
     puts option_parser
@@ -25,151 +26,177 @@ parser.parse!(into: options)
 
 cache = FedoraCache.new
 
-def round_tripped_ng_xml(cocina, druid)
-  Nokogiri::XML(Cocina::ToFedora::Descriptive.transform(cocina, druid).to_xml) { |config| config.default_xml.noblanks }
-end
+Dor::Services::Client.configure(url: Settings.dor_services.url,
+                                token: Settings.dor_services.token)
 
-def cocina_props(ng_xml, druid, label, notifier)
-  title_builder = Cocina::FromFedora::Descriptive::TitleBuilderStrategy.find(label: label)
-  Cocina::FromFedora::Descriptive.props(title_builder: title_builder, mods: ng_xml, druid: druid, notifier: notifier)
-end
-
-def node_count_match?(ng_xml1, ng_xml2)
-  ng_xml1.root.elements.size == ng_xml2.root.elements.size
-end
-
-# rubocop:disable Metrics/ParameterLists
-# rubocop:disable Metrics/AbcSize
-# rubocop:disable Metrics/BlockLength
-# rubocop:disable Metrics/PerceivedComplexity
-def write_result(druid, original_ng_xml, roundtrip_ng_xml, cocina, differences, reverse_differences, data_errors, mods_msg)
+def write_result(druid, orig_cocina_hash, roundtrip_cocina_hash, diff_datastreams)
   File.open("results/#{druid}.txt", 'w') do |file|
     file.write("Druid: #{druid}\n\n")
 
-    if mods_msg.is_a?(Array)
-      mods_msg.each do |msg|
-        file.write("MODS error: #{msg}\n")
-      end
-      file.write("\nNote that data errors are from the original XML, not the normalized XML shown below.\n\n")
-    else
-      file.write("#{mods_msg}\n\n")
+    cocina_keys = (orig_cocina_hash.keys + roundtrip_cocina_hash.keys).uniq
+    cocina_keys.each do |cocina_key|
+      next if DeepEqual.match?(orig_cocina_hash[cocina_key], roundtrip_cocina_hash[cocina_key])
+
+      file.write("Diff for #{cocina_key}:\n")
+      file.write(Diffy::Diff.new("#{JSON.pretty_generate(orig_cocina_hash[cocina_key])}\n", "#{JSON.pretty_generate(roundtrip_cocina_hash[cocina_key])}\n"))
+      file.write("\n\n")
     end
 
-    if data_errors.present?
-      data_errors.each do |data_error|
-        file.write("Data error: #{data_error.msg}")
-        file.write(" (#{data_error.context}") if data_error.context.present?
-        file.write("\n")
-      end
-      file.write("\nNote that data errors are from the original XML, not the normalized XML shown below.\n\n")
+    diff_datastreams.each_pair do |dsid, ng_xmls|
+      orig_ds_ng_xml, ds_ng_xml = ng_xmls
+
+      file.write("Diff for #{dsid}:\n")
+      file.write(Diffy::Diff.new("#{orig_ds_ng_xml.to_xml}\n", "#{ds_ng_xml.to_xml}\n"))
+      file.write("\n\n")
     end
-
-    file.write("Node count mismatch between original and roundtripped.\n") unless node_count_match?(original_ng_xml, roundtrip_ng_xml)
-
-    differences.each_with_index do |difference, index|
-      file.write("Differences #{index + 1}\n")
-      file.write("Original node:\n#{difference.mods_node1}\n")
-      if difference.mods_node2
-        file.write("Best guess roundtripped node:\n#{difference.mods_node2}\n")
-        file.write("Difference:\n#{Diffy::Diff.new("#{difference.mods_node1}\n", "#{difference.mods_node2}\n")}\n")
-      else
-        file.write("Could not find similar roundtripped node.\n")
-      end
-    end
-
-    reverse_differences.each_with_index do |difference, index|
-      file.write("Differences #{index + 1}\n")
-      file.write("Roundtripped node:\n#{difference.mods_node1}\n")
-      if difference.mods_node2
-        file.write("Best guess original node:\n#{difference.mods_node2}\n")
-        file.write("Difference:\n#{Diffy::Diff.new("#{difference.mods_node1}\n", "#{difference.mods_node2}\n")}\n")
-      else
-        file.write("Could not find similar original node.\n")
-      end
-    end
-
-    file.write("\nOriginal XML:\n#{original_ng_xml.to_xml}\n")
-    file.write("Roundtripped XML:\n#{roundtrip_ng_xml.to_xml}\n")
-    file.write("Cocina:\n#{JSON.pretty_generate(cocina)}\n\n")
   end
 end
-# rubocop:enable Metrics/ParameterLists
-# rubocop:enable Metrics/AbcSize
-# rubocop:enable Metrics/BlockLength
-# rubocop:enable Metrics/PerceivedComplexity
 
-def write_error(druid, original_ng_xml, cocina, error)
+def write_error(druid, error)
   File.open("results/#{druid}.txt", 'w') do |file|
     file.write("Druid: #{druid}\n\n")
     file.write("Error: #{error}\n\n")
-    file.write("Expected XML:\n#{original_ng_xml.to_xml}\n\n")
-    file.write("Cocina:\n#{JSON.pretty_generate(cocina)}\n\n") if cocina
     file.write("Backtrace:\n")
     file.write(error.backtrace.join("\n"))
+    if error.cause
+      file.write("\n\nCause:\n")
+      file.write(error.cause.backtrace.join("\n"))
+    end
   end
 end
 
-def validate_mods(ng_xml)
-  result = ModsValidator.valid?(ng_xml)
+# A little monkeypatching never hurt anyone, right?
 
-  result.failure? ? result.failure : 'Valid MODS'
+# Monkeypatch to retrieve tags using dor-services-client so that does not need to be run on dor-services-app server.
+class AdministrativeTags
+  def self.project(pid:)
+    tag = Dor::Services::Client.object(pid)
+                               .administrative_tags
+                               .list
+                               .find { |check_tag| check_tag.start_with?('Project :') }
+
+    return [] unless tag
+
+    [tag.split(' : ', 2).last]
+  end
+
+  def self.content_type(pid:)
+    tag = Dor::Services::Client.object(pid)
+                               .administrative_tags
+                               .list
+                               .find { |check_tag| check_tag.start_with?('Process : Content Type :') }
+
+    return [] unless tag
+
+    [tag.split(' : ').last]
+  end
 end
 
-# rubocop:disable Metrics/CyclomaticComplexity
-def validate_druid(druid, cache, fast: false)
-  begin
-    original_ng_xml = cache.descmd_xml(druid)
-    label = cache.label(druid)
-  rescue StandardError
-    return :missing
+module ActiveFedora
+  # Monkeypatch to avoid hitting Solr.
+  class SolrService
+    def self.query(query); end
   end
+end
 
-  notifier = DataErrorNotifier.new
+module ActiveFedora
+  # Monkeypatch to avoid hitting Solr.
+  class SolrService
+    def self.reify_solr_results(_result)
+      []
+    end
+  end
+end
+
+def load_fedora_obj(druid, cache)
+  label, datastreams = cache.label_and_datastreams(druid).value!
+
+  obj = fedora_class(datastreams['RELS-EXT']).new(pid: druid, label: label)
+  FedoraCache::DATASTREAMS.each do |dsid|
+    datastream = datastreams[dsid]
+    obj.datastreams[dsid].content = datastream if datastream
+  end
+  obj.relationships = obj.rels_ext.content
+  obj
+end
+
+def fedora_class(rels_ext)
+  rels_ext_ng_xml = Nokogiri::XML(rels_ext)
+  model = rels_ext_ng_xml.root.xpath('//fedora-model:hasModel', 'fedora-model' => 'info:fedora/fedora-system:def/model#').first['rdf:resource']
+  case model
+  when 'info:fedora/afmodel:Dor_Collection'
+    Dor::Collection
+  when 'info:fedora/afmodel:Dor_AdminPolicyObject'
+    Dor::AdminPolicyObject
+  when 'info:fedora/afmodel:Dor_Item'
+    Dor::Item
+  else
+    raise 'Unmapped'
+  end
+end
+
+def ng_xml_for(xml)
+  Nokogiri::XML(xml) { |config| config.default_xml.noblanks }
+end
+
+def validate_druid(druid, cache)
+  return :missing unless cache.cached?(druid)
+
   begin
-    cocina_props = cocina_props(original_ng_xml, druid, label, notifier)
-    cocina = Cocina::Models::Description.new(cocina_props)
+    fedora_obj = load_fedora_obj(druid, cache)
   rescue StandardError => e
-    write_error(druid, original_ng_xml, cocina_props, e) unless fast
-    return :to_cocina_error
+    return :unmapped if e.message == 'Unmapped'
+
+    raise
   end
 
   begin
-    # Perform approved XML normalization changes to avoid noise in roundtrip failures
-    norm_original_ng_xml = Cocina::ModsNormalizer.normalize(mods_ng_xml: original_ng_xml, druid: druid, label: label)
+    orig_cocina_obj = Cocina::Mapper.build(fedora_obj, notifier: DataErrorNotifier.new)
   rescue StandardError => e
-    write_error(druid, original_ng_xml, cocina_props, e) unless fast
-    return :mods_normalizer_error
+    write_error(druid, e)
+    return :mapping_error
   end
+
+  orig_cocina_hash = orig_cocina_obj.to_h
 
   begin
-    roundtrip_ng_xml = round_tripped_ng_xml(cocina, druid)
+    roundtrip_cocina_obj = Cocina::ObjectUpdater.run(fedora_obj, orig_cocina_obj, trial: true, notifier: DataErrorNotifier.new)
   rescue StandardError => e
-    write_error(druid, original_ng_xml, cocina_props, e) unless fast
-    return :to_fedora_error
+    write_error(druid, e)
+    return :update_error
+  end
+  roundtrip_cocina_hash = roundtrip_cocina_obj.to_h
+
+  diff_datastreams = {}
+  FedoraCache::DATASTREAMS.each do |dsid|
+    result = cache.datastream(druid, dsid)
+    next if result.failure?
+
+    orig_ds_ng_xml = ng_xml_for(result.value!)
+
+    ds_ng_xml = ng_xml_for(fedora_obj.datastreams[dsid].content)
+    next if EquivalentXml.equivalent?(orig_ds_ng_xml, ds_ng_xml, { element_order: false, normalize_whitespace: false })
+
+    diff_datastreams[dsid] = [orig_ds_ng_xml, ds_ng_xml]
   end
 
-  if fast
-    return ModsEquivalentService.equivalent?(norm_original_ng_xml, roundtrip_ng_xml) ? :success : :different
-  end
+  return :success if DeepEqual.match?(normalize(orig_cocina_hash), roundtrip_cocina_hash)
 
-  equiv = ModsEquivalentService.equivalent_with_result?(norm_original_ng_xml, roundtrip_ng_xml)
+  # && diff_datastreams.empty?
+  # Currently only determining success based on cocina.
+  # However, in future might want to also check datastreams. This would require normalization.
 
-  return :success if equiv.success?
-
-  # If not equivalent, but no diffs reported, then try in reverse.
-  reverse_equiv = ModsEquivalentService.equivalent_with_result?(roundtrip_ng_xml, norm_original_ng_xml) if equiv.failure.empty?
-
-  write_result(druid,
-               norm_original_ng_xml,
-               roundtrip_ng_xml,
-               cocina_props,
-               equiv.failure,
-               Array(reverse_equiv&.failure),
-               notifier.data_errors,
-               validate_mods(original_ng_xml))
+  write_result(druid, orig_cocina_hash, roundtrip_cocina_hash, diff_datastreams)
   :different
 end
-# rubocop:enable Metrics/CyclomaticComplexity
+
+def normalize(cocina_hash)
+  # Remove space from source id, e.g., "sul: M0443_S2_D-K_B9_F33_011"
+  source_id = cocina_hash.dig(:identification, :sourceId)
+  cocina_hash[:identification][:sourceId] = source_id.gsub(/ *: */, ':') if source_id
+
+  cocina_hash
+end
 
 def percentage(raw_num, denom)
   (100 * raw_num.to_f / denom).round(3)
@@ -189,17 +216,17 @@ else
 end
 
 results = Parallel.map(druids, progress: 'Testing') do |druid|
-  validate_druid(druid, cache, fast: options[:fast])
+  validate_druid(druid, cache)
 end
-counts = { different: 0, success: 0, to_cocina_error: 0, to_fedora_error: 0, missing: 0, mods_normalizer_error: 0 }
+counts = { different: 0, success: 0, mapping_error: 0, update_error: 0, missing: 0, unmapped: 0 }
 results.each { |result| counts[result] += 1 }
 
-denom = druids.size - counts[:missing]
+denom = druids.size - counts[:missing] - counts[:unmapped]
 
 puts "Status (n=#{druids.size}; not using Missing for success/different/error stats):"
 puts "  Success:   #{counts[:success]} (#{percentage(counts[:success], denom)}%)"
 puts "  Different: #{counts[:different]} (#{percentage(counts[:different], denom)}%)"
-puts "  To Cocina error:     #{counts[:to_cocina_error]} (#{percentage(counts[:to_cocina_error], denom)}%)"
-puts "  To Fedora error:     #{counts[:to_fedora_error]} (#{percentage(counts[:to_fedora_error], denom)}%)"
-puts "  MODS normalizer error:     #{counts[:mods_normalizer_error]} (#{percentage(counts[:mods_normalizer_error], denom)}%)"
-puts "  Missing (no descMetadata):     #{counts[:missing]} (#{(100 * counts[:missing].to_f / druids.size).round(3)}%)"
+puts "  Mapping error:     #{counts[:mapping_error]} (#{percentage(counts[:mapping_error], denom)}%)"
+puts "  Update error:     #{counts[:update_error]} (#{percentage(counts[:update_error], denom)}%)"
+puts "  Missing:     #{counts[:missing]} (#{(100 * counts[:missing].to_f / druids.size).round(3)}%)"
+puts "  Unmapped:     #{counts[:unmapped]} (#{(100 * counts[:unmapped].to_f / druids.size).round(3)}%)"

--- a/bin/validate-desc-cocina-roundtrip
+++ b/bin/validate-desc-cocina-roundtrip
@@ -1,0 +1,204 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../config/environment'
+require_relative '../lib/fedora_cache'
+require_relative '../lib/data_error_notifier'
+require 'set'
+require 'optparse'
+require 'diffy'
+
+options = { random: false, druids: [], fast: false }
+parser = OptionParser.new do |option_parser|
+  option_parser.banner = 'Usage: bin/validate-desc-cocina-roundtrip [options]'
+
+  option_parser.on('-sSAMPLE', '--sample SAMPLE', Integer, 'Sample size, otherwise all druids.')
+  option_parser.on('-r', '--random', 'Select random druids.')
+  option_parser.on('-f', '--fast', 'Do not write results files.')
+  option_parser.on('-dDRUIDS', '--druids DRUIDS', Array, 'List of druids (instead of druids.txt).')
+  option_parser.on('-h', '--help', 'Displays help.') do
+    puts option_parser
+    exit
+  end
+end
+parser.parse!(into: options)
+
+cache = FedoraCache.new
+
+def round_tripped_ng_xml(cocina, druid)
+  Nokogiri::XML(Cocina::ToFedora::Descriptive.transform(cocina, druid).to_xml) { |config| config.default_xml.noblanks }
+end
+
+def cocina_props(ng_xml, druid, label, notifier)
+  title_builder = Cocina::FromFedora::Descriptive::TitleBuilderStrategy.find(label: label)
+  Cocina::FromFedora::Descriptive.props(title_builder: title_builder, mods: ng_xml, druid: druid, notifier: notifier)
+end
+
+def node_count_match?(ng_xml1, ng_xml2)
+  ng_xml1.root.elements.size == ng_xml2.root.elements.size
+end
+
+# rubocop:disable Metrics/ParameterLists
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/BlockLength
+# rubocop:disable Metrics/PerceivedComplexity
+def write_result(druid, original_ng_xml, roundtrip_ng_xml, cocina, differences, reverse_differences, data_errors, mods_msg)
+  File.open("results/#{druid}.txt", 'w') do |file|
+    file.write("Druid: #{druid}\n\n")
+
+    if mods_msg.is_a?(Array)
+      mods_msg.each do |msg|
+        file.write("MODS error: #{msg}\n")
+      end
+      file.write("\nNote that data errors are from the original XML, not the normalized XML shown below.\n\n")
+    else
+      file.write("#{mods_msg}\n\n")
+    end
+
+    if data_errors.present?
+      data_errors.each do |data_error|
+        file.write("Data error: #{data_error.msg}")
+        file.write(" (#{data_error.context}") if data_error.context.present?
+        file.write("\n")
+      end
+      file.write("\nNote that data errors are from the original XML, not the normalized XML shown below.\n\n")
+    end
+
+    file.write("Node count mismatch between original and roundtripped.\n") unless node_count_match?(original_ng_xml, roundtrip_ng_xml)
+
+    differences.each_with_index do |difference, index|
+      file.write("Differences #{index + 1}\n")
+      file.write("Original node:\n#{difference.mods_node1}\n")
+      if difference.mods_node2
+        file.write("Best guess roundtripped node:\n#{difference.mods_node2}\n")
+        file.write("Difference:\n#{Diffy::Diff.new("#{difference.mods_node1}\n", "#{difference.mods_node2}\n")}\n")
+      else
+        file.write("Could not find similar roundtripped node.\n")
+      end
+    end
+
+    reverse_differences.each_with_index do |difference, index|
+      file.write("Differences #{index + 1}\n")
+      file.write("Roundtripped node:\n#{difference.mods_node1}\n")
+      if difference.mods_node2
+        file.write("Best guess original node:\n#{difference.mods_node2}\n")
+        file.write("Difference:\n#{Diffy::Diff.new("#{difference.mods_node1}\n", "#{difference.mods_node2}\n")}\n")
+      else
+        file.write("Could not find similar original node.\n")
+      end
+    end
+
+    file.write("\nOriginal XML:\n#{original_ng_xml.to_xml}\n")
+    file.write("Roundtripped XML:\n#{roundtrip_ng_xml.to_xml}\n")
+    file.write("Cocina:\n#{JSON.pretty_generate(cocina)}\n\n")
+  end
+end
+# rubocop:enable Metrics/ParameterLists
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/BlockLength
+# rubocop:enable Metrics/PerceivedComplexity
+
+def write_error(druid, original_ng_xml, cocina, error)
+  File.open("results/#{druid}.txt", 'w') do |file|
+    file.write("Druid: #{druid}\n\n")
+    file.write("Error: #{error}\n\n")
+    file.write("Expected XML:\n#{original_ng_xml.to_xml}\n\n")
+    file.write("Cocina:\n#{JSON.pretty_generate(cocina)}\n\n") if cocina
+    file.write("Backtrace:\n")
+    file.write(error.backtrace.join("\n"))
+  end
+end
+
+def validate_mods(ng_xml)
+  result = ModsValidator.valid?(ng_xml)
+
+  result.failure? ? result.failure : 'Valid MODS'
+end
+
+# rubocop:disable Metrics/CyclomaticComplexity
+def validate_druid(druid, cache, fast: false)
+  result = cache.label_and_desc_metadata(druid)
+  return :missing if result.failure?
+
+  label, original_xml = result.value!
+  original_ng_xml = Nokogiri::XML(original_xml)
+
+  notifier = DataErrorNotifier.new
+  begin
+    cocina_props = cocina_props(original_ng_xml, druid, label, notifier)
+    cocina = Cocina::Models::Description.new(cocina_props)
+  rescue StandardError => e
+    write_error(druid, original_ng_xml, cocina_props, e) unless fast
+    return :to_cocina_error
+  end
+
+  begin
+    # Perform approved XML normalization changes to avoid noise in roundtrip failures
+    norm_original_ng_xml = Cocina::ModsNormalizer.normalize(mods_ng_xml: original_ng_xml, druid: druid, label: label)
+  rescue StandardError => e
+    write_error(druid, original_ng_xml, cocina_props, e) unless fast
+    return :mods_normalizer_error
+  end
+
+  begin
+    roundtrip_ng_xml = round_tripped_ng_xml(cocina, druid)
+  rescue StandardError => e
+    write_error(druid, original_ng_xml, cocina_props, e) unless fast
+    return :to_fedora_error
+  end
+
+  if fast
+    return ModsEquivalentService.equivalent?(norm_original_ng_xml, roundtrip_ng_xml) ? :success : :different
+  end
+
+  equiv = ModsEquivalentService.equivalent_with_result?(norm_original_ng_xml, roundtrip_ng_xml)
+
+  return :success if equiv.success?
+
+  # If not equivalent, but no diffs reported, then try in reverse.
+  reverse_equiv = ModsEquivalentService.equivalent_with_result?(roundtrip_ng_xml, norm_original_ng_xml) if equiv.failure.empty?
+
+  write_result(druid,
+               norm_original_ng_xml,
+               roundtrip_ng_xml,
+               cocina_props,
+               equiv.failure,
+               Array(reverse_equiv&.failure),
+               notifier.data_errors,
+               validate_mods(original_ng_xml))
+  :different
+end
+# rubocop:enable Metrics/CyclomaticComplexity
+
+def percentage(raw_num, denom)
+  (100 * raw_num.to_f / denom).round(3)
+end
+
+unless options[:fast]
+  FileUtils.rm_rf('results')
+  FileUtils.mkdir_p('results')
+end
+
+if options[:druids].empty?
+  druids = File.read('druids.txt').split
+  druids.shuffle! if options[:random]
+  druids = druids.take(options[:sample]) if options[:sample]
+else
+  druids = options[:druids]
+end
+
+results = Parallel.map(druids, progress: 'Testing') do |druid|
+  validate_druid(druid, cache, fast: options[:fast])
+end
+counts = { different: 0, success: 0, to_cocina_error: 0, to_fedora_error: 0, missing: 0, mods_normalizer_error: 0 }
+results.each { |result| counts[result] += 1 }
+
+denom = druids.size - counts[:missing]
+
+puts "Status (n=#{druids.size}; not using Missing for success/different/error stats):"
+puts "  Success:   #{counts[:success]} (#{percentage(counts[:success], denom)}%)"
+puts "  Different: #{counts[:different]} (#{percentage(counts[:different], denom)}%)"
+puts "  To Cocina error:     #{counts[:to_cocina_error]} (#{percentage(counts[:to_cocina_error], denom)}%)"
+puts "  To Fedora error:     #{counts[:to_fedora_error]} (#{percentage(counts[:to_fedora_error], denom)}%)"
+puts "  MODS normalizer error:     #{counts[:mods_normalizer_error]} (#{percentage(counts[:mods_normalizer_error], denom)}%)"
+puts "  Missing (no descMetadata):     #{counts[:missing]} (#{(100 * counts[:missing].to_f / druids.size).round(3)}%)"

--- a/bin/validate-to-desc-cocina
+++ b/bin/validate-to-desc-cocina
@@ -3,14 +3,16 @@
 
 require_relative '../config/environment'
 require_relative '../lib/fedora_cache'
+require_relative '../lib/data_error_notifier'
 require 'optparse'
 
 options = { unique_filename: false }
 parser = OptionParser.new do |option_parser|
-  option_parser.banner = 'Usage: bin/validate-to-fedora [options]'
+  option_parser.banner = 'Usage: bin/validate-to-desc-cocina [options]'
 
   option_parser.on('-sSAMPLE', '--sample SAMPLE', Integer, 'Sample size, otherwise all druids.')
   option_parser.on('-u', '--unique-filename', 'Result file named for branch and runtime') { options[:unique_filename] = true }
+  option_parser.on('-a', '--apo', 'Include APO in report (slower).') { options[:apo] = true }
   option_parser.on('-h', '--help', 'Displays help.') do
     puts option_parser
     exit
@@ -42,35 +44,24 @@ def print_results(aggregated_error_results, label)
   end
 end
 
-def write_results(file, aggregated_error_results, label)
+def apo_for(druid)
+  puts "Fetching #{druid}"
+  Dor.find(druid).admin_policy_object_id
+end
+
+def write_results(file, aggregated_error_results, label, with_apo)
   aggregated_error_results.each do |error_result|
     file.write("#{label}: #{error_result[0]} (#{error_result[1].size} errors)\n")
-    error_result[1].each { |druid| file.write("#{druid}\n") }
+    error_result[1].each do |druid|
+      file.write(druid)
+      file.write(" (APO: #{apo_for(druid)})") if with_apo
+      file.write("\n")
+    end
   end
 end
 
 def summary_line_for(label, count)
   "#{label}: #{count} of #{@sample_size} (#{100 * count.to_f / @sample_size}%)\n"
-end
-
-def validate_druid(druid, cache)
-  begin
-    title_builder = Cocina::FromFedora::Descriptive::TitleBuilderStrategy.find(label: cache.label(druid))
-    desc_props = Cocina::FromFedora::Descriptive.props(title_builder: title_builder, mods: cache.descmd_xml(druid), druid: druid)
-    cocina = Cocina::Models::Description.new(desc_props)
-  rescue StandardError => e
-    return Result.new(druid, e.message, :missing) if e.message == 'Missing item'
-
-    return Result.new(druid, e.message.gsub('\n', ' '), :to_cocina_error)
-  end
-
-  begin
-    Cocina::ToFedora::Descriptive.transform(cocina, druid)
-  rescue StandardError => e
-    return Result.new(druid, e.message.gsub('\n', ' '), :to_fedora_error)
-  end
-
-  nil
 end
 
 def branch_name
@@ -88,7 +79,7 @@ end
 def results_file_name(use_unique_filename)
   return 'results.txt' unless use_unique_filename
 
-  "results_to-fedora_#{now_str}_#{branch_name}_#{short_commit_hash}.txt"
+  "results_to-cocina_#{now_str}_#{branch_name}_#{short_commit_hash}.txt"
 end
 
 druids = File.read('druids.txt').split
@@ -98,29 +89,47 @@ druids = druids.take(options[:sample]) if options[:sample]
 Result = Struct.new(:druid, :msg, :error_type)
 
 results = Parallel.map(druids, progress: 'Testing') do |druid|
-  validate_druid(druid, cache)
+  notifier = DataErrorNotifier.new
+
+  result = cache.label_and_desc_metadata(druid)
+  return Result.new(druid, 'Missing', :missing) if result.failure?
+
+  label, mods_xml = result.value!
+  mods_ng_xml = Nokogiri::XML(mods_xml)
+
+  title_builder = Cocina::FromFedora::Descriptive::TitleBuilderStrategy.find(label: label)
+  desc_props = Cocina::FromFedora::Descriptive.props(title_builder: title_builder, mods: mods_ng_xml, druid: druid, notifier: notifier)
+  Cocina::Models::Description.new(desc_props)
+  notifier.error? ? Result.new(druid, notifier.data_errors.first.msg, :data_error) : nil
+rescue StandardError => e
+  Result.new(druid, e.message.gsub('\n', ' '), :to_cocina_error)
 end.compact
 
-counts = { to_cocina_error: 0, to_fedora_error: 0, missing: 0, data_error: 0 }
+error_results = results.select { |result| result.error_type == :to_cocina_error }
+data_error_results = results.select { |result| result.error_type == :data_error }
+
+counts = { to_cocina_error: 0, missing: 0, data_error: 0 }
 results.each { |result| counts[result.error_type] += 1 }
 
-puts summary_line_for('To Fedora error', counts[:to_fedora_error])
 puts summary_line_for('To Cocina error', counts[:to_cocina_error])
 puts summary_line_for('Data error', counts[:data_error])
 puts summary_line_for('Missing (no descMetadata)', counts[:missing])
 puts "\n"
 
-error_results = results.select { |result| result.error_type == :to_fedora_error }
 results_by_error = results_by(error_results)
-aggregated_error_results = aggregated_errors_for(results_by_error)
+results_by_data_error = results_by(data_error_results)
 
-print_results(aggregated_error_results, 'To Fedora error')
+aggregated_error_results = aggregated_errors_for(results_by_error)
+aggregated_data_error_results = aggregated_errors_for(results_by_data_error)
+
+print_results(aggregated_error_results, 'Error')
+print_results(aggregated_data_error_results, 'Data error')
 
 File.open(results_file_name(options[:unique_filename]), 'w') do |file|
-  file.write(summary_line_for('To Fedora error', counts[:to_fedora_error]))
   file.write(summary_line_for('To Cocina error', counts[:to_cocina_error]))
   file.write(summary_line_for('Data error', counts[:data_error]))
-  file.write(summary_line_for('Missing (no descMetadata)', counts[:missing]))
+  file.write(summary_line_for('Missing', counts[:missing]))
   file.write("\n")
-  write_results(file, aggregated_error_results, 'To Fedora error')
+  write_results(file, aggregated_error_results, 'Error', options[:apo])
+  write_results(file, aggregated_data_error_results, 'Data error', options[:apo])
 end

--- a/bin/validate-to-mods
+++ b/bin/validate-to-mods
@@ -3,16 +3,14 @@
 
 require_relative '../config/environment'
 require_relative '../lib/fedora_cache'
-require_relative '../lib/data_error_notifier'
 require 'optparse'
 
 options = { unique_filename: false }
 parser = OptionParser.new do |option_parser|
-  option_parser.banner = 'Usage: bin/validate-to-cocina [options]'
+  option_parser.banner = 'Usage: bin/validate-to-mods [options]'
 
   option_parser.on('-sSAMPLE', '--sample SAMPLE', Integer, 'Sample size, otherwise all druids.')
   option_parser.on('-u', '--unique-filename', 'Result file named for branch and runtime') { options[:unique_filename] = true }
-  option_parser.on('-a', '--apo', 'Include APO in report (slower).') { options[:apo] = true }
   option_parser.on('-h', '--help', 'Displays help.') do
     puts option_parser
     exit
@@ -44,24 +42,39 @@ def print_results(aggregated_error_results, label)
   end
 end
 
-def apo_for(druid)
-  puts "Fetching #{druid}"
-  Dor.find(druid).admin_policy_object_id
-end
-
-def write_results(file, aggregated_error_results, label, with_apo)
+def write_results(file, aggregated_error_results, label)
   aggregated_error_results.each do |error_result|
     file.write("#{label}: #{error_result[0]} (#{error_result[1].size} errors)\n")
-    error_result[1].each do |druid|
-      file.write(druid)
-      file.write(" (APO: #{apo_for(druid)})") if with_apo
-      file.write("\n")
-    end
+    error_result[1].each { |druid| file.write("#{druid}\n") }
   end
 end
 
 def summary_line_for(label, count)
   "#{label}: #{count} of #{@sample_size} (#{100 * count.to_f / @sample_size}%)\n"
+end
+
+def validate_druid(druid, cache)
+  result = cache.label_and_desc_metadata(druid)
+  return Result.new(druid, 'Missing', :missing) if result.failure?
+
+  label, mods_xml = result.value!
+  mods_ng_xml = Nokogiri::XML(mods_xml)
+
+  begin
+    title_builder = Cocina::FromFedora::Descriptive::TitleBuilderStrategy.find(label: label)
+    desc_props = Cocina::FromFedora::Descriptive.props(title_builder: title_builder, mods: mods_ng_xml, druid: druid)
+    cocina = Cocina::Models::Description.new(desc_props)
+  rescue StandardError => e
+    return Result.new(druid, e.message.gsub('\n', ' '), :to_cocina_error)
+  end
+
+  begin
+    Cocina::ToFedora::Descriptive.transform(cocina, druid)
+  rescue StandardError => e
+    return Result.new(druid, e.message.gsub('\n', ' '), :to_fedora_error)
+  end
+
+  nil
 end
 
 def branch_name
@@ -79,7 +92,7 @@ end
 def results_file_name(use_unique_filename)
   return 'results.txt' unless use_unique_filename
 
-  "results_to-cocina_#{now_str}_#{branch_name}_#{short_commit_hash}.txt"
+  "results_to-fedora_#{now_str}_#{branch_name}_#{short_commit_hash}.txt"
 end
 
 druids = File.read('druids.txt').split
@@ -89,44 +102,29 @@ druids = druids.take(options[:sample]) if options[:sample]
 Result = Struct.new(:druid, :msg, :error_type)
 
 results = Parallel.map(druids, progress: 'Testing') do |druid|
-  notifier = DataErrorNotifier.new
-  title_builder = Cocina::FromFedora::Descriptive::TitleBuilderStrategy.find(label: cache.label(druid))
-  desc_props = Cocina::FromFedora::Descriptive.props(title_builder: title_builder, mods: cache.descmd_xml(druid), druid: druid, notifier: notifier)
-  Cocina::Models::Description.new(desc_props)
-  notifier.error? ? Result.new(druid, notifier.data_errors.first.msg, :data_error) : nil
-rescue StandardError => e
-  if e.message == 'Missing item'
-    Result.new(druid, e.message, :missing)
-  else
-    Result.new(druid, e.message.gsub('\n', ' '), :to_cocina_error)
-  end
+  validate_druid(druid, cache)
 end.compact
 
-error_results = results.select { |result| result.error_type == :to_cocina_error }
-data_error_results = results.select { |result| result.error_type == :data_error }
-
-counts = { to_cocina_error: 0, missing: 0, data_error: 0 }
+counts = { to_cocina_error: 0, to_fedora_error: 0, missing: 0, data_error: 0 }
 results.each { |result| counts[result.error_type] += 1 }
 
+puts summary_line_for('To Fedora error', counts[:to_fedora_error])
 puts summary_line_for('To Cocina error', counts[:to_cocina_error])
 puts summary_line_for('Data error', counts[:data_error])
 puts summary_line_for('Missing (no descMetadata)', counts[:missing])
 puts "\n"
 
+error_results = results.select { |result| result.error_type == :to_fedora_error }
 results_by_error = results_by(error_results)
-results_by_data_error = results_by(data_error_results)
-
 aggregated_error_results = aggregated_errors_for(results_by_error)
-aggregated_data_error_results = aggregated_errors_for(results_by_data_error)
 
-print_results(aggregated_error_results, 'Error')
-print_results(aggregated_data_error_results, 'Data error')
+print_results(aggregated_error_results, 'To Fedora error')
 
 File.open(results_file_name(options[:unique_filename]), 'w') do |file|
+  file.write(summary_line_for('To Fedora error', counts[:to_fedora_error]))
   file.write(summary_line_for('To Cocina error', counts[:to_cocina_error]))
   file.write(summary_line_for('Data error', counts[:data_error]))
-  file.write(summary_line_for('Missing', counts[:missing]))
+  file.write(summary_line_for('Missing (no descMetadata)', counts[:missing]))
   file.write("\n")
-  write_results(file, aggregated_error_results, 'Error', options[:apo])
-  write_results(file, aggregated_data_error_results, 'Data error', options[:apo])
+  write_results(file, aggregated_error_results, 'To Fedora error')
 end

--- a/spec/services/deep_equal_spec.rb
+++ b/spec/services/deep_equal_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeepEqual do
+  it 'compares objects' do
+    expect(described_class.match?('foo', 'foo')).to be true
+    expect(described_class.match?('foo', 'bar')).to be false
+  end
+
+  it 'compares arrays ignoring order' do
+    expect(described_class.match?(['foo', 'bar'], ['foo', 'bar'])).to be true
+    expect(described_class.match?(['foo', 'bar'], ['bar', 'foo'])).to be true
+    expect(described_class.match?(['foo', 'bar'], ['bar'])).to be false
+  end
+
+  it 'compares hashes' do
+    expect(described_class.match?({ a: 'foo', b: 'bar' }, { a: 'foo', b: 'bar' })).to be true
+    expect(described_class.match?({ a: 'foo', b: 'bar' }, { a: 'foo', c: 'bar' })).to be false
+    expect(described_class.match?({ a: 'foo', b: 'bar' }, { a: 'foo', b: 'foo' })).to be false
+  end
+
+  it 'deep compares hashes' do
+    expect(described_class.match?({ a: 'foo', b: ['foo', 'bar'] }, { a: 'foo', b: ['bar', 'foo'] })).to be true
+    expect(described_class.match?({ a: 'foo', b: ['foo', 'bar'] }, { a: 'foo', b: ['bar'] })).to be false
+  end
+end


### PR DESCRIPTION
## Why was this change made?
So we can find mapping errors before our users do.


## How was this change tested?
Local


## Which documentation and/or configurations were updated?
README


