### PR TITLE
Validate descriptive roundtripping for legacy metadata updates.

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -37,7 +37,8 @@ class MetadataController < ApplicationController
       values = params[section]
       next unless values
 
-      LegacyMetadataService.update_datastream_if_newer(datastream: @item.datastreams[datastream_name],
+      LegacyMetadataService.update_datastream_if_newer(item: @item,
+                                                       datastream_name: datastream_name,
                                                        updated: Time.zone.parse(values[:updated]),
                                                        content: values[:content],
                                                        event_factory: EventFactory)

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -157,8 +157,8 @@ module Cocina
 
     def validate(obj)
       if Settings.enabled_features.validate_descriptive_roundtrip.create
-        validator = DescriptionRoundtripValidator.new(obj)
-        raise RoundtripValidationError, validator.error unless validator.valid?
+        result = DescriptionRoundtripValidator.valid_from_cocina?(obj)
+        raise RoundtripValidationError, result.failure unless result.success?
       end
 
       # Validate will raise an error if not valid.

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -147,8 +147,8 @@ module Cocina
       raise NotImplemented, 'Updating descriptive metadata not supported' if !update_descriptive? && client_attempted_metadata_update?
 
       if has_changed?(:description) && update_descriptive? && Settings.enabled_features.validate_descriptive_roundtrip.update
-        validator = DescriptionRoundtripValidator.new(obj)
-        raise RoundtripValidationError, validator.error unless validator.valid?
+        result = DescriptionRoundtripValidator.valid_from_cocina?(obj)
+        raise RoundtripValidationError, result.failure unless result.success?
       end
     end
     # rubocop:enable Style/GuardClause

--- a/app/services/legacy_metadata_service.rb
+++ b/app/services/legacy_metadata_service.rb
@@ -15,12 +15,13 @@ class LegacyMetadataService
 
   # If the updated value is newer than then createDate of the datastream, then update it.
   # @raise [DatastreamValidationError] if datastream fails validation
-  def self.update_datastream_if_newer(datastream:, updated:, content:, event_factory:)
-    new(datastream: datastream, updated: updated, content: content, event_factory: event_factory).update_datastream_if_newer
+  def self.update_datastream_if_newer(item:, datastream_name:, updated:, content:, event_factory:)
+    new(item: item, datastream_name: datastream_name, updated: updated, content: content, event_factory: event_factory).update_datastream_if_newer
   end
 
-  def initialize(datastream:, updated:, content:, event_factory:)
-    @datastream = datastream
+  def initialize(item:, datastream_name:, updated:, content:, event_factory:)
+    @item = item
+    @datastream = item.datastreams[datastream_name]
     @updated = updated
     @content = content
     @event_factory = event_factory
@@ -44,7 +45,7 @@ class LegacyMetadataService
 
   private
 
-  attr_reader :datastream, :updated, :content, :event_factory
+  attr_reader :datastream, :updated, :content, :event_factory, :item
 
   def validate_rights_metadata
     result = Fedora::RightsValidator.valid?(datastream.ng_xml)
@@ -54,6 +55,11 @@ class LegacyMetadataService
   def validate_desc_metadata
     result = ModsValidator.valid?(datastream.ng_xml)
     raise DatastreamValidationError.new('MODS validation failed', detail: result.failure.join(' ')) if result.failure?
+
+    if Settings.enabled_features.validate_descriptive_roundtrip.legacy
+      result = Cocina::DescriptionRoundtripValidator.valid_from_fedora?(item)
+      raise DatastreamValidationError.new('MODS roundtripping failed', detail: result.failure) unless result.success?
+    end
 
     raise DatastreamValidationError, "#{datastream.pid} descMetadata missing required fields (<title>)" if datastream.mods_title.blank?
   end

--- a/app/validators/cocina/description_roundtrip_validator.rb
+++ b/app/validators/cocina/description_roundtrip_validator.rb
@@ -3,15 +3,18 @@
 module Cocina
   # Validates that descriptive metadata roundtrips.
   class DescriptionRoundtripValidator
-    # @param [RequestAdminPolicy, RequestDRO, RequestCollection, AdminPolicy, DRO, Collection]
-    def initialize(cocina_object)
-      @cocina_object = cocina_object
+    class << self
+      include Dry::Monads[:result]
     end
 
-    attr_reader :error
+    # Validates roundtrip from Cocina to MODS to Cocina
+    # @param [RequestAdminPolicy, RequestDRO, RequestCollection, AdminPolicy, DRO, Collection]
+    # @return [Dry::Monads::Result]
+    def self.valid_from_cocina?(cocina_object)
+      return Success() if cocina_object.description.nil?
 
-    def valid?
-      return true if cocina_object.description.nil?
+      # Requests do not have druids.
+      druid = cocina_object.respond_to?(:externalIdentifier) ? cocina_object.externalIdentifier : nil
 
       descriptive_ng_xml = ToFedora::Descriptive.transform(cocina_object.description, druid).doc
       # Map MODS back to Cocina.
@@ -20,20 +23,30 @@ module Cocina
 
       # Compare original description against roundtripped Cocina.
       unless DeepEqual.match?(roundtrip_description, cocina_object.description.to_h)
-        @error = "Roundtripping of descriptive metadata unsuccessful. Expected #{cocina_object.description.to_h} but received #{roundtrip_description}."
-        return false
+        return Failure("Roundtripping of descriptive metadata unsuccessful. Expected #{cocina_object.description.to_h} but received #{roundtrip_description}.")
       end
 
-      true
+      Success()
     end
 
-    private
+    # Validates roundtrip from MODS to Cocina to MODS
+    # @param [Fedora::Item, Fedora::AdminPolicy, Fedora::Collection]
+    # @return [Dry::Monads::Result]
+    def self.valid_from_fedora?(fedora_object)
+      title_builder = Cocina::FromFedora::Descriptive::TitleBuilderStrategy.find(label: fedora_object.label)
+      description_props = Cocina::FromFedora::Descriptive.props(title_builder: title_builder, mods: fedora_object.descMetadata.ng_xml, druid: fedora_object.pid)
+      cocina_description = Cocina::Models::Description.new(description_props)
 
-    attr_reader :cocina_object
+      roundtrip_mods_ng_xml = Cocina::ToFedora::Descriptive.transform(cocina_description, fedora_object.pid).doc
 
-    def druid
-      # Requests do not have druids.
-      @druid ||= cocina_object.respond_to?(:externalIdentifier) ? cocina_object.externalIdentifier : nil
+      # Perform approved XML normalization changes to avoid noise in roundtrip failures
+      norm_original_ng_xml = Cocina::ModsNormalizer.normalize(mods_ng_xml: fedora_object.descMetadata.ng_xml, druid: fedora_object.pid, label: fedora_object.label)
+
+      unless ModsEquivalentService.equivalent?(norm_original_ng_xml, roundtrip_mods_ng_xml)
+        return Failure("Roundtripping of descriptive metadata unsuccessful. Expected #{fedora_object.descMetadata.ng_xml.to_xml} but received #{roundtrip_mods_ng_xml.to_xml}.")
+      end
+
+      Success()
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,7 @@ enabled_features:
   validate_descriptive_roundtrip:
     update: true
     create: true
+    legacy: true
 
 content:
   base_dir: '/dor/workspace'

--- a/spec/services/cocina/object_updater_spec.rb
+++ b/spec/services/cocina/object_updater_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 # Tests whether partial updates are handled correctly.
 # It does not test the updates themselves.
 RSpec.describe Cocina::ObjectUpdater do
+  include Dry::Monads[:result]
+
   subject(:update) { described_class.run(item, cocina_object, event_factory: event_factory, trial: trial) }
 
   # For the existing item.
@@ -82,13 +84,11 @@ RSpec.describe Cocina::ObjectUpdater do
     end
 
     context 'when updating description' do
-      let(:description_roundtrip_validator) { instance_double(Cocina::DescriptionRoundtripValidator, 'valid?' => true) }
-
       before do
         allow(desc_metadata).to receive(:content=)
         allow(desc_metadata).to receive(:content_will_change!)
         allow(Cocina::ToFedora::Descriptive).to receive(:transform).and_return(Nokogiri::XML::Builder.new)
-        allow(Cocina::DescriptionRoundtripValidator).to receive(:new).and_return(description_roundtrip_validator)
+        allow(Cocina::DescriptionRoundtripValidator).to receive(:valid_from_cocina?).and_return(Success())
       end
 
       context 'when description has changed' do
@@ -198,13 +198,11 @@ RSpec.describe Cocina::ObjectUpdater do
     end
 
     context 'when updating description' do
-      let(:description_roundtrip_validator) { instance_double(Cocina::DescriptionRoundtripValidator, 'valid?' => true) }
-
       before do
         allow(desc_metadata).to receive(:content=)
         allow(desc_metadata).to receive(:content_will_change!)
         allow(Cocina::ToFedora::Descriptive).to receive(:transform).and_return(Nokogiri::XML::Builder.new)
-        allow(Cocina::DescriptionRoundtripValidator).to receive(:new).and_return(description_roundtrip_validator)
+        allow(Cocina::DescriptionRoundtripValidator).to receive(:valid_from_cocina?).and_return(Success())
       end
 
       context 'when description has changed' do
@@ -331,13 +329,11 @@ RSpec.describe Cocina::ObjectUpdater do
     end
 
     context 'when updating description' do
-      let(:description_roundtrip_validator) { instance_double(Cocina::DescriptionRoundtripValidator, 'valid?' => true) }
-
       before do
         allow(desc_metadata).to receive(:content=)
         allow(desc_metadata).to receive(:content_will_change!)
         allow(Cocina::ToFedora::Descriptive).to receive(:transform).and_return(Nokogiri::XML::Builder.new)
-        allow(Cocina::DescriptionRoundtripValidator).to receive(:new).and_return(description_roundtrip_validator)
+        allow(Cocina::DescriptionRoundtripValidator).to receive(:valid_from_cocina?).and_return(Success())
       end
 
       context 'when description has changed' do

--- a/spec/services/legacy_metadata_service_spec.rb
+++ b/spec/services/legacy_metadata_service_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe LegacyMetadataService do
 
   describe '.update_datastream_if_newer' do
     subject(:update) do
-      described_class.update_datastream_if_newer(datastream: datastream,
+      described_class.update_datastream_if_newer(item: item,
+                                                 datastream_name: 'descMetadata',
                                                  updated: updated,
                                                  content: content,
                                                  event_factory: event_factory)
@@ -15,12 +16,25 @@ RSpec.describe LegacyMetadataService do
 
     let(:event_factory) { class_double(EventFactory, create: true) }
     let(:updated) { Time.zone.parse('2019-08-09T19:18:15Z') }
-    let(:content) { '<descMetadata><foo/></descMetadata>' }
+    let(:content) do
+      <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <titleInfo>
+            <title>One title</title>
+          </titleInfo>
+        </mods>
+      XML
+    end
     let(:title) { ['One title'] }
+    let(:item) do
+      instance_double(Dor::Item, datastreams: { 'descMetadata' => datastream }, label: 'test label', pid: 'druid:bc123df4567')
+    end
     let(:datastream) do
       instance_double(Dor::DescMetadataDS, createDate: create_date,
                                            dsid: 'descMetadata',
-                                           pid: 'druid:123',
+                                           pid: 'druid:bc123df4567',
                                            :content= => nil,
                                            mods_title: title)
     end
@@ -28,6 +42,7 @@ RSpec.describe LegacyMetadataService do
     before do
       allow(datastream).to receive(:ng_xml).and_return(Nokogiri::XML(content))
       allow(ModsValidator).to receive(:valid?).and_return(Success())
+      allow(Cocina::DescriptionRoundtripValidator).to receive(:valid_from_fedora?).and_return(Success())
     end
 
     context 'with a new datastream' do
@@ -38,6 +53,7 @@ RSpec.describe LegacyMetadataService do
         expect(datastream).to have_received(:content=).with(content)
         expect(event_factory).to have_received(:create)
         expect(ModsValidator).to have_received(:valid?)
+        expect(Cocina::DescriptionRoundtripValidator).to have_received(:valid_from_fedora?)
       end
     end
 
@@ -56,8 +72,10 @@ RSpec.describe LegacyMetadataService do
       let(:title) { [] }
 
       it 'raises an error' do
-        expect { update }.to raise_error 'druid:123 descMetadata missing required fields (<title>)'
+        expect { update }.to raise_error 'druid:bc123df4567 descMetadata missing required fields (<title>)'
       end
     end
+
+    # TODO: Test roundtrip error. Cocina::FromFedora::Descriptive.props
   end
 end

--- a/spec/validators/cocina/description_roundtrip_validator_spec.rb
+++ b/spec/validators/cocina/description_roundtrip_validator_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::DescriptionRoundtripValidator do
+  describe '.valid_from_cocina?' do
+    let(:result) { described_class.valid_from_cocina?(cocina_object) }
+
+    let(:cocina_hash) do
+      {
+        type: Cocina::Models::Vocab.book,
+        label: 'Born to Run',
+        version: 1,
+        access: {
+          access: 'world',
+          download: 'none'
+        },
+        description: {
+          title: [{ value: 'Born to Run' }],
+          purl: 'http://purl.stanford.edu/ff111df4567',
+          access: {
+            digitalRepository: [
+              { value: 'Stanford Digital Repository' }
+            ]
+          }
+        },
+        administrative: {
+          hasAdminPolicy: 'druid:dd999df4567'
+        },
+        identification: { sourceId: 'googlebooks:999999' },
+        externalIdentifier: 'druid:ff111df4567'
+      }
+    end
+
+    let(:cocina_object) { Cocina::Models::DRO.new(cocina_hash) }
+
+    context 'when valid' do
+      it 'returns success' do
+        expect(result.success?).to be true
+      end
+    end
+
+    context 'when invalid' do
+      before do
+        changed_cocina_hash = cocina_hash[:description].except(:purl)
+        allow(Cocina::FromFedora::Descriptive).to receive(:props).and_return(changed_cocina_hash)
+      end
+
+      it 'returns failure' do
+        expect(result.failure?).to be true
+      end
+    end
+
+    context 'with request' do
+      let(:cocina_object) { Cocina::Models::RequestDRO.new(cocina_hash.except(:externalIdentifier)) }
+
+      it 'returns success' do
+        expect(result.success?).to be true
+      end
+    end
+  end
+
+  describe '.valid_from_fedora?' do
+    let(:result) { described_class.valid_from_fedora?(fedora_object) }
+
+    let(:fedora_object) do
+      Dor::Item.new(
+        pid: 'druid:ff111df4567',
+        label: 'Chi Running'
+      ).tap do |item|
+        item.descMetadata.content = mods
+      end
+    end
+
+    let(:mods) do
+      <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.7">
+          <titleInfo>
+            <title>Chi Running</title>
+          </titleInfo>
+        </mods>
+      XML
+    end
+
+    context 'when valid' do
+      it 'returns success' do
+        expect(result.success?).to be true
+      end
+    end
+
+    context 'when invalid' do
+      before do
+        allow(Cocina::ModsNormalizer).to receive(:normalize).and_return(Nokogiri::XML(mods.gsub('Chi Running', 'Zen of Running')))
+      end
+
+      it 'returns failure' do
+        expect(result.failure?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #2515

## Why was this change made?
Prevent non-roundtrippable descriptive metadata from entering via legacy endpoint.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA