### PR TITLE
Provide an API to provide datastream list and content for the Argo UX

### DIFF
--- a/app/controllers/datastreams_controller.rb
+++ b/app/controllers/datastreams_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# A controller to display datastreams for an object.
+# This controller is intended to be temporary until we can decouple Argo's UX
+# from the datastream abstraction.
+class DatastreamsController < ApplicationController
+  before_action :load_item
+
+  def index
+    result = @item.datastreams
+                  .reject { |name, instance| instance.new? || name == 'workflows' }
+                  .values
+                  .map { |ds| { label: ds.label, dsid: ds.dsid, pid: ds.pid, size: ds.size, mimeType: ds.mimeType } }
+    render json: result
+  end
+
+  def show
+    render xml: @item.datastreams[params[:id]].content
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,9 @@ Rails.application.routes.draw do
       resource :embargo, only: [:update]
       resource :shelve, only: [:create]
 
-      resources :metadata, only: [] do
+      resource :metadata, only: [] do
+        resources :datastreams, only: %i[index show]
+
         collection do
           patch 'legacy', action: :update_legacy_metadata
           get 'dublin_core'

--- a/openapi.yml
+++ b/openapi.yml
@@ -775,6 +775,46 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UpdateLegacyMetadata'
+  '/v1/objects/{object_id}/metadata/datastreams':
+    get:
+      tags:
+        - objects
+      summary: Retrieve the list of datastreams
+      description: 'This is meant to be a temporary API until we can remove the datastream abstraction from the Argo UX'
+      operationId: 'datastreams#index'
+      responses:
+        '200':
+          description: OK
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
+  '/v1/objects/{object_id}/metadata/datastreams/{dsid}':
+    get:
+      tags:
+        - objects
+      summary: Retrieve the contents of a datastream
+      description: 'This is meant to be a temporary API until we can remove the datastream abstraction from the Argo UX'
+      operationId: 'datastreams#show'
+      responses:
+        '200':
+          description: OK
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
+        - name: dsid
+          in: path
+          description: ID of datastream
+          required: true
+          schema:
+            type: string
   '/v1/objects/{object_id}/metadata/dublin_core':
     get:
       tags:

--- a/spec/requests/datastreams_spec.rb
+++ b/spec/requests/datastreams_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Datastreams' do
+  let(:druid) { 'druid:mx123qw2323' }
+  let(:object) { Dor::Item.new(pid: druid) }
+
+  before do
+    allow(Dor).to receive(:find).and_return(object)
+  end
+
+  describe 'get a list' do
+    before do
+      object.datastreams['workflows'] = instance_double(ActiveFedora::Datastream, new?: false)
+      object.versionMetadata.content = 'hello'
+      allow(object.versionMetadata).to receive(:new?).and_return(false)
+      object.contentMetadata.content = 'howdy'
+      allow(object.contentMetadata).to receive(:new?).and_return(false)
+    end
+
+    it 'returns a 200' do
+      get "/v1/objects/#{druid}/metadata/datastreams",
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+
+      expect(response.status).to eq(200)
+      expect(response.body).to eq '[{"label":"Version Metadata","dsid":"versionMetadata","pid":"druid:mx123qw2323","size":null,"mimeType":"text/xml"},' \
+        '{"label":"Content Metadata","dsid":"contentMetadata","pid":"druid:mx123qw2323","size":null,"mimeType":"text/xml"}]'
+    end
+  end
+
+  describe 'get a single datastream' do
+    let(:content) do
+      <<~XML
+        <versionMetadata objectId="druid:bq653yd1233">
+          <version versionId="1" tag="1.0.0">
+            <description>Initial Version</description>
+          </version>
+        </versionMetadata>
+      XML
+    end
+
+    before do
+      object.versionMetadata.content = content
+    end
+
+    it 'returns a 200' do
+      get "/v1/objects/#{druid}/metadata/datastreams/versionMetadata",
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+
+      expect(response.status).to eq(200)
+      expect(response.body).to eq content.chomp
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

This will allow us to maintain the existing Argo UI while decoupling it from Fedora.

## How was this change tested?



## Which documentation and/or configurations were updated?



