### PR TITLE
Do not load Dor::Item when retrieving administrative tags.

### DIFF
--- a/app/controllers/administrative_tags_controller.rb
+++ b/app/controllers/administrative_tags_controller.rb
@@ -3,7 +3,7 @@
 # Administrative tags controller (nested resource under objects)
 class AdministrativeTagsController < ApplicationController
   # This just validates that this is an existing object
-  before_action :load_item, only: %i[create index update destroy]
+  before_action :load_item, only: %i[create update destroy]
 
   rescue_from(ActiveFedora::ObjectNotFoundError) do |e|
     render status: :not_found, plain: e.message

--- a/openapi.yml
+++ b/openapi.yml
@@ -364,8 +364,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/AdministrativeTag'
-        '404':
-          description: Object not found
       parameters:
         - name: object_id
           in: path

--- a/spec/requests/administrative_tags_spec.rb
+++ b/spec/requests/administrative_tags_spec.rb
@@ -19,32 +19,16 @@ RSpec.describe 'Administrative tags' do
   end
 
   describe '#show' do
-    context 'when item is not found' do
-      before do
-        allow(Dor).to receive(:find)
-          .and_raise(ActiveFedora::ObjectNotFoundError, "Unable to find '#{druid}' in fedora. See logger for details.")
-      end
-
-      it 'returns a 404' do
-        get "/v1/objects/#{druid}/administrative_tags",
-            headers: { 'Authorization' => "Bearer #{jwt}" }
-        expect(response.status).to eq(404)
-        expect(response.body).to eq('Unable to find \'druid:mx123qw2323\' in fedora. See logger for details.')
-      end
+    before do
+      allow(AdministrativeTags).to receive(:for).and_return(tags)
     end
 
-    context 'when item is found' do
-      before do
-        allow(AdministrativeTags).to receive(:for).and_return(tags)
-      end
-
-      it 'returns a 200' do
-        get "/v1/objects/#{druid}/administrative_tags",
-            headers: { 'Authorization' => "Bearer #{jwt}" }
-        expect(AdministrativeTags).to have_received(:for).with(pid: druid).once
-        expect(response.status).to eq(200)
-        expect(response.body).to eq(tags.to_json)
-      end
+    it 'returns a 200' do
+      get "/v1/objects/#{druid}/administrative_tags",
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(AdministrativeTags).to have_received(:for).with(pid: druid).once
+      expect(response.status).to eq(200)
+      expect(response.body).to eq(tags.to_json)
     end
   end
 


### PR DESCRIPTION
## Why was this change made?
The Dor::Item isn't necessary. In the case of roundtrip testing, this is a significant performance hit and breaks the testing when Fedora blips. It also places an unnecessary load on Fedora.

## How was this change tested?
NA


## Which documentation and/or configurations were updated?
NA


