### PR TITLE
Remove blanks when validating descriptive roundtripping.

### DIFF
--- a/app/validators/cocina/description_roundtrip_validator.rb
+++ b/app/validators/cocina/description_roundtrip_validator.rb
@@ -21,8 +21,11 @@ module Cocina
       title_builder = FromFedora::Descriptive::TitleBuilderStrategy.find(label: cocina_object.label)
       roundtrip_description = FromFedora::Descriptive.props(title_builder: title_builder, mods: descriptive_ng_xml, druid: druid)
 
+      # With Rails 6.1, .delete_if can be replace by compact_blank (for deleting empty array).
+      orig_description = cocina_object.description.to_h.delete_if { |_k, v| v.blank? }
+
       # Compare original description against roundtripped Cocina.
-      unless DeepEqual.match?(roundtrip_description, cocina_object.description.to_h)
+      unless DeepEqual.match?(roundtrip_description, orig_description)
         return Failure("Roundtripping of descriptive metadata unsuccessful. Expected #{cocina_object.description.to_h} but received #{roundtrip_description}.")
       end
 

--- a/spec/validators/cocina/description_roundtrip_validator_spec.rb
+++ b/spec/validators/cocina/description_roundtrip_validator_spec.rb
@@ -40,6 +40,18 @@ RSpec.describe Cocina::DescriptionRoundtripValidator do
       end
     end
 
+    context 'when has empty values' do
+      let(:cocina_object) do
+        new_cocina_hash = cocina_hash.dup
+        new_cocina_hash[:description][:relatedResource] = []
+        Cocina::Models::DRO.new(new_cocina_hash)
+      end
+
+      it 'ignores and returns success' do
+        expect(result.success?).to be true
+      end
+    end
+
     context 'when invalid' do
       before do
         changed_cocina_hash = cocina_hash[:description].except(:purl)


### PR DESCRIPTION
closes #2621

## Why was this change made?
Cocina allows empty arrays, which can confuse roundtripping.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


