### PR TITLE
When setting the license, make sure to blank existing licenses

### DIFF
--- a/app/services/cocina/to_fedora/access.rb
+++ b/app/services/cocina/to_fedora/access.rb
@@ -38,13 +38,22 @@ module Cocina
           item.rightsMetadata.creative_commons = license_code
           item.rightsMetadata.creative_commons.uri = access.license
           item.rightsMetadata.creative_commons_human = Dor::CreativeCommonsLicenseService.property(license_code).label
+          item.rightsMetadata.open_data_commons = ''
+          item.rightsMetadata.open_data_commons.uri = ''
+          item.rightsMetadata.open_data_commons_human = ''
         elsif Dor::OpenDataLicenseService.key?(license_code)
           item.rightsMetadata.open_data_commons = license_code
           item.rightsMetadata.open_data_commons.uri = access.license
           item.rightsMetadata.open_data_commons_human = Dor::OpenDataLicenseService.property(license_code).label
+          item.rightsMetadata.creative_commons = ''
+          item.rightsMetadata.creative_commons.uri = ''
+          item.rightsMetadata.creative_commons_human = ''
         elsif license_code == 'none'
           item.rightsMetadata.creative_commons = license_code
           item.rightsMetadata.creative_commons_human = 'no Creative Commons (CC) license'
+          item.rightsMetadata.open_data_commons = ''
+          item.rightsMetadata.open_data_commons.uri = ''
+          item.rightsMetadata.open_data_commons_human = ''
         else
           raise ArgumentError, "'#{license_code}' is not a valid license code"
         end

--- a/spec/services/cocina/to_fedora/access_spec.rb
+++ b/spec/services/cocina/to_fedora/access_spec.rb
@@ -114,6 +114,71 @@ RSpec.describe Cocina::ToFedora::Access do
     end
   end
 
+  # NOTE: This example shows that when mapping back to Fedora we are REPLACING
+  #       the existing license, not merely setting it
+  context 'with an existing (ODC) license of a different class than the new one (CC)' do
+    let(:access) do
+      Cocina::Models::Access.new(license: 'https://creativecommons.org/licenses/by-nc-nd/3.0/')
+    end
+
+    before do
+      collection.rightsMetadata.content = <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction"/>
+            <human type="creativeCommons"/>
+            <machine type="creativeCommons" uri=""/>
+            <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
+            <machine type="openDataCommons" uri="http://opendatacommons.org/licenses/by/1.0/">odc-by</machine>
+          </use>
+          <copyright>
+            <human/>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the xml, blanking the existing license' do
+      apply
+      expect(collection.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction"/>
+            <human type="creativeCommons">Attribution Non-Commercial, No Derivatives 3.0 Unported</human>
+            <machine type="creativeCommons" uri="https://creativecommons.org/licenses/by-nc-nd/3.0/">by-nc-nd</machine>
+            <human type="openDataCommons"/>
+            <machine type="openDataCommons" uri=""/>
+          </use>
+          <copyright>
+            <human/>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
+  end
+
   context 'with a CC license' do
     let(:access) do
       Cocina::Models::Access.new(license: 'https://creativecommons.org/licenses/by-nc-nd/3.0/')


### PR DESCRIPTION
Connects to sul-dlss/argo#2404


## Why was this change made?

Without this change, if I have (e.g.) an ODC license set and then set a CC license, the item or collection will now have multiple licenses.


## How was this change tested?

CI


## Which documentation and/or configurations were updated?

None


