### PR TITLE
Don't publish files that purl doesn't use

### DIFF
--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -29,20 +29,10 @@ module Publish
     attr_reader :item
 
     # @raise [Dor::DataError]
-    # rubocop:disable Metrics/AbcSize
     def transfer_metadata(release_tags)
-      transfer_to_document_store(DublinCoreService.new(item).ng_xml.to_xml(&:no_declaration), 'dc')
-
-      %w[identityMetadata contentMetadata].each do |stream|
-        transfer_to_document_store(item.datastreams[stream].content.to_s, stream) if item.datastreams[stream]
-      end
-
-      release_date = item.is_a?(Dor::Item) && item.embargoMetadata.status == 'embargoed' ? item.embargoMetadata.release_date : nil
-      transfer_to_document_store(RightsMetadata.new(item.rightsMetadata.ng_xml, release_date: release_date).create.to_xml, 'rightsMetadata')
       transfer_to_document_store(PublicXmlService.new(item, released_for: release_tags).to_xml, 'public')
       transfer_to_document_store(PublicDescMetadataService.new(item).to_xml, 'mods')
     end
-    # rubocop:enable Metrics/AbcSize
 
     # Clear out the document cache for this item
     def unpublish

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -96,10 +96,6 @@ RSpec.describe Publish::MetadataTransferService do
 
       context 'with an item' do
         before do
-          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<identityMetadata/, 'identityMetadata')
-          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<contentMetadata/, 'contentMetadata')
-          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<rightsMetadata/, 'rightsMetadata')
-          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<oai_dc:dc/, 'dc')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<publicObject/, 'public')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<mods:mods/, 'mods')
           expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(no_args)
@@ -112,7 +108,6 @@ RSpec.describe Publish::MetadataTransferService do
         it 'identityMetadta, contentMetadata, rightsMetadata, generated dublin core, and public xml' do
           item.rightsMetadata.content = "<rightsMetadata><access type='discover'><machine><world/></machine></access></rightsMetadata>"
           service.publish
-          expect(Publish::DublinCoreService).to have_received(:new).with(item)
           expect(Publish::PublicXmlService).to have_received(:new).with(item, released_for: release_tags)
           expect(Publish::PublicDescMetadataService).to have_received(:new).with(item)
         end
@@ -134,10 +129,6 @@ RSpec.describe Publish::MetadataTransferService do
         end
 
         before do
-          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<identityMetadata/, 'identityMetadata')
-          expect_any_instance_of(described_class).not_to receive(:transfer_to_document_store).with(/<contentMetadata/, 'contentMetadata')
-          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<rightsMetadata/, 'rightsMetadata')
-          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<oai_dc:dc/, 'dc')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<publicObject/, 'public')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<mods:mods/, 'mods')
           expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(no_args)


### PR DESCRIPTION
## Why was this change made?
It's unnecessary complexity.  Purl has no used for these files.


## How was this change tested?



## Which documentation and/or configurations were updated?



