### PR TITLE
Add a broken test for #2659

### DIFF
--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -1019,7 +1019,8 @@ RSpec.describe 'Update object' do
                                               }
                                             ]
                                           }
-                                        ]
+                                        ],
+                                        referencesAgreement: "druid:bc123df4567",
                                       },
                                       externalIdentifier: druid)
     end
@@ -1050,6 +1051,7 @@ RSpec.describe 'Update object' do
             "collectionsForRegistration":["druid:gg888df4567","druid:bb888gg4444"],
             "hasAdminPolicy":"druid:dd999df4567",
             "defaultAccess":#{default_access.to_json},
+            "referencesAgreement":"druid:bc123df4567",
             "roles":[{"name":"dor-apo-manager","members":[{"type":"workgroup","identifier":"sdr:psm-staff"}]}]
           },
           "description":{"title":[{"value":"This is my title"}]}}


### PR DESCRIPTION
## Why was this change made?
Illustrates the problem in #2659.  The existing test does not attempt to set `referencesAgreement`


## How was this change tested?



## Which documentation and/or configurations were updated?



