### PR TITLE
update object updater spec

### DIFF
--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -126,9 +126,14 @@ module Cocina
 
     def update_content_metadata(fedora_object, cocina_object)
       # We don't want to overwrite contentMetadata unless they provided structural.contains
+      # Note that a change to a book content type will generate completely new structural metadata, and
+      # thus lead to a full replacement of the contentMetadata with the new bookData node.
       if cocina_object.structural&.contains
         fedora_object.contentMetadata.content = Cocina::ToFedora::ContentMetadataGenerator.generate(druid: fedora_object.pid, object: cocina_object)
       else
+        # remove bookData reading order node if no reading direction is specified in the cocina model
+        # ...this can happen if the content type is changed from a book type to a non-book type
+        fedora_object.contentMetadata.ng_xml.xpath('//bookData').each(&:remove) unless cocina_object.structural&.hasMemberOrders
         fedora_object.contentMetadata.contentType = ToFedora::ContentType.map(cocina_object.type)
       end
     end


### PR DESCRIPTION
## Why was this change made?

Related to sul-dlss/argo#2562.  Ideally, this should be merged and deployed first, but not super critical (it will just leave some extraneous XML in contentMetadata in certain circumstances if the argo PR is deployed first).

The problem occurs if you change the content type from a book type to a non-book type, as this will currently leave behind the unneeded `<bookData>` node. As noted in a comment in the code, everything in DSA works fine when you switch from a non-book type to a book type, because in this case the changes in sul-dlss/argo#2562 will generate  a completely updated structural part of the cocina-model, which will then rebuild and replace the contentMetadata, thus adding the new `<bookData>` node.  

This PR:
- removes these extra nodes when you are switching content types in a way that does not generate new structural (i.e. not going to a book type).
- adds a new test block
- updates the explanation of some existing tests

## How was this change tested?

Updated/new tests

## Which documentation and/or configurations were updated?



