### PR TITLE
Revert "Bootstrap the Ur-APO"

### DIFF
--- a/docker/invoke.sh
+++ b/docker/invoke.sh
@@ -22,9 +22,5 @@ set -e
 echo "Migrating db"
 bin/rails db:migrate
 
-# Create the Ur-APO ('druid:hv992ry2431') and ensure it's in Solr.
-# We can't use the remote indexing service because it depends on dor-services-app being up.
-bin/rails runner "Dor::AdminPolicyObject.create!(pid: 'druid:hv992ry2431', label: 'Ur-Apo'); ActiveFedora::SolrService.add(id: 'druid:hv992ry2431', has_model_ssim: 'info:fedora/afmodel:Dor_AdminPolicyObject'); ActiveFedora::SolrService.commit"
-
 echo "Running server"
 exec bin/puma -C config/puma.rb config.ru


### PR DESCRIPTION
This reverts commit ea6ce21165c38bbd180357dc830ee9a839c7614b.

## Why was this change made?

This was preventing the argo tests from passing.  While this is a nice to have, it's not critical. We can do this with a `docker-compose web exec` instead.



## How was this change tested?



## Which documentation and/or configurations were updated?



