### PR TITLE
Fetch datastreams before writing to zip.

### DIFF
--- a/lib/fedora_cache.rb
+++ b/lib/fedora_cache.rb
@@ -32,18 +32,19 @@ class FedoraCache
     object = fetch_object(druid)
     return if object.nil?
 
+    datastreams = {}
+    DATASTREAMS.each do |dsid|
+      datastream = fetch_datastream(druid, dsid)
+      datastreams[dsid] = datastream if datastream
+    end
+
     zip_path = zip_path_for(druid)
     path = File.dirname(zip_path)
     FileUtils.mkdir_p(path) unless Dir.exist?(path)
 
     Zip::File.open(zip_path, Zip::File::CREATE) do |zipfile|
       zipfile.get_output_stream('object.xml') { |file| file.write(object) }
-      DATASTREAMS.each do |dsid|
-        datastream = fetch_datastream(druid, dsid)
-        next if datastream.nil?
-
-        zipfile.get_output_stream("#{dsid}.xml") { |file| file.write(datastream) }
-      end
+      datastreams.each_pair { |dsid, datastream| zipfile.get_output_stream("#{dsid}.xml") { |file| file.write(datastream) } }
     end
   end
 


### PR DESCRIPTION
## Why was this change made?
Minimize the risk of creating an incomplete cache zip (which may occur when interrupting cache generation). This minimizes the amount of time that a zip is open for writing by performing the slow operations (fetch) before opening the zip.


## How was this change tested?
Local


## Which documentation and/or configurations were updated?
NA


