### PR TITLE
rename administrative_metadata (was apo_rights)

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -66,7 +66,7 @@ module Cocina
         add_description(fedora_apo, cocina_admin_policy)
 
         Cocina::ToFedora::DefaultRights.write(fedora_apo.defaultObjectRights, cocina_admin_policy.administrative.defaultAccess) if cocina_admin_policy.administrative.defaultAccess
-        Cocina::ToFedora::ApoRights.write(fedora_apo.administrativeMetadata, cocina_admin_policy.administrative)
+        Cocina::ToFedora::AdministrativeMetadata.write(fedora_apo.administrativeMetadata, cocina_admin_policy.administrative)
         Cocina::ToFedora::Roles.write(fedora_apo, Array(cocina_admin_policy.administrative.roles))
         Cocina::ToFedora::Identity.apply(fedora_apo, label: cocina_admin_policy.label)
       end

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -80,7 +80,7 @@ module Cocina
       if has_changed?(:administrative)
         fedora_object.admin_policy_object_id = cocina_object.administrative.hasAdminPolicy
         Cocina::ToFedora::DefaultRights.write(fedora_object.defaultObjectRights, cocina_object.administrative.defaultAccess) if cocina_object.administrative.defaultAccess
-        Cocina::ToFedora::ApoRights.write(fedora_object.administrativeMetadata, cocina_object.administrative)
+        Cocina::ToFedora::AdministrativeMetadata.write(fedora_object.administrativeMetadata, cocina_object.administrative)
         Cocina::ToFedora::Roles.write(fedora_object, Array(cocina_object.administrative.roles))
       end
     end

--- a/app/services/cocina/to_fedora/administrative_metadata.rb
+++ b/app/services/cocina/to_fedora/administrative_metadata.rb
@@ -4,7 +4,7 @@ module Cocina
   module ToFedora
     # This transforms the AdminPolicyAdministrative schema to the
     # Fedora 3 data model rights
-    class ApoRights
+    class AdministrativeMetadata
       def self.write(administrative_metadata, administrative)
         ng_xml = administrative_metadata.ng_xml
         admin_node = ng_xml.xpath('//administrativeMetadata').first

--- a/spec/services/cocina/object_updater_spec.rb
+++ b/spec/services/cocina/object_updater_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Cocina::ObjectUpdater do
     context 'when updating administrative' do
       before do
         allow(item).to receive(:admin_policy_object_id=)
-        allow(Cocina::ToFedora::ApoRights).to receive(:write)
+        allow(Cocina::ToFedora::AdministrativeMetadata).to receive(:write)
         allow(Cocina::ToFedora::Roles).to receive(:write)
       end
 
@@ -133,7 +133,7 @@ RSpec.describe Cocina::ObjectUpdater do
         it 'updates administrative' do
           update
           expect(item).to have_received(:admin_policy_object_id=).with('druid:dd999df4567')
-          expect(Cocina::ToFedora::ApoRights).to have_received(:write)
+          expect(Cocina::ToFedora::AdministrativeMetadata).to have_received(:write)
           expect(Cocina::ToFedora::Roles).to have_received(:write)
         end
       end
@@ -142,7 +142,7 @@ RSpec.describe Cocina::ObjectUpdater do
         it 'does not update administrative' do
           update
           expect(item).not_to have_received(:admin_policy_object_id=)
-          expect(Cocina::ToFedora::ApoRights).not_to have_received(:write)
+          expect(Cocina::ToFedora::AdministrativeMetadata).not_to have_received(:write)
           expect(Cocina::ToFedora::Roles).not_to have_received(:write)
         end
       end


### PR DESCRIPTION
## Why was this change made?

"apo_rights" was misleading as the class is specific to the administrativeMetadata datastream - no "rights" involved.  If there is a desire to keep "apo" in the name, I would consider "apo_administrative_metadata" as an alternative.

## How was this change tested?

unit tests.

## Which documentation and/or configurations were updated?



