### PR TITLE
Add RabbitMQ notifications when an object is updated

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -41,6 +41,9 @@ class ObjectsController < ApplicationController
     update_request = Cocina::Models.build(params.except(:action, :controller, :id).to_unsafe_h)
     persisted_cocina_object = Cocina::ObjectUpdater.run(fedora_object, update_request)
 
+    # Broadcast this update action to a topic
+    Notifications::ObjectUpdated.publish(model: cocina_object) if Settings.rabbitmq.enabled
+
     render json: persisted_cocina_object
   rescue Cocina::RoundtripValidationError => e
     Honeybadger.notify(e)

--- a/app/services/notifications/object_updated.rb
+++ b/app/services/notifications/object_updated.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Notifications
+  # Send a message to a RabbitMQ exchange that an item has been updated.
+  # The primary use case here is that an index may need to be updated (dor-indexing-app)
+  class ObjectUpdated
+    def self.publish(model:)
+      Rails.logger.debug "Publishing Rabbitmq Message for updating #{model.externalIdentifier}"
+      new(model: model, channel: RabbitChannel.instance).publish
+      Rails.logger.debug "Published Rabbitmq Message for updating #{model.externalIdentifier}"
+    end
+
+    def initialize(model:, channel:)
+      @model = model
+      @channel = channel
+    end
+
+    def publish
+      message = { model: model.to_h }
+      exchange.publish(message.to_json, routing_key: routing_key)
+    end
+
+    private
+
+    attr_reader :model, :channel
+
+    def exchange
+      channel.topic('sdr.objects.updated')
+    end
+
+    # Using the project as a routing key because listeners may only care about their projects.
+    def routing_key
+      model.is_a?(Cocina::Models::AdminPolicy) ? 'SDR' : model.administrative.partOfProject
+    end
+  end
+end

--- a/app/services/notifications/rabbit_channel.rb
+++ b/app/services/notifications/rabbit_channel.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Notifications
+  # Creates a connection to RabbitMQ using the Bunny gem
+  class RabbitChannel
+    include Singleton
+
+    delegate :topic, to: :channel
+
+    def channel
+      @channel ||= connection.create_channel
+    end
+
+    def connection
+      @connection ||= Bunny.new(hostname: Settings.rabbitmq.hostname,
+                                vhost: Settings.rabbitmq.vhost,
+                                username: Settings.rabbitmq.username,
+                                password: Settings.rabbitmq.password).tap(&:start)
+    end
+  end
+end

--- a/spec/services/notifications/object_updated_spec.rb
+++ b/spec/services/notifications/object_updated_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Notifications::ObjectCreated do
+RSpec.describe Notifications::ObjectUpdated do
   subject(:publish) { described_class.publish(model: model) }
 
   let(:data) { { data: '455' } }
@@ -40,9 +40,13 @@ RSpec.describe Notifications::ObjectCreated do
                                       type: Cocina::Models::Vocab.admin_policy)
     end
 
+    before do
+      allow(model).to receive(:to_h).and_return(data)
+    end
+
     it 'is successful' do
       publish
-      expect(topic).not_to have_received(:publish)
+      expect(topic).to have_received(:publish).with('{"model":{"data":"455"}}', routing_key: 'SDR')
     end
   end
 end

--- a/spec/services/notifications/rabbit_channel_spec.rb
+++ b/spec/services/notifications/rabbit_channel_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Notifications::RabbitChannel do
+  let(:bunny) { instance_double(Bunny::Session, start: true, create_channel: channel) }
+  let(:channel) { instance_double(Bunny::Channel, topic: topic) }
+  let(:topic) { instance_double(Bunny::Exchange) }
+
+  before do
+    allow(Bunny).to receive(:new).and_return(bunny)
+  end
+
+  describe '#topic' do
+    subject { described_class.instance.topic('sdr.whatever') }
+
+    it { is_expected.to eq topic }
+  end
+end


### PR DESCRIPTION


## Why was this change made?

This will allow us to trigger indexing and lower the load on DSA, because we send the model to the channel. Then DSA can read the data off the channel rather than having to make a GET request back to DSA.

Ref #2559


## How was this change tested?



## Which documentation and/or configurations were updated?



