### PR TITLE
Filter out blank subject classification editions

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -114,7 +114,7 @@ module Cocina
             source = {
               code: code_for(subject),
               uri: Authority.normalize_uri(subject[:authorityURI]),
-              version: subject['edition']
+              version: subject['edition'].presence # We are not interested in blank versions
             }.compact
             attrs[:source] = source unless source.empty?
             attrs[:uri] = ValueURI.sniff(subject[:valueURI], notifier)

--- a/spec/services/cocina/mapping/descriptive/mods/subject_classification_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_classification_spec.rb
@@ -79,6 +79,36 @@ RSpec.describe 'MODS subject classification <--> cocina mappings' do
     end
   end
 
+  describe 'Classification with blank edition' do
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <classification authority="ddc" edition="">949.6</classification>
+        XML
+      end
+
+      let(:roundtrip_mods) do
+        <<~XML
+          <classification authority="ddc">949.6</classification>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          subject: [
+            {
+              type: 'classification',
+              value: '949.6',
+              source: {
+                code: 'ddc'
+              }
+            }
+          ]
+        }
+      end
+    end
+  end
+
   describe 'Classification with display label' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do


### PR DESCRIPTION
Fixes #2695

## Why was this change made?

Self-evident.

## How was this change tested?

CI + sdr-deploy:

### BEFORE

```
$ bin/validate-cocina-roundtrip -s 10000
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9743 (99.959%)
  Different: 4 (0.041%)
  Mapping error:     0 (0.0%)
  Update error:     0 (0.0%)
  Missing:     0 (0.0%)
  Unmapped:     253 (2.53%)
  Bad cache:     0 (0.0%)

$ bin/validate-desc-cocina-roundtrip -fs 10000
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9952 (99.97%)
  Different: 3 (0.03%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     45 (0.45%)
```

### AFTER

```
$ bin/validate-cocina-roundtrip -s 10000
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9743 (99.959%)
  Different: 4 (0.041%)
  Mapping error:     0 (0.0%)
  Update error:     0 (0.0%)
  Missing:     0 (0.0%)
  Unmapped:     253 (2.53%)
  Bad cache:     0 (0.0%)

$ bin/validate-desc-cocina-roundtrip -fs 10000
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9952 (99.97%)
  Different: 3 (0.03%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     45 (0.45%)
```

## Which documentation and/or configurations were updated?

None


