### PR TITLE
Adds roundtrip validation when refreshing desc metadata.

### DIFF
--- a/app/controllers/metadata_refresh_controller.rb
+++ b/app/controllers/metadata_refresh_controller.rb
@@ -10,7 +10,7 @@ class MetadataRefreshController < ApplicationController
 
   def refresh
     status = RefreshMetadataAction.run(identifiers: identifiers,
-                                       datastream: @item.descMetadata)
+                                       fedora_object: @item)
     return render status: :unprocessable_entity, plain: "#{@item.pid} had no resolvable identifiers: #{identifiers.inspect}" unless status
     return render status: :internal_server_error, plain: "#{@item.pid} descMetadata missing required fields (<title>)" if missing_required_fields?
 

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -115,7 +115,7 @@ module Cocina
 
       # Synch from symphony if a catkey is present
       if item.catkey
-        RefreshMetadataAction.run(identifiers: ["catkey:#{item.catkey}"], datastream: item.descMetadata)
+        RefreshMetadataAction.run(identifiers: ["catkey:#{item.catkey}"], fedora_object: item)
         label = MetadataService.label_from_mods(item.descMetadata.ng_xml)
         item.label = truncate_label(label)
         item.objectLabel = label

--- a/bin/refresh-metadata
+++ b/bin/refresh-metadata
@@ -23,7 +23,7 @@ druids.each_with_index do |druid, index|
   puts "#{druid} (#{index + 1})\n"
   object = Dor.find(druid)
   orig_xml = object.descMetadata.ng_xml.canonicalize
-  status = RefreshMetadataAction.run(identifiers: object.identityMetadata.otherId.collect(&:to_s), datastream: object.descMetadata)
+  status = RefreshMetadataAction.run(identifiers: object.identityMetadata.otherId.collect(&:to_s), fedora_object: object)
   if status
     if orig_xml == object.descMetadata.ng_xml.canonicalize
       puts 'No change'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,6 +6,7 @@ enabled_features:
     update: true
     create: true
     legacy: true
+    refresh: true
 
 content:
   base_dir: '/dor/workspace'

--- a/spec/requests/metadata_refresh_spec.rb
+++ b/spec/requests/metadata_refresh_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Refresh metadata' do
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
       expect(RefreshMetadataAction).to have_received(:run)
-        .with(datastream: object.descMetadata, identifiers: [':catkey:123'])
+        .with(fedora_object: object, identifiers: [':catkey:123'])
       expect(object).to have_received(:save)
     end
   end
@@ -39,7 +39,7 @@ RSpec.describe 'Refresh metadata' do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body).to eq 'druid:1234 had no resolvable identifiers: [":uuid:1234"]'
       expect(RefreshMetadataAction).to have_received(:run)
-        .with(datastream: object.descMetadata, identifiers: [':uuid:1234'])
+        .with(fedora_object: object, identifiers: [':uuid:1234'])
       expect(object).not_to have_received(:save)
     end
   end
@@ -56,7 +56,7 @@ RSpec.describe 'Refresh metadata' do
       expect(response.status).to eq(500)
       expect(response.body).to eq('druid:1234 descMetadata missing required fields (<title>)')
       expect(RefreshMetadataAction).to have_received(:run)
-        .with(datastream: object.descMetadata, identifiers: [':catkey:123'])
+        .with(fedora_object: object, identifiers: [':catkey:123'])
       expect(object).not_to have_received(:save)
     end
   end

--- a/spec/services/cocina/object_creator_spec.rb
+++ b/spec/services/cocina/object_creator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Cocina::ObjectCreator do
     allow(Dor).to receive(:find).with(apo).and_return(Dor::AdminPolicyObject.new)
     allow(Dor::SuriService).to receive(:mint_id).and_return('druid:mb046vj7485')
     allow(RefreshMetadataAction).to receive(:run) do |args|
-      args[:datastream].mods_title = 'foo'
+      args[:fedora_object].descMetadata.mods_title = 'foo'
     end
     allow(SynchronousIndexer).to receive(:reindex_remotely)
   end

--- a/spec/services/refresh_metadata_action_spec.rb
+++ b/spec/services/refresh_metadata_action_spec.rb
@@ -3,16 +3,42 @@
 require 'rails_helper'
 
 RSpec.describe RefreshMetadataAction do
-  subject(:refresh) { described_class.run(identifiers: ['catkey:123'], datastream: item.descMetadata) }
+  include Dry::Monads[:result]
+
+  subject(:refresh) { described_class.run(identifiers: ['catkey:123'], fedora_object: item) }
 
   let(:item) { Dor::Item.new }
 
+  let(:mods) do
+    <<~XML
+      <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.7">
+        <titleInfo>
+          <title>Paying for College</title>
+        </titleInfo>
+      </mods>
+    XML
+  end
+
   before do
-    allow(MetadataService).to receive(:fetch).and_return('<xml/>')
+    allow(MetadataService).to receive(:fetch).and_return(mods)
+    allow(Honeybadger).to receive(:notify)
   end
 
   it 'gets the data and puts it in descMetadata' do
     expect(refresh).not_to be_nil
-    expect(item.descMetadata.content).to eq '<xml/>'
+    expect(item.descMetadata.ng_xml).to be_equivalent_to Nokogiri::XML(mods)
+    expect(Honeybadger).not_to have_received(:notify)
+  end
+
+  context 'when validation fails' do
+    before do
+      allow(Cocina::DescriptionRoundtripValidator).to receive(:valid_from_fedora?).and_return(Failure())
+    end
+
+    it 'gets the data and puts it in descMetadata and Honeybadger notifies' do
+      expect(refresh).not_to be_nil
+      expect(item.descMetadata.ng_xml).to be_equivalent_to Nokogiri::XML(mods)
+      expect(Honeybadger).to have_received(:notify)
+    end
   end
 end


### PR DESCRIPTION
closes #2532

## Why was this change made?
Help identify desc metadata with roundtripping problems.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


