### PR TITLE
unpin simplecov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ group :test, :development do
   gem 'rubocop-performance'
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
-  gem 'simplecov', '~> 0.17.1' # https://github.com/codeclimate/test-reporter/issues/413
+  gem 'simplecov'
   gem 'super_diff'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,11 +455,12 @@ GEM
     sidekiq-statistic (1.4.0)
       sidekiq (>= 5.0)
       tilt (~> 2.0)
-    simplecov (0.17.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.2)
     solrizer (3.4.1)
       activesupport
       daemons
@@ -571,7 +572,7 @@ DEPENDENCIES
   rubyzip (>= 1.0.0)
   sidekiq (~> 6.0)
   sidekiq-statistic
-  simplecov (~> 0.17.1)
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   super_diff


### PR DESCRIPTION
## Why was this change made?

We don't need to pin simplecov anymore now that we switched to code-climate


## How was this change tested?



## Which documentation and/or configurations were updated?



