### PR TITLE
Serialize the release date correctly

### DIFF
--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -63,10 +63,14 @@ module Publish
     end
 
     def public_rights_metadata
-      @public_rights_metadata ||= begin
-        release_date = object.is_a?(Dor::Item) && object.embargoMetadata.status == 'embargoed' ? object.embargoMetadata.release_date : nil
-        RightsMetadata.new(object.rightsMetadata.ng_xml, release_date: release_date).create
-      end
+      @public_rights_metadata ||= RightsMetadata.new(object.rightsMetadata.ng_xml, release_date: release_date).create
+    end
+
+    def release_date
+      return unless object.is_a?(Dor::Item)
+      return unless object.embargoMetadata.status == 'embargoed'
+
+      object.embargoMetadata.release_date.first.to_datetime.utc.iso8601
     end
 
     def public_identity_metadata

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -106,6 +106,43 @@ RSpec.describe Publish::PublicXmlService do
       end
     end
 
+    context 'with an embargo' do
+      let(:embargo) do
+        <<~XML
+          <embargoMetadata>
+            <status>embargoed</status>
+            <releaseDate>2021-10-08T00:00:00Z</releaseDate>
+            <twentyPctVisibilityStatus/>
+            <twentyPctVisibilityReleaseDate/>
+            <releaseAccess>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+            </releaseAccess>
+          </embargoMetadata>
+        XML
+      end
+
+      let(:result) do
+        ng_xml.at_xpath('/publicObject/rightsMetadata/access[@type="read"]/machine/embargoReleaseDate').text
+      end
+
+      before do
+        item.embargoMetadata.content = embargo
+      end
+
+      it 'adds embargo to the rights' do
+        expect(result).to eq '2021-10-08T00:00:00Z'
+      end
+    end
+
     context 'produces xml with' do
       let(:now) { Time.now.utc }
 


### PR DESCRIPTION
## Why was this change made?

Previously this was getting returned as an array of DateTime objects which does not serialize automatically into the required format.  This explicitly picks the first element an casts it as expected similar to how OM does: https://github.com/samvera-deprecated/om/blob/cf34329b45f608f6addfe3786c0fcb2ac93ef0e2/lib/om/xml/term.rb#L104


## How was this change tested?
Republished https://argo-stage.stanford.edu/view/druid:dt084sz4619 and now it shows in purl as embargoed


## Which documentation and/or configurations were updated?



