### PR TITLE
Require label and descMetadata be present when getting from cache.

### DIFF
--- a/lib/fedora_cache.rb
+++ b/lib/fedora_cache.rb
@@ -57,6 +57,8 @@ class FedoraCache
     return result if result.failure?
 
     contents = result.value!
+    return Failure() unless contents.key?('object') && contents.key?('descMetadata')
+
     Success([label_for(contents['object']), contents['descMetadata']])
   end
 


### PR DESCRIPTION
closes #2553

## Why was this change made?
Cached objects missing descMetadata were not being correctly handled.


## How was this change tested?
Local


## Which documentation and/or configurations were updated?
NA


