### PR TITLE
"obj" var name disambiguation

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -36,11 +36,11 @@ class ObjectsController < ApplicationController
   end
 
   def update
-    obj = Dor.find(params[:id])
+    fedora_object = Dor.find(params[:id])
     update_request = Cocina::Models.build(params.except(:action, :controller, :id).to_unsafe_h)
-    cocina_object = Cocina::ObjectUpdater.run(obj, update_request)
+    persisted_cocina_object = Cocina::ObjectUpdater.run(fedora_object, update_request)
 
-    render json: cocina_object
+    render json: persisted_cocina_object
   rescue Cocina::RoundtripValidationError => e
     Honeybadger.notify(e)
     json_api_error(status: e.status, message: e.message)

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -11,6 +11,7 @@ module Cocina
     # @param [#create] event_factory creates events
     # @param [boolean] trial do not persist or event; run all mappings regardless of changes
     # @param [Cocina::FromFedora::DataErrorNotifier] notifier
+    # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]
     def self.run(fedora_object, cocina_object, event_factory: EventFactory, trial: false, notifier: nil)
       new(fedora_object, cocina_object, trial: trial).run(event_factory: event_factory, notifier: notifier)
     end
@@ -23,6 +24,7 @@ module Cocina
     end
 
     # rubocop:disable Metrics/AbcSize
+    # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]
     def run(event_factory:, notifier: nil)
       @orig_cocina_object = Mapper.build(fedora_object, notifier: notifier)
 


### PR DESCRIPTION
## Why was this change made?

I found these var names a bit confusing when i was doing some initial debugging on https://github.com/sul-dlss/dor-services-app/issues/2598.  In particular, the use of `obj` as the second param to `ObjectUpdater.run` (and corresponding ivar name in the class) for a cocina model instance, but in the caller (`ObjectsController#update`) as a Fedora object passed as the first param to `ObjectUpdater.run` made it cumbersome to trace through what was happening by copying and running parts of the code individually in Rails console.

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

n/a, though hopefully this hews closer to the convention suggested by https://github.com/sul-dlss/cocina-models/#usage-conventions

