### PR TITLE
Create the AdminPolicy before running the validation for its existance

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -11,6 +11,8 @@ module Cocina
     # @param [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAdminPolicy] obj
     # @raises SymphonyReader::ResponseError if symphony connection failed
     def create(obj, event_factory:, persister:)
+      ensure_ur_admin_policy_exists if Settings.enabled_features.create_ur_admin_policy && obj.administrative.hasAdminPolicy == Settings.ur_admin_policy.druid
+
       validate(obj)
 
       af_model = create_from_model(obj, persister: persister)
@@ -32,8 +34,6 @@ module Cocina
     # @return [Dor::Abstract] a persisted ActiveFedora model
     # @raises SymphonyReader::ResponseError if symphony connection failed
     def create_from_model(obj, persister:)
-      ensure_ur_admin_policy_exists if Settings.enabled_features.create_ur_admin_policy && obj.administrative.hasAdminPolicy == Settings.ur_admin_policy.druid
-
       af_object = case obj
                   when Cocina::Models::RequestAdminPolicy
                     create_apo(obj)


### PR DESCRIPTION
## Why was this change made?

Previously it could get a validation failure when it validated the AdminPolicy and found that it didn't exist yet.  The creation came too late.


## How was this change tested?



## Which documentation and/or configurations were updated?



