### PR TITLE
tweak mapping of parallel title value types

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -61,7 +61,6 @@ module Cocina
         end
 
         def display_types?(node_set)
-          return false if node_set.all? { |node| node['type'] == 'translated' || node['usage'] == 'primary' }
           return false if node_set.all? { |node| node['type'] == 'uniform' }
 
           true

--- a/app/services/cocina/to_fedora/descriptive/title.rb
+++ b/app/services/cocina/to_fedora/descriptive/title.rb
@@ -69,6 +69,7 @@ module Cocina
         end
 
         # rubocop:disable Metrics/PerceivedComplexity
+        # rubocop:disable Metrics/AbcSize
         def write_parallel(title:, title_info_attrs: {})
           title_alt_rep_group = id_generator.next_altrepgroup
 
@@ -84,7 +85,7 @@ module Cocina
             elsif title.parallelValue.any? { |parallel_value| parallel_value.status == 'primary' }
               if parallel_title.status == 'primary'
                 parallel_attrs[:usage] = 'primary'
-              else
+              elsif parallel_title.type == 'translated'
                 parallel_attrs[:type] = 'translated'
               end
             end
@@ -98,6 +99,7 @@ module Cocina
           end
         end
         # rubocop:enable Metrics/PerceivedComplexity
+        # rubocop:enable Metrics/AbcSize
 
         def write_grouped(title:, title_info_attrs: {})
           title.groupedValue.each { |grouped_title| write_basic(title: grouped_title, title_info_attrs: title_info_attrs) }

--- a/spec/services/cocina/mapping/descriptive/mods/title_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/title_info_spec.rb
@@ -149,7 +149,8 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
                     source: {
                       code: 'iso639-2b'
                     }
-                  }
+                  },
+                  type: 'translated'
                 }
               ]
             }
@@ -227,7 +228,8 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
                     source: {
                       code: 'iso639-2b'
                     }
-                  }
+                  },
+                  type: 'translated'
                 }
               ]
             }


### PR DESCRIPTION
* stricter check when mapping cocina `title` `parallelValue` `type` info back to fedora/MODS `titleInfo` `type` attribute
* relax restriction on when MODS `titleInfo` `type` attribute value is included in cocina `title` `parallelValue` element

## Why was this change made?

fixes #2658

## How was this change tested?

unit tests, roundtrip validation script on sdr-deploy

```
[deploy@sdr-deploy dor-services-app]$ bin/validate-desc-cocina-roundtrip -s 500000
Testing |Time: 00:46:08 | ================================================================================== | Time: 00:46:08
Status (n=500000; not using Missing for success/different/error stats):
  Success:   496618 (99.791%)
  Different: 1042 (0.209%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     2340 (0.468%)
[deploy@sdr-deploy dor-services-app]$ 
[deploy@sdr-deploy dor-services-app]$ git status
On branch main
Your branch is up to date with 'origin/main'.
[deploy@sdr-deploy dor-services-app]$ 
[deploy@sdr-deploy dor-services-app]$ git checkout 2658-stricter-translated-check
Branch '2658-stricter-translated-check' set up to track remote branch '2658-stricter-translated-check' from 'origin'.
Switched to a new branch '2658-stricter-translated-check'
[deploy@sdr-deploy dor-services-app]$ 
[deploy@sdr-deploy dor-services-app]$ bin/validate-desc-cocina-roundtrip -s 500000
Testing |Time: 00:31:09 | ================================================================================== | Time: 00:31:09
Status (n=500000; not using Missing for success/different/error stats):
  Success:   497534 (99.975%)
  Different: 126 (0.025%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     2340 (0.468%)
[deploy@sdr-deploy dor-services-app]$ 
```

looks like a nice improvement when tested on 500k objects (down to 126 different, from 1042)

## Which documentation and/or configurations were updated?

n/a