### PR TITLE
Add a feature flag for synching versions with preservation

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,6 +38,11 @@ workflow:
   shift_age: 'weekly'
   timeout: 60
 
+version_service:
+  # Turn sync_with_preservation to false in a testing environment where you don't
+  # have a preservation-catalog container
+  sync_with_preservation: true
+
 # URLs
 fedora_url: 'https://user:password@fedora.example.com:1000/fedora'
 solr:


### PR DESCRIPTION


## Why was this change made?
This will allow for richer tests in the Argo testing environment, where we don't have a preservation-catalog container.


## How was this change tested?



## Which documentation and/or configurations were updated?



