### PR TITLE
Refactor to make the parameters reveal the intention

### DIFF
--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -27,7 +27,7 @@ module Cocina
           has_member_orders = build_has_member_orders
           structural[:hasMemberOrders] = has_member_orders if has_member_orders.present?
 
-          contains = FileSets.build(item.contentMetadata, version: item.current_version.to_i, tags: AdministrativeTags.for(pid: item.id))
+          contains = FileSets.build(item.contentMetadata, version: item.current_version.to_i, ignore_resource_type_errors: project_phoenix?)
           structural[:contains] = contains if contains.present?
 
           structural[:hasAgreement] = item.identityMetadata.agreementId.first unless item.identityMetadata.agreementId.empty?
@@ -45,6 +45,10 @@ module Cocina
       private
 
       attr_reader :item, :type
+
+      def project_phoenix?
+        AdministrativeTags.for(pid: item.id).include?('Google Book : GBS VIEW_FULL')
+      end
 
       def build_has_member_orders
         member_orders = create_member_order if type == Cocina::Models::Vocab.book

--- a/spec/services/cocina/from_fedora/file_sets_spec.rb
+++ b/spec/services/cocina/from_fedora/file_sets_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Cocina::FromFedora::FileSets do
   describe '.resource_type' do
-    subject { described_class.resource_type(node) }
+    subject { described_class.resource_type(node, ignore_resource_type_errors: false) }
 
     let(:node) { Nokogiri::XML::DocumentFragment.parse("<resource type=\"#{type}\" />").at_css('resource') }
 
@@ -20,21 +20,21 @@ RSpec.describe Cocina::FromFedora::FileSets do
       it { is_expected.to eq 'http://cocina.sul.stanford.edu/models/resources/3d.jsonld' }
     end
 
-    context 'when an invalid resource type' do
+    context 'when the resource type is invalid' do
       let(:type) { 'bogus' }
 
       before { allow(Honeybadger).to receive(:notify) }
 
-      context 'with non project phoenix tag' do
+      context 'when ignore_resource_type_errors is not set' do
         it 'notifies Honeybadger' do
-          described_class.resource_type(node, tags: ['Project : FunStuff'])
+          described_class.resource_type(node, ignore_resource_type_errors: false)
           expect(Honeybadger).to have_received(:notify)
         end
       end
 
-      context 'with project phoenix tag' do
+      context 'when ignore_resource_type_errors is set' do
         it 'does not notify Honeybadger' do
-          described_class.resource_type(node, tags: ['Google Book : GBS VIEW_FULL', 'Project : FunStuff'])
+          described_class.resource_type(node, ignore_resource_type_errors: true)
           expect(Honeybadger).not_to have_received(:notify)
         end
       end


### PR DESCRIPTION

## Why was this change made?

There's no need for the FromFedora::FileSet class to know about tags, all it needs to know is whether to notify Honeybadger or not


## How was this change tested?



## Which documentation and/or configurations were updated?



