### PR TITLE
Add the embargoReleaseDate to rightsMetadata just as it is sent to purl

### DIFF
--- a/app/services/embargo_service.rb
+++ b/app/services/embargo_service.rb
@@ -23,22 +23,17 @@ class EmbargoService
   def create
     return unless release_date
 
-    # This is set because embargoMetadata datastream is not sent to Purl and
-    # sul-embed needs to know this value: https://github.com/sul-dlss/sul-embed/blob/305b3c12924a3de19040e8c96f3335e9e26ce013/app/models/embed/purl.rb#L54
-    # In the future we could just write this into the rightsMetadata that is transfered
-    # to Purl via the Publish::RightsMetadata service.
-    item.rightsMetadata.embargo_release_date = release_date
-
-    item.embargoMetadata.release_date = release_date
-    item.embargoMetadata.status = 'embargoed'
-
-    item.embargoMetadata.release_access_node = Nokogiri::XML(generic_access_xml)
-    item.embargoMetadata.use_and_reproduction_statement = use_and_reproduction_statement if use_and_reproduction_statement
+    embargoMetadata.release_date = release_date
+    embargoMetadata.status = 'embargoed'
+    embargoMetadata.release_access_node = Nokogiri::XML(generic_access_xml)
+    embargoMetadata.use_and_reproduction_statement = use_and_reproduction_statement if use_and_reproduction_statement
   end
 
   private
 
   attr_reader :item, :release_date, :access, :use_and_reproduction_statement
+
+  delegate :embargoMetadata, to: :item
 
   def generic_access_xml
     <<-XML

--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -29,6 +29,7 @@ module Publish
     attr_reader :item
 
     # @raise [Dor::DataError]
+    # rubocop:disable Metrics/AbcSize
     def transfer_metadata(release_tags)
       transfer_to_document_store(DublinCoreService.new(item).ng_xml.to_xml(&:no_declaration), 'dc')
 
@@ -36,10 +37,12 @@ module Publish
         transfer_to_document_store(item.datastreams[stream].content.to_s, stream) if item.datastreams[stream]
       end
 
-      transfer_to_document_store(RightsMetadata.new(item.rightsMetadata.ng_xml).create.to_xml, 'rightsMetadata')
+      release_date = item.is_a?(Dor::Item) && item.embargoMetadata.status == 'embargoed' ? item.embargoMetadata.release_date : nil
+      transfer_to_document_store(RightsMetadata.new(item.rightsMetadata.ng_xml, release_date: release_date).create.to_xml, 'rightsMetadata')
       transfer_to_document_store(PublicXmlService.new(item, released_for: release_tags).to_xml, 'public')
       transfer_to_document_store(PublicDescMetadataService.new(item).to_xml, 'mods')
     end
+    # rubocop:enable Metrics/AbcSize
 
     # Clear out the document cache for this item
     def unpublish

--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -63,7 +63,10 @@ module Publish
     end
 
     def public_rights_metadata
-      @public_rights_metadata ||= RightsMetadata.new(object.rightsMetadata.ng_xml).create
+      @public_rights_metadata ||= begin
+        release_date = object.is_a?(Dor::Item) && object.embargoMetadata.status == 'embargoed' ? object.embargoMetadata.release_date : nil
+        RightsMetadata.new(object.rightsMetadata.ng_xml, release_date: release_date).create
+      end
     end
 
     def public_identity_metadata


### PR DESCRIPTION


## Why was this change made?
There's no reason for us to have this tracked in two places.  This makes it clear which place is the canonical location.


## How was this change tested?



## Which documentation and/or configurations were updated?



