### PR TITLE
Revert "Add shared-mime-info to the dockerfile"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN apk add --update --no-cache  \
   git \
   postgresql-dev \
   postgresql-client \
-  shared-mime-info \
   tzdata
 
 # Get bundler 2.0


### PR DESCRIPTION
This reverts commit 5d886e05d7f282a13566b4385aeee4c9d01b6d43.

## Why was this change made?

This is no longer necessary now that mimemagic is no longer in the Gemfile.lock

## How was this change tested?



## Which documentation and/or configurations were updated?



