### PR TITLE
fix reading direction specified in contentMetadata

### DIFF
--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -57,7 +57,7 @@ module Cocina
       end
 
       def create_member_order
-        reading_direction = item.contentMetadata.ng_xml.xpath('//bookData/@readingDirection').first&.value
+        reading_direction = item.contentMetadata.ng_xml.xpath('//bookData/@readingOrder').first&.value
         # See https://consul.stanford.edu/pages/viewpage.action?spaceKey=chimera&title=DOR+content+types%2C+resource+types+and+interpretive+metadata
         case reading_direction
         when 'ltr'

--- a/spec/services/cocina/from_fedora/dro_structural_spec.rb
+++ b/spec/services/cocina/from_fedora/dro_structural_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe Cocina::FromFedora::DroStructural do
   context 'with bookData' do
     subject { structural[:hasMemberOrders].first[:viewingDirection] }
 
-    let(:book_data) { "<bookData readingDirection=\"#{reading_direction}\" />" }
+    let(:book_data) { "<bookData readingOrder=\"#{reading_direction}\" />" }
     let(:xml) do
       <<~XML
         <contentMetadata type="book" id="druid:hx013yf6680">


### PR DESCRIPTION
## Why was this change made?

There is a typo in the modeling for book direction.  This fixes it to match what we do and for the documentation shown here: https://consul.stanford.edu/pages/viewpage.action?spaceKey=chimera&title=DOR+content+types%2C+resource+types+and+interpretive+metadata

## How was this change tested?

Updated the test.


## Which documentation and/or configurations were updated?



