### PR TITLE
Update mime-magic to 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,7 +262,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
The old versions have been yanked, which prevents this project from being deployed

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



