### PR TITLE
Update to cocina 0.58.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.58.0'
+gem 'cocina-models', '~> 0.58.2'
 gem 'dor-rights-auth', '>= 1.5.0' # required for new CDL rights
 gem 'dor-services', '~> 9.6'
 gem 'dor-workflow-client', '~> 3.17'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.58.1)
+    cocina-models (0.58.2)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -528,7 +528,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.58.0)
+  cocina-models (~> 0.58.2)
   committee
   config
   deprecation

--- a/openapi.yml
+++ b/openapi.yml
@@ -1354,6 +1354,7 @@ components:
           description: The human readable copyright statement that applies
           example: Copyright World Trade Organization
           type: string
+          nullable: true
         download:
           description: >
             Download access level. This is used in the transition from Fedora as
@@ -1373,6 +1374,7 @@ components:
             readLocation at registration that is copied down to all the files.
 
           type: string
+          nullable: true
           enum:
             - 'spec'
             - 'music'
@@ -1384,9 +1386,11 @@ components:
           description: The human readable use and reproduction statement that applies
           example: Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).
           type: string
+          nullable: true
         license:
           description: The license governing reuse of the Collection. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
           type: string
+          nullable: true
     AppliesTo:
       description: Property model for indicating the parts, aspects, or versions of the resource to which a
         descriptive element is applicable.


### PR DESCRIPTION
This allows some properties of the AdminPolicyDefaultAccess to be set to null

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



