### PR TITLE
Consistently map licenses, copyright statements, and use statements for items and collections

### DIFF
--- a/app/services/cocina/from_fedora/dro_access.rb
+++ b/app/services/cocina/from_fedora/dro_access.rb
@@ -16,8 +16,9 @@ module Cocina
       def props
         super.tap do |access|
           access[:embargo] = embargo unless embargo.empty?
-          access[:useAndReproductionStatement] = rights_metadata_ds.use_statement.first if rights_metadata_ds.use_statement.first.present?
-          access[:copyright] = rights_metadata_ds.copyright.first if rights_metadata_ds.copyright.first.present?
+          access[:useAndReproductionStatement] = use_statement if use_statement.present?
+          access[:copyright] = copyright if copyright.present?
+          access[:license] = license_uri if license_uri.present?
         end
       end
 

--- a/app/services/cocina/to_fedora/access.rb
+++ b/app/services/cocina/to_fedora/access.rb
@@ -23,12 +23,42 @@ module Cocina
         Dor::RightsMetadataDS.upd_rights_xml_for_rights_type(item.rightsMetadata.ng_xml, Rights.rights_type(access))
         # This invalidates the dra_object, which is necessary if re-mapping.
         item.rightsMetadata.content = item.rightsMetadata.ng_xml.to_s
+        item.rightsMetadata.copyright = access.copyright if access.copyright
+        item.rightsMetadata.use_statement = access.useAndReproductionStatement if access.useAndReproductionStatement
+        lookup_and_assign_license! if access.license
         item.rightsMetadata.ng_xml_will_change!
       end
 
       private
 
       attr_reader :item, :access
+
+      def lookup_and_assign_license! # rubocop:disable Metrics/AbcSize
+        if Dor::CreativeCommonsLicenseService.key?(license_code)
+          item.rightsMetadata.creative_commons = license_code
+          item.rightsMetadata.creative_commons.uri = access.license
+          item.rightsMetadata.creative_commons_human = Dor::CreativeCommonsLicenseService.property(license_code).label
+        elsif Dor::OpenDataLicenseService.key?(license_code)
+          item.rightsMetadata.open_data_commons = license_code
+          item.rightsMetadata.open_data_commons.uri = access.license
+          item.rightsMetadata.open_data_commons_human = Dor::OpenDataLicenseService.property(license_code).label
+        elsif license_code == 'none'
+          item.rightsMetadata.creative_commons = license_code
+          item.rightsMetadata.creative_commons_human = 'no Creative Commons (CC) license'
+        else
+          raise ArgumentError, "'#{license_code}' is not a valid license code"
+        end
+      end
+
+      def license_code
+        license_codes.fetch(access.license)
+      end
+
+      def license_codes
+        DefaultRights::LICENSE_CODES.merge(
+          Cocina::FromFedora::Access::NONE_LICENSE_URI => 'none'
+        )
+      end
     end
   end
 end

--- a/app/services/cocina/to_fedora/dro_access.rb
+++ b/app/services/cocina/to_fedora/dro_access.rb
@@ -9,6 +9,7 @@ module Cocina
         create_embargo(access.embargo) if access.embargo
         item.rightsMetadata.copyright = access.copyright if access.copyright
         item.rightsMetadata.use_statement = access.useAndReproductionStatement if access.useAndReproductionStatement
+        lookup_and_assign_license! if access.license
 
         super
       end

--- a/spec/services/cocina/from_fedora/access_spec.rb
+++ b/spec/services/cocina/from_fedora/access_spec.rb
@@ -84,4 +84,87 @@ RSpec.describe Cocina::FromFedora::Access do
       expect(access).to eq(access: 'world')
     end
   end
+
+  context 'with an ODC license' do
+    let(:xml) do
+      <<~XML
+        <rightsMetadata>
+          <use>
+            <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
+            <machine type="openDataCommons">odc-by</machine>
+          </use>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the hash' do
+      expect(access).to eq(access: 'citation-only', license: 'http://opendatacommons.org/licenses/by/1.0/')
+    end
+  end
+
+  context 'with a CC license' do
+    let(:xml) do
+      <<~XML
+        <rightsMetadata>
+          <use>
+            <human type="creativeCommons">Attribution Non-Commercial, No Derivatives 3.0 Unported</human>
+            <machine type="creativeCommons">by-nc-nd</machine>
+          </use>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the hash' do
+      expect(access).to eq(access: 'citation-only', license: 'https://creativecommons.org/licenses/by-nc-nd/3.0/')
+    end
+  end
+
+  context 'with a "none" license' do
+    let(:xml) do
+      <<~XML
+        <rightsMetadata>
+          <use>
+            <human type="creativeCommons">no Creative Commons (CC) license</human>
+            <machine type="creativeCommons">none</machine>
+          </use>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the hash' do
+      expect(access).to eq(access: 'citation-only', license: 'http://cocina.sul.stanford.edu/licenses/none')
+    end
+  end
+
+  context 'with a use statement' do
+    let(:xml) do
+      <<~XML
+        <rightsMetadata>
+          <use>
+            <human type="useAndReproduction">User agrees that, where applicable, stuff.</human>
+          </use>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the hash' do
+      expect(access).to eq(access: 'citation-only', useAndReproductionStatement: 'User agrees that, where applicable, stuff.')
+    end
+  end
+
+  context 'with a copyright statement' do
+    let(:xml) do
+      <<~XML
+        <rightsMetadata>
+          <copyright>
+            <human>User agrees that, where applicable, stuff.</human>
+          </use>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the hash' do
+      expect(access).to eq(access: 'citation-only', copyright: 'User agrees that, where applicable, stuff.')
+    end
+  end
 end

--- a/spec/services/cocina/from_fedora/dro_access_spec.rb
+++ b/spec/services/cocina/from_fedora/dro_access_spec.rb
@@ -245,4 +245,55 @@ RSpec.describe Cocina::FromFedora::DROAccess do
       expect(access).to eq(access: 'world', download: 'none')
     end
   end
+
+  context 'with an ODC license' do
+    let(:xml) do
+      <<~XML
+        <rightsMetadata>
+          <use>
+            <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
+            <machine type="openDataCommons">odc-by</machine>
+          </use>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the hash' do
+      expect(access).to include(license: 'http://opendatacommons.org/licenses/by/1.0/')
+    end
+  end
+
+  context 'with a CC license' do
+    let(:xml) do
+      <<~XML
+        <rightsMetadata>
+          <use>
+            <human type="creativeCommons">Attribution Non-Commercial, No Derivatives 3.0 Unported</human>
+            <machine type="creativeCommons">by-nc-nd</machine>
+          </use>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the hash' do
+      expect(access).to include(license: 'https://creativecommons.org/licenses/by-nc-nd/3.0/')
+    end
+  end
+
+  context 'with a "none" license' do
+    let(:xml) do
+      <<~XML
+        <rightsMetadata>
+          <use>
+            <human type="creativeCommons">no Creative Commons (CC) license</human>
+            <machine type="creativeCommons">none</machine>
+          </use>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the hash' do
+      expect(access).to include(license: 'http://cocina.sul.stanford.edu/licenses/none')
+    end
+  end
 end

--- a/spec/services/cocina/to_fedora/access_spec.rb
+++ b/spec/services/cocina/to_fedora/access_spec.rb
@@ -3,44 +3,218 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::ToFedora::Access do
-  subject(:apply) { described_class.apply(item, access) }
+  subject(:apply) { described_class.apply(collection, access) }
 
-  let(:item) do
+  let(:collection) do
     Dor::Collection.new
   end
 
-  describe 'with stanford access' do
+  context 'with stanford access' do
     let(:access) do
-      Cocina::Models::DROAccess.new(access: 'stanford', download: 'none')
+      Cocina::Models::Access.new(access: 'stanford')
     end
 
     it 'builds the xml' do
       apply
-      expect(item.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
+      expect(collection.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
         <?xml version="1.0"?>
-          <rightsMetadata>
-            <access type="discover">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <access type="read">
-              <machine>
-                <group rule="no-download">stanford</group>
-              </machine>
-            </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <human type="creativeCommons"/>
-              <machine type="creativeCommons" uri=""/>
-              <human type="openDataCommons"/>
-              <machine type="openDataCommons" uri=""/>
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
-          </rightsMetadata>
-        </xml>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <group>stanford</group>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction"/>
+            <human type="creativeCommons"/>
+            <machine type="creativeCommons" uri=""/>
+            <human type="openDataCommons"/>
+            <machine type="openDataCommons" uri=""/>
+          </use>
+          <copyright>
+            <human/>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'with copyright statement' do
+    let(:access) do
+      Cocina::Models::Access.new(copyright: 'A Very Good Copyright')
+    end
+
+    it 'builds the xml' do
+      apply
+      expect(collection.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction"/>
+            <human type="creativeCommons"/>
+            <machine type="creativeCommons" uri=""/>
+            <human type="openDataCommons"/>
+            <machine type="openDataCommons" uri=""/>
+          </use>
+          <copyright>
+            <human>A Very Good Copyright</human>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'with use statement' do
+    let(:access) do
+      Cocina::Models::Access.new(useAndReproductionStatement: 'A Very Good Use Statement')
+    end
+
+    it 'builds the xml' do
+      apply
+      expect(collection.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction">A Very Good Use Statement</human>
+            <human type="creativeCommons"/>
+            <machine type="creativeCommons" uri=""/>
+            <human type="openDataCommons"/>
+            <machine type="openDataCommons" uri=""/>
+          </use>
+          <copyright>
+            <human/>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'with a CC license' do
+    let(:access) do
+      Cocina::Models::Access.new(license: 'https://creativecommons.org/licenses/by-nc-nd/3.0/')
+    end
+
+    it 'builds the xml' do
+      apply
+      expect(collection.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction"/>
+            <human type="creativeCommons">Attribution Non-Commercial, No Derivatives 3.0 Unported</human>
+            <machine type="creativeCommons" uri="https://creativecommons.org/licenses/by-nc-nd/3.0/">by-nc-nd</machine>
+            <human type="openDataCommons"/>
+            <machine type="openDataCommons" uri=""/>
+          </use>
+          <copyright>
+            <human/>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'with an ODC license' do
+    let(:access) do
+      Cocina::Models::Access.new(license: 'http://opendatacommons.org/licenses/by/1.0/')
+    end
+
+    it 'builds the xml' do
+      apply
+      expect(collection.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction"/>
+            <human type="creativeCommons"/>
+            <machine type="creativeCommons" uri=""/>
+            <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
+            <machine type="openDataCommons" uri="http://opendatacommons.org/licenses/by/1.0/">odc-by</machine>
+          </use>
+          <copyright>
+            <human/>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'with a "none" license' do
+    let(:access) do
+      Cocina::Models::Access.new(license: 'http://cocina.sul.stanford.edu/licenses/none')
+    end
+
+    it 'builds the xml' do
+      apply
+      expect(collection.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction"/>
+            <human type="creativeCommons">no Creative Commons (CC) license</human>
+            <machine type="creativeCommons" uri="">none</machine>
+            <human type="openDataCommons"/>
+            <machine type="openDataCommons" uri=""/>
+          </use>
+          <copyright>
+            <human/>
+          </copyright>
+        </rightsMetadata>
       XML
     end
   end

--- a/spec/services/cocina/to_fedora/dro_access_spec.rb
+++ b/spec/services/cocina/to_fedora/dro_access_spec.rb
@@ -46,4 +46,109 @@ RSpec.describe Cocina::ToFedora::DROAccess do
       XML
     end
   end
+
+  context 'with a CC license' do
+    let(:access) do
+      Cocina::Models::DROAccess.new(license: 'https://creativecommons.org/licenses/by-nc-nd/3.0/')
+    end
+
+    it 'builds the xml' do
+      apply
+      expect(item.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction"/>
+            <human type="creativeCommons">Attribution Non-Commercial, No Derivatives 3.0 Unported</human>
+            <machine type="creativeCommons" uri="https://creativecommons.org/licenses/by-nc-nd/3.0/">by-nc-nd</machine>
+            <human type="openDataCommons"/>
+            <machine type="openDataCommons" uri=""/>
+          </use>
+          <copyright>
+            <human/>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'with an ODC license' do
+    let(:access) do
+      Cocina::Models::DROAccess.new(license: 'http://opendatacommons.org/licenses/by/1.0/')
+    end
+
+    it 'builds the xml' do
+      apply
+      expect(item.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction"/>
+            <human type="creativeCommons"/>
+            <machine type="creativeCommons" uri=""/>
+            <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
+            <machine type="openDataCommons" uri="http://opendatacommons.org/licenses/by/1.0/">odc-by</machine>
+          </use>
+          <copyright>
+            <human/>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'with a "none" license' do
+    let(:access) do
+      Cocina::Models::DROAccess.new(license: 'http://cocina.sul.stanford.edu/licenses/none')
+    end
+
+    it 'builds the xml' do
+      apply
+      expect(item.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction"/>
+            <human type="creativeCommons">no Creative Commons (CC) license</human>
+            <machine type="creativeCommons" uri="">none</machine>
+            <human type="openDataCommons"/>
+            <machine type="openDataCommons" uri=""/>
+          </use>
+          <copyright>
+            <human/>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
Connects to sul-dlss/argo#2404
Fixes sul-dlss/argo#2612

## Why was this change made?

Data loss is bad.

## How was this change tested?

CI. Should prolly be tested in QA by @andrewjbtw before we go forward.

## Which documentation and/or configurations were updated?

None

