### PR TITLE
Create an API endpoint that returns the version log

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -3,6 +3,21 @@
 class VersionsController < ApplicationController
   before_action :load_item
 
+  def index
+    return render json: {} unless @item.respond_to?(:versionMetadata)
+
+    # add an entry with version id, tag and description for each version
+    versions = (1..@item.current_version.to_i).map do |version_number|
+      {
+        versionId: version_number,
+        tag: @item.versionMetadata.tag_for_version(version_number.to_s),
+        message: @item.versionMetadata.description_for_version(version_number.to_s)
+      }
+    end
+
+    render json: { versions: versions }
+  end
+
   def create
     VersionService.open(@item, open_params, event_factory: EventFactory)
     render plain: @item.current_version

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,7 @@ Rails.application.routes.draw do
 
       resources :events, only: [:create, :index], defaults: { format: :json }
 
-      resources :versions, only: [:create] do
+      resources :versions, only: [:create, :index] do
         collection do
           get 'openable'
           get 'current'

--- a/openapi.yml
+++ b/openapi.yml
@@ -930,6 +930,25 @@ paths:
           required: false
           description: Indicates if accessionWF should be started after closing the version
   '/v1/objects/{object_id}/versions':
+    get:
+      tags:
+        - versions
+      summary: The version log for this object
+      operationId: 'versions#index'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionLog'
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
     post:
       tags:
         - versions
@@ -2595,6 +2614,29 @@ components:
       # environments and deployed environments that use Apache & Passenger
       pattern: '^.+(\+(?:%3A|:)\+.+)+$'
       example: 'Foo+%3A+Bar+%3A+Baz'
+    Version:
+      type: object
+      description: 'Similar to the version inventory specified by OCFL: https://ocfl.io/draft/spec/#version-inventory'
+      properties:
+        versionId:
+          type: integer
+          description: the number of the version
+        tag:
+          type: string
+          description: the number of the version
+        message:
+          type: string
+          description: a message that explans what changed
+      required:
+        - number
+    VersionLog:
+      type: object
+      description: 'Similar to the version inventory specified by OCFL: https://ocfl.io/draft/spec/#version-inventory'
+      properties:
+        versions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Version'
     BackgroundJobResultResponse:
       type: object
       properties:

--- a/spec/requests/versions_inventory_spec.rb
+++ b/spec/requests/versions_inventory_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Release tags' do
+  let(:druid) { 'druid:mx123qw2323' }
+  let(:object) { Dor::Item.new(pid: druid) }
+
+  before do
+    allow(Dor).to receive(:find).and_return(object)
+
+    object.versionMetadata.content = <<~XML
+      <versionMetadata objectId="druid:bq653yd1233">
+        <version versionId="1" tag="1.0.0">
+          <description>Initial Version</description>
+        </version>
+        <version versionId="2" tag="2.0.0">
+          <description>pre-assembly re-accession</description>
+        </version>
+        <version versionId="3" tag="3.0.0">
+          <description>pre-assembly re-accession</description>
+        </version>
+      </versionMetadata>
+    XML
+  end
+
+  it 'returns a 200' do
+    get "/v1/objects/#{druid}/versions",
+        headers: { 'Authorization' => "Bearer #{jwt}" }
+
+    expect(response.status).to eq(200)
+    expect(response.body).to eq '{"versions":[{"versionId":1,"tag":"1.0.0","message":"Initial Version"},' \
+      '{"versionId":2,"tag":"2.0.0","message":"pre-assembly re-accession"},' \
+      '{"versionId":3,"tag":"3.0.0","message":"pre-assembly re-accession"}]}'
+  end
+end


### PR DESCRIPTION
## Why was this change made?

To decouple Argo from Fedora 3 and to create APIs.

## How was this change tested?



## Which documentation and/or configurations were updated?



