### PR TITLE
Eventual unique identifiers for files and file sets.

### DIFF
--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -27,7 +27,7 @@ module Cocina
           has_member_orders = build_has_member_orders
           structural[:hasMemberOrders] = has_member_orders if has_member_orders.present?
 
-          contains = FileSets.build(item.contentMetadata, version: item.current_version.to_i, id: item.pid)
+          contains = FileSets.build(item.contentMetadata, version: item.current_version.to_i)
           structural[:contains] = contains if contains.present?
 
           structural[:hasAgreement] = item.identityMetadata.agreementId.first unless item.identityMetadata.agreementId.empty?

--- a/app/services/cocina/id_generator.rb
+++ b/app/services/cocina/id_generator.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Cocina
+  # Generates identifiers for use within Cocina model.
+  class IdGenerator
+    ID_NAMESPACE = 'http://cocina.sul.stanford.edu/'
+
+    def self.generate_fileset_id
+      generate_id('fileSet')
+    end
+
+    def self.generate_or_existing_fileset_id(existing_id)
+      cocina_id?(existing_id) ? existing_id : generate_fileset_id
+    end
+
+    def self.generate_file_id
+      generate_id('file')
+    end
+
+    def self.generate_or_existing_file_id(existing_id)
+      cocina_id?(existing_id) ? existing_id : generate_file_id
+    end
+
+    def self.cocina_id?(id)
+      id.present? && id.start_with?(ID_NAMESPACE)
+    end
+
+    def self.generate_id(type)
+      "#{ID_NAMESPACE}#{type}/#{SecureRandom.uuid}"
+    end
+    private_class_method :generate_id
+  end
+end

--- a/app/services/cocina/to_fedora/content_metadata_generator.rb
+++ b/app/services/cocina/to_fedora/content_metadata_generator.rb
@@ -49,12 +49,11 @@ module Cocina
         @resource_type_counters ||= Hash.new(0)
       end
 
-      # @param [String] id
       # @param [Hash] cocina_file
       # @return [Nokogiri::XML::Node] the file node
-      def create_file_node(id, cocina_file)
+      def create_file_node(cocina_file)
         Nokogiri::XML::Node.new('file', @xml_doc).tap do |file_node|
-          file_node['id'] = id
+          file_node['id'] = cocina_file.filename
           file_node['mimetype'] = cocina_file.hasMimeType
           file_node['size'] = cocina_file.size
           file_node['publish'] = publish_attr(cocina_file)
@@ -91,10 +90,8 @@ module Cocina
       # @param [String] type resource type to use
       # @param [Integer] sequence
       def create_resource_node(cocina_fileset, type, sequence)
-        pid = druid.gsub('druid:', '') # remove druid prefix when creating IDs
-
         Nokogiri::XML::Node.new('resource', @xml_doc).tap do |resource|
-          resource['id'] = "#{pid}_#{sequence}"
+          resource['id'] = IdGenerator.generate_or_existing_fileset_id(cocina_fileset.respond_to?(:externalIdentifier) ? cocina_fileset.externalIdentifier : nil)
           resource['sequence'] = sequence
           resource['type'] = type
 
@@ -106,7 +103,7 @@ module Cocina
 
       def create_file_nodes(resource, cocina_fileset)
         cocina_fileset.structural.contains.each do |cocina_file|
-          resource.add_child(create_file_node(cocina_file.filename, cocina_file))
+          resource.add_child(create_file_node(cocina_file))
         end
       end
 

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -180,7 +180,7 @@ def validate_druid(druid, cache)
     diff_datastreams[dsid] = [orig_ds_ng_xml, ds_ng_xml]
   end
 
-  return :success if DeepEqual.match?(normalize(orig_cocina_hash), roundtrip_cocina_hash)
+  return :success if DeepEqual.match?(normalize_orig(orig_cocina_hash), normalize(roundtrip_cocina_hash))
 
   # && diff_datastreams.empty?
   # Currently only determining success based on cocina.
@@ -190,11 +190,20 @@ def validate_druid(druid, cache)
   :different
 end
 
-def normalize(cocina_hash)
+def normalize_orig(cocina_hash)
   # Remove space from source id, e.g., "sul: M0443_S2_D-K_B9_F33_011"
   source_id = cocina_hash.dig(:identification, :sourceId)
   cocina_hash[:identification][:sourceId] = source_id.gsub(/ *: */, ':') if source_id
 
+  normalize(cocina_hash)
+end
+
+def normalize(cocina_hash)
+  # Remove file and fileSet externalIdentifiers, since usually regenerated.
+  Array(cocina_hash.dig(:structural, :contains)).each do |file_set|
+    file_set.delete(:externalIdentifier)
+    Array(file_set.dig(:structural, :contains)).each { |file| file.delete(:externalIdentifier) }
+  end
   cocina_hash
 end
 

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -472,16 +472,21 @@ RSpec.describe 'Create object' do
       end
 
       context 'when access match' do
+        before do
+          # This gives every file and file set the same UUID. In reality, they would be unique.
+          allow(SecureRandom).to receive(:uuid).and_return('123-456-789')
+        end
+
         let(:expected_structural) do
           { contains: [
             {
               type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
-              externalIdentifier: 'gg777gg7777_1', label: 'Page 1', version: 1,
+              externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/123-456-789', label: 'Page 1', version: 1,
               structural: {
                 contains: [
                   {
                     type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
-                    externalIdentifier: 'druid:gg777gg7777/00001.html',
+                    externalIdentifier: 'http://cocina.sul.stanford.edu/file/123-456-789',
                     label: '00001.html',
                     filename: '00001.html',
                     size: 0,
@@ -499,7 +504,7 @@ RSpec.describe 'Create object' do
                     administrative: { publish: false, sdrPreserve: true, shelve: false }
                   }, {
                     type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
-                    externalIdentifier: 'druid:gg777gg7777/00001.jp2',
+                    externalIdentifier: 'http://cocina.sul.stanford.edu/file/123-456-789',
                     label: '00001.jp2',
                     filename: '00001.jp2',
                     size: 0, version: 1,
@@ -511,13 +516,13 @@ RSpec.describe 'Create object' do
               }
             }, {
               type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
-              externalIdentifier: 'gg777gg7777_2',
+              externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/123-456-789',
               label: 'Page 2', version: 1,
               structural: {
                 contains: [
                   {
                     type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
-                    externalIdentifier: 'druid:gg777gg7777/00002.html',
+                    externalIdentifier: 'http://cocina.sul.stanford.edu/file/123-456-789',
                     label: '00002.html', filename: '00002.html', size: 0,
                     version: 1, hasMimeType: 'text/html',
                     hasMessageDigests: [],
@@ -525,7 +530,7 @@ RSpec.describe 'Create object' do
                     administrative: { publish: false, sdrPreserve: true, shelve: false }
                   }, {
                     type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
-                    externalIdentifier: 'druid:gg777gg7777/00002.jp2',
+                    externalIdentifier: 'http://cocina.sul.stanford.edu/file/123-456-789',
                     label: '00002.jp2',
                     filename: '00002.jp2',
                     size: 0, version: 1,

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -543,7 +543,7 @@ RSpec.describe 'Update object' do
     context 'when files are provided' do
       let(:file1) do
         {
-          'externalIdentifier' => 'file1',
+          'externalIdentifier' => 'http://cocina.sul.stanford.edu/file/123-456-789',
           'version' => 1,
           'type' => 'http://cocina.sul.stanford.edu/models/file.jsonld',
           'filename' => '00001.html',
@@ -574,7 +574,7 @@ RSpec.describe 'Update object' do
 
       let(:file2) do
         {
-          'externalIdentifier' => 'file2',
+          'externalIdentifier' => 'http://cocina.sul.stanford.edu/file/223-456-789',
           'version' => 1,
           'type' => 'http://cocina.sul.stanford.edu/models/file.jsonld',
           'filename' => '00001.jp2',
@@ -594,7 +594,7 @@ RSpec.describe 'Update object' do
 
       let(:file3) do
         {
-          'externalIdentifier' => 'file3',
+          'externalIdentifier' => 'http://cocina.sul.stanford.edu/file/323-456-789',
           'version' => 1,
           'type' => 'http://cocina.sul.stanford.edu/models/file.jsonld',
           'filename' => '00002.html',
@@ -614,7 +614,7 @@ RSpec.describe 'Update object' do
 
       let(:file4) do
         {
-          'externalIdentifier' => 'file4',
+          'externalIdentifier' => 'http://cocina.sul.stanford.edu/file/423-456-789',
           'version' => 1,
           'type' => 'http://cocina.sul.stanford.edu/models/file.jsonld',
           'filename' => '00002.jp2',
@@ -635,14 +635,14 @@ RSpec.describe 'Update object' do
       let(:filesets) do
         [
           {
-            'externalIdentifier' => 'fs1',
+            'externalIdentifier' => 'http://cocina.sul.stanford.edu/fileSet/234-567-890',
             'version' => 1,
             'type' => 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
             'label' => 'Page 1',
             'structural' => { 'contains' => [file1, file2] }
           },
           {
-            'externalIdentifier' => 'fs2',
+            'externalIdentifier' => 'http://cocina.sul.stanford.edu/fileSet/334-567-890',
             'version' => 1,
             'type' => 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
             'label' => 'Page 2',
@@ -675,18 +675,23 @@ RSpec.describe 'Update object' do
       end
 
       context 'when access match' do
+        before do
+          # This gives every file and file set the same UUID. In reality, they would be unique.
+          allow(SecureRandom).to receive(:uuid).and_return('123-456-789')
+        end
+
         let(:structural) do
           {
             isMemberOf: ['druid:xx888xx7777'],
             contains: [
               {
                 type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
-                externalIdentifier: 'gg777gg7777_1', label: 'Page 1', version: 1,
+                externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/234-567-890', label: 'Page 1', version: 1,
                 structural: {
                   contains: [
                     {
                       type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
-                      externalIdentifier: 'druid:gg777gg7777/00001.html',
+                      externalIdentifier: 'http://cocina.sul.stanford.edu/file/123-456-789',
                       label: '00001.html',
                       filename: '00001.html',
                       size: 0,
@@ -704,7 +709,7 @@ RSpec.describe 'Update object' do
                       administrative: { publish: false, sdrPreserve: true, shelve: false }
                     }, {
                       type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
-                      externalIdentifier: 'druid:gg777gg7777/00001.jp2',
+                      externalIdentifier: 'http://cocina.sul.stanford.edu/file/123-456-789',
                       label: '00001.jp2',
                       filename: '00001.jp2',
                       size: 0, version: 1,
@@ -716,13 +721,13 @@ RSpec.describe 'Update object' do
                 }
               }, {
                 type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
-                externalIdentifier: 'gg777gg7777_2',
+                externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/334-567-890',
                 label: 'Page 2', version: 1,
                 structural: {
                   contains: [
                     {
                       type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
-                      externalIdentifier: 'druid:gg777gg7777/00002.html',
+                      externalIdentifier: 'http://cocina.sul.stanford.edu/file/123-456-789',
                       label: '00002.html', filename: '00002.html', size: 0,
                       version: 1, hasMimeType: 'text/html',
                       hasMessageDigests: [],
@@ -730,7 +735,7 @@ RSpec.describe 'Update object' do
                       administrative: { publish: false, sdrPreserve: true, shelve: false }
                     }, {
                       type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
-                      externalIdentifier: 'druid:gg777gg7777/00002.jp2',
+                      externalIdentifier: 'http://cocina.sul.stanford.edu/file/123-456-789',
                       label: '00002.jp2',
                       filename: '00002.jp2',
                       size: 0, version: 1,
@@ -750,7 +755,6 @@ RSpec.describe 'Update object' do
           patch "/v1/objects/#{druid}",
                 params: data,
                 headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-
           expect(response.body).to eq expected.to_json
           expect(response.status).to eq(200)
           expect(item.contentMetadata.resource.file.count).to eq 4

--- a/spec/services/cocina/from_fedora/dro_structural_spec.rb
+++ b/spec/services/cocina/from_fedora/dro_structural_spec.rb
@@ -71,6 +71,11 @@ RSpec.describe Cocina::FromFedora::DroStructural do
   end
 
   context 'when item has resources that lack identifiers and labels' do
+    before do
+      # This gives every file and file set the same UUID. In reality, they would be unique.
+      allow(SecureRandom).to receive(:uuid).and_return('123-456-789')
+    end
+
     let(:xml) do
       <<~XML
         <contentMetadata type="file" objectId="druid:dd116zh0343">
@@ -120,11 +125,10 @@ RSpec.describe Cocina::FromFedora::DroStructural do
 
       resource1 = structural[:contains].first
       expect(resource1[:label]).to eq 'Folder 1'
-      expect(resource1[:externalIdentifier]).to eq "#{item.pid}_1"
+      expect(resource1[:externalIdentifier]).to eq 'http://cocina.sul.stanford.edu/fileSet/123-456-789'
 
       resource2 = structural[:contains].second
-      expect(resource2[:label]).to eq "#{item.pid}_2"
-      expect(resource2[:externalIdentifier]).to eq "#{item.pid}_2"
+      expect(resource2[:label]).to eq 'http://cocina.sul.stanford.edu/fileSet/123-456-789'
     end
   end
 

--- a/spec/services/cocina/to_fedora/content_metadata_generator_spec.rb
+++ b/spec/services/cocina/to_fedora/content_metadata_generator_spec.rb
@@ -4,14 +4,14 @@ require 'rails_helper'
 
 RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
   subject(:generate) do
-    described_class.generate(druid: 'druid:bc123de5678', object: model)
+    described_class.generate(druid: 'druid:bc123df5678', object: model)
   end
 
   let(:model) do
     Cocina::Models.build_request(JSON.parse(data))
   end
 
-  let(:druid) { 'druid:bc123de5678' }
+  let(:druid) { 'druid:bc123df5678' }
 
   let(:file1) do
     {
@@ -160,6 +160,11 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
     JSON
   end
 
+  before do
+    # This gives every file and file set the same UUID. In reality, they would be unique.
+    allow(SecureRandom).to receive(:uuid).and_return('123-456-789')
+  end
+
   context 'with a book' do
     let(:object_type) { Cocina::Models::Vocab.book }
     let(:structural) do
@@ -195,9 +200,9 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
 
     it 'generates contentMetadata.xml' do
       expect(generate).to be_equivalent_to <<~XML
-        <contentMetadata objectId="druid:bc123de5678" type="book">
+        <contentMetadata objectId="druid:bc123df5678" type="book">
           <bookData readingOrder="rtl" />
-          <resource id="bc123de5678_1" sequence="1" type="page">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="1" type="page">
             <label>Page 1</label>
             <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription">
               <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
@@ -207,12 +212,12 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
               <imageData height="200" width="300"/>
             </file>
           </resource>
-          <resource id="bc123de5678_2" sequence="2" type="page">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="2" type="page">
             <label>Page 2</label>
             <file id="00002.html" mimetype="text/html" size="1914" preserve="yes" publish="yes" shelve="no"/>
             <file id="00002.jp2" mimetype="image/jp2" size="111467" preserve="yes" publish="yes" shelve="yes"/>
           </resource>
-          <resource id="bc123de5678_3" sequence="3" type="object">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="3" type="object">
             <label>Object 1</label>
             <file id="checksum.txt" mimetype="text/plain" size="11468" preserve="yes" publish="yes" shelve="yes"/>
           </resource>
@@ -226,8 +231,8 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
 
     it 'generates contentMetadata.xml' do
       expect(generate).to be_equivalent_to <<~XML
-        <contentMetadata objectId="druid:bc123de5678" type="image">
-          <resource id="bc123de5678_1" sequence="1" type="file">
+        <contentMetadata objectId="druid:bc123df5678" type="image">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="1" type="file">
             <label>Page 1</label>
             <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription">
               <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
@@ -237,7 +242,7 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
               <imageData height="200" width="300"/>
             </file>
           </resource>
-          <resource id="bc123de5678_2" sequence="2" type="file">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="2" type="file">
             <label>Page 2</label>
             <file id="00002.html" mimetype="text/html" size="1914" preserve="yes" publish="yes" shelve="no"/>
             <file id="00002.jp2" mimetype="image/jp2" size="111467" preserve="yes" publish="yes" shelve="yes"/>
@@ -252,8 +257,8 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
 
     it 'generates contentMetadata.xml' do
       expect(generate).to be_equivalent_to <<~XML
-        <contentMetadata objectId="druid:bc123de5678" type="image">
-          <resource id="bc123de5678_1" sequence="1" type="file">
+        <contentMetadata objectId="druid:bc123df5678" type="image">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="1" type="file">
             <label>Page 1</label>
             <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription">
               <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
@@ -263,7 +268,7 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
               <imageData height="200" width="300"/>
             </file>
           </resource>
-          <resource id="bc123de5678_2" sequence="2" type="file">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="2" type="file">
             <label>Page 2</label>
             <file id="00002.html" mimetype="text/html" size="1914" preserve="yes" publish="yes" shelve="no"/>
             <file id="00002.jp2" mimetype="image/jp2" size="111467" preserve="yes" publish="yes" shelve="yes"/>
@@ -352,22 +357,22 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
 
     it 'generates contentMetadata.xml' do
       expect(generate).to be_equivalent_to <<~XML
-        <contentMetadata objectId="druid:bc123de5678" type="geo">
-          <resource id="bc123de5678_1" sequence="1" type="object">
+        <contentMetadata objectId="druid:bc123df5678" type="geo">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="1" type="object">
             <label>Data</label>
             <file id="00001.zip" mimetype="application/zip" size="997" publish="no" shelve="no" preserve="yes">
               <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
               <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
             </file>
           </resource>
-          <resource id="bc123de5678_2" sequence="2" type="file">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="2" type="file">
             <label>Preview</label>
             <file id="00001.jp2" mimetype="image/jp2" size="149570" publish="yes" shelve="yes" preserve="yes">
               <imageData height="200" width="300"/>
             </file>
             <file id="00002.jp2" mimetype="image/jp2" size="111467" publish="yes" shelve="yes" preserve="yes"/>
           </resource>
-          <resource id="bc123de5678_3" sequence="3" type="file">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="3" type="file">
             <label>Attachment</label>
             <file id="00002.xml" mimetype="text/xml" size="1914" publish="yes" shelve="no" preserve="yes"/>
           </resource>
@@ -394,8 +399,8 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
 
     it 'generates contentMetadata.xml' do
       expect(generate).to be_equivalent_to <<~XML
-        <contentMetadata objectId="druid:bc123de5678" type="webarchive-seed">
-          <resource id="bc123de5678_1" sequence="1" type="image">
+        <contentMetadata objectId="druid:bc123df5678" type="webarchive-seed">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="1" type="image">
             <label>Preview</label>
             <file id="00001.jp2" mimetype="image/jp2" size="149570" preserve="yes" publish="yes" shelve="yes">
               <imageData height="200" width="300"/>
@@ -411,8 +416,8 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
 
     it 'generates contentMetadata.xml' do
       expect(generate).to be_equivalent_to <<~XML
-        <contentMetadata objectId="druid:bc123de5678" type="document">
-          <resource id="bc123de5678_1" sequence="1" type="file">
+        <contentMetadata objectId="druid:bc123df5678" type="document">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="1" type="file">
             <label>Page 1</label>
             <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription">
               <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
@@ -422,7 +427,7 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
               <imageData height="200" width="300"/>
             </file>
           </resource>
-          <resource id="bc123de5678_2" sequence="2" type="file">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="2" type="file">
             <label>Page 2</label>
             <file id="00002.html" mimetype="text/html" size="1914" preserve="yes" publish="yes" shelve="no"/>
             <file id="00002.jp2" mimetype="image/jp2" size="111467" preserve="yes" publish="yes" shelve="yes"/>
@@ -484,15 +489,15 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
 
     it 'generates contentMetadata.xml' do
       expect(generate).to be_equivalent_to <<~XML
-        <contentMetadata objectId="druid:bc123de5678" type="media">
-          <resource id="bc123de5678_1" sequence="1" type="video">
+        <contentMetadata objectId="druid:bc123df5678" type="media">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="1" type="video">
             <label>Page 1</label>
             <file id="bb012xz4244_pm.mpeg" mimetype="video/mpeg" size="997" preserve="yes" publish="no" shelve="no">
               <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
               <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
             </file>
           </resource>
-          <resource id="bc123de5678_2" sequence="2" type="file">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="2" type="file">
             <label>Page 2</label>
             <file id="00002.html" mimetype="text/html" size="1914" preserve="yes" publish="yes" shelve="no"/>
             <file id="00002.jp2" mimetype="image/jp2" size="111467" preserve="yes" publish="yes" shelve="yes"/>
@@ -554,8 +559,8 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
 
     it 'generates contentMetadata.xml but does not add a thumb attribute on the resource' do
       expect(generate).to be_equivalent_to <<~XML
-        <contentMetadata objectId="druid:bc123de5678" type="media">
-          <resource id="bc123de5678_1" sequence="1" type="video">
+        <contentMetadata objectId="druid:bc123df5678" type="media">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="1" type="video">
             <label>Page 1</label>
             <file id="bb012xz4244_pm.mpeg" mimetype="video/mpeg" size="997" preserve="yes" publish="no" shelve="no">
               <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
@@ -565,7 +570,7 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
               <imageData height="200" width="300"/>
             </file>
           </resource>
-          <resource id="bc123de5678_2" sequence="2" type="file">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="2" type="file">
             <label>Page 2</label>
             <file id="00002.html" mimetype="text/html" size="1914" preserve="yes" publish="yes" shelve="no"/>
             <file id="00002.jp2" mimetype="image/jp2" size="111467" preserve="yes" publish="yes" shelve="yes"/>
@@ -626,8 +631,8 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
 
     it 'generates contentMetadata.xml but does not add a thumb attribute on the resource' do
       expect(generate).to be_equivalent_to <<~XML
-        <contentMetadata objectId="druid:bc123de5678" type="media">
-          <resource id="bc123de5678_1" sequence="1" type="audio">
+        <contentMetadata objectId="druid:bc123df5678" type="media">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="1" type="audio">
             <label>Page 1</label>
             <file id="bb015cf9132_ars0021_201006112000_11_01_sl.m4a" mimetype="audio/mp4" size="997" preserve="yes" publish="no" shelve="no">
               <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
@@ -637,7 +642,75 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
               <imageData height="200" width="300"/>
             </file>
           </resource>
-          <resource id="bc123de5678_2" sequence="2" type="file">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="2" type="file">
+            <label>Page 2</label>
+            <file id="00002.html" mimetype="text/html" size="1914" preserve="yes" publish="yes" shelve="no"/>
+            <file id="00002.jp2" mimetype="image/jp2" size="111467" preserve="yes" publish="yes" shelve="yes"/>
+          </resource>
+        </contentMetadata>
+      XML
+    end
+  end
+
+  context 'with a DRO (not a RequestDRO)' do
+    let(:model) do
+      Cocina::Models.build(JSON.parse(data))
+    end
+
+    let(:object_type) { Cocina::Models::Vocab.book }
+
+    let(:filesets) do
+      [
+        {
+          'version' => 1,
+          'type' => 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+          'label' => 'Page 1',
+          'structural' => { 'contains' => [file1, file2] },
+          'externalIdentifier' => 'http://cocina.sul.stanford.edu/fileSet/012-345-678' # Existing id should be retained.
+        },
+        {
+          'version' => 1,
+          'type' => 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+          'label' => 'Page 2',
+          'structural' => { 'contains' => [file3, file4] },
+          'externalIdentifier' => 'page_2' # Existing incorrect id should be replaced.
+        }
+      ]
+    end
+
+    let(:data) do
+      <<~JSON
+        { "externalIdentifier":"druid:bc123df5678",
+          "type":"#{object_type}",
+          "label":"The object label","version":1,"access":{},
+          "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
+          "description":{"title":[{"status":"primary","value":"the object title"}]},
+          "identification":{"sourceId":"sul:9999999"},
+          "structural":#{structural.to_json}}
+      JSON
+    end
+
+    before do
+      file1['externalIdentifier'] = 'http://cocina.sul.stanford.edu/file/112-345-678'
+      file2['externalIdentifier'] = 'http://cocina.sul.stanford.edu/file/212-345-678'
+      file3['externalIdentifier'] = 'http://cocina.sul.stanford.edu/file/312-345-678'
+      file4['externalIdentifier'] = 'http://cocina.sul.stanford.edu/file/412-345-678'
+    end
+
+    it 'generates contentMetadata.xml' do
+      expect(generate).to be_equivalent_to <<~XML
+        <contentMetadata objectId="druid:bc123df5678" type="book">
+          <resource id="http://cocina.sul.stanford.edu/fileSet/012-345-678" sequence="1" type="file">
+            <label>Page 1</label>
+            <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription">
+              <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
+              <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
+            </file>
+            <file id="00001.jp2" mimetype="image/jp2" size="149570" preserve="yes" publish="yes" shelve="yes">
+              <imageData height="200" width="300"/>
+            </file>
+          </resource>
+          <resource id="http://cocina.sul.stanford.edu/fileSet/123-456-789" sequence="2" type="file">
             <label>Page 2</label>
             <file id="00002.html" mimetype="text/html" size="1914" preserve="yes" publish="yes" shelve="no"/>
             <file id="00002.jp2" mimetype="image/jp2" size="111467" preserve="yes" publish="yes" shelve="yes"/>


### PR DESCRIPTION
closes #2513

## Why was this change made?
Allow for unique and addressable identifiers for files and filesets.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


