### PR TITLE
do not type type="parallel" in multiscript titles

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -56,7 +56,7 @@ module Cocina
             parallelValue: simple_or_structured(node_set, display_types: display_types?(node_set))
           }.tap do |result|
             type = parallel_type(node_set)
-            result[:type] = type if type
+            result[:type] = type if type && type != 'parallel'
           end
         end
 

--- a/spec/services/cocina/mapping/descriptive/mods/subject_title_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_title_spec.rb
@@ -153,8 +153,9 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
   end
 
   describe 'altRepGroup for alternative title (880-246)' do
-    # based on druid:cp165bv2167
-    xit 'not implemented' do
+    it_behaves_like 'MODS cocina mapping' do
+      # based on druid:cp165bv2167
+
       let(:mods) do
         <<~XML
           <titleInfo usage="primary">
@@ -166,10 +167,10 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
           <titleInfo type="translated">
              <title>Contemporary Chinese literature from Taiwan, &lt;2005-&gt;</title>
           </titleInfo>
-          <titleInfo type="translated" altRepGroup="01">
+          <titleInfo type="translated" altRepGroup="1">
              <title>Dang dai Taiwan wen xue xuan yi &lt;2002-&gt;</title>
           </titleInfo>
-          <titleInfo type="alternative" altRepGroup="01">
+          <titleInfo type="alternative" altRepGroup="1">
              <title>當代台灣文學選譯 &lt;2002-&gt;</title>
           </titleInfo>
         XML


### PR DESCRIPTION
## Why was this change made?

Fixes #2528 - extraneous type="parallel" node in some mappings


## How was this change tested?



## Which documentation and/or configurations were updated?



