### PR TITLE
Bootstrap the Ur-APO

### DIFF
--- a/docker/invoke.sh
+++ b/docker/invoke.sh
@@ -22,5 +22,9 @@ set -e
 echo "Migrating db"
 bin/rails db:migrate
 
+# Create the Ur-APO ('druid:hv992ry2431') and ensure it's in Solr.
+# We can't use the remote indexing service because it depends on dor-services-app being up.
+bin/rails runner "Dor::AdminPolicyObject.create!(pid: 'druid:hv992ry2431', label: 'Ur-Apo'); ActiveFedora::SolrService.add(id: 'druid:hv992ry2431', has_model_ssim: 'info:fedora/afmodel:Dor_AdminPolicyObject'); ActiveFedora::SolrService.commit"
+
 echo "Running server"
 exec bin/puma -C config/puma.rb config.ru


### PR DESCRIPTION


## Why was this change made?

This ensures an UR-APO exists so that new APOs can be registered and have an APO to register into

## How was this change tested?



## Which documentation and/or configurations were updated?



