### PR TITLE
disambiguate names of some vars in cocina mappings

### DIFF
--- a/app/services/cocina/from_fedora/apo.rb
+++ b/app/services/cocina/from_fedora/apo.rb
@@ -4,47 +4,47 @@ module Cocina
   module FromFedora
     # Creates Cocina APO objects from Fedora objects
     class APO
-      # @param [Dor::Item,Dor::Etd] item
+      # @param [Dor::AdminPolicyObject] fedora_apo
       # @param [Cocina::FromFedora::DataErrorNotifier] notifier
       # @return [Hash] a hash that can be mapped to a cocina model
-      def self.props(item, notifier: nil)
-        new(item, notifier: notifier).props
+      def self.props(fedora_apo, notifier: nil)
+        new(fedora_apo, notifier: notifier).props
       end
 
-      def initialize(item, notifier: nil)
-        @item = item
+      def initialize(fedora_apo, notifier: nil)
+        @fedora_apo = fedora_apo
         @notifier = notifier
       end
 
       def props
         {
-          externalIdentifier: item.pid,
+          externalIdentifier: fedora_apo.pid,
           type: Cocina::Models::Vocab.admin_policy,
-          label: item.label,
-          version: item.current_version.to_i,
+          label: fedora_apo.label,
+          version: fedora_apo.current_version.to_i,
           administrative: build_apo_administrative
         }.tap do |props|
-          title_builder = FromFedora::Descriptive::TitleBuilderStrategy.find(label: item.label)
-          description = FromFedora::Descriptive.props(title_builder: title_builder, mods: item.descMetadata.ng_xml, druid: item.pid, notifier: notifier)
+          title_builder = FromFedora::Descriptive::TitleBuilderStrategy.find(label: fedora_apo.label)
+          description = FromFedora::Descriptive.props(title_builder: title_builder, mods: fedora_apo.descMetadata.ng_xml, druid: fedora_apo.pid, notifier: notifier)
           props[:description] = description unless description.nil?
         end
       end
 
       private
 
-      attr_reader :item, :notifier
+      attr_reader :fedora_apo, :notifier
 
       def build_apo_administrative
         {}.tap do |admin|
-          registration_workflows = item.administrativeMetadata.ng_xml.xpath('//administrativeMetadata/registration/workflow/@id').map(&:value)
-          registration_collections = item.administrativeMetadata.ng_xml.xpath('//administrativeMetadata/registration/collection/@id').map(&:value)
-          dissemination_workflow = item.administrativeMetadata.ng_xml.xpath('//administrativeMetadata/dissemination/workflow/@id').text
-          admin[:defaultObjectRights] = item.defaultObjectRights.content # Deprecated. Use defaultAccess instead
-          admin[:defaultAccess] = build_default_access(item.defaultObjectRights)
+          registration_workflows = fedora_apo.administrativeMetadata.ng_xml.xpath('//administrativeMetadata/registration/workflow/@id').map(&:value)
+          registration_collections = fedora_apo.administrativeMetadata.ng_xml.xpath('//administrativeMetadata/registration/collection/@id').map(&:value)
+          dissemination_workflow = fedora_apo.administrativeMetadata.ng_xml.xpath('//administrativeMetadata/dissemination/workflow/@id').text
+          admin[:defaultObjectRights] = fedora_apo.defaultObjectRights.content # Deprecated. Use defaultAccess instead
+          admin[:defaultAccess] = build_default_access(fedora_apo.defaultObjectRights)
           admin[:disseminationWorkflow] = dissemination_workflow if dissemination_workflow.present?
           admin[:registrationWorkflow] = registration_workflows if registration_workflows.present?
           admin[:collectionsForRegistration] = registration_collections if registration_collections.present?
-          admin[:hasAdminPolicy] = item.admin_policy_object_id
+          admin[:hasAdminPolicy] = fedora_apo.admin_policy_object_id
           admin[:roles] = build_roles
         end
       end
@@ -56,7 +56,7 @@ module Cocina
       # @return [Array<Hash>] the list of name and members
       def build_roles
         # rubocop:disable Rails/DynamicFindBy  false positive
-        item.roleMetadata.find_by_xpath('/roleMetadata/role').map do |role|
+        fedora_apo.roleMetadata.find_by_xpath('/roleMetadata/role').map do |role|
           members = role.xpath('group/identifier').map { |ident| { type: ident['type'], identifier: ident.text } }
           { name: role['type'], members: members }
         end

--- a/app/services/cocina/to_fedora/roles.rb
+++ b/app/services/cocina/to_fedora/roles.rb
@@ -5,11 +5,11 @@ module Cocina
     # This transforms the AdminPolicyAdministrative schema to the
     # Fedora 3 roles
     class Roles
-      def self.write(apo, roles)
-        apo.purge_roles
+      def self.write(fedora_apo, roles)
+        fedora_apo.purge_roles
         roles.each do |role|
           role.members.each do |member|
-            apo.add_roleplayer(role.name, member.identifier, member.type.to_sym)
+            fedora_apo.add_roleplayer(role.name, member.identifier, member.type.to_sym)
           end
         end
       end


### PR DESCRIPTION
## Why was this change made?

less confusion is a good thing.

## How was this change tested?

unit tests still work.  yay.

## Which documentation and/or configurations were updated?



