### PR TITLE
do not send HB alerts for project phoenix books with invalid resource types

### DIFF
--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -27,7 +27,7 @@ module Cocina
           has_member_orders = build_has_member_orders
           structural[:hasMemberOrders] = has_member_orders if has_member_orders.present?
 
-          contains = FileSets.build(item.contentMetadata, version: item.current_version.to_i)
+          contains = FileSets.build(item.contentMetadata, version: item.current_version.to_i, tags: AdministrativeTags.for(pid: item.id))
           structural[:contains] = contains if contains.present?
 
           structural[:hasAgreement] = item.identityMetadata.agreementId.first unless item.identityMetadata.agreementId.empty?

--- a/app/services/cocina/from_fedora/file_sets.rb
+++ b/app/services/cocina/from_fedora/file_sets.rb
@@ -4,14 +4,14 @@ module Cocina
   module FromFedora
     # builds the FileSet instance from a Dor::Item
     class FileSets
-      def self.build(content_metadata_ds, version:)
+      def self.build(content_metadata_ds, version:, tags: [])
         content_metadata_ds.ng_xml.xpath('//resource[file]').map do |resource_node|
           files = build_files(resource_node.xpath('file'), version: version)
           structural = {}
           structural[:contains] = files if files.present?
           {
             externalIdentifier: IdGenerator.generate_or_existing_fileset_id(resource_node['id']),
-            type: resource_type(resource_node),
+            type: resource_type(resource_node, tags: tags),
             version: version,
             structural: structural
           }.tap do |attrs|
@@ -22,13 +22,14 @@ module Cocina
         end
       end
 
-      def self.resource_type(resource_node)
+      def self.resource_type(resource_node, tags: [])
         val = resource_node['type']&.underscore
         val = 'three_dimensional' if val == '3d'
         if val && Cocina::Models::Vocab::Resources.respond_to?(val)
           Cocina::Models::Vocab::Resources.public_send(val)
         else
-          Honeybadger.notify("Invalid resource type: '#{val}'")
+          # skip Honeybadber alerts for Project Phoenix (old Google books) which are known to have bad resource types
+          Honeybadger.notify("Invalid resource type: '#{val}'") unless tags.include?('Google Book : GBS VIEW_FULL')
           Cocina::Models::Vocab::Resources.file
         end
       end

--- a/spec/services/cocina/from_fedora/file_sets_spec.rb
+++ b/spec/services/cocina/from_fedora/file_sets_spec.rb
@@ -19,5 +19,25 @@ RSpec.describe Cocina::FromFedora::FileSets do
 
       it { is_expected.to eq 'http://cocina.sul.stanford.edu/models/resources/3d.jsonld' }
     end
+
+    context 'when an invalid resource type' do
+      let(:type) { 'bogus' }
+
+      before { allow(Honeybadger).to receive(:notify) }
+
+      context 'with non project phoenix tag' do
+        it 'notifies Honeybadger' do
+          described_class.resource_type(node, tags: ['Project : FunStuff'])
+          expect(Honeybadger).to have_received(:notify)
+        end
+      end
+
+      context 'with project phoenix tag' do
+        it 'does not notify Honeybadger' do
+          described_class.resource_type(node, tags: ['Google Book : GBS VIEW_FULL', 'Project : FunStuff'])
+          expect(Honeybadger).not_to have_received(:notify)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?

So we don't spam HB

## How was this change tested?



## Which documentation and/or configurations were updated?



