### PR TITLE
Adjust the public XML sent to purl to have the new license tag sent

### DIFF
--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -36,7 +36,7 @@ module Publish
         transfer_to_document_store(item.datastreams[stream].content.to_s, stream) if item.datastreams[stream]
       end
 
-      transfer_to_document_store(RightsMetadata.new(item.rightsMetadata.ng_xml).to_xml, 'rightsMetadata')
+      transfer_to_document_store(RightsMetadata.new(item.rightsMetadata.ng_xml).create.to_xml, 'rightsMetadata')
       transfer_to_document_store(PublicXmlService.new(item, released_for: release_tags).to_xml, 'public')
       transfer_to_document_store(PublicDescMetadataService.new(item).to_xml, 'mods')
     end

--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -63,7 +63,7 @@ module Publish
     end
 
     def public_rights_metadata
-      @public_rights_metadata ||= object.datastreams['rightsMetadata'].ng_xml.clone
+      @public_rights_metadata ||= RightsMetadata.new(object.rightsMetadata.ng_xml).create
     end
 
     def public_identity_metadata

--- a/app/services/publish/rights_metadata.rb
+++ b/app/services/publish/rights_metadata.rb
@@ -36,10 +36,10 @@ module Publish
       'http://opendatacommons.org/licenses/odbl/1.0/' => Resource.new('odc-odbl', 'Open Data Commons Open Database License 1.0')
     }.freeze
 
-    # @return [String] the original xml with the legacy style rights added so that the description can be displayed.
-    def to_xml
+    # @return [Nokogiri::Xml] the original xml with the legacy style rights added so that the description can be displayed.
+    def create
       license_uri = original.xpath('/rightsMetadata/use/license').text.presence
-      return original.to_xml unless license_uri && LICENSE_CODES.key?(license_uri)
+      return original.clone unless license_uri && LICENSE_CODES.key?(license_uri)
 
       use_node = original.xpath('/rightsMetadata/use').first
       license = LICENSE_CODES.fetch(license_uri)
@@ -54,7 +54,7 @@ module Publish
         use_node.add_child("<machine type=\"openDataCommons\" uri=\"#{license_uri}\">#{license.code}</machine>")
         use_node.add_child("<human type=\"openDataCommons\">#{license.label}</human>")
       end
-      original.to_xml
+      original.clone
     end
   end
 end

--- a/spec/services/publish/rights_metadata_spec.rb
+++ b/spec/services/publish/rights_metadata_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe Publish::RightsMetadata do
   subject(:service) { described_class.new(Nokogiri::XML(original)) }
 
-  describe '#to_xml' do
-    subject(:result) { service.to_xml }
+  describe '#create' do
+    subject(:result) { service.create }
 
     context 'when no license node is present' do
       let(:original) do


### PR DESCRIPTION


## Why was this change made?

Previously we were adjusting the rightsMetadata.xml, but purl doesn't use that. It uses the rightsMetadata inside the public xml

## How was this change tested?



## Which documentation and/or configurations were updated?



