### PR TITLE
Return the correct cocina type for agreements

### DIFF
--- a/app/services/cocina/from_fedora/dro.rb
+++ b/app/services/cocina/from_fedora/dro.rb
@@ -49,6 +49,8 @@ module Cocina
       attr_reader :item, :notifier
 
       def dro_type
+        return Cocina::Models::Vocab.agreement if item.is_a? Dor::Agreement
+
         case item.contentMetadata.contentType.first
         when 'image'
           if /^Manuscript/.match?(AdministrativeTags.content_type(pid: item.pid).first)

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -113,7 +113,7 @@ module Cocina
       if has_changed?(:label) || has_changed?(:structural)
         label = has_changed?(:label) ? cocina_object.label : fedora_object.label
         agreement_id = has_changed?(:structural) ? cocina_object.structural&.hasAgreement : nil
-        Cocina::ToFedora::Identity.apply(fedora_object, label: label, object_type: 'item', agreement_id: agreement_id)
+        Cocina::ToFedora::Identity.apply(fedora_object, label: label, agreement_id: agreement_id)
       end
       Cocina::ToFedora::DROAccess.apply(fedora_object, cocina_object.access) if has_changed?(:access)
       update_content_metadata(fedora_object, cocina_object) if has_changed?(:structural) || has_changed?(:type)

--- a/app/services/cocina/to_fedora/identity.rb
+++ b/app/services/cocina/to_fedora/identity.rb
@@ -6,12 +6,12 @@ module Cocina
     # Fedora 3 data model identityMetadata
     class Identity
       # @param [String] agreement_id (nil) the identifier for the agreement. Note that only items have an agreement.
-      def self.apply(item, label:, object_type:, agreement_id: nil)
+      def self.apply(item, label:, agreement_id: nil)
         item.objectId = item.pid
         item.objectCreator = 'DOR'
         # May have already been set when setting descriptive metadata.
         item.objectLabel = label if item.objectLabel.empty?
-        item.objectType = object_type
+        item.objectType = item.object_type # This comes from the class definition in dor-services
         item.identityMetadata.agreementId = agreement_id if agreement_id
       end
     end

--- a/spec/services/cocina/object_creator_spec.rb
+++ b/spec/services/cocina/object_creator_spec.rb
@@ -225,6 +225,27 @@ RSpec.describe Cocina::ObjectCreator do
         expect { result }.to raise_error Cocina::ValidationError
       end
     end
+
+    context 'when the type is agreement' do
+      let(:params) do
+        {
+          'type' => 'http://cocina.sul.stanford.edu/models/agreement.jsonld',
+          'label' => 'My Agreement',
+          'access' => {},
+          'version' => 1,
+          'administrative' => {
+            'hasAdminPolicy' => apo
+          },
+          'identification' => {
+            'sourceId' => 'identifier:1'
+          }
+        }
+      end
+
+      it 'creates an agreement' do
+        expect(result.type).to eq Cocina::Models::Vocab.agreement
+      end
+    end
   end
 
   context 'when Cocina::Models::RequestCollection is received' do


### PR DESCRIPTION
## Why was this change made?

Agreements were being returned with type: "http://cocina.sul.stanford.edu/models/object.jsonld"

## How was this change tested?



## Which documentation and/or configurations were updated?



