### PR TITLE
Stop sending an extra parameter to ToFedora::Identity

### DIFF
--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -73,7 +73,7 @@ module Cocina
     def update_apo
       # fedora_object.source_id = cocina_object.identification.sourceId
       if has_changed?(:label)
-        Cocina::ToFedora::Identity.apply(fedora_object, label: cocina_object.label, object_type: 'adminPolicy')
+        Cocina::ToFedora::Identity.apply(fedora_object, label: cocina_object.label)
         fedora_object.label = truncate_label(cocina_object.label)
       end
 

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -956,7 +956,7 @@ RSpec.describe 'Update object' do
   context 'when an APO is provided' do
     let(:item) do
       Dor::AdminPolicyObject.new(pid: druid,
-                                 label: label).tap do |item|
+                                 label: 'old value').tap do |item|
         item.descMetadata.title_info.main_title = 'This is my title'
         item.administrativeMetadata.default_workflow = 'myWorkflow'
         item.administrativeMetadata.add_default_collection 'druid:gh333qq4444'


### PR DESCRIPTION


## Why was this change made?

Fixes #2642

## How was this change tested?



## Which documentation and/or configurations were updated?



