### PR TITLE
fix deprecation warning from sidekiq

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   require 'sidekiq/web'
-  Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
   mount Sidekiq::Web => '/queues'
 
   scope '/v1' do


### PR DESCRIPTION
## Why was this change made?

So we stop getting daily emails from cron that look like this:

```
WARNING: Sidekiq::Web.session_secret= is no longer relevant and will be removed in Sidekiq 7.0. /opt/app/dor_services/dor_services/shared/bundle/ruby/2.7.0/gems/sidekiq-6.2.0/lib/sidekiq/web.rb:75:in `set'
```

See https://github.com/mperham/sidekiq/issues/4846

## How was this change tested?



## Which documentation and/or configurations were updated?



