### PR TITLE
Remove remaining let(:druid) statements from specs

### DIFF
--- a/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
@@ -790,9 +790,8 @@ RSpec.describe 'MODS name <--> cocina mappings' do
   end
 
   describe 'Name repeated with different roles' do
+    # based on druid:jr089rh8500
     xit 'unimplemented spec: name repeated with different roles' do
-      let(:druid) { 'druid:jr089rh8500' }
-
       let(:mods) do
         <<~XML
           <name type="personal" usage="primary" valueURI="http://id.loc.gov/authorities/names/no2001053444">
@@ -852,9 +851,8 @@ RSpec.describe 'MODS name <--> cocina mappings' do
   end
 
   describe 'Name and role in different scripts' do
+    # based on druid:jk495jh4582
     xit 'not implemented' do
-      let(:druid) { 'druid:jk495jh4582' }
-
       let(:mods) do
         <<~XML
           <name type="personal" altRepGroup="08">

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_place_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_place_spec.rb
@@ -109,9 +109,8 @@ RSpec.describe 'MODS originInfo place <--> cocina mappings' do
   end
 
   describe 'Place - text and code in same place element, different authority on each' do
+    # based on druid:kn689tm8699
     xit 'not implemented - placeTerm in same place element with different authority' do
-      let(:druid) { 'druid:kn689tm8699' }
-
       let(:mods) do
         <<~XML
           <originInfo displayLabel="Place of creation" eventType="production">

--- a/spec/services/cocina/mapping/descriptive/mods/physical_description_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/physical_description_spec.rb
@@ -155,9 +155,8 @@ RSpec.describe 'MODS physicalDescription <--> cocina mappings' do
   end
 
   describe 'Multilingual physical descriptions' do
+    # based on druid:bx458nk9866
     xit 'not implemented' do
-      let(:druid) { 'druid:bx458nk9866' }
-
       let(:mods) do
         <<~XML
           <physicalDescription altRepGroup="01">

--- a/spec/services/cocina/mapping/descriptive/mods/subject_name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_name_spec.rb
@@ -106,9 +106,8 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
   end
 
   describe 'Name subject with description' do
+    # based on druid:fv368nn6038
     xit 'not implemented - name subject with description' do
-      let(:druid) { 'druid:fv368nn6038' }
-
       let(:mods) do
         <<~XML
           <subject>

--- a/spec/services/cocina/mapping/descriptive/mods/subject_title_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_title_spec.rb
@@ -153,9 +153,8 @@ RSpec.describe 'MODS subject topic <--> cocina mappings' do
   end
 
   describe 'altRepGroup for alternative title (880-246)' do
+    # based on druid:cp165bv2167
     xit 'not implemented' do
-      let(:druid) { 'druid:cp165bv2167' }
-
       let(:mods) do
         <<~XML
           <titleInfo usage="primary">


### PR DESCRIPTION
## Why was this change made?
let(:druid) statements were generating unnecessary data


## How was this change tested?
n/a


## Which documentation and/or configurations were updated?
n/a


