### PR TITLE
allow resource labels to be blank if they do not exist

### DIFF
--- a/app/services/cocina/from_fedora/file_sets.rb
+++ b/app/services/cocina/from_fedora/file_sets.rb
@@ -15,9 +15,7 @@ module Cocina
             version: version,
             structural: structural
           }.tap do |attrs|
-            label = resource_node.xpath('label').text
-            # Use external identifier if label blank (which it is at least for some WAS Crawls).
-            attrs[:label] = label.presence || attrs[:externalIdentifier]
+            attrs[:label] = resource_node.xpath('label').text # some will be missing labels, they will just be blank
           end
         end
       end

--- a/spec/services/cocina/from_fedora/dro_structural_spec.rb
+++ b/spec/services/cocina/from_fedora/dro_structural_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Cocina::FromFedora::DroStructural do
       expect(resource1[:externalIdentifier]).to eq 'http://cocina.sul.stanford.edu/fileSet/123-456-789'
 
       resource2 = structural[:contains].second
-      expect(resource2[:label]).to eq 'http://cocina.sul.stanford.edu/fileSet/123-456-789'
+      expect(resource2[:label]).to eq ''
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #2625 - allow resource labels in cocina to be blank if they are not in contentMetadata.

Cocina model requires label, but should be ok with it blank: https://github.com/sul-dlss/cocina-models/blob/main/lib/cocina/models/file_set.rb#L29

## How was this change tested?

Updated existing test to reflect change.

## Which documentation and/or configurations were updated?



