### PR TITLE
Allow the rails log to be used for workflow

### DIFF
--- a/app/services/workflow_client_factory.rb
+++ b/app/services/workflow_client_factory.rb
@@ -3,7 +3,11 @@
 # This initializes the workflow client with values from settings
 class WorkflowClientFactory
   def self.build
-    logger = Logger.new(Settings.workflow.logfile, Settings.workflow.shift_age)
+    logger = if Settings.workflow.logfile == 'rails'
+               Rails.logger
+             else
+               Logger.new(Settings.workflow.logfile, Settings.workflow.shift_age)
+             end
     Dor::Workflow::Client.new(url: Settings.workflow_url, logger: logger, timeout: Settings.workflow.timeout)
   end
 end


### PR DESCRIPTION


## Why was this change made?
Fixes #2692 which was a problem because the docker container has no disk persistence


## How was this change tested?



## Which documentation and/or configurations were updated?



