### PR TITLE
notify if names have same altRepGroup but differ in type

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -35,6 +35,7 @@ module Cocina
 
         def build
           grouped_altrepgroup_name_nodes, other_name_nodes = AltRepGroup.split(nodes: deduped_name_nodes)
+          check_altrepgroup_type_inconsistency(grouped_altrepgroup_name_nodes)
           contributors = grouped_altrepgroup_name_nodes.map { |name_nodes| build_name_nodes(name_nodes) } + \
                          other_name_nodes.map { |name_node| build_name_nodes([name_node]) }
           adjust_primary(contributors.compact).presence
@@ -61,6 +62,15 @@ module Cocina
           notifier.warn('Duplicate name entry') if name_nodes.size != uniq_name_nodes.size
 
           uniq_name_nodes
+        end
+
+        def check_altrepgroup_type_inconsistency(grouped_altrepgroup_name_nodes)
+          grouped_altrepgroup_name_nodes.each do |altrepgroup_name_nodes|
+            altrepgroup_name_types = altrepgroup_name_nodes.group_by { |name_node| name_node['type'] }.keys
+            next unless altrepgroup_name_types.size > 1
+
+            notifier.error('Multiple types for same altRepGroup', { types: altrepgroup_name_types })
+          end
         end
 
         def build_name_nodes(name_nodes)


### PR DESCRIPTION
## Why was this change made?

fixes #2456

## How was this change tested?

unit tests, roundtrip validation on sdr-deploy (as expected, numbers remain unchanged, since this only adds notification for bad data):
```
[deploy@sdr-deploy dor-services-app]$ bin/validate-desc-cocina-roundtrip -s 100000 
Testing |Time: 00:10:27 | ================================================================================== | Time: 00:10:27
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99346 (99.776%)
  Different: 223 (0.224%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     431 (0.431%)
[deploy@sdr-deploy dor-services-app]$ 
[deploy@sdr-deploy dor-services-app]$ git checkout 2456-notify-on-names-same-altRepGroup-diff-type
Branch '2456-notify-on-names-same-altRepGroup-diff-type' set up to track remote branch '2456-notify-on-names-same-altRepGroup-diff-type' from 'origin'.
Switched to a new branch '2456-notify-on-names-same-altRepGroup-diff-type'
[deploy@sdr-deploy dor-services-app]$ 
[deploy@sdr-deploy dor-services-app]$ bin/validate-desc-cocina-roundtrip -s 100000 
Testing |Time: 00:05:00 | ================================================================================== | Time: 00:05:00
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99346 (99.776%)
  Different: 223 (0.224%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     431 (0.431%)
[deploy@sdr-deploy dor-services-app]$ 
```

## Which documentation and/or configurations were updated?

n/a

