### PR TITLE
Match Cocina structures as JSON but give hashes to SuperDiff

### DIFF
--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'Create object' do
         post '/v1/objects',
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
         expect(response.status).to eq(201)
         expect(response.location).to eq "/v1/objects/#{druid}"
         expect(MetadataService).to have_received(:fetch).with('catkey:8888')
@@ -124,7 +124,7 @@ RSpec.describe 'Create object' do
         post '/v1/objects',
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
 
         expect(response.status).to eq(201)
         expect(response.location).to eq "/v1/objects/#{druid}"
@@ -177,7 +177,7 @@ RSpec.describe 'Create object' do
         post '/v1/objects',
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
         expect(response.status).to eq(201)
         expect(response.location).to eq "/v1/objects/#{druid}"
       end
@@ -218,7 +218,7 @@ RSpec.describe 'Create object' do
         post '/v1/objects',
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
         expect(response.status).to eq(201)
         expect(response.location).to eq "/v1/objects/#{druid}"
       end

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe 'Create object' do
                  headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
           end.to change(Event, :count).by(1)
           expect(a_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:gg777gg7777')).to have_been_made
-          expect(response.body).to eq expected.to_json
+          expect(response.body).to equal_cocina_model(expected)
           expect(response.status).to eq(201)
           expect(response.location).to eq "/v1/objects/#{druid}"
           expect(MetadataService).to have_received(:fetch).with('catkey:8888')
@@ -184,7 +184,7 @@ RSpec.describe 'Create object' do
                params: data,
                headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
           expect(a_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:gg777gg7777')).to have_been_made
-          expect(response.body).to eq expected.to_json
+          expect(response.body).to equal_cocina_model(expected)
           expect(response.status).to eq(201)
           expect(response.location).to eq "/v1/objects/#{druid}"
 
@@ -220,7 +220,7 @@ RSpec.describe 'Create object' do
                params: data,
                headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
           expect(a_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:gg777gg7777')).to have_been_made
-          expect(response.body).to eq expected.to_json
+          expect(response.body).to equal_cocina_model(expected)
           expect(response.status).to eq(201)
           expect(response.location).to eq "/v1/objects/#{druid}"
 
@@ -288,7 +288,6 @@ RSpec.describe 'Create object' do
               'type' => 'md5',
               'digest' => 'e6d52da47a5ade91ae31227b978fb023'
             }
-
           ]
         }
       end
@@ -469,8 +468,7 @@ RSpec.describe 'Create object' do
                   source_id: 'googlebooks:999999',
                   collection_ids: [],
                   catkey: nil, label: 'This is my label')
-
-          expect(response.body).to eq expected.to_json
+          expect(response.body).to equal_cocina_model(expected)
           expect(response.status).to eq(201)
           expect(item.contentMetadata.resource.file.count).to eq 4
           expect(response.location).to eq "/v1/objects/#{druid}"
@@ -528,7 +526,7 @@ RSpec.describe 'Create object' do
                 source_id: 'googlebooks:999999',
                 collection_ids: ['druid:xx888xx7777'],
                 catkey: nil, label: 'This is my label')
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
         expect(response.status).to eq(201)
         expect(response.location).to eq "/v1/objects/#{druid}"
       end
@@ -613,7 +611,7 @@ RSpec.describe 'Create object' do
         post '/v1/objects',
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
         expect(response.status).to eq(201)
         expect(response.location).to eq "/v1/objects/#{druid}"
         expect(a_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:gg777gg7777')).to have_been_made
@@ -664,7 +662,7 @@ RSpec.describe 'Create object' do
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
         expect(a_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:gg777gg7777')).to have_been_made
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
         expect(response.status).to eq(201)
         expect(response.location).to eq "/v1/objects/#{druid}"
 
@@ -731,7 +729,7 @@ RSpec.describe 'Create object' do
       post '/v1/objects',
            params: data,
            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-      expect(response.body).to eq expected.to_json
+      expect(response.body).to equal_cocina_model(expected)
       expect(response.status).to eq(201)
       expect(response.location).to eq "/v1/objects/#{druid}"
     end
@@ -867,7 +865,7 @@ RSpec.describe 'Create object' do
         post '/v1/objects',
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
 
         expect(response.status).to eq(201)
         expect(response.location).to eq "/v1/objects/#{druid}"
@@ -888,8 +886,9 @@ RSpec.describe 'Create object' do
         post '/v1/objects',
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
         expect(UrAdminPolicyFactory).to have_received(:create)
+
         expect(response.status).to eq(201)
         expect(response.location).to eq "/v1/objects/#{druid}"
       end
@@ -945,7 +944,7 @@ RSpec.describe 'Create object' do
         post '/v1/objects',
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
 
         expect(response.status).to eq(201)
         expect(response.location).to eq "/v1/objects/#{druid}"
@@ -1003,7 +1002,7 @@ RSpec.describe 'Create object' do
       post '/v1/objects',
            params: data,
            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-      expect(response.body).to eq expected.to_json
+      expect(response.body).to equal_cocina_model(expected)
       expect(response.status).to eq(201)
       expect(response.location).to eq '/v1/objects/druid:gg777gg7777'
     end
@@ -1059,7 +1058,7 @@ RSpec.describe 'Create object' do
       post '/v1/objects',
            params: data,
            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-      expect(response.body).to eq expected.to_json
+      expect(response.body).to equal_cocina_model(expected)
       expect(response.status).to eq(201)
       expect(response.location).to eq '/v1/objects/druid:gg777gg7777'
     end
@@ -1115,7 +1114,7 @@ RSpec.describe 'Create object' do
            params: data,
            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
 
-      expect(response.body).to eq expected.to_json
+      expect(response.body).to equal_cocina_model(expected)
       expect(response.status).to eq(201)
       expect(response.location).to eq '/v1/objects/druid:gg777gg7777'
     end
@@ -1162,7 +1161,7 @@ RSpec.describe 'Create object' do
         post '/v1/objects',
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
         expect(response.status).to eq(201)
         expect(response.location).to eq '/v1/objects/druid:gg777gg7777'
       end
@@ -1203,7 +1202,7 @@ RSpec.describe 'Create object' do
         post '/v1/objects',
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
         expect(response.status).to eq(201)
         expect(response.location).to eq '/v1/objects/druid:gg777gg7777'
       end
@@ -1274,7 +1273,7 @@ RSpec.describe 'Create object' do
         post '/v1/objects',
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
         expect(response.status).to eq(201)
         expect(response.location).to eq '/v1/objects/druid:gg777gg7777'
       end
@@ -1322,7 +1321,7 @@ RSpec.describe 'Create object' do
       post '/v1/objects',
            params: data,
            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-      expect(response.body).to eq expected.to_json
+      expect(response.body).to equal_cocina_model(expected)
       expect(response.status).to eq(201)
       expect(response.location).to eq '/v1/objects/druid:gg777gg7777'
       expect(AdministrativeTags).not_to have_received(:create)
@@ -1370,7 +1369,7 @@ RSpec.describe 'Create object' do
       post '/v1/objects',
            params: data,
            headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-      expect(response.body).to eq expected.to_json
+      expect(response.body).to equal_cocina_model(expected)
       expect(response.status).to eq(201)
       expect(response.location).to eq '/v1/objects/druid:gg777gg7777'
       expect(AdministrativeTags).to have_received(:create).with(pid: 'druid:gg777gg7777',

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe 'Update object' do
     expect(response.status).to eq(200)
     expect(item).to have_received(:save!)
     expect(item).to have_received(:admin_policy_object_id=).with(apo_druid)
-    expect(response.body).to eq expected.to_json
+    expect(response.body).to equal_cocina_model(expected)
 
     # Tags are created.
     expect(AdministrativeTags).to have_received(:create).with(pid: druid, tags: ['Process : Content Type : Book (rtl)'])
@@ -180,7 +180,7 @@ RSpec.describe 'Update object' do
               headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
         expect(response.status).to eq(200)
         expect(item).to have_received(:save!)
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
       end
     end
 
@@ -345,7 +345,7 @@ RSpec.describe 'Update object' do
             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
       expect(response.status).to eq(200)
       expect(item).to have_received(:save!)
-      expect(response.body).to eq expected.to_json
+      expect(response.body).to equal_cocina_model(expected)
     end
   end
 
@@ -378,7 +378,7 @@ RSpec.describe 'Update object' do
             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
       expect(response.status).to eq(200)
       expect(item).to have_received(:save!)
-      expect(response.body).to eq expected.to_json
+      expect(response.body).to equal_cocina_model(expected)
     end
   end
 
@@ -394,7 +394,7 @@ RSpec.describe 'Update object' do
             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
       expect(response.status).to eq(200)
       expect(item).to have_received(:save!)
-      expect(response.body).to eq expected.to_json
+      expect(response.body).to equal_cocina_model(expected)
 
       # Tags are updated.
       expect(AdministrativeTags).not_to have_received(:create)
@@ -414,7 +414,7 @@ RSpec.describe 'Update object' do
             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
       expect(response.status).to eq(200)
       expect(item).to have_received(:save!)
-      expect(response.body).to eq expected.to_json
+      expect(response.body).to equal_cocina_model(expected)
 
       # Tags are not updated or created.
       expect(AdministrativeTags).not_to have_received(:create)
@@ -540,7 +540,7 @@ RSpec.describe 'Update object' do
         patch "/v1/objects/#{druid}",
               params: data,
               headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
         expect(response.status).to eq 200
 
         # Identity metadata set correctly.
@@ -560,7 +560,7 @@ RSpec.describe 'Update object' do
         patch "/v1/objects/#{druid}",
               params: data,
               headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
         expect(response.status).to eq(200)
       end
     end
@@ -781,7 +781,7 @@ RSpec.describe 'Update object' do
           patch "/v1/objects/#{druid}",
                 params: data,
                 headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-          expect(response.body).to eq expected.to_json
+          expect(response.body).to equal_cocina_model(expected)
           expect(response.status).to eq(200)
           expect(item.contentMetadata.resource.file.count).to eq 4
         end
@@ -829,7 +829,7 @@ RSpec.describe 'Update object' do
         patch "/v1/objects/#{druid}",
               params: data,
               headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
         expect(response.status).to eq(200)
       end
     end
@@ -893,7 +893,7 @@ RSpec.describe 'Update object' do
             params: data,
             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
 
-      expect(response.body).to eq expected.to_json
+      expect(response.body).to equal_cocina_model(expected)
       expect(response.status).to eq(200)
     end
   end
@@ -948,7 +948,7 @@ RSpec.describe 'Update object' do
       patch "/v1/objects/#{druid}",
             params: data,
             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-      expect(response.body).to eq expected.to_json
+      expect(response.body).to equal_cocina_model(expected)
       expect(response.status).to eq(200)
     end
   end
@@ -1066,7 +1066,7 @@ RSpec.describe 'Update object' do
         patch "/v1/objects/#{druid}",
               params: data,
               headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
 
         expect(response.status).to eq(200)
       end
@@ -1114,7 +1114,7 @@ RSpec.describe 'Update object' do
         patch "/v1/objects/#{druid}",
               params: data,
               headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to eq expected.to_json
+        expect(response.body).to equal_cocina_model(expected)
 
         expect(response.status).to eq(200)
       end
@@ -1172,7 +1172,7 @@ RSpec.describe 'Update object' do
       patch "/v1/objects/#{druid}",
             params: data,
             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-      expect(response.body).to eq expected.to_json
+      expect(response.body).to equal_cocina_model(expected)
       expect(response.status).to eq(200)
     end
   end

--- a/spec/support/cocina_matchers.rb
+++ b/spec/support/cocina_matchers.rb
@@ -1,0 +1,39 @@
+# typed: true
+# frozen_string_literal: true
+
+# Provides RSpec matchers for Cocina models
+module CocinaMatchers
+  extend RSpec::Matchers::DSL
+
+  # The `equal_cocina_model` matcher compares a JSON string as actual value
+  # against a Cocina model coerced to JSON as expected value. We want to compare
+  # these as JSON rather than as hashes, else we'll have to start
+  # deep-converting some values within the hashes, thinking of date/time values
+  # in particular. This matching behavior continues what dor-services-app was
+  # already doing before this custom matcher was written.
+  #
+  # Note, though, that when actual and expected values do *not* match, we coerce
+  # both values to hashes to allow the `super_diff` gem to highlight the areas
+  # that differ. This is easier to scan than two giant JSON strings.
+  matcher :equal_cocina_model do |expected|
+    match do |actual|
+      actual == expected.to_json
+    rescue NoMethodError
+      warn "Could not match cocina models because expected is not a valid JSON string: #{expected}"
+      false
+    end
+
+    failure_message do |actual|
+      SuperDiff::EqualityMatchers::Hash.new(
+        expected: expected.to_h.deep_symbolize_keys,
+        actual: JSON.parse(actual, symbolize_names: true)
+      ).fail
+    rescue StandardError => e
+      "ERROR in CocinaMatchers: #{e}"
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include CocinaMatchers, type: :request
+end


### PR DESCRIPTION

## Why was this change made?

The `equal_cocina_model` matcher compares a JSON string as actual value against a Cocina model coerced to JSON as expected value. We want to compare these as JSON rather than as hashes, else we'll have to start deep-converting some values within the hashes, thinking of date/time values in particular. This matching behavior continues what dor-services-app was already doing before this custom matcher was written.

Note, though, that when actual and expected values do *not* match, we coerce both values to hashes to allow the `super_diff` gem to highlight the areas that differ. This is easier to scan than two giant JSON strings.


## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

