### PR TITLE
Bump dependency to cocina-models 0.58.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.57.0'
+gem 'cocina-models', '~> 0.58.0'
 gem 'dor-rights-auth', '>= 1.5.0' # required for new CDL rights
 gem 'dor-services', '~> 9.6'
 gem 'dor-workflow-client', '~> 3.17'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.57.0)
+    cocina-models (0.58.1)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -146,9 +146,9 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (6.31.0)
+    dor-services-client (6.32.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.57.0)
+      cocina-models (~> 0.58.0)
       deprecation
       faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
@@ -235,7 +235,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     iso-639 (0.2.10)
@@ -528,7 +528,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.57.0)
+  cocina-models (~> 0.58.0)
   committee
   config
   deprecation


### PR DESCRIPTION
## Why was this change made?
Allow values that are optional to be cleared out (set to null).


## How was this change tested?

Ran integration tests on stage & qa.

## Which documentation and/or configurations were updated?



