### PR TITLE
Ensure use and license fields are initialized before setting them

### DIFF
--- a/app/services/cocina/to_fedora/access.rb
+++ b/app/services/cocina/to_fedora/access.rb
@@ -34,6 +34,8 @@ module Cocina
       attr_reader :item, :access
 
       def lookup_and_assign_license! # rubocop:disable Metrics/AbcSize
+        initialize_license_fields!
+
         if Dor::CreativeCommonsLicenseService.key?(license_code)
           item.rightsMetadata.creative_commons = license_code
           item.rightsMetadata.creative_commons.uri = access.license
@@ -58,6 +60,20 @@ module Cocina
         DefaultRights::LICENSE_CODES.merge(
           Cocina::FromFedora::Access::NONE_LICENSE_URI => 'none'
         )
+      end
+
+      def use_field
+        item.rightsMetadata.find_by_terms(:use).first # rubocop:disable Rails/DynamicFindBy
+      end
+
+      def initialize_field!(field_name, root_term = item.rightsMetadata.ng_xml.root)
+        item.rightsMetadata.add_child_node(root_term, field_name)
+      end
+
+      def initialize_license_fields!
+        initialize_field!(:use) if use_field.blank?
+        initialize_field!(:creative_commons, use_field) if item.rightsMetadata.creative_commons.blank?
+        initialize_field!(:open_data_commons, use_field) if item.rightsMetadata.open_data_commons.blank?
       end
     end
   end

--- a/app/services/cocina/to_fedora/dro_access.rb
+++ b/app/services/cocina/to_fedora/dro_access.rb
@@ -7,9 +7,6 @@ module Cocina
     class DROAccess < Access
       def apply
         create_embargo(access.embargo) if access.embargo
-        item.rightsMetadata.copyright = access.copyright if access.copyright
-        item.rightsMetadata.use_statement = access.useAndReproductionStatement if access.useAndReproductionStatement
-        lookup_and_assign_license! if access.license
 
         super
       end

--- a/config/initializers/rights_metadata_monkeypatch.rb
+++ b/config/initializers/rights_metadata_monkeypatch.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Dor
+  # These templates live in DefaultObjectRights but not in the RightsMetadataDS
+  #
+  # We rely on them when mapping to Cocina
+  class RightsMetadataDS < ActiveFedora::OmDatastream
+    define_template :creative_commons do |xml|
+      xml.human(type: 'creativeCommons')
+      xml.machine(type: 'creativeCommons', uri: '')
+    end
+
+    define_template :open_data_commons do |xml|
+      xml.human(type: 'openDataCommons')
+      xml.machine(type: 'openDataCommons', uri: '')
+    end
+
+    define_template(:use, &:use)
+  end
+end

--- a/spec/services/cocina/to_fedora/dro_access_spec.rb
+++ b/spec/services/cocina/to_fedora/dro_access_spec.rb
@@ -9,7 +9,67 @@ RSpec.describe Cocina::ToFedora::DROAccess do
     Dor::Item.new
   end
 
-  describe 'with cdl access' do
+  context 'with an object lacking a license to start' do
+    let(:item) do
+      Dor::Item.new
+    end
+    let(:access) do
+      Cocina::Models::DROAccess.new(
+        license: 'http://opendatacommons.org/licenses/by/1.0/',
+        copyright: 'New Copyright Statement',
+        useAndReproductionStatement: 'New Use Statement'
+      )
+    end
+
+    before do
+      item.rightsMetadata.content = <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the xml' do
+      apply
+      expect(item.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction">New Use Statement</human>
+            <human type="creativeCommons"/>
+            <machine type="creativeCommons" uri=""/>
+            <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
+            <machine type="openDataCommons" uri="http://opendatacommons.org/licenses/by/1.0/">odc-by</machine>
+          </use>
+          <copyright>
+            <human>New Copyright Statement</human>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'with cdl access' do
     let(:access) do
       Cocina::Models::DROAccess.new(access: 'citation-only', controlledDigitalLending: true, download: 'none')
     end


### PR DESCRIPTION
Connects to sul-dlss/argo#2404

## Why was this change made?

I honestly am not sure if we would ever see this in production but I have data that looks like this in Argo locally and I figured it was worth writing a new test and patching it in. Not sure what the harm is, despite the small cost of added code.


## How was this change tested?

CI, local testing

## Which documentation and/or configurations were updated?

None

