### PR TITLE
Fix bug with rights determinations when metadata has multiple access nodes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -163,10 +163,10 @@ RSpec/MessageSpies:
     - 'spec/services/shelving_service_spec.rb'
     - 'spec/services/version_service_spec.rb'
 
-# Offense count: 222
+# Offense count: 225
 # Configuration parameters: AllowSubject.
 RSpec/MultipleMemoizedHelpers:
-  Max: 20
+  Max: 22
 
 # Offense count: 15
 # Configuration parameters: IgnoreSharedExamples.

--- a/app/services/cocina/to_fedora/access.rb
+++ b/app/services/cocina/to_fedora/access.rb
@@ -19,12 +19,8 @@ module Cocina
       end
 
       def apply
-        # See https://github.com/sul-dlss/dor-services/blob/main/lib/dor/datastreams/rights_metadata_ds.rb
-        Dor::RightsMetadataDS.upd_rights_xml_for_rights_type(rightsMetadata.ng_xml, Rights.rights_type(access))
-        # This invalidates the dra_object, which is necessary if re-mapping.
-        rightsMetadata.content = rightsMetadata.ng_xml.to_s
-        rightsMetadata.copyright = access.copyright if access.copyright
-        rightsMetadata.use_statement = access.useAndReproductionStatement if access.useAndReproductionStatement
+        RightsMetadataGenerator.generate(rights: rightsMetadata, access: access)
+        update_rights_statements!
         License.update(rightsMetadata, access.license) if access.license
       end
 
@@ -33,6 +29,12 @@ module Cocina
       attr_reader :item, :access
 
       delegate :rightsMetadata, to: :item
+
+      def update_rights_statements!
+        rightsMetadata.copyright = access.copyright if access.copyright
+        rightsMetadata.use_statement = access.useAndReproductionStatement if access.useAndReproductionStatement
+        rightsMetadata.ng_xml_will_change!
+      end
     end
   end
 end

--- a/app/services/cocina/to_fedora/rights_metadata_generator.rb
+++ b/app/services/cocina/to_fedora/rights_metadata_generator.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+module Cocina
+  module ToFedora
+    # Builds the rightsMetadata xml from cocina
+    class RightsMetadataGenerator
+      # @param [Dor::RightsMetadataDS] rights the DOR Rights metadata datastream
+      # @param [Cocina::Models::DROAccess, Cocina::Models::Access] access access/rights metadata in Cocina
+      def self.generate(rights:, access:)
+        new(rights: rights, access: access).generate
+      end
+
+      def initialize(rights:, access:)
+        @rights = rights
+        @access = access
+      end
+
+      # Adapted copypasta from https://github.com/sul-dlss/dor-services/blob/main/lib/dor/datastreams/rights_metadata_ds.rb
+      def generate
+        rights.ng_xml_will_change!
+
+        # Remove existing access nodes to begin rebuilding them from Cocina
+        rights_xml.search('//rightsMetadata/access').each(&:remove)
+
+        # Add discover access node
+        rights_xml.root.add_child(discover_access_node)
+
+        # Add read access node
+        rights_xml.root.add_child(read_access_node)
+
+        # Add download access node if needed
+        rights_xml.root.add_child(download_access_node) if download_access_node
+
+        rights_xml.to_xml
+      end
+
+      private
+
+      attr_reader :rights, :access
+
+      def rights_xml
+        rights.ng_xml
+      end
+
+      def discover_access_node
+        Nokogiri::XML::Node.new('access', rights_xml).tap do |access_node|
+          access_node.set_attribute('type', 'discover')
+          machine_node = Nokogiri::XML::Node.new('machine', rights_xml)
+          access_level_node = Nokogiri::XML::Node.new(discover_label, rights_xml)
+          machine_node.add_child(access_level_node)
+          access_node.add_child(machine_node)
+        end
+      end
+
+      # NOTE: The discover node is either 'none' for a dark object or 'world' for any other rights option
+      def discover_label
+        return 'none' if access.access == 'dark'
+
+        'world'
+      end
+
+      def read_access_node
+        Nokogiri::XML::Node.new('access', rights_xml).tap do |access_node|
+          access_node.set_attribute('type', 'read')
+          machine_node = Nokogiri::XML::Node.new('machine', rights_xml)
+          machine_node.add_child(read_access_level_node)
+          access_node.add_child(machine_node)
+        end
+      end
+
+      def read_access_level_node
+        if cdl_access?
+          cdl_node = Nokogiri::XML::Node.new('cdl', rights_xml)
+          group_node = Nokogiri::XML::Node.new('group', cdl_node)
+          group_node.content = 'stanford'
+          group_node.set_attribute('rule', 'no-download')
+          cdl_node.add_child(group_node)
+          cdl_node
+        elsif world_read_access?
+          world_node = Nokogiri::XML::Node.new('world', rights_xml)
+          world_node.set_attribute('rule', 'no-download') if no_download? || location_based_download? || stanford_download?
+          world_node
+        elsif stanford_read_access?
+          group_node = Nokogiri::XML::Node.new('group', rights_xml)
+          group_node.content = 'stanford'
+          group_node.set_attribute('rule', 'no-download') if no_download? || location_based_download?
+          group_node
+        elsif location_based_access?
+          loc_node = Nokogiri::XML::Node.new('location', rights_xml)
+          loc_node.content = access.readLocation
+          loc_node.set_attribute('rule', 'no-download') if no_download?
+          loc_node
+        else # we know it is citation-only or dark at this point
+          Nokogiri::XML::Node.new('none', rights_xml)
+        end
+      end
+
+      def download_access_node
+        return unless (location_based_download? && (stanford_read_access? || world_read_access?)) ||
+                      (stanford_download? && world_read_access?)
+
+        Nokogiri::XML::Node.new('access', rights_xml).tap do |access_node|
+          access_node.set_attribute('type', 'read')
+          machine_node = Nokogiri::XML::Node.new('machine', rights_xml)
+          machine_node.add_child(download_access_level_node)
+          access_node.add_child(machine_node)
+        end
+      end
+
+      def download_access_level_node
+        if location_based_download?
+          loc_node = Nokogiri::XML::Node.new('location', rights_xml)
+          loc_node.content = access.readLocation
+          loc_node
+        elsif stanford_download?
+          group_node = Nokogiri::XML::Node.new('group', rights_xml)
+          group_node.content = 'stanford'
+          group_node
+        end
+      end
+
+      def world_read_access?
+        access.access == 'world'
+      end
+
+      def stanford_read_access?
+        access.access == 'stanford'
+      end
+
+      def cdl_access?
+        access.try(:controlledDigitalLending)
+      end
+
+      def location_based_access?
+        access.access == 'location-based' && access.try(:readLocation)
+      end
+
+      def no_download?
+        access.try(:download) == 'none'
+      end
+
+      def stanford_download?
+        access.try(:download) == 'stanford'
+      end
+
+      def location_based_download?
+        access.try(:download) == 'location-based' && access.try(:readLocation)
+      end
+    end
+  end
+end

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -1042,7 +1042,7 @@ RSpec.describe 'Create object' do
       <<~JSON
         { "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
           "label":"This is my label","version":1,
-          "access":{"access":"location-based","readLocation":"m&m"},
+          "access":{"access":"location-based","download":"location-based","readLocation":"m&m"},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
           "description":{"title":[{"value":"This is my title"}],"purl":"http://purl.stanford.edu/gg777gg7777","access":{"digitalRepository":[{"value":"Stanford Digital Repository"}]}},
           "identification":{"sourceId":"googlebooks:999999"},

--- a/spec/services/cocina/from_fedora/access_spec.rb
+++ b/spec/services/cocina/from_fedora/access_spec.rb
@@ -14,157 +14,406 @@ RSpec.describe Cocina::FromFedora::Access do
     allow(item).to receive(:rightsMetadata).and_return(rights_metadata_ds)
   end
 
-  describe 'with world access' do
-    let(:xml) do
-      <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-        </rightsMetadata>
-      XML
+  describe 'access rights' do
+    context 'when citation-only' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <none/>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access as citation-only' do
+        expect(access).to eq(access: 'citation-only')
+      end
     end
 
-    it 'builds the hash' do
-      expect(access).to eq(access: 'world')
+    context 'when controlled digital lending' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <cdl>
+                  <group rule="no-download">stanford</group>
+                </cdl>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access as stanford with cdl = true' do
+        expect(access).to eq(access: 'stanford', controlledDigitalLending: true)
+      end
+    end
+
+    context 'when dark' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <none/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <none/>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access as dark' do
+        expect(access).to eq(access: 'dark')
+      end
+    end
+
+    context 'when stanford' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <group>stanford</group>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access as stanford' do
+        expect(access).to eq(access: 'stanford')
+      end
+    end
+
+    context 'when stanford (no-download)' do
+      let(:xml) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <group rule="no-download">stanford</group>
+              </machine>
+            </access>
+            <access type="read">
+              <file>foo_bar.pdf</file>
+              <machine>
+                <world/>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access as stanford' do
+        expect(access).to eq(access: 'stanford')
+      end
+    end
+
+    context 'when stanford + world (no-download)' do
+      let(:xml) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <group>stanford</group>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world rule="no-download"/>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access as world' do
+        expect(access).to eq(access: 'world')
+      end
+    end
+
+    context 'when world' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access as world' do
+        expect(access).to eq(access: 'world')
+      end
+    end
+
+    context 'when world (no-download)' do
+      let(:xml) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world rule="no-download"/>
+              </machine>
+            </access>
+            <access type="read">
+              <file>foo_bar.pdf</file>
+              <machine>
+                <world/>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access as world' do
+        expect(access).to eq(access: 'world')
+      end
+    end
+
+    ['ars', 'art', 'hoover', 'm&m', 'music', 'spec'].each do |location|
+      context "with location:#{location}" do
+        let(:xml) do
+          <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <location>#{CGI.escapeHTML(location)}</location>
+                </machine>
+              </access>
+            </rightsMetadata>
+          XML
+        end
+
+        it "specifies access as location-based for #{location}" do
+          expect(access).to eq(access: 'location-based', readLocation: location)
+        end
+      end
+
+      context "with location:#{location} (no-download)" do
+        let(:xml) do
+          <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <location rule="no-download">#{CGI.escapeHTML(location)}</location>
+                </machine>
+              </access>
+            </rightsMetadata>
+          XML
+        end
+
+        it "specifies access as location-based for #{location}" do
+          expect(access).to eq(access: 'location-based', readLocation: location)
+        end
+      end
+
+      context "with location:#{location} + stanford (no-download)" do
+        let(:xml) do
+          <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <location>#{CGI.escapeHTML(location)}</location>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <group rule="no-download">stanford</group>
+                </machine>
+              </access>
+            </rightsMetadata>
+          XML
+        end
+
+        it "specifies access as stanford for #{location}" do
+          expect(access).to eq(access: 'stanford', readLocation: location)
+        end
+      end
+
+      context "with location:#{location} + world (no-download)" do
+        let(:xml) do
+          <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <location>#{CGI.escapeHTML(location)}</location>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <world rule="no-download"/>
+                </machine>
+              </access>
+            </rightsMetadata>
+          XML
+        end
+
+        it "specifies access as world for #{location}" do
+          expect(access).to eq(access: 'world', readLocation: location)
+        end
+      end
     end
   end
 
-  context 'with location access' do
-    let(:xml) do
-      <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <location>spec</location>
-            </machine>
-          </access>
-        </rightsMetadata>
-      XML
+  describe 'licenses and rights statements' do
+    context 'with an ODC license' do
+      let(:xml) do
+        <<~XML
+          <rightsMetadata>
+            <use>
+              <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
+              <machine type="openDataCommons">odc-by</machine>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'builds the hash' do
+        expect(access).to eq(access: 'dark', license: 'http://opendatacommons.org/licenses/by/1.0/')
+      end
     end
 
-    it 'builds the hash' do
-      expect(access).to eq(access: 'location-based', readLocation: 'spec')
-    end
-  end
+    context 'with a CC license' do
+      let(:xml) do
+        <<~XML
+          <rightsMetadata>
+            <use>
+              <human type="creativeCommons">Attribution Non-Commercial, No Derivatives 3.0 Unported</human>
+              <machine type="creativeCommons">by-nc-nd</machine>
+            </use>
+          </rightsMetadata>
+        XML
+      end
 
-  context 'with no-download' do
-    let(:xml) do
-      <<~XML
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <world rule="no-download"/>
-            </machine>
-          </access>
-        </rightsMetadata>
-      XML
+      it 'builds the hash' do
+        expect(access).to eq(access: 'dark', license: 'https://creativecommons.org/licenses/by-nc-nd/3.0/')
+      end
     end
 
-    it 'builds the hash' do
-      expect(access).to eq(access: 'world')
-    end
-  end
+    context 'with a "none" license' do
+      let(:xml) do
+        <<~XML
+          <rightsMetadata>
+            <use>
+              <human type="creativeCommons">no Creative Commons (CC) license</human>
+              <machine type="creativeCommons">none</machine>
+            </use>
+          </rightsMetadata>
+        XML
+      end
 
-  context 'with an ODC license' do
-    let(:xml) do
-      <<~XML
-        <rightsMetadata>
-          <use>
-            <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
-            <machine type="openDataCommons">odc-by</machine>
-          </use>
-        </rightsMetadata>
-      XML
-    end
-
-    it 'builds the hash' do
-      expect(access).to eq(access: 'citation-only', license: 'http://opendatacommons.org/licenses/by/1.0/')
-    end
-  end
-
-  context 'with a CC license' do
-    let(:xml) do
-      <<~XML
-        <rightsMetadata>
-          <use>
-            <human type="creativeCommons">Attribution Non-Commercial, No Derivatives 3.0 Unported</human>
-            <machine type="creativeCommons">by-nc-nd</machine>
-          </use>
-        </rightsMetadata>
-      XML
+      it 'builds the hash' do
+        expect(access).to eq(access: 'dark', license: 'http://cocina.sul.stanford.edu/licenses/none')
+      end
     end
 
-    it 'builds the hash' do
-      expect(access).to eq(access: 'citation-only', license: 'https://creativecommons.org/licenses/by-nc-nd/3.0/')
-    end
-  end
+    context 'with a use statement' do
+      let(:xml) do
+        <<~XML
+          <rightsMetadata>
+            <use>
+              <human type="useAndReproduction">User agrees that, where applicable, stuff.</human>
+            </use>
+          </rightsMetadata>
+        XML
+      end
 
-  context 'with a "none" license' do
-    let(:xml) do
-      <<~XML
-        <rightsMetadata>
-          <use>
-            <human type="creativeCommons">no Creative Commons (CC) license</human>
-            <machine type="creativeCommons">none</machine>
-          </use>
-        </rightsMetadata>
-      XML
-    end
-
-    it 'builds the hash' do
-      expect(access).to eq(access: 'citation-only', license: 'http://cocina.sul.stanford.edu/licenses/none')
-    end
-  end
-
-  context 'with a use statement' do
-    let(:xml) do
-      <<~XML
-        <rightsMetadata>
-          <use>
-            <human type="useAndReproduction">User agrees that, where applicable, stuff.</human>
-          </use>
-        </rightsMetadata>
-      XML
+      it 'builds the hash' do
+        expect(access).to eq(access: 'dark', useAndReproductionStatement: 'User agrees that, where applicable, stuff.')
+      end
     end
 
-    it 'builds the hash' do
-      expect(access).to eq(access: 'citation-only', useAndReproductionStatement: 'User agrees that, where applicable, stuff.')
-    end
-  end
+    context 'with a copyright statement' do
+      let(:xml) do
+        <<~XML
+          <rightsMetadata>
+            <copyright>
+              <human>User agrees that, where applicable, stuff.</human>
+            </use>
+          </rightsMetadata>
+        XML
+      end
 
-  context 'with a copyright statement' do
-    let(:xml) do
-      <<~XML
-        <rightsMetadata>
-          <copyright>
-            <human>User agrees that, where applicable, stuff.</human>
-          </use>
-        </rightsMetadata>
-      XML
-    end
-
-    it 'builds the hash' do
-      expect(access).to eq(access: 'citation-only', copyright: 'User agrees that, where applicable, stuff.')
+      it 'builds the hash' do
+        expect(access).to eq(access: 'dark', copyright: 'User agrees that, where applicable, stuff.')
+      end
     end
   end
 end

--- a/spec/services/cocina/from_fedora/dro_access_spec.rb
+++ b/spec/services/cocina/from_fedora/dro_access_spec.rb
@@ -86,32 +86,6 @@ RSpec.describe Cocina::FromFedora::DROAccess do
     end
   end
 
-  describe 'with cdl access' do
-    let(:xml) do
-      <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <cdl>
-                <group rule="no-download">stanford</group>
-              </cdl>
-            </machine>
-          </access>
-        </rightsMetadata>
-      XML
-    end
-
-    it 'builds the hash' do
-      expect(access).to eq(access: 'citation-only', download: 'none', controlledDigitalLending: true)
-    end
-  end
-
   describe 'with copyright but no use statement (contrived example)' do
     let(:xml) do
       <<~XML
@@ -175,77 +149,6 @@ RSpec.describe Cocina::FromFedora::DROAccess do
     end
   end
 
-  context 'with world access' do
-    let(:xml) do
-      <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-        </rightsMetadata>
-      XML
-    end
-
-    it 'builds the hash' do
-      expect(access).to eq(access: 'world', download: 'world')
-    end
-  end
-
-  context 'with location access' do
-    let(:xml) do
-      <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <location>spec</location>
-            </machine>
-          </access>
-        </rightsMetadata>
-      XML
-    end
-
-    it 'builds the hash' do
-      expect(access).to eq(access: 'location-based', readLocation: 'spec', download: 'location-based')
-    end
-  end
-
-  context 'with no-download' do
-    let(:xml) do
-      <<~XML
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <world rule="no-download"/>
-            </machine>
-          </access>
-        </rightsMetadata>
-      XML
-    end
-
-    it 'builds the hash' do
-      expect(access).to eq(access: 'world', download: 'none')
-    end
-  end
-
   context 'with an ODC license' do
     let(:xml) do
       <<~XML
@@ -294,6 +197,324 @@ RSpec.describe Cocina::FromFedora::DROAccess do
 
     it 'builds the hash' do
       expect(access).to include(license: 'http://cocina.sul.stanford.edu/licenses/none')
+    end
+  end
+
+  describe 'access and download rights' do
+    context 'when citation-only' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <none/>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access as citation-only w/ no download' do
+        expect(access).to eq(access: 'citation-only', download: 'none')
+      end
+    end
+
+    context 'when controlled digital lending' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <cdl>
+                  <group rule="no-download">stanford</group>
+                </cdl>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access as stanford with cdl = true and no download' do
+        expect(access).to eq(access: 'stanford', controlledDigitalLending: true, download: 'none')
+      end
+    end
+
+    context 'when dark' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <none/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <none/>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access as dark with no download' do
+        expect(access).to eq(access: 'dark', download: 'none')
+      end
+    end
+
+    context 'when stanford' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <group>stanford</group>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access and download as stanford' do
+        expect(access).to eq(access: 'stanford', download: 'stanford')
+      end
+    end
+
+    context 'when stanford (no-download)' do
+      let(:xml) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <group rule="no-download">stanford</group>
+              </machine>
+            </access>
+            <access type="read">
+              <file>foo_bar.pdf</file>
+              <machine>
+                <world/>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access as stanford with no download' do
+        expect(access).to eq(access: 'stanford', download: 'none')
+      end
+    end
+
+    context 'when stanford + world (no-download)' do
+      let(:xml) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <group>stanford</group>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world rule="no-download"/>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access as world with stanford download' do
+        expect(access).to eq(access: 'world', download: 'stanford')
+      end
+    end
+
+    context 'when world' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access and download as world' do
+        expect(access).to eq(access: 'world', download: 'world')
+      end
+    end
+
+    context 'when world (no-download)' do
+      let(:xml) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world rule="no-download"/>
+              </machine>
+            </access>
+            <access type="read">
+              <file>foo_bar.pdf</file>
+              <machine>
+                <world/>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access as world with no download' do
+        expect(access).to eq(access: 'world', download: 'none')
+      end
+    end
+
+    ['ars', 'art', 'hoover', 'm&m', 'music', 'spec'].each do |location|
+      context "with location:#{location}" do
+        let(:xml) do
+          <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <location>#{CGI.escapeHTML(location)}</location>
+                </machine>
+              </access>
+            </rightsMetadata>
+          XML
+        end
+
+        it "specifies access and download as location-based for #{location}" do
+          expect(access).to eq(access: 'location-based', readLocation: location, download: 'location-based')
+        end
+      end
+
+      context "with location:#{location} (no-download)" do
+        let(:xml) do
+          <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <location rule="no-download">#{CGI.escapeHTML(location)}</location>
+                </machine>
+              </access>
+            </rightsMetadata>
+          XML
+        end
+
+        it "specifies access as location-based for #{location} with no download" do
+          expect(access).to eq(access: 'location-based', readLocation: location, download: 'none')
+        end
+      end
+
+      context "with location:#{location} + stanford (no-download)" do
+        let(:xml) do
+          <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <location>#{CGI.escapeHTML(location)}</location>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <group rule="no-download">stanford</group>
+                </machine>
+              </access>
+            </rightsMetadata>
+          XML
+        end
+
+        it "specifies access as stanford and download as location-based for #{location}" do
+          expect(access).to eq(access: 'stanford', readLocation: location, download: 'location-based')
+        end
+      end
+
+      context "with location:#{location} + world (no-download)" do
+        let(:xml) do
+          <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <location>#{CGI.escapeHTML(location)}</location>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <world rule="no-download"/>
+                </machine>
+              </access>
+            </rightsMetadata>
+          XML
+        end
+
+        it "specifies access as world and download as location-based for #{location}" do
+          expect(access).to eq(access: 'world', readLocation: location, download: 'location-based')
+        end
+      end
     end
   end
 end

--- a/spec/services/cocina/to_fedora/rights_metadata_generator_spec.rb
+++ b/spec/services/cocina/to_fedora/rights_metadata_generator_spec.rb
@@ -1,0 +1,411 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::ToFedora::RightsMetadataGenerator do
+  subject(:generate) do
+    described_class.generate(rights: rights, access: access)
+  end
+
+  let(:access) { Cocina::Models::DROAccess.new(JSON.parse(cocina)) }
+  let(:item) { instantiate_fixture('druid:hj097bm8879', Dor::Item) }
+  let(:rights) { item.rightsMetadata }
+  let(:rights_statements) do
+    <<~XML
+      <use>
+        <human type="creativeCommons">Attribution Non-Commercial Share Alike 3.0 Unported</human>
+        <machine type="creativeCommons">by-nc-sa</machine>
+      </use>
+      <use>
+        <human type="useAndReproduction">To obtain permission to publish or reproduce commercially, please contact the Digital  Rare Map Librarian, David Rumsey Map Center at rumseymapcenter@stanford.edu.</human>
+      </use>
+      <copyright>
+        <human type="copyright">Property rights reside with the repository, Copyright &#xA9; Stanford University. Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license.</human>
+      </copyright>
+    XML
+  end
+
+  context 'when citation-only' do
+    let(:cocina) do
+      <<~JSON
+        {
+          "access": "citation-only",
+          "download": "none"
+        }
+      JSON
+    end
+
+    it 'maps rights metadata as expected' do
+      expect(generate).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          #{rights_statements}
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'when controlled digital lending' do
+    let(:cocina) do
+      <<~JSON
+        {
+          "access": "stanford",
+          "controlledDigitalLending": true,
+          "download": "none"
+        }
+      JSON
+    end
+
+    it 'maps rights metadata as expected' do
+      expect(generate).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <cdl>
+                <group rule="no-download">stanford</group>
+              </cdl>
+            </machine>
+          </access>
+          #{rights_statements}
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'when dark' do
+    let(:cocina) do
+      <<~JSON
+        {
+          "access": "dark",
+          "download": "none"
+        }
+      JSON
+    end
+
+    it 'maps rights metadata as expected' do
+      expect(generate).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          #{rights_statements}
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'when stanford' do
+    let(:cocina) do
+      <<~JSON
+        {
+          "access": "stanford",
+          "download": "stanford"
+        }
+      JSON
+    end
+
+    it 'maps rights metadata as expected' do
+      expect(generate).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <group>stanford</group>
+            </machine>
+          </access>
+          #{rights_statements}
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'when stanford (no-download)' do
+    let(:cocina) do
+      <<~JSON
+        {
+          "access": "stanford",
+          "download": "none"
+        }
+      JSON
+    end
+
+    it 'maps rights metadata as expected' do
+      expect(generate).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <group rule="no-download">stanford</group>
+            </machine>
+          </access>
+          #{rights_statements}
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'when stanford + world (no-download)' do
+    let(:cocina) do
+      <<~JSON
+        {
+          "access": "world",
+          "download": "stanford"
+        }
+      JSON
+    end
+
+    it 'maps rights metadata as expected' do
+      expect(generate).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <group>stanford</group>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <world rule="no-download"/>
+            </machine>
+          </access>
+          #{rights_statements}
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'when world' do
+    let(:cocina) do
+      <<~JSON
+        {
+          "access": "world",
+          "download": "world"
+        }
+      JSON
+    end
+
+    it 'maps rights metadata as expected' do
+      expect(generate).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          #{rights_statements}
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'when world (no-download)' do
+    let(:cocina) do
+      <<~JSON
+        {
+          "access": "world",
+          "download": "none"
+        }
+      JSON
+    end
+
+    it 'maps rights metadata as expected' do
+      expect(generate).to be_equivalent_to <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <world rule="no-download"/>
+            </machine>
+          </access>
+          #{rights_statements}
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  ['ars', 'art', 'hoover', 'm&m', 'music', 'spec'].each do |location|
+    context "when location:#{location}" do
+      let(:cocina) do
+        <<~JSON
+          {
+            "access": "location-based",
+            "download": "location-based",
+            "readLocation": "#{location}"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <location>#{CGI.escapeHTML(location)}</location>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+
+    context "when location:#{location} (no-download)" do
+      let(:cocina) do
+        <<~JSON
+          {
+            "access": "location-based",
+            "download": "none",
+            "readLocation": "#{location}"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <location rule="no-download">#{CGI.escapeHTML(location)}</location>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+
+    context "when location:#{location} + stanford (no-download)" do
+      let(:cocina) do
+        <<~JSON
+          {
+            "access": "stanford",
+            "download": "location-based",
+            "readLocation": "#{location}"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <location>#{CGI.escapeHTML(location)}</location>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <group rule="no-download">stanford</group>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+
+    context "when location:#{location} + world (no-download)" do
+      let(:cocina) do
+        <<~JSON
+          {
+            "access": "world",
+            "download": "location-based",
+            "readLocation": "#{location}"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <location>#{CGI.escapeHTML(location)}</location>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world rule="no-download"/>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+  end
+end


### PR DESCRIPTION
Connects to sul-dlss/argo#2382

## Why was this change made?

Rights metadata containing e.g. file-specific nodes reveal a bug in the prior `FromFedora/Access` implementation, namely the assumption that the presence of a single access=read node is meaningful. Instead of hand-crafted, buggy XPaths, re-use the logic that is already in place in the dor-rights-auth gem.

This PR adds full object-level rights mappings on both the to- and from-fedora sides (32 cases a piece).


## How was this change tested?

CI, locally, and tested in QA by Andrew, who comments below that this is good to go.

## Which documentation and/or configurations were updated?

None

