### PR TITLE
Fix sidekiq web UI

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -54,5 +54,9 @@ module DorServices
 
     # This makes sure our Postgres enums function are persisted to the schema
     config.active_record.schema_format = :sql
+
+    # Set up a session store so we can access the Sidekiq Web UI
+    # See: https://github.com/mperham/sidekiq/wiki/Monitoring#rails-api-application-session-configuration
+    config.session_store :cookie_store, key: '_dor-services-app_session'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
+require 'sidekiq/web'
+
+# From Sidekiq docs: https://github.com/mperham/sidekiq/wiki/Monitoring#rails-api-application-session-configuration
+# Configure Sidekiq-specific session middleware
+Sidekiq::Web.use ActionDispatch::Cookies
+Sidekiq::Web.use Rails.application.config.session_store, Rails.application.config.session_options
+
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-
-  require 'sidekiq/web'
   mount Sidekiq::Web => '/queues'
 
   scope '/v1' do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,10 +24,13 @@ services:
       DATABASE_PORT: 5432
       RAILS_LOG_TO_STDOUT: 'true'
       REDIS_URL: redis://redis:6379/
+      # We don't actually use this anywhere but the rails server needs it in production env
+      SECRET_KEY_BASE: e0221b0233dbe4914fae9405c1e179eb1db71379fd999c51265123a6dde45c8281235307dda0b8c06633b702a05679391a950a483f8c624642eb3c3211d4241d
       SOLR_URL: http://solr:8983/solr/dorservices
       SETTINGS__SSL__CERT_FILE: /app/spec/support/certs/spec.crt
       SETTINGS__SSL__KEY_FILE: /app/spec/support/certs/spec.key
       SETTINGS__SSL__KEY_PASS: thisisatleast4bytes
+      SETTINGS__REDIS_URL: redis://redis:6379/
       SETTINGS__SOLR__URL: http://solr:8983/solr/dorservices
       SETTINGS__FEDORA_URL: http://fedoraAdmin:fedoraAdmin@fcrepo:8080/fedora
       SETTINGS__SURI__URL: http://suri:3000
@@ -46,6 +49,7 @@ services:
       SETTINGS__SSL__CERT_FILE: /app/spec/support/certs/spec.crt
       SETTINGS__SSL__KEY_FILE: /app/spec/support/certs/spec.key
       SETTINGS__SSL__KEY_PASS: thisisatleast4bytes
+      SETTINGS__REDIS_URL: redis://redis:6379/
       SETTINGS__SOLR__URL: http://solr:8983/solr/dorservices
       SETTINGS__FEDORA_URL: http://fedoraAdmin:fedoraAdmin@fcrepo:8080/fedora
       SETTINGS__SURI__URL: http://suri:3000


### PR DESCRIPTION
Fixes #2638

## Why was this change made?

This PR follows the instructions from the Sidekiq docs: https://github.com/mperham/sidekiq/wiki/Monitoring#rails-api-application-session-configuration

It also adds a SECRET_KEY_BASE to the web docker-compose service, which is required now that we switched to RAILS_ENV=production. This value is not used anywhere else, so it seems safe to have here. No .env hijinks needed, I do not think.



## How was this change tested?

CI, locally

## Which documentation and/or configurations were updated?

None


