### PR TITLE
Create a license node for storing the license URI

### DIFF
--- a/app/services/cocina/from_fedora/access.rb
+++ b/app/services/cocina/from_fedora/access.rb
@@ -4,8 +4,6 @@ module Cocina
   module FromFedora
     # builds the Access subschema for Collections
     class Access
-      NONE_LICENSE_URI = 'http://cocina.sul.stanford.edu/licenses/none'
-
       def self.collection_props(rights_metadata_ds)
         props = new(rights_metadata_ds).props
         # Collection access does not have download
@@ -22,7 +20,7 @@ module Cocina
           access: access_rights,
           download: download? ? access_rights : 'none',
           readLocation: location,
-          license: license_uri,
+          license: License.find(rights_metadata_ds),
           copyright: copyright,
           useAndReproductionStatement: use_statement
         }.compact.tap do |h|
@@ -33,16 +31,6 @@ module Cocina
       private
 
       attr_reader :rights_metadata_ds
-
-      def license_uri
-        return NONE_LICENSE_URI if rights_metadata_ds.use_license.first == 'none'
-
-        if rights_metadata_ds.open_data_commons.first.present?
-          Dor::OpenDataLicenseService.property(rights_metadata_ds.open_data_commons.first).uri
-        elsif rights_metadata_ds.creative_commons.first.present?
-          Dor::CreativeCommonsLicenseService.property(rights_metadata_ds.creative_commons.first).uri
-        end
-      end
 
       def rights_object
         rights_metadata_ds.dra_object.obj_lvl

--- a/app/services/cocina/from_fedora/dro_access.rb
+++ b/app/services/cocina/from_fedora/dro_access.rb
@@ -16,10 +16,10 @@ module Cocina
       def props
         super.tap do |access|
           access[:embargo] = embargo unless embargo.empty?
-          access[:useAndReproductionStatement] = use_statement if use_statement.present?
-          access[:copyright] = copyright if copyright.present?
-          access[:license] = license_uri if license_uri.present?
-        end
+          access[:useAndReproductionStatement] = use_statement
+          access[:copyright] = copyright
+          access[:license] = License.find(rights_metadata_ds)
+        end.compact
       end
 
       private

--- a/app/services/cocina/from_fedora/license.rb
+++ b/app/services/cocina/from_fedora/license.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Cocina
+  module FromFedora
+    # builds the License URI.
+    # First tries the license node.
+    # If that is not found, try the open_data_commons/creative_commons accessor
+    class License
+      # Only used in some legacy ETDs and not actually permitted per the Project Chimera docs.
+      NONE_LICENSE_URI = 'http://cocina.sul.stanford.edu/licenses/none'
+
+      # @return [String] the URI of the license.
+      def self.find(datastream)
+        datastream.ng_xml.xpath('/rightsMetadata/use/license').text.presence || find_legacy_license(datastream)
+      end
+
+      def self.find_legacy_license(datastream)
+        return NONE_LICENSE_URI if datastream.use_license.first == 'none'
+
+        uris = datastream.ng_xml.xpath('/rightsMetadata/use/machine[@uri]').map { |node| node['uri'] }.reject(&:blank?)
+        return uris.first if uris.present?
+
+        if datastream.open_data_commons.first.present?
+          Dor::OpenDataLicenseService.property(datastream.open_data_commons.first).uri
+        elsif datastream.creative_commons.first.present?
+          Dor::CreativeCommonsLicenseService.property(datastream.creative_commons.first).uri
+        end
+      end
+      private_class_method :find_legacy_license
+    end
+  end
+end

--- a/app/services/cocina/to_fedora/license.rb
+++ b/app/services/cocina/to_fedora/license.rb
@@ -4,27 +4,6 @@ module Cocina
   module ToFedora
     # This transforms a license URI into the xml to be written on a Fedora 3 datastream.
     class License
-      Resource = Struct.new(:code, :label)
-      # These codes are the only codes accepted by DefaultObjectRightsDS#use_license=
-      # so we can't just add to this list without updating that method.
-      # https://github.com/sul-dlss/dor-services/blob/main/lib/dor/services/creative_commons_license_service.rb
-      # https://github.com/sul-dlss/dor-services/blob/main/lib/dor/services/open_data_license_service.rb
-      LICENSE_CODES = {
-        nil => Resource.new(nil, nil),
-        Cocina::FromFedora::Access::NONE_LICENSE_URI => Resource.new('none', 'no Creative Commons (CC) license'), # Only used in some legacy ETDs.
-        'https://creativecommons.org/share-your-work/public-domain/cc0/' => Resource.new('cc0', 'No Rights Reserved'),
-        'https://creativecommons.org/licenses/by/3.0/' => Resource.new('by', 'Attribution 3.0 Unported'),
-        'https://creativecommons.org/licenses/by-sa/3.0/' => Resource.new('by-sa', 'Attribution Share Alike 3.0 Unported'),
-        'https://creativecommons.org/licenses/by-nd/3.0/' => Resource.new('by-nd', 'Attribution No Derivatives 3.0 Unported'),
-        'https://creativecommons.org/licenses/by-nc/3.0/' => Resource.new('by-nc', 'Attribution Non-Commercial 3.0 Unported'),
-        'https://creativecommons.org/licenses/by-nc-sa/3.0/' => Resource.new('by-nc-sa', 'Attribution Non-Commercial Share Alike 3.0 Unported'),
-        'https://creativecommons.org/licenses/by-nc-nd/3.0/' => Resource.new('by-nc-nd', 'Attribution Non-Commercial, No Derivatives 3.0 Unported'),
-        'https://creativecommons.org/publicdomain/mark/1.0/' => Resource.new('pdm', 'Public Domain Mark 1.0'),
-        'http://opendatacommons.org/licenses/pddl/1.0/' => Resource.new('pddl', 'Open Data Commons Public Domain Dedication and License 1.0'),
-        'http://opendatacommons.org/licenses/by/1.0/' => Resource.new('odc-by', 'Open Data Commons Attribution License 1.0'),
-        'http://opendatacommons.org/licenses/odbl/1.0/' => Resource.new('odc-odbl', 'Open Data Commons Open Database License 1.0')
-      }.freeze
-
       def self.update(datastream, uri)
         new(datastream, uri).update
       end
@@ -35,70 +14,34 @@ module Cocina
       end
 
       def update
-        initialize_license_fields!
-        license = LICENSE_CODES.fetch(uri)
-
-        if uri.blank?
-          clear_licenses
-        elsif uri.start_with?('https://creativecommons.org/')
-          assign_creative_commons_license(uri, license)
-        elsif uri.start_with?('http://opendatacommons.org/')
-          assign_open_data_commons_license(uri, license)
-        elsif uri == Cocina::FromFedora::Access::NONE_LICENSE_URI
-          datastream.creative_commons = license.code
-          datastream.creative_commons.uri = ''
-          datastream.creative_commons_human = license.label
-          datastream.open_data_commons = ''
-          datastream.open_data_commons.uri = ''
-          datastream.open_data_commons_human = ''
-        else
-          raise ArgumentError, "'#{uri}' is not a valid license code"
+        initialize_use_node!
+        clear_licenses
+        if uri # don't build a license node if there is no license
+          license_node = use_node.xpath('license').first || use_node.add_child('<license/>').first
+          license_node.content = uri
         end
+
+        datastream.ng_xml_will_change!
       end
 
       private
 
       attr_reader :uri, :datastream
 
-      def assign_open_data_commons_license(uri, license)
-        datastream.open_data_commons = license.code
-        datastream.open_data_commons.uri = uri
-        datastream.open_data_commons_human = license.label
-        datastream.creative_commons = ''
-        datastream.creative_commons.uri = ''
-        datastream.creative_commons_human = ''
-      end
-
-      def assign_creative_commons_license(uri, license)
-        datastream.creative_commons = license.code
-        datastream.creative_commons.uri = uri
-        datastream.creative_commons_human = license.label
-        datastream.open_data_commons = ''
-        datastream.open_data_commons.uri = ''
-        datastream.open_data_commons_human = ''
-      end
-
+      # Remove the legacy nodes
       def clear_licenses
-        datastream.creative_commons = ''
-        datastream.creative_commons.uri = ''
-        datastream.creative_commons_human = ''
-        datastream.open_data_commons = ''
-        datastream.open_data_commons.uri = ''
-        datastream.open_data_commons_human = ''
+        datastream.ng_xml.xpath('/rightsMetadata/use/machine[@type="openDataCommons"]').each(&:remove)
+        datastream.ng_xml.xpath('/rightsMetadata/use/machine[@type="creativeCommons"]').each(&:remove)
+        datastream.ng_xml.xpath('/rightsMetadata/use/human[@type="openDataCommons"]').each(&:remove)
+        datastream.ng_xml.xpath('/rightsMetadata/use/human[@type="creativeCommons"]').each(&:remove)
       end
 
-      def use_field
-        datastream.find_by_terms(:use).first # rubocop:disable Rails/DynamicFindBy
+      def use_node
+        datastream.ng_xml.xpath('/rightsMetadata/use').first
       end
 
-      def initialize_field!(field_name, root_term = datastream.ng_xml.root)
-        datastream.add_child_node(root_term, field_name)
-      end
-
-      def initialize_license_fields!
-        initialize_field!(:use) if use_field.blank?
-        initialize_field!(:creative_commons, use_field) if datastream.creative_commons.blank?
-        initialize_field!(:open_data_commons, use_field) if datastream.open_data_commons.blank?
+      def initialize_use_node!
+        datastream.add_child_node(datastream.ng_xml.root, :use) unless use_node
       end
     end
   end

--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -32,9 +32,11 @@ module Publish
     def transfer_metadata(release_tags)
       transfer_to_document_store(DublinCoreService.new(item).ng_xml.to_xml(&:no_declaration), 'dc')
 
-      %w[identityMetadata contentMetadata rightsMetadata].each do |stream|
+      %w[identityMetadata contentMetadata].each do |stream|
         transfer_to_document_store(item.datastreams[stream].content.to_s, stream) if item.datastreams[stream]
       end
+
+      transfer_to_document_store(RightsMetadata.new(item.rightsMetadata.ng_xml).to_xml, 'rightsMetadata')
       transfer_to_document_store(PublicXmlService.new(item, released_for: release_tags).to_xml, 'public')
       transfer_to_document_store(PublicDescMetadataService.new(item).to_xml, 'mods')
     end

--- a/app/services/publish/rights_metadata.rb
+++ b/app/services/publish/rights_metadata.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Publish
+  # Exports the rightsMetadata XML that is sent to purl.stanford.edu
+  class RightsMetadata
+    attr_reader :original
+
+    # @param [Nokogiri::XML] original
+    def initialize(original)
+      @original = original
+    end
+
+    Resource = Struct.new(:code, :label)
+    # These codes are the only codes accepted by DefaultObjectRightsDS#use_license=
+    # so we can't just add to this list without updating that method.
+    # https://github.com/sul-dlss/dor-services/blob/main/lib/dor/services/creative_commons_license_service.rb
+    # https://github.com/sul-dlss/dor-services/blob/main/lib/dor/services/open_data_license_service.rb
+    LICENSE_CODES = {
+      Cocina::FromFedora::License::NONE_LICENSE_URI => Resource.new('none', 'no Creative Commons (CC) license'), # Only used in some legacy ETDs.
+      'https://creativecommons.org/share-your-work/public-domain/cc0/' => Resource.new('cc0', 'No Rights Reserved'),
+      'https://creativecommons.org/licenses/by/3.0/' => Resource.new('by', 'Attribution 3.0 Unported'),
+      'https://creativecommons.org/licenses/by-sa/3.0/' => Resource.new('by-sa', 'Attribution Share Alike 3.0 Unported'),
+      'https://creativecommons.org/licenses/by-nd/3.0/' => Resource.new('by-nd', 'Attribution No Derivatives 3.0 Unported'),
+      'https://creativecommons.org/licenses/by-nc/3.0/' => Resource.new('by-nc', 'Attribution Non-Commercial 3.0 Unported'),
+      'https://creativecommons.org/licenses/by-nc-sa/3.0/' => Resource.new('by-nc-sa', 'Attribution Non-Commercial Share Alike 3.0 Unported'),
+      'https://creativecommons.org/licenses/by-nc-nd/3.0/' => Resource.new('by-nc-nd', 'Attribution Non-Commercial, No Derivatives 3.0 Unported'),
+      'https://creativecommons.org/licenses/by/4.0/' => Resource.new('by', 'Attribution 4.0 International (CC BY 4.0)'),
+      'https://creativecommons.org/licenses/by-sa/4.0/' => Resource.new('by-sa', 'Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)'),
+      'https://creativecommons.org/licenses/by-nd/4.0/' => Resource.new('by-nd', 'Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)'),
+      'https://creativecommons.org/licenses/by-nc/4.0/' => Resource.new('by-nc', 'Attribution-NonCommercial 4.0 International (CC BY-NC 4.0) '),
+      'https://creativecommons.org/licenses/by-nc-sa/4.0/' => Resource.new('by-nc-sa', 'Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)'),
+      'https://creativecommons.org/licenses/by-nc-nd/4.0/' => Resource.new('by-nc-nd', 'Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)'),
+      'https://creativecommons.org/publicdomain/mark/1.0/' => Resource.new('pdm', 'Public Domain Mark 1.0'),
+      'http://opendatacommons.org/licenses/pddl/1.0/' => Resource.new('pddl', 'Open Data Commons Public Domain Dedication and License 1.0'),
+      'http://opendatacommons.org/licenses/by/1.0/' => Resource.new('odc-by', 'Open Data Commons Attribution License 1.0'),
+      'http://opendatacommons.org/licenses/odbl/1.0/' => Resource.new('odc-odbl', 'Open Data Commons Open Database License 1.0')
+    }.freeze
+
+    # @return [String] the original xml with the legacy style rights added so that the description can be displayed.
+    def to_xml
+      license_uri = original.xpath('/rightsMetadata/use/license').text.presence
+      return original.to_xml unless license_uri && LICENSE_CODES.key?(license_uri)
+
+      use_node = original.xpath('/rightsMetadata/use').first
+      license = LICENSE_CODES.fetch(license_uri)
+      case license_uri
+      when Cocina::FromFedora::License::NONE_LICENSE_URI
+        use_node.add_child("<machine type=\"creativeCommons\">#{license.code}</machine>")
+        use_node.add_child("<human type=\"creativeCommons\">#{license.label}</human>")
+      when %r{://creativecommons.org/}
+        use_node.add_child("<machine type=\"creativeCommons\" uri=\"#{license_uri}\">#{license.code}</machine>")
+        use_node.add_child("<human type=\"creativeCommons\">#{license.label}</human>")
+      when %r{://opendatacommons.org/}
+        use_node.add_child("<machine type=\"openDataCommons\" uri=\"#{license_uri}\">#{license.code}</machine>")
+        use_node.add_child("<human type=\"openDataCommons\">#{license.label}</human>")
+      end
+      original.to_xml
+    end
+  end
+end

--- a/config/initializers/rights_metadata_monkeypatch.rb
+++ b/config/initializers/rights_metadata_monkeypatch.rb
@@ -5,52 +5,11 @@ module Dor
   #
   # We rely on them when mapping to Cocina
   class RightsMetadataDS < ActiveFedora::OmDatastream
-    define_template :creative_commons do |xml|
-      xml.human(type: 'creativeCommons')
-      xml.machine(type: 'creativeCommons', uri: '')
-    end
-
-    define_template :open_data_commons do |xml|
-      xml.human(type: 'openDataCommons')
-      xml.machine(type: 'openDataCommons', uri: '')
-    end
-
     define_template(:use, &:use)
   end
 
   # Overwrite some definitions on the DefaultObjectRightsDS (used in AdminPolicies)
   class DefaultObjectRightsDS < ActiveFedora::OmDatastream
-    # Here we patch in the "use" node definition.
-    set_terminology do |t|
-      t.root path: 'rightsMetadata', index_as: [:not_searchable]
-      t.copyright path: 'copyright/human', index_as: [:symbol]
-      t.use_statement path: '/use/human[@type=\'useAndReproduction\']', index_as: [:symbol]
-
-      t.use do
-        t.machine
-        t.human
-      end
-
-      t.creative_commons path: '/use/machine[@type=\'creativeCommons\']', type: 'creativeCommons' do
-        t.uri path: '@uri'
-      end
-      t.creative_commons_human path: '/use/human[@type=\'creativeCommons\']'
-      t.open_data_commons path: '/use/machine[@type=\'openDataCommons\']', type: 'openDataCommons' do
-        t.uri path: '@uri'
-      end
-      t.open_data_commons_human path: '/use/human[@type=\'openDataCommons\']'
-    end
-
-    define_template :creative_commons do |xml|
-      xml.human(type: 'creativeCommons')
-      xml.machine(type: 'creativeCommons', uri: '')
-    end
-
-    define_template :open_data_commons do |xml|
-      xml.human(type: 'openDataCommons')
-      xml.machine(type: 'openDataCommons', uri: '')
-    end
-
     define_template(:use, &:use)
   end
 end

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -752,7 +752,7 @@ RSpec.describe 'Create object' do
                                         }
                                       },
                                       administrative: {
-                                        defaultObjectRights: default_object_rights,
+                                        defaultObjectRights: expected_default_object_rights,
                                         defaultAccess: {
                                           access: 'location-based',
                                           download: 'location-based',
@@ -798,6 +798,32 @@ RSpec.describe 'Create object' do
            <use>
               <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
               <machine type="openDataCommons" uri="http://opendatacommons.org/licenses/by/1.0/">odc-by</machine>
+              <human type="useAndReproduction">Whatever makes you happy</human>
+           </use>
+           <copyright>
+              <human>My copyright statement</human>
+           </copyright>
+        </rightsMetadata>
+      XML
+    end
+
+    let(:expected_default_object_rights) do
+      <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+
+        <rightsMetadata>
+           <access type="discover">
+              <machine>
+                 <world/>
+              </machine>
+           </access>
+           <access type="read">
+              <machine>
+                 <location>ars</location>
+              </machine>
+           </access>
+           <use>
+              <license>http://opendatacommons.org/licenses/by/1.0/</license>
               <human type="useAndReproduction">Whatever makes you happy</human>
            </use>
            <copyright>

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -979,8 +979,7 @@ RSpec.describe 'Update object' do
               </machine>
            </access>
            <use>
-              <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
-              <machine type="openDataCommons" uri="http://opendatacommons.org/licenses/by/1.0/">odc-by</machine>
+              <license>http://opendatacommons.org/licenses/by/1.0/</license>
               <human type="useAndReproduction">Whatever makes you happy</human>
            </use>
            <copyright>

--- a/spec/services/cocina/from_fedora/access_spec.rb
+++ b/spec/services/cocina/from_fedora/access_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Cocina::FromFedora::Access do
   let(:item) do
     Dor::Collection.new
   end
-  let(:rights_metadata_ds) { Dor::RightsMetadataDS.new.tap { |ds| ds.content = xml } }
+  let(:rights_metadata_ds) { Dor::RightsMetadataDS.from_xml(xml) }
 
   before do
     allow(item).to receive(:rightsMetadata).and_return(rights_metadata_ds)

--- a/spec/services/cocina/from_fedora/license_spec.rb
+++ b/spec/services/cocina/from_fedora/license_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::FromFedora::License do
+  subject(:license) { described_class.find(rights_metadata_ds) }
+
+  let(:rights_metadata_ds) { Dor::RightsMetadataDS.from_xml(xml) }
+  let(:xml) do
+    <<~XML
+      <?xml version="1.0"?>
+      <rightsMetadata>
+        #{use}
+      </rightsMetadata>
+    XML
+  end
+
+  describe 'with the license node' do
+    let(:use) { '<use><license>https://spdx.org/licenses/Apache-2.0</license></use>' }
+
+    it 'finds the license' do
+      expect(license).to eq 'https://spdx.org/licenses/Apache-2.0'
+    end
+  end
+
+  describe 'with the machine uri attribute' do
+    let(:use) do
+      <<~XML
+        <use>
+          <machine type="creativeCommons" uri="https://creativecommons.org/licenses/by-sa/4.0/">by-sa</machine>
+        </use>
+      XML
+    end
+
+    it 'finds the license' do
+      expect(license).to eq 'https://creativecommons.org/licenses/by-sa/4.0/'
+    end
+  end
+
+  describe 'with the an empty machine uri attribute' do
+    let(:use) do
+      <<~XML
+        <use>
+          <machine type="creativeCommons" uri=""></machine>
+          <machine type="openDataCommons">odc-by</machine>
+        </use>
+      XML
+    end
+
+    it 'finds the license' do
+      expect(license).to eq 'http://opendatacommons.org/licenses/by/1.0/'
+    end
+  end
+
+  describe 'with just a code' do
+    let(:use) do
+      <<~XML
+        <use>
+          <human type="creativeCommons">CC-BY SA 4.0</human>
+          <machine type="creativeCommons">by-sa</machine>
+        </use>
+      XML
+    end
+
+    it 'finds the license' do
+      expect(license).to eq 'https://creativecommons.org/licenses/by-sa/3.0/'
+    end
+  end
+
+  describe 'with none (to support some non-compliant legacy ETDs)' do
+    let(:use) do
+      <<~XML
+        <use>
+          <machine type="creativeCommons">none</machine>
+          <machine type="openDataCommons"></machine>
+        </use>
+      XML
+    end
+
+    it 'finds the license' do
+      expect(license).to eq 'http://cocina.sul.stanford.edu/licenses/none'
+    end
+  end
+end

--- a/spec/services/cocina/to_fedora/access_spec.rb
+++ b/spec/services/cocina/to_fedora/access_spec.rb
@@ -137,10 +137,7 @@ RSpec.describe Cocina::ToFedora::Access do
           </access>
           <use>
             <human type="useAndReproduction"/>
-            <human type="creativeCommons"/>
-            <machine type="creativeCommons" uri=""/>
-            <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
-            <machine type="openDataCommons" uri="http://opendatacommons.org/licenses/by/1.0/">odc-by</machine>
+            <license>http://opendatacommons.org/licenses/by/1.0/</license>
           </use>
           <copyright>
             <human/>
@@ -166,10 +163,7 @@ RSpec.describe Cocina::ToFedora::Access do
           </access>
           <use>
             <human type="useAndReproduction"/>
-            <human type="creativeCommons">Attribution Non-Commercial, No Derivatives 3.0 Unported</human>
-            <machine type="creativeCommons" uri="https://creativecommons.org/licenses/by-nc-nd/3.0/">by-nc-nd</machine>
-            <human type="openDataCommons"/>
-            <machine type="openDataCommons" uri=""/>
+            <license>https://creativecommons.org/licenses/by-nc-nd/3.0/</license>
           </use>
           <copyright>
             <human/>
@@ -201,10 +195,7 @@ RSpec.describe Cocina::ToFedora::Access do
           </access>
           <use>
             <human type="useAndReproduction"/>
-            <human type="creativeCommons">Attribution Non-Commercial, No Derivatives 3.0 Unported</human>
-            <machine type="creativeCommons" uri="https://creativecommons.org/licenses/by-nc-nd/3.0/">by-nc-nd</machine>
-            <human type="openDataCommons"/>
-            <machine type="openDataCommons" uri=""/>
+            <license>https://creativecommons.org/licenses/by-nc-nd/3.0/</license>
           </use>
           <copyright>
             <human/>
@@ -236,10 +227,7 @@ RSpec.describe Cocina::ToFedora::Access do
           </access>
           <use>
             <human type="useAndReproduction"/>
-            <human type="creativeCommons"/>
-            <machine type="creativeCommons" uri=""/>
-            <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
-            <machine type="openDataCommons" uri="http://opendatacommons.org/licenses/by/1.0/">odc-by</machine>
+            <license>http://opendatacommons.org/licenses/by/1.0/</license>
           </use>
           <copyright>
             <human/>
@@ -271,10 +259,7 @@ RSpec.describe Cocina::ToFedora::Access do
           </access>
           <use>
             <human type="useAndReproduction"/>
-            <human type="creativeCommons">no Creative Commons (CC) license</human>
-            <machine type="creativeCommons" uri="">none</machine>
-            <human type="openDataCommons"/>
-            <machine type="openDataCommons" uri=""/>
+            <license>http://cocina.sul.stanford.edu/licenses/none</license>
           </use>
           <copyright>
             <human/>

--- a/spec/services/cocina/to_fedora/default_rights_spec.rb
+++ b/spec/services/cocina/to_fedora/default_rights_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe Cocina::ToFedora::DefaultRights do
   describe 'write' do
     subject(:write) { described_class.write(default_object_rights_ds, default_access) }
 
+    let(:license_nodes) { default_object_rights_ds.ng_xml.xpath('//use/license') }
+    let(:license) { license_nodes.text }
+
     context 'when license is not present' do
       let(:default_access) do
         Cocina::Models::AdminPolicyDefaultAccess.new(
@@ -21,7 +24,7 @@ RSpec.describe Cocina::ToFedora::DefaultRights do
 
       it 'builds the xml' do
         write
-        expect(default_object_rights_ds.use_license).to be_nil
+        expect(license_nodes).to be_empty
       end
     end
 
@@ -36,7 +39,7 @@ RSpec.describe Cocina::ToFedora::DefaultRights do
 
       it 'builds the xml' do
         write
-        expect(default_object_rights_ds.use_license).to eq 'pdm'
+        expect(license).to eq 'https://creativecommons.org/publicdomain/mark/1.0/'
       end
     end
 
@@ -51,7 +54,7 @@ RSpec.describe Cocina::ToFedora::DefaultRights do
 
       it 'builds the xml' do
         write
-        expect(default_object_rights_ds.use_license).to eq 'pddl'
+        expect(license).to eq 'http://opendatacommons.org/licenses/pddl/1.0/'
       end
     end
   end

--- a/spec/services/cocina/to_fedora/dro_access_spec.rb
+++ b/spec/services/cocina/to_fedora/dro_access_spec.rb
@@ -56,10 +56,7 @@ RSpec.describe Cocina::ToFedora::DROAccess do
           </access>
           <use>
             <human type="useAndReproduction">New Use Statement</human>
-            <human type="creativeCommons"/>
-            <machine type="creativeCommons" uri=""/>
-            <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
-            <machine type="openDataCommons" uri="http://opendatacommons.org/licenses/by/1.0/">odc-by</machine>
+            <license>http://opendatacommons.org/licenses/by/1.0/</license>
           </use>
           <copyright>
             <human>New Copyright Statement</human>
@@ -129,10 +126,7 @@ RSpec.describe Cocina::ToFedora::DROAccess do
           </access>
           <use>
             <human type="useAndReproduction"/>
-            <human type="creativeCommons">Attribution Non-Commercial, No Derivatives 3.0 Unported</human>
-            <machine type="creativeCommons" uri="https://creativecommons.org/licenses/by-nc-nd/3.0/">by-nc-nd</machine>
-            <human type="openDataCommons"/>
-            <machine type="openDataCommons" uri=""/>
+            <license>https://creativecommons.org/licenses/by-nc-nd/3.0/</license>
           </use>
           <copyright>
             <human/>
@@ -164,10 +158,7 @@ RSpec.describe Cocina::ToFedora::DROAccess do
           </access>
           <use>
             <human type="useAndReproduction"/>
-            <human type="creativeCommons"/>
-            <machine type="creativeCommons" uri=""/>
-            <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
-            <machine type="openDataCommons" uri="http://opendatacommons.org/licenses/by/1.0/">odc-by</machine>
+            <license>http://opendatacommons.org/licenses/by/1.0/</license>
           </use>
           <copyright>
             <human/>
@@ -199,10 +190,7 @@ RSpec.describe Cocina::ToFedora::DROAccess do
           </access>
           <use>
             <human type="useAndReproduction"/>
-            <human type="creativeCommons">no Creative Commons (CC) license</human>
-            <machine type="creativeCommons" uri="">none</machine>
-            <human type="openDataCommons"/>
-            <machine type="openDataCommons" uri=""/>
+            <license>http://cocina.sul.stanford.edu/licenses/none</license>
           </use>
           <copyright>
             <human/>

--- a/spec/services/cocina/to_fedora/license_spec.rb
+++ b/spec/services/cocina/to_fedora/license_spec.rb
@@ -17,11 +17,8 @@ RSpec.describe Cocina::ToFedora::License do
       expect(datastream.ng_xml.xpath('//use')).to be_equivalent_to <<~XML
         <use>
            <human type="useAndReproduction"/>
-           <human type="creativeCommons">No Rights Reserved</human>
-           <machine type="creativeCommons" uri="https://creativecommons.org/share-your-work/public-domain/cc0/">cc0</machine>
-           <human type="openDataCommons"/>
-           <machine type="openDataCommons" uri=""/>
-         </use>
+           <license>https://creativecommons.org/share-your-work/public-domain/cc0/</license>
+        </use>
       XML
     end
   end

--- a/spec/services/publish/rights_metadata_spec.rb
+++ b/spec/services/publish/rights_metadata_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Publish::RightsMetadata do
+  subject(:service) { described_class.new(Nokogiri::XML(original)) }
+
+  describe '#to_xml' do
+    subject(:result) { service.to_xml }
+
+    context 'when no license node is present' do
+      let(:original) do
+        <<~XML
+          <rightsMetadata>
+            <use>
+               <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
+               <machine type="openDataCommons" uri="http://opendatacommons.org/licenses/by/1.0/">odc-by</machine>
+               <human type="useAndReproduction">Whatever makes you happy</human>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'returns the original value' do
+        expect(result).to be_equivalent_to(original)
+      end
+    end
+
+    context 'when a open data commons license node is present' do
+      let(:original) do
+        <<~XML
+          <rightsMetadata>
+            <use>
+               <license>http://opendatacommons.org/licenses/by/1.0/</license>
+               <human type="useAndReproduction">Whatever makes you happy</human>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <use>
+               <license>http://opendatacommons.org/licenses/by/1.0/</license>
+               <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
+               <machine type="openDataCommons" uri="http://opendatacommons.org/licenses/by/1.0/">odc-by</machine>
+               <human type="useAndReproduction">Whatever makes you happy</human>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'adds the human and machine nodes' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when a creativecommons license node is present' do
+      let(:original) do
+        <<~XML
+          <rightsMetadata>
+            <use>
+               <license>https://creativecommons.org/licenses/by-nd/4.0/</license>
+               <human type="useAndReproduction">Whatever makes you happy</human>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <use>
+               <license>https://creativecommons.org/licenses/by-nd/4.0/</license>
+               <human type="creativeCommons">Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)</human>
+               <machine type="creativeCommons" uri="https://creativecommons.org/licenses/by-nd/4.0/">by-nd</machine>
+               <human type="useAndReproduction">Whatever makes you happy</human>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'adds the human and machine nodes' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when the "none" license is present' do
+      let(:original) do
+        <<~XML
+          <rightsMetadata>
+            <use>
+               <license>http://cocina.sul.stanford.edu/licenses/none</license>
+               <human type="useAndReproduction">Whatever makes you happy</human>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <use>
+               <license>http://cocina.sul.stanford.edu/licenses/none</license>
+               <human type="creativeCommons">no Creative Commons (CC) license</human>
+               <machine type="creativeCommons">none</machine>
+               <human type="useAndReproduction">Whatever makes you happy</human>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'adds the human and machine nodes' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

This allows us to accept more licenses including the CC 4.0 licenses.  This still preserves how we publish the data to PURL, so although we can now accept all the licenses that H2 accepts, PURL will not yet know how to display them all.

Fixes #2628
Fixes #2592

Once this is merged and deployed we should be able to remediate: https://argo.stanford.edu/view/druid:qk286xn8411

## How was this change tested?



## Which documentation and/or configurations were updated?



