### PR TITLE
print current branch info with roundtrip test results

### DIFF
--- a/bin/validate-desc-cocina-roundtrip
+++ b/bin/validate-desc-cocina-roundtrip
@@ -174,6 +174,14 @@ def percentage(raw_num, denom)
   (100 * raw_num.to_f / denom).round(3)
 end
 
+def branch_name
+  `git rev-parse --abbrev-ref HEAD`.strip
+end
+
+def short_commit_hash
+  `git rev-parse --short HEAD`.strip
+end
+
 unless options[:fast]
   FileUtils.rm_rf('results')
   FileUtils.mkdir_p('results')
@@ -187,6 +195,7 @@ else
   druids = options[:druids]
 end
 
+puts "On branch name: #{branch_name} (commit: #{short_commit_hash})..."
 results = Parallel.map(druids, progress: 'Testing') do |druid|
   validate_druid(druid, cache, fast: options[:fast])
 end


### PR DESCRIPTION
## Why was this change made?

for easier skimming when coming back to test output, and easier visual comparison of results copied from different runs (i.e., assuage my own OCD tendencies)

## How was this change tested?

small run on sdr-deploy:
```
[deploy@sdr-deploy dor-services-app]$ bin/validate-desc-cocina-roundtrip -s 1
warning: parser/current is loading parser/ruby27, which recognizes
warning: 2.7.2-compliant syntax, but you are running 2.7.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
/opt/app/deploy/sdr-deploy/shared/bundle/ruby/2.7.0/gems/actionpack-5.2.5/lib/action_dispatch/middleware/stack.rb:37: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/opt/app/deploy/sdr-deploy/shared/bundle/ruby/2.7.0/gems/actionpack-5.2.5/lib/action_dispatch/middleware/static.rb:111: warning: The called method `initialize' is defined here
On branch name: branch-info_validate-desc-cocina-roundtrip (commit: 5f49196f)...
Testing |Time: 00:00:00 | ================================================================================== | Time: 00:00:00
Status (n=1; not using Missing for success/different/error stats):
  Success:   1 (100.0%)
  Different: 0 (0.0%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     0 (0.0%)
[deploy@sdr-deploy dor-services-app]$ 
```

## Which documentation and/or configurations were updated?

n/a
