### PR TITLE
Bootstrap the Ur-AdminPolicy

### DIFF
--- a/app/services/ur_admin_policy_factory.rb
+++ b/app/services/ur_admin_policy_factory.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Creates the Ur-AdminPolicy which is the apo that governs itself and all of the other AdminPolicies in the system
+class UrAdminPolicyFactory
+  # If an object references the Ur-AdminPolicy, it has to exist first.
+  # This is particularly important in testing, where the repository may be empty.
+  def self.create
+    Dor::AdminPolicyObject.new(pid: Settings.ur_admin_policy.druid,
+                               label: Settings.ur_admin_policy.label,
+                               agreement_object_id: Settings.ur_admin_policy.druid,
+                               mods_title: Settings.ur_admin_policy.label).tap do |ur_apo|
+      ur_apo.add_relationship(:is_governed_by, "info:fedora/#{Settings.ur_admin_policy.druid}")
+      ur_apo.save!
+    end
+
+    # Solves an odd bootstrapping problem, where the dor-indexing-app can only index cocina-models,
+    # but cocina-model can't be built unless the AdminPolicy is found in Solr
+    ActiveFedora::SolrService.add(id: Settings.ur_admin_policy.druid,
+                                  objectType_ssim: ['adminPolicy'],
+                                  has_model_ssim: 'info:fedora/afmodel:Dor_AdminPolicyObject')
+    ActiveFedora::SolrService.commit
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,12 @@ enabled_features:
     create: true
     legacy: true
     refresh: true
+  create_ur_admin_policy: false
+
+# Ur Admin Policy
+ur_admin_policy:
+  druid: druid:hv992ry2431
+  label: Ur-APO
 
 content:
   base_dir: '/dor/workspace'

--- a/spec/services/ur_admin_policy_factory_spec.rb
+++ b/spec/services/ur_admin_policy_factory_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UrAdminPolicyFactory do
+  subject(:create) { described_class.create }
+
+  let(:ur_apo) { instance_double(Dor::AdminPolicyObject, save!: true, add_relationship: true) }
+
+  before do
+    allow(Dor::AdminPolicyObject).to receive(:exists?).and_return(false)
+    allow(Dor::AdminPolicyObject).to receive(:new).and_return(ur_apo)
+    allow(ActiveFedora::SolrService).to receive_messages(add: true, commit: true)
+  end
+
+  it 'creates the Ur-AdminPolicy' do
+    create
+    expect(ur_apo).to have_received(:save!)
+    expect(ActiveFedora::SolrService).to have_received(:add)
+    expect(ActiveFedora::SolrService).to have_received(:commit)
+  end
+end


### PR DESCRIPTION


## Why was this change made?

There is no way to create new objects in the system until the Ur-AdminPolicy exists.  Presently Argo has a factory that writes directly into Fedora to accomplish this, but we want to decouple Argo from Fedora.  Now, we can turn on a feature flag when this is run in a test container which will automatically bootstrap the Ur-AdminPolicy.

## How was this change tested?



## Which documentation and/or configurations were updated?



