### PR TITLE
Create an endpoint for applying admin policy defaults

### DIFF
--- a/app/controllers/admin_policy_defaults_controller.rb
+++ b/app/controllers/admin_policy_defaults_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Applies the AdminPolicy defaults to a repository object
+class AdminPolicyDefaultsController < ApplicationController
+  before_action :load_item, only: :apply
+
+  def apply
+    @item.rightsMetadata.content = @item.admin_policy_object.defaultObjectRights.content
+    @item.save!
+    head :no_content
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
         post 'notify_goobi'
         post 'accession'
         post 'refresh_metadata', to: 'metadata_refresh#refresh'
+        post 'apply_admin_policy_defaults', to: 'admin_policy_defaults#apply'
       end
       resources :members, only: [:index], defaults: { format: :json }
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -540,6 +540,27 @@ paths:
               properties:
                 administrative_tag:
                   $ref: '#/components/schemas/AdministrativeTag'
+  '/v1/objects/{id}/apply_admin_policy_defaults':
+    post:
+      tags:
+        - objects
+      summary: Applies the default values (copyright, use_statement, rights) from the admin policy
+      description: ''
+      operationId: 'admin_policy_defaults#apply'
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not found
+        '500':
+          description: Internal server error
+      parameters:
+        - name: id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
   '/v1/objects/{id}/refresh_metadata':
     post:
       tags:

--- a/spec/requests/apply_admin_policy_defaults_spec.rb
+++ b/spec/requests/apply_admin_policy_defaults_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Get the object' do
+  before do
+    allow(Dor).to receive(:find).and_return(object)
+    allow(object).to receive(:save!)
+  end
+
+  let(:object) { Dor::Item.new(admin_policy_object: admin_policy) }
+  let(:admin_policy) do
+    Dor::AdminPolicyObject.new.tap do |coll|
+      coll.defaultObjectRights.content = '<foo/>'
+    end
+  end
+
+  it 'copies the rights metadata from the AdminPolicy to the object' do
+    post '/v1/objects/druid:mk420bs7601/apply_admin_policy_defaults',
+         headers: { 'Authorization' => "Bearer #{jwt}" }
+    expect(response).to be_successful
+    expect(object.rightsMetadata.content).to eq '<foo/>'
+    expect(object).to have_received(:save!)
+  end
+end


### PR DESCRIPTION


## Why was this change made?
This will be used so that we can decouple Argo from Fedora.


## How was this change tested?



## Which documentation and/or configurations were updated?



