### PR TITLE
allow objects that are currently opened to be accessioned properly

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -80,9 +80,12 @@ class ObjectsController < ApplicationController
   def accession
     workflow = params[:workflow] || default_start_accession_workflow
 
-    # if this is an existing versionable object, open and close it without starting accessioning
+    # if this is an existing versionable object, open and close it without starting accessionWF
     if VersionService.can_open?(@item, params)
       VersionService.open(@item, params, event_factory: EventFactory)
+      VersionService.close(@item, params.merge(start_accession: false), event_factory: EventFactory)
+    # if this is an existing accessioned object that is currently open, just close it without starting accessionWF
+    elsif VersionService.open_for_versioning?(@item, params)
       VersionService.close(@item, params.merge(start_accession: false), event_factory: EventFactory)
     end
 

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -91,7 +91,7 @@ class ObjectsController < ApplicationController
       VersionService.open(@item, params, event_factory: EventFactory)
       VersionService.close(@item, params.merge(start_accession: false), event_factory: EventFactory)
     # if this is an existing accessioned object that is currently open, just close it without starting accessionWF
-    elsif VersionService.open_for_versioning?(@item, params)
+    elsif VersionService.open?(@item)
       VersionService.close(@item, params.merge(start_accession: false), event_factory: EventFactory)
     end
 

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -80,6 +80,12 @@ class ObjectsController < ApplicationController
   def accession
     workflow = params[:workflow] || default_start_accession_workflow
 
+    # if this object is currently already in accessioning, we cannot start it again
+    if VersionService.in_accessioning?(@item)
+      head :not_acceptable
+      return
+    end
+
     # if this is an existing versionable object, open and close it without starting accessionWF
     if VersionService.can_open?(@item, params)
       VersionService.open(@item, params, event_factory: EventFactory)

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -18,6 +18,10 @@ class VersionService
     new(work, event_factory: event_factory).close(opts)
   end
 
+  def self.in_accessioning?(work)
+    new(work).accessioning?
+  end
+
   def initialize(work, event_factory: nil)
     @work = work
     @event_factory = event_factory

--- a/spec/requests/start_accession_spec.rb
+++ b/spec/requests/start_accession_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
       post "/v1/objects/#{druid}/accession",
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(workflow_client).to have_received(:create_workflow_by_name).with(object.pid, default_start_accession_workflow, version: '1')
-      expect(VersionService).not_to have_received(:open).with(object, base_params, event_factory)
+      expect(VersionService).not_to have_received(:open)
       expect(VersionService).to have_received(:close).with(object, base_params.merge('start_accession' => false), event_factory)
     end
   end

--- a/spec/requests/start_accession_spec.rb
+++ b/spec/requests/start_accession_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
     before do
       allow(VersionService).to receive(:in_accessioning?).and_return(false)
       allow(VersionService).to receive(:can_open?).and_return(false)
-      allow(VersionService).to receive(:open_for_versioning?).and_return(false)
+      allow(VersionService).to receive(:open?).and_return(false)
     end
 
     it 'does not open or close a version and starts default workflow' do
@@ -77,7 +77,7 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
     before do
       allow(VersionService).to receive(:in_accessioning?).and_return(false)
       allow(VersionService).to receive(:can_open?).and_return(false)
-      allow(VersionService).to receive(:open_for_versioning?).and_return(true)
+      allow(VersionService).to receive(:open?).and_return(true)
     end
 
     it 'closes a version and starts default workflow' do

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe VersionService do
     end
   end
 
+  describe '.in_accessioning?' do
+    let(:instance) { instance_double(described_class, accessioning?: true) }
+
+    before do
+      allow(described_class).to receive(:new).and_return(instance)
+    end
+
+    it 'creates a new service instance and sends #accessioning?' do
+      described_class.in_accessioning?(obj)
+      expect(instance).to have_received(:accessioning?).once
+    end
+  end
+
   describe '.open' do
     subject(:open) { described_class.open(obj, event_factory: event_factory) }
 


### PR DESCRIPTION
## Why was this change made?


~~HOLD:~~ Currently causing an integration tests to fail in QA (UPDATE: These tests all fail even with main branch of DSA deployed to QA, so likely unrelated to the work in this PR)

```
SDR_ENV=qa rspec ./spec/features/create_apo_spec.rb:19 # Use Argo to create an APO and verify new objects inherit it's rights is expected to have text "The following defaults will apply to all newly registered objects."
```
~~The pre-assembly spec is causing this exception with the legacy_metadata service: https://app.honeybadger.io/projects/50568/faults/78762991   .... assume because it is closing a version now via the new codepath?  But not sure why this is a problem.~~

-------
Came out of discussions on some work being done by John here: https://github.com/sul-dlss/sdr-api/pull/285 

The method we call to start accessioning (currently in pre-assembly and goobi, but soon to be sdr-api as well) handles the following two scenarios:

* A newly registered object that has not been accessioned
* An object that has been accessioned and is not yet opened

This change handles a potential third scenario:

* An object that has been accessioned and is in an open state

If not handled as in this PR, I believe objects in the last state will currently result in a version mismatch error, as we will start the accessionWF without closing them, which will end up trying to send an object to Preservation core with the same version as the last one sent.

NEWLY ADDED:

* if an object is currently being accessioned, return a 406 and do nothing

## How was this change tested?

Added a new test

## Which documentation and/or configurations were updated?



