### PR TITLE
Use the correct URL that matches what is used by Argo

### DIFF
--- a/app/services/publish/rights_metadata.rb
+++ b/app/services/publish/rights_metadata.rb
@@ -17,7 +17,6 @@ module Publish
     # https://github.com/sul-dlss/dor-services/blob/main/lib/dor/services/open_data_license_service.rb
     LICENSE_CODES = {
       Cocina::FromFedora::License::NONE_LICENSE_URI => Resource.new('none', 'no Creative Commons (CC) license'), # Only used in some legacy ETDs.
-      'https://creativecommons.org/share-your-work/public-domain/cc0/' => Resource.new('cc0', 'No Rights Reserved'),
       'https://creativecommons.org/licenses/by/3.0/' => Resource.new('by', 'Attribution 3.0 Unported'),
       'https://creativecommons.org/licenses/by-sa/3.0/' => Resource.new('by-sa', 'Attribution Share Alike 3.0 Unported'),
       'https://creativecommons.org/licenses/by-nd/3.0/' => Resource.new('by-nd', 'Attribution No Derivatives 3.0 Unported'),
@@ -31,6 +30,7 @@ module Publish
       'https://creativecommons.org/licenses/by-nc-sa/4.0/' => Resource.new('by-nc-sa', 'Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)'),
       'https://creativecommons.org/licenses/by-nc-nd/4.0/' => Resource.new('by-nc-nd', 'Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)'),
       'https://creativecommons.org/publicdomain/mark/1.0/' => Resource.new('pdm', 'Public Domain Mark 1.0'),
+      'https://creativecommons.org/publicdomain/zero/1.0/' => Resource.new('cc0', 'No Rights Reserved'),
       'http://opendatacommons.org/licenses/pddl/1.0/' => Resource.new('pddl', 'Open Data Commons Public Domain Dedication and License 1.0'),
       'http://opendatacommons.org/licenses/by/1.0/' => Resource.new('odc-by', 'Open Data Commons Attribution License 1.0'),
       'http://opendatacommons.org/licenses/odbl/1.0/' => Resource.new('odc-odbl', 'Open Data Commons Open Database License 1.0')


### PR DESCRIPTION


## Why was this change made?
https://github.com/sul-dlss/argo/blob/fcec47fbe7d6acb28597f618025613335d713567/app/forms/apo_form.rb#L87


## How was this change tested?



## Which documentation and/or configurations were updated?



