### PR TITLE
Map file-level rights metadata between Fedora and Cocina

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -163,10 +163,10 @@ RSpec/MessageSpies:
     - 'spec/services/shelving_service_spec.rb'
     - 'spec/services/version_service_spec.rb'
 
-# Offense count: 298
+# Offense count: 301
 # Configuration parameters: AllowSubject.
 RSpec/MultipleMemoizedHelpers:
-  Max: 22
+  Max: 23
 
 # Offense count: 15
 # Configuration parameters: IgnoreSharedExamples.

--- a/app/services/cocina/from_fedora/access.rb
+++ b/app/services/cocina/from_fedora/access.rb
@@ -17,26 +17,17 @@ module Cocina
 
       def props
         {
-          access: access_rights,
-          download: download,
-          readLocation: location,
           license: License.find(rights_metadata_ds),
           copyright: copyright,
           useAndReproductionStatement: use_statement
-        }.compact.tap do |h|
-          h[:controlledDigitalLending] = true if controlled_digital_lending?
-        end
+        }
+          .merge(AccessRights.props(rights_metadata_ds.dra_object, rights_xml: rights_metadata_ds.to_xml))
+          .compact
       end
 
       private
 
       attr_reader :rights_metadata_ds
-
-      delegate :controlled_digital_lending?, :dark?, :citation_only?, :obj_lvl, to: :rights_object
-
-      def rights_object
-        rights_metadata_ds.dra_object
-      end
 
       def copyright
         rights_metadata_ds.copyright.first.presence
@@ -44,95 +35,6 @@ module Cocina
 
       def use_statement
         rights_metadata_ds.use_statement.first.presence
-      end
-
-      # @note This method implements an algorithm for determining download
-      #       access based on both the object-level rights and the object-level
-      #       download, using helper methods that lean on the `dor-rights-auth`
-      #       gem.
-      def download
-        # Some access types dictate no downloading. Handle those cases first.
-        return 'none' if no_download? || stanford_no_download? || world_no_download? || location_no_download?
-
-        # Then check to see if download is based on location
-        return 'location-based' if location_based_download?
-
-        # If no specific download rules have been found yet and there are no explicit download rules set, set download to access rights
-        return access_rights if no_world_or_group_download_rules?
-
-        # Finally: the only remaining case is when rights are stanford + world (no-download), so grant download to stanford
-        return 'stanford' if stanford_world_no_download?
-
-        raise "Unexpected download rights: #{obj_lvl}"
-      end
-
-      def no_download?
-        citation_only? || dark? || controlled_digital_lending?
-      end
-
-      def no_world_or_group_download_rules?
-        obj_lvl.world.rule.nil? && obj_lvl.group.fetch(:stanford).rule.nil?
-      end
-
-      def stanford_no_download?
-        stanford? &&
-          obj_lvl.group.fetch(:stanford).rule == 'no-download' &&
-          !(location && obj_lvl.location.fetch(location).value)
-      end
-
-      def world_no_download?
-        world? &&
-          obj_lvl.world.rule == 'no-download' &&
-          !stanford? &&
-          !(location && obj_lvl.location.fetch(location).value)
-      end
-
-      def location_no_download?
-        location &&
-          obj_lvl.location.fetch(location).value &&
-          obj_lvl.location.fetch(location).rule == 'no-download'
-      end
-
-      def location_based_download?
-        location &&
-          obj_lvl.location.fetch(location).value &&
-          obj_lvl.location.fetch(location).rule.nil?
-      end
-
-      def stanford_world_no_download?
-        stanford? && obj_lvl.world.rule == 'no-download'
-      end
-
-      def stanford?
-        obj_lvl.group.fetch(:stanford).value
-      end
-
-      def world?
-        obj_lvl.world.value
-      end
-
-      def location
-        @location ||= obj_lvl.location.keys.first
-      end
-
-      # Map values from dor-services
-      # https://github.com/sul-dlss/dor-services/blob/b9b4768eac560ef99b4a8d03475ea31fe4ae2367/lib/dor/datastreams/rights_metadata_ds.rb#L221-L228
-      # to https://github.com/sul-dlss/cocina-models/blob/main/docs/maps/DRO.json#L102
-      def access_rights
-        @access_rights ||=
-          if world?
-            'world'
-          elsif stanford? || controlled_digital_lending?
-            'stanford'
-          elsif citation_only?
-            'citation-only'
-          elsif dark?
-            'dark'
-          elsif location
-            'location-based'
-          else
-            raise "Cannot interpret access rights from #{rights_metadata_ds.to_xml}"
-          end
       end
     end
   end

--- a/app/services/cocina/from_fedora/access/access_rights.rb
+++ b/app/services/cocina/from_fedora/access/access_rights.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+module Cocina
+  module FromFedora
+    class Access
+      # builds the access rights portion of the Access subschema
+      class AccessRights
+        def self.props(rights_object, rights_xml:)
+          new(rights_object, rights_xml: rights_xml).props
+        end
+
+        def initialize(rights_object, rights_xml:)
+          @rights_object = rights_object
+          @rights_xml = rights_xml
+        end
+
+        def props
+          {
+            access: access_rights,
+            download: download,
+            readLocation: location
+          }.compact.tap do |h|
+            h[:controlledDigitalLending] = true if controlled_digital_lending?
+          end
+        end
+
+        private
+
+        attr_reader :rights_object, :rights_xml
+
+        # @note This method implements an algorithm for determining download
+        #       access for objects and files based on both the rights setting
+        #       and the download setting, using helper methods that lean on the
+        #       `dor-rights-auth` gem.
+        def download
+          # Some access types dictate no downloading. Handle those cases first.
+          return 'none' if no_download? || stanford_no_download? || world_no_download? || location_no_download?
+
+          # Then check to see if download is based on location
+          return 'location-based' if location_based_download?
+
+          # If no specific download rules have been found yet and there are no explicit download rules set, set download to access rights
+          return access_rights if no_world_or_group_download_rules?
+
+          # Finally: the only remaining case is when rights are stanford + world (no-download), so grant download to stanford
+          return 'stanford' if stanford_world_no_download?
+
+          raise "Unexpected download rights: #{contextual_rights}"
+        end
+
+        # These next few methods are admittedly a little gross. But! They allow
+        # objects to use the full `Dor::RightsAuth` struct, which is returned by
+        # a method on the rights metadata datastream, while allowing files to
+        # use the `Dor::EntityRights` substruct of `Dor::RightsAuth`, which is
+        # how file rights are parsed by `dor-rights-auth`. And the algorithms
+        # for determining access and download are complex, so I'm OK with the
+        # timidness of these checks given the value we get in return.
+        def contextual_rights
+          return rights_object.obj_lvl if rights_object.respond_to?(:obj_lvl)
+
+          rights_object
+        end
+
+        def citation_only?
+          return false unless rights_object.respond_to?(:citation_only?)
+
+          rights_object.citation_only?
+        end
+
+        def controlled_digital_lending?
+          return contextual_rights.controlled_digital_lending unless contextual_rights.controlled_digital_lending.respond_to?(:value)
+
+          contextual_rights.controlled_digital_lending.value
+        end
+
+        def dark?
+          !(world? ||
+            stanford? ||
+            controlled_digital_lending? ||
+            location)
+        end
+
+        def no_download?
+          citation_only? || dark? || controlled_digital_lending?
+        end
+
+        def no_world_or_group_download_rules?
+          contextual_rights.world.rule.nil? && contextual_rights.group.fetch(:stanford).rule.nil?
+        end
+
+        def stanford_no_download?
+          stanford? &&
+            contextual_rights.group.fetch(:stanford).rule == 'no-download' &&
+            !(location && contextual_rights.location.fetch(location).value)
+        end
+
+        def world_no_download?
+          world? &&
+            contextual_rights.world.rule == 'no-download' &&
+            !stanford? &&
+            !(location && contextual_rights.location.fetch(location).value)
+        end
+
+        def location_no_download?
+          location &&
+            contextual_rights.location.fetch(location).value &&
+            contextual_rights.location.fetch(location).rule == 'no-download'
+        end
+
+        def location_based_download?
+          location &&
+            contextual_rights.location.fetch(location).value &&
+            contextual_rights.location.fetch(location).rule.nil?
+        end
+
+        def stanford_world_no_download?
+          stanford? && contextual_rights.world.rule == 'no-download'
+        end
+
+        def stanford?
+          contextual_rights.group.fetch(:stanford).value
+        end
+
+        def world?
+          contextual_rights.world.value
+        end
+
+        def location
+          @location ||= contextual_rights.location.keys.first
+        end
+
+        # Map values from dor-services
+        # https://github.com/sul-dlss/dor-services/blob/b9b4768eac560ef99b4a8d03475ea31fe4ae2367/lib/dor/datastreams/rights_metadata_ds.rb#L221-L228
+        # to https://github.com/sul-dlss/cocina-models/blob/main/docs/maps/DRO.json#L102
+        def access_rights
+          @access_rights ||=
+            if world?
+              'world'
+            elsif stanford? || controlled_digital_lending?
+              'stanford'
+            elsif citation_only?
+              'citation-only'
+            elsif dark?
+              'dark'
+            elsif location
+              'location-based'
+            else
+              raise "Cannot interpret access rights from #{rights_xml}"
+            end
+        end
+      end
+    end
+  end
+end

--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -27,7 +27,13 @@ module Cocina
           has_member_orders = build_has_member_orders
           structural[:hasMemberOrders] = has_member_orders if has_member_orders.present?
 
-          contains = FileSets.build(item.contentMetadata, version: item.current_version.to_i, ignore_resource_type_errors: project_phoenix?)
+          # To build file sets, we need to consider both content metadata and
+          # rights metadata, the latter of which is used to map file-specific
+          # access/rights.
+          contains = FileSets.build(item.contentMetadata,
+                                    rights_metadata: item.rightsMetadata,
+                                    version: item.current_version.to_i,
+                                    ignore_resource_type_errors: project_phoenix?)
           structural[:contains] = contains if contains.present?
 
           structural[:hasAgreement] = item.identityMetadata.agreementId.first unless item.identityMetadata.agreementId.empty?

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -89,7 +89,7 @@ module Cocina
         add_dro_tags(pid, cocina_item)
 
         apply_default_access(fedora_item)
-        Cocina::ToFedora::DROAccess.apply(fedora_item, cocina_item.access) if cocina_item.access
+        Cocina::ToFedora::DROAccess.apply(fedora_item, cocina_item.access, cocina_item.structural) if cocina_item.access || cocina_item.structural
 
         fedora_item.contentMetadata.content = Cocina::ToFedora::ContentMetadataGenerator.generate(druid: pid, object: cocina_item)
         Cocina::ToFedora::Identity.apply(fedora_item, label: cocina_item.label, agreement_id: cocina_item.structural&.hasAgreement)

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -119,7 +119,7 @@ module Cocina
         agreement_id = has_changed?(:structural) ? cocina_object.structural&.hasAgreement : nil
         Cocina::ToFedora::Identity.apply(fedora_object, label: label, agreement_id: agreement_id)
       end
-      Cocina::ToFedora::DROAccess.apply(fedora_object, cocina_object.access) if has_changed?(:access)
+      Cocina::ToFedora::DROAccess.apply(fedora_object, cocina_object.access, cocina_object.structural) if has_changed?(:access) || has_changed?(:structural)
       update_content_metadata(fedora_object, cocina_object) if has_changed?(:structural) || has_changed?(:type)
 
       add_tags(fedora_object.pid, cocina_object)

--- a/app/services/cocina/to_fedora/access.rb
+++ b/app/services/cocina/to_fedora/access.rb
@@ -9,24 +9,28 @@ module Cocina
       #       See https://argo.stanford.edu/view/druid:bb142ws0723 as an example
       # @param [Dor::Item, Dor::Collection] item
       # @param [Cocina::Models::DROAccess, Cocina::Models::Access] access
-      def self.apply(item, access)
-        new(item, access).apply
+      # @param [Cocina::Models::DROStructural] structural
+      def self.apply(item, access, structural = nil)
+        new(item, access, structural).apply
       end
 
-      def initialize(item, access)
+      def initialize(item, access, structural)
         @item = item
         @access = access
+        @structural = structural
       end
 
       def apply
-        RightsMetadataGenerator.generate(rights: rightsMetadata, access: access)
+        return if access.nil?
+
+        RightsMetadataGenerator.generate(rights: rightsMetadata, access: access, structural: structural)
         update_rights_statements!
         License.update(rightsMetadata, access.license) if access.license
       end
 
       private
 
-      attr_reader :item, :access
+      attr_reader :item, :access, :structural
 
       delegate :rightsMetadata, to: :item
 

--- a/app/services/cocina/to_fedora/dro_access.rb
+++ b/app/services/cocina/to_fedora/dro_access.rb
@@ -6,7 +6,7 @@ module Cocina
     # Fedora 3 data model rightsMetadata
     class DROAccess < Access
       def apply
-        create_embargo(access.embargo) if access.embargo
+        create_embargo(access.embargo) if access&.embargo
 
         super
       end

--- a/app/services/cocina/to_fedora/rights/file_level.rb
+++ b/app/services/cocina/to_fedora/rights/file_level.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+module Cocina
+  module ToFedora
+    class Rights
+      # Builds the rightsMetadata xml from cocina for a file
+      class FileLevel
+        # @param [Nokogiri::XML::Document] rights_xml an XML document representing rights metadata
+        # @param [Cocina::Models::DROAccess, Cocina::Models::Access] access access/rights metadata in Cocina
+        # @param [Cocina::Models::DROStructural] structural structural metadata in Cocina
+        # @return [Array<Nokogiri::XML::Element>]
+        def self.generate(rights_xml:, access:, structural:)
+          new(rights_xml: rights_xml, access: access, structural: structural).generate
+        end
+
+        # @param [Nokogiri::XML::Document] rights_xml an XML document representing rights metadata
+        # @param [Cocina::Models::DROAccess, Cocina::Models::Access] access access/rights metadata in Cocina
+        # @param [Cocina::Models::DROStructural] structural structural metadata in Cocina
+        def initialize(rights_xml:, access:, structural:)
+          @rights_xml = rights_xml
+          @access = access
+          @structural = structural
+        end
+
+        # @return [Array<Nokogiri::XML::Element>]
+        def generate
+          [].tap do |nodes|
+            file_sets.each do |file_set|
+              file_set.structural.contains.each do |file|
+                next unless file_access_different_than_item_access?(file.access)
+
+                read_access_node = Nokogiri::XML::Node.new('access', rights_xml).tap do |access_node|
+                  access_node.set_attribute('type', 'read')
+                  file_node = Nokogiri::XML::Node.new('file', rights_xml)
+                  file_node.content = file.filename
+                  access_node.add_child(file_node)
+                end
+
+                read_access_node.add_child(read_machine_node(file.access))
+
+                if (download_node = download_machine_node(file.access))
+                  read_access_node.add_child(download_node)
+                end
+
+                nodes << read_access_node
+              end
+            end
+          end
+        end
+
+        private
+
+        attr_reader :rights_xml, :access, :structural
+
+        def file_sets
+          Array(structural&.contains)
+        end
+
+        def file_access_different_than_item_access?(file_access)
+          file_access.to_h.slice(*file_access_props) != access.to_h.slice(*file_access_props)
+        end
+
+        def file_access_props
+          %i[access controlledDigitalLending download readLocation]
+        end
+
+        def read_machine_node(file_access)
+          Nokogiri::XML::Node.new('machine', rights_xml).tap do |machine_node| # rubocop:disable Metrics/BlockLength
+            read_access_level_node =
+              if cdl_access?(file_access)
+                cdl_node = Nokogiri::XML::Node.new('cdl', rights_xml)
+                group_node = Nokogiri::XML::Node.new('group', cdl_node)
+                group_node.content = 'stanford'
+                group_node.set_attribute('rule', 'no-download')
+                cdl_node.add_child(group_node)
+                cdl_node
+              elsif world_read_access?(file_access)
+                world_node = Nokogiri::XML::Node.new('world', rights_xml)
+                world_node.set_attribute('rule', 'no-download') if no_download?(file_access) || location_based_download?(file_access) || stanford_download?(file_access)
+                world_node
+              elsif stanford_read_access?(file_access)
+                group_node = Nokogiri::XML::Node.new('group', rights_xml)
+                group_node.content = 'stanford'
+                group_node.set_attribute('rule', 'no-download') if no_download?(file_access) || location_based_download?(file_access)
+                group_node
+              elsif location_based_access?(file_access)
+                loc_node = Nokogiri::XML::Node.new('location', rights_xml)
+                loc_node.content = file_access.readLocation
+                loc_node.set_attribute('rule', 'no-download') if no_download?(file_access)
+                loc_node
+              else # we know it is citation-only or dark at this point
+                Nokogiri::XML::Node.new('none', rights_xml)
+              end
+            machine_node.add_child(read_access_level_node)
+          end
+        end
+
+        def download_machine_node(file_access)
+          return unless (location_based_download?(file_access) && (stanford_read_access?(file_access) || world_read_access?(file_access))) ||
+                        (stanford_download?(file_access) && world_read_access?(file_access))
+
+          Nokogiri::XML::Node.new('machine', rights_xml).tap do |machine_node|
+            download_access_level_node =
+              if location_based_download?(file_access)
+                loc_node = Nokogiri::XML::Node.new('location', rights_xml)
+                loc_node.content = file_access.readLocation
+                loc_node
+              elsif stanford_download?(file_access)
+                group_node = Nokogiri::XML::Node.new('group', rights_xml)
+                group_node.content = 'stanford'
+                group_node
+              end
+
+            machine_node.add_child(download_access_level_node)
+          end
+        end
+
+        def world_read_access?(file_access)
+          file_access.access == 'world'
+        end
+
+        def stanford_read_access?(file_access)
+          file_access.access == 'stanford'
+        end
+
+        def cdl_access?(file_access)
+          file_access.try(:controlledDigitalLending)
+        end
+
+        def location_based_access?(file_access)
+          file_access.access == 'location-based' && file_access.try(:readLocation)
+        end
+
+        def no_download?(file_access)
+          file_access.try(:download) == 'none'
+        end
+
+        def stanford_download?(file_access)
+          file_access.try(:download) == 'stanford'
+        end
+
+        def location_based_download?(file_access)
+          file_access.try(:download) == 'location-based' && file_access.try(:readLocation)
+        end
+      end
+    end
+  end
+end

--- a/app/services/cocina/to_fedora/rights/object_level.rb
+++ b/app/services/cocina/to_fedora/rights/object_level.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+module Cocina
+  module ToFedora
+    class Rights
+      # Builds the rightsMetadata xml from cocina for an object (item/collection)
+      class ObjectLevel
+        # @param [Nokogiri::XML::Document] rights_xml an XML document representing rights metadata
+        # @param [Cocina::Models::DROAccess, Cocina::Models::Access] access access/rights metadata in Cocina
+        # @return [Array<Nokogiri::XML::Element>]
+        def self.generate(rights_xml:, access:)
+          new(rights_xml: rights_xml, access: access).generate
+        end
+
+        # @param [Nokogiri::XML::Document] rights_xml an XML document representing rights metadata
+        # @param [Cocina::Models::DROAccess, Cocina::Models::Access] access access/rights metadata in Cocina
+        def initialize(rights_xml:, access:)
+          @rights_xml = rights_xml
+          @access = access
+        end
+
+        # @return [Array<Nokogiri::XML::Element>]
+        def generate
+          [].tap do |nodes|
+            # Add discover access node
+            nodes << discover_access_node
+
+            # Add read access node
+            nodes << read_access_node
+
+            # Add download access node if needed
+            nodes << download_access_node if download_access_node
+          end
+        end
+
+        private
+
+        attr_reader :rights_xml, :access
+
+        def discover_access_node
+          Nokogiri::XML::Node.new('access', rights_xml).tap do |access_node|
+            access_node.set_attribute('type', 'discover')
+            machine_node = Nokogiri::XML::Node.new('machine', rights_xml)
+            access_level_node = Nokogiri::XML::Node.new(discover_label, rights_xml)
+            machine_node.add_child(access_level_node)
+            access_node.add_child(machine_node)
+          end
+        end
+
+        # NOTE: The discover node is either 'none' for a dark object or 'world' for any other rights option
+        def discover_label
+          return 'none' if access.access == 'dark'
+
+          'world'
+        end
+
+        def read_access_node
+          Nokogiri::XML::Node.new('access', rights_xml).tap do |access_node|
+            access_node.set_attribute('type', 'read')
+            machine_node = Nokogiri::XML::Node.new('machine', rights_xml)
+            machine_node.add_child(read_access_level_node)
+            access_node.add_child(machine_node)
+          end
+        end
+
+        def read_access_level_node
+          if cdl_access?
+            cdl_node = Nokogiri::XML::Node.new('cdl', rights_xml)
+            group_node = Nokogiri::XML::Node.new('group', cdl_node)
+            group_node.content = 'stanford'
+            group_node.set_attribute('rule', 'no-download')
+            cdl_node.add_child(group_node)
+            cdl_node
+          elsif world_read_access?
+            world_node = Nokogiri::XML::Node.new('world', rights_xml)
+            world_node.set_attribute('rule', 'no-download') if no_download? || location_based_download? || stanford_download?
+            world_node
+          elsif stanford_read_access?
+            group_node = Nokogiri::XML::Node.new('group', rights_xml)
+            group_node.content = 'stanford'
+            group_node.set_attribute('rule', 'no-download') if no_download? || location_based_download?
+            group_node
+          elsif location_based_access?
+            loc_node = Nokogiri::XML::Node.new('location', rights_xml)
+            loc_node.content = access.readLocation
+            loc_node.set_attribute('rule', 'no-download') if no_download?
+            loc_node
+          else # we know it is citation-only or dark at this point
+            Nokogiri::XML::Node.new('none', rights_xml)
+          end
+        end
+
+        def download_access_node
+          return unless (location_based_download? && (stanford_read_access? || world_read_access?)) ||
+                        (stanford_download? && world_read_access?)
+
+          Nokogiri::XML::Node.new('access', rights_xml).tap do |access_node|
+            access_node.set_attribute('type', 'read')
+            machine_node = Nokogiri::XML::Node.new('machine', rights_xml)
+            machine_node.add_child(download_access_level_node)
+            access_node.add_child(machine_node)
+          end
+        end
+
+        def download_access_level_node
+          if location_based_download?
+            loc_node = Nokogiri::XML::Node.new('location', rights_xml)
+            loc_node.content = access.readLocation
+            loc_node
+          elsif stanford_download?
+            group_node = Nokogiri::XML::Node.new('group', rights_xml)
+            group_node.content = 'stanford'
+            group_node
+          end
+        end
+
+        def world_read_access?
+          access.access == 'world'
+        end
+
+        def stanford_read_access?
+          access.access == 'stanford'
+        end
+
+        def cdl_access?
+          access.try(:controlledDigitalLending)
+        end
+
+        def location_based_access?
+          access.access == 'location-based' && access.try(:readLocation)
+        end
+
+        def no_download?
+          access.try(:download) == 'none'
+        end
+
+        def stanford_download?
+          access.try(:download) == 'stanford'
+        end
+
+        def location_based_download?
+          access.try(:download) == 'location-based' && access.try(:readLocation)
+        end
+      end
+    end
+  end
+end

--- a/app/services/cocina/to_fedora/rights_metadata_generator.rb
+++ b/app/services/cocina/to_fedora/rights_metadata_generator.rb
@@ -6,145 +6,47 @@ module Cocina
     class RightsMetadataGenerator
       # @param [Dor::RightsMetadataDS] rights the DOR Rights metadata datastream
       # @param [Cocina::Models::DROAccess, Cocina::Models::Access] access access/rights metadata in Cocina
-      def self.generate(rights:, access:)
-        new(rights: rights, access: access).generate
+      # @param [Cocina::Models::DROStructural] structural structural metadata in Cocina
+      # @return [String] Fedora rights metadata XML
+      def self.generate(rights:, access:, structural: nil)
+        new(rights: rights, access: access, structural: structural).generate
       end
 
-      def initialize(rights:, access:)
+      # @param [Dor::RightsMetadataDS] rights the DOR Rights metadata datastream
+      # @param [Cocina::Models::DROAccess, Cocina::Models::Access] access access/rights metadata in Cocina
+      # @param [Cocina::Models::DROStructural] structural structural metadata in Cocina
+      def initialize(rights:, access:, structural:)
         @rights = rights
         @access = access
+        @structural = structural
       end
 
-      # Adapted copypasta from https://github.com/sul-dlss/dor-services/blob/main/lib/dor/datastreams/rights_metadata_ds.rb
+      # @return [String] Fedora rights metadata XML
       def generate
+        return if access.nil?
+
         rights.ng_xml_will_change!
 
         # Remove existing access nodes to begin rebuilding them from Cocina
         rights_xml.search('//rightsMetadata/access').each(&:remove)
 
-        # Add discover access node
-        rights_xml.root.add_child(discover_access_node)
+        Rights::ObjectLevel.generate(rights_xml: rights_xml, access: access).each do |object_access_node|
+          rights_xml.root.add_child(object_access_node)
+        end
 
-        # Add read access node
-        rights_xml.root.add_child(read_access_node)
-
-        # Add download access node if needed
-        rights_xml.root.add_child(download_access_node) if download_access_node
+        Rights::FileLevel.generate(rights_xml: rights_xml, access: access, structural: structural).each do |file_access_node|
+          rights_xml.root.add_child(file_access_node)
+        end
 
         rights_xml.to_xml
       end
 
       private
 
-      attr_reader :rights, :access
+      attr_reader :rights, :access, :structural
 
       def rights_xml
         rights.ng_xml
-      end
-
-      def discover_access_node
-        Nokogiri::XML::Node.new('access', rights_xml).tap do |access_node|
-          access_node.set_attribute('type', 'discover')
-          machine_node = Nokogiri::XML::Node.new('machine', rights_xml)
-          access_level_node = Nokogiri::XML::Node.new(discover_label, rights_xml)
-          machine_node.add_child(access_level_node)
-          access_node.add_child(machine_node)
-        end
-      end
-
-      # NOTE: The discover node is either 'none' for a dark object or 'world' for any other rights option
-      def discover_label
-        return 'none' if access.access == 'dark'
-
-        'world'
-      end
-
-      def read_access_node
-        Nokogiri::XML::Node.new('access', rights_xml).tap do |access_node|
-          access_node.set_attribute('type', 'read')
-          machine_node = Nokogiri::XML::Node.new('machine', rights_xml)
-          machine_node.add_child(read_access_level_node)
-          access_node.add_child(machine_node)
-        end
-      end
-
-      def read_access_level_node
-        if cdl_access?
-          cdl_node = Nokogiri::XML::Node.new('cdl', rights_xml)
-          group_node = Nokogiri::XML::Node.new('group', cdl_node)
-          group_node.content = 'stanford'
-          group_node.set_attribute('rule', 'no-download')
-          cdl_node.add_child(group_node)
-          cdl_node
-        elsif world_read_access?
-          world_node = Nokogiri::XML::Node.new('world', rights_xml)
-          world_node.set_attribute('rule', 'no-download') if no_download? || location_based_download? || stanford_download?
-          world_node
-        elsif stanford_read_access?
-          group_node = Nokogiri::XML::Node.new('group', rights_xml)
-          group_node.content = 'stanford'
-          group_node.set_attribute('rule', 'no-download') if no_download? || location_based_download?
-          group_node
-        elsif location_based_access?
-          loc_node = Nokogiri::XML::Node.new('location', rights_xml)
-          loc_node.content = access.readLocation
-          loc_node.set_attribute('rule', 'no-download') if no_download?
-          loc_node
-        else # we know it is citation-only or dark at this point
-          Nokogiri::XML::Node.new('none', rights_xml)
-        end
-      end
-
-      def download_access_node
-        return unless (location_based_download? && (stanford_read_access? || world_read_access?)) ||
-                      (stanford_download? && world_read_access?)
-
-        Nokogiri::XML::Node.new('access', rights_xml).tap do |access_node|
-          access_node.set_attribute('type', 'read')
-          machine_node = Nokogiri::XML::Node.new('machine', rights_xml)
-          machine_node.add_child(download_access_level_node)
-          access_node.add_child(machine_node)
-        end
-      end
-
-      def download_access_level_node
-        if location_based_download?
-          loc_node = Nokogiri::XML::Node.new('location', rights_xml)
-          loc_node.content = access.readLocation
-          loc_node
-        elsif stanford_download?
-          group_node = Nokogiri::XML::Node.new('group', rights_xml)
-          group_node.content = 'stanford'
-          group_node
-        end
-      end
-
-      def world_read_access?
-        access.access == 'world'
-      end
-
-      def stanford_read_access?
-        access.access == 'stanford'
-      end
-
-      def cdl_access?
-        access.try(:controlledDigitalLending)
-      end
-
-      def location_based_access?
-        access.access == 'location-based' && access.try(:readLocation)
-      end
-
-      def no_download?
-        access.try(:download) == 'none'
-      end
-
-      def stanford_download?
-        access.try(:download) == 'stanford'
-      end
-
-      def location_based_download?
-        access.try(:download) == 'location-based' && access.try(:readLocation)
       end
     end
   end

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -422,7 +422,7 @@ RSpec.describe 'Create object' do
                     filename: '00001.jp2',
                     size: 0, version: 1,
                     hasMimeType: 'image/jp2', hasMessageDigests: [],
-                    access: { access: 'world', download: 'world' },
+                    access: { access: 'stanford', download: 'none' },
                     administrative: { publish: true, sdrPreserve: true, shelve: true }
                   }
                 ]
@@ -449,7 +449,7 @@ RSpec.describe 'Create object' do
                     size: 0, version: 1,
                     hasMimeType: 'image/jp2',
                     hasMessageDigests: [],
-                    access: { access: 'world', download: 'world' },
+                    access: { access: 'world', download: 'none' },
                     administrative: { publish: true, sdrPreserve: true, shelve: true }
                   }
                 ]

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe 'Update object' do
       item.identityMetadata.barcode = '36105036289000'
       item.rightsMetadata.content = Cocina::ToFedora::RightsMetadataGenerator.generate(
         rights: Dor::RightsMetadataDS.new,
-        access: cocina_access
+        access: cocina_access,
+        structural: cocina_structural
       )
     end
   end
@@ -55,6 +56,7 @@ RSpec.describe 'Update object' do
       hasAgreement: 'druid:cd777df7777'
     }
   end
+  let(:cocina_structural) { Cocina::Models::DROStructural.new(structural) }
   let(:access) { 'world' }
   let(:download) { 'world' }
   let(:cocina_access) do

--- a/spec/services/cocina/from_fedora/dro_access_spec.rb
+++ b/spec/services/cocina/from_fedora/dro_access_spec.rb
@@ -6,10 +6,7 @@ RSpec.describe Cocina::FromFedora::DROAccess do
   subject(:access) { described_class.props(item.rightsMetadata, embargo: embargo) }
 
   let(:embargo) { {} }
-
-  let(:item) do
-    Dor::Item.new
-  end
+  let(:item) { Dor::Item.new }
   let(:rights_metadata_ds) { Dor::RightsMetadataDS.new.tap { |ds| ds.content = xml } }
 
   before do
@@ -49,7 +46,31 @@ RSpec.describe Cocina::FromFedora::DROAccess do
     end
   end
 
-  describe 'access and download rights' do
+  describe 'access and download rights for items' do
+    context 'when citation-only' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <none/>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'specifies access as citation-only w/ no download' do
+        expect(access).to eq(access: 'citation-only', download: 'none')
+      end
+    end
+
     context 'when controlled digital lending' do
       let(:xml) do
         <<~XML

--- a/spec/services/cocina/from_fedora/dro_structural_spec.rb
+++ b/spec/services/cocina/from_fedora/dro_structural_spec.rb
@@ -191,11 +191,12 @@ RSpec.describe Cocina::FromFedora::DroStructural do
       expect(file1[:hasMessageDigests].first[:type]).to eq 'sha1'
       expect(file1[:administrative][:shelve]).to eq true
       expect(file1[:administrative][:sdrPreserve]).to eq false
-      expect(file1[:access][:access]).to eq('world')
+      expect(file1[:administrative][:publish]).to eq true
 
       file2 = folder1[:structural][:contains][1]
       expect(file2[:administrative][:shelve]).to eq false
       expect(file2[:administrative][:sdrPreserve]).to eq true
+      expect(file2[:administrative][:publish]).to eq false
       expect(file2[:access][:access]).to eq('dark')
     end
   end

--- a/spec/services/cocina/from_fedora/file_sets_spec.rb
+++ b/spec/services/cocina/from_fedora/file_sets_spec.rb
@@ -3,8 +3,60 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::FromFedora::FileSets do
-  describe '.resource_type' do
-    subject { described_class.resource_type(node, ignore_resource_type_errors: false) }
+  let(:content_xml) do
+    <<~XML
+      <contentMetadata objectId="druid:gs491bt1345" type="media">
+        <resource id="gs491bt1345_1" sequence="1" type="audio">
+          <label>Audio file</label>
+          <file id="gs491bt1345_sample_01_00_pm.wav" mimetype="audio/x-wav" size="299569842" publish="no" shelve="no" preserve="yes">
+            <checksum type="sha1">ccde1331b5bc6c3dce0231c352c7a11f1fd3e77f</checksum>
+            <checksum type="md5">d46055f03b4a9dc30fcfdfebea473127</checksum>
+          </file>
+          <file id="gs491bt1345_sample_01_00_sh.wav" mimetype="audio/x-wav" size="91743738" publish="no" shelve="no" preserve="yes">
+            <checksum type="sha1">a9cb4668c42c5416a301759ff40fe365ea2467a3</checksum>
+            <checksum type="md5">188c0c972bc039c679bf984e75c7500e</checksum>
+          </file>
+          <file id="gs491bt1345_sample_01_00_sl.m4a" mimetype="audio/mp4" size="16798755" publish="yes" shelve="yes" preserve="yes">
+            <checksum type="sha1">8d95b3b77f900b6d229ee32d05f927d75cbce032</checksum>
+            <checksum type="md5">b044b593d0d444180e82de064594339a</checksum>
+          </file>
+        </resource>
+        <resource id="gs491bt1345_2" sequence="2" type="file">
+          <label>Program PDF</label>
+          <file id="gs491bt1345_sample_md.pdf" mimetype="application/pdf" size="930089" publish="yes" shelve="yes" preserve="yes">
+            <checksum type="sha1">3b342f7b87f126997088720c1220122d41c8c159</checksum>
+            <checksum type="md5">6ed0004f39657ff81dff7b2b017fb9d9</checksum>
+          </file>
+        </resource>
+      </contentMetadata>
+    XML
+  end
+  let(:ignore_resource_type_errors) { false }
+  let(:instance) do
+    described_class.new(content_metadata_ds,
+                        rights_metadata: rights_metadata_ds,
+                        version: 1,
+                        ignore_resource_type_errors: ignore_resource_type_errors)
+  end
+  let(:content_metadata_ds) do
+    instance_double(Dor::ContentMetadataDS,
+                    ng_xml: Nokogiri::XML(content_xml))
+  end
+  let(:rights_metadata_ds) do
+    instance_double(Dor::RightsMetadataDS,
+                    new?: false,
+                    ng_xml: Nokogiri::XML(rights_xml),
+                    dra_object: Dor::RightsAuth.parse(rights_xml, true))
+  end
+  let(:rights_xml) do
+    <<~XML
+      <rightsMetadata>
+      </rightsMetadata>
+    XML
+  end
+
+  describe '#resource_type' do
+    subject { instance.send(:resource_type, node) }
 
     let(:node) { Nokogiri::XML::DocumentFragment.parse("<resource type=\"#{type}\" />").at_css('resource') }
 
@@ -27,15 +79,298 @@ RSpec.describe Cocina::FromFedora::FileSets do
 
       context 'when ignore_resource_type_errors is not set' do
         it 'notifies Honeybadger' do
-          described_class.resource_type(node, ignore_resource_type_errors: false)
+          instance.send(:resource_type, node)
           expect(Honeybadger).to have_received(:notify)
         end
       end
 
       context 'when ignore_resource_type_errors is set' do
+        let(:ignore_resource_type_errors) { true }
+
         it 'does not notify Honeybadger' do
-          described_class.resource_type(node, ignore_resource_type_errors: true)
+          instance.send(:resource_type, node)
           expect(Honeybadger).not_to have_received(:notify)
+        end
+      end
+    end
+  end
+
+  describe 'file-level access rights' do
+    let(:rights_xml) do
+      <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          #{file_specific_rights}
+        </rightsMetadata>
+      XML
+    end
+    let(:rights_metadata_ds) do
+      instance_double(Dor::RightsMetadataDS,
+                      new?: false,
+                      ng_xml: Nokogiri::XML(rights_xml),
+                      dra_object: Dor::RightsAuth.parse(rights_xml, true))
+    end
+    let(:item_cocina_rights) do
+      {
+        access: 'world',
+        download: 'world'
+      }
+    end
+    let(:type) { Cocina::Models::Vocab.media }
+    let(:structural) { instance.build }
+    let(:audio_fileset) { structural.first[:structural][:contains] }
+    let(:text_fileset) { structural.last[:structural][:contains] }
+
+    context 'when controlled digital lending' do
+      let(:file_specific_rights) do
+        <<~XML
+          <access type="read">
+            <file>gs491bt1345_sample_md.pdf</file>
+            <machine>
+              <cdl>
+                <group rule="no-download">stanford</group>
+              </cdl>
+            </machine>
+          </access>
+        XML
+      end
+
+      it 'returns no access metadata for files without their own rights' do
+        expect(audio_fileset.pluck(:access)).to all(eq(item_cocina_rights))
+      end
+
+      it 'generates file-level access metadata for files with their own rights' do
+        expect(text_fileset.pluck(:access)).to include(access: 'stanford', controlledDigitalLending: true, download: 'none')
+      end
+    end
+
+    context 'when dark' do
+      let(:file_specific_rights) do
+        <<~XML
+          <access type="read">
+            <file>gs491bt1345_sample_md.pdf</file>
+            <machine>
+              <none/>
+            </machine>
+          </access>
+        XML
+      end
+
+      it 'returns no access metadata for files without their own rights' do
+        expect(audio_fileset.pluck(:access)).to all(eq(item_cocina_rights))
+      end
+
+      it 'generates file-level access metadata for files with their own rights' do
+        expect(text_fileset.pluck(:access)).to include(access: 'dark', download: 'none')
+      end
+    end
+
+    context 'when stanford' do
+      let(:file_specific_rights) do
+        <<~XML
+          <access type="read">
+            <file>gs491bt1345_sample_md.pdf</file>
+            <machine>
+              <group>stanford</group>
+            </machine>
+          </access>
+        XML
+      end
+
+      it 'returns no access metadata for files without their own rights' do
+        expect(audio_fileset.pluck(:access)).to all(eq(item_cocina_rights))
+      end
+
+      it 'generates file-level access metadata for files with their own rights' do
+        expect(text_fileset.pluck(:access)).to include(access: 'stanford', download: 'stanford')
+      end
+    end
+
+    context 'when stanford (no-download)' do
+      let(:file_specific_rights) do
+        <<~XML
+          <access type="read">
+            <file>gs491bt1345_sample_md.pdf</file>
+            <machine>
+              <group rule="no-download">stanford</group>
+            </machine>
+          </access>
+        XML
+      end
+
+      it 'returns no access metadata for files without their own rights' do
+        expect(audio_fileset.pluck(:access)).to all(eq(item_cocina_rights))
+      end
+
+      it 'generates file-level access metadata for files with their own rights' do
+        expect(text_fileset.pluck(:access)).to include(access: 'stanford', download: 'none')
+      end
+    end
+
+    context 'when stanford + world (no-download)' do
+      let(:file_specific_rights) do
+        <<~XML
+          <access type="read">
+            <file>gs491bt1345_sample_md.pdf</file>
+            <machine>
+              <group>stanford</group>
+            </machine>
+            <machine>
+              <world rule="no-download"/>
+            </machine>
+          </access>
+        XML
+      end
+
+      it 'returns no access metadata for files without their own rights' do
+        expect(audio_fileset.pluck(:access)).to all(eq(item_cocina_rights))
+      end
+
+      it 'generates file-level access metadata for files with their own rights' do
+        expect(text_fileset.pluck(:access)).to include(access: 'world', download: 'stanford')
+      end
+    end
+
+    context 'when world' do
+      let(:file_specific_rights) do
+        <<~XML
+          <access type="read">
+            <file>gs491bt1345_sample_md.pdf</file>
+            <machine>
+              <world/>
+            </machine>
+          </access>
+        XML
+      end
+
+      it 'returns no access metadata for files without their own rights' do
+        expect(audio_fileset.pluck(:access)).to all(eq(item_cocina_rights))
+      end
+
+      it 'generates file-level access metadata for files with their own rights' do
+        expect(text_fileset.pluck(:access)).to include(access: 'world', download: 'world')
+      end
+    end
+
+    context 'when world (no-download)' do
+      let(:file_specific_rights) do
+        <<~XML
+          <access type="read">
+            <file>gs491bt1345_sample_md.pdf</file>
+            <machine>
+              <world rule="no-download"/>
+            </machine>
+          </access>
+        XML
+      end
+
+      it 'returns no access metadata for files without their own rights' do
+        expect(audio_fileset.pluck(:access)).to all(eq(item_cocina_rights))
+      end
+
+      it 'generates file-level access metadata for files with their own rights' do
+        expect(text_fileset.pluck(:access)).to include(access: 'world', download: 'none')
+      end
+    end
+
+    ['ars', 'art', 'hoover', 'm&m', 'music', 'spec'].each do |location|
+      context "with location:#{location}" do
+        let(:file_specific_rights) do
+          <<~XML
+            <access type="read">
+              <file>gs491bt1345_sample_md.pdf</file>
+              <machine>
+                <location>#{CGI.escapeHTML(location)}</location>
+              </machine>
+            </access>
+          XML
+        end
+
+        it 'returns no access metadata for files without their own rights' do
+          expect(audio_fileset.pluck(:access)).to all(eq(item_cocina_rights))
+        end
+
+        it 'generates file-level access metadata for files with their own rights' do
+          expect(text_fileset.pluck(:access)).to include(access: 'location-based', download: 'location-based', readLocation: location)
+        end
+      end
+
+      context "with location:#{location} (no-download)" do
+        let(:file_specific_rights) do
+          <<~XML
+            <access type="read">
+              <file>gs491bt1345_sample_md.pdf</file>
+              <machine>
+                <location rule="no-download">#{CGI.escapeHTML(location)}</location>
+              </machine>
+            </access>
+          XML
+        end
+
+        it 'returns no access metadata for files without their own rights' do
+          expect(audio_fileset.pluck(:access)).to all(eq(item_cocina_rights))
+        end
+
+        it 'generates file-level access metadata for files with their own rights' do
+          expect(text_fileset.pluck(:access)).to include(access: 'location-based', download: 'none', readLocation: location)
+        end
+      end
+
+      context "with location:#{location} + stanford (no-download)" do
+        let(:file_specific_rights) do
+          <<~XML
+            <access type="read">
+              <file>gs491bt1345_sample_md.pdf</file>
+              <machine>
+                <location>#{CGI.escapeHTML(location)}</location>
+              </machine>
+              <machine>
+                <group rule="no-download">stanford</group>
+              </machine>
+            </access>
+          XML
+        end
+
+        it 'returns no access metadata for files without their own rights' do
+          expect(audio_fileset.pluck(:access)).to all(eq(item_cocina_rights))
+        end
+
+        it 'generates file-level access metadata for files with their own rights' do
+          expect(text_fileset.pluck(:access)).to include(access: 'stanford', download: 'location-based', readLocation: location)
+        end
+      end
+
+      context "with location:#{location} + world (no-download)" do
+        let(:file_specific_rights) do
+          <<~XML
+            <access type="read">
+              <file>gs491bt1345_sample_md.pdf</file>
+              <machine>
+                <location>#{CGI.escapeHTML(location)}</location>
+              </machine>
+              <machine>
+                <world rule="no-download"/>
+              </machine>
+            </access>
+          XML
+        end
+
+        it 'returns no access metadata for files without their own rights' do
+          expect(audio_fileset.pluck(:access)).to all(eq(item_cocina_rights))
+        end
+
+        it 'generates file-level access metadata for files with their own rights' do
+          expect(text_fileset.pluck(:access)).to include(access: 'world', download: 'location-based', readLocation: location)
         end
       end
     end

--- a/spec/services/cocina/object_updater_spec.rb
+++ b/spec/services/cocina/object_updater_spec.rb
@@ -442,10 +442,14 @@ RSpec.describe Cocina::ObjectUpdater do
     context 'when updating structural without a contains block and with reading direction' do
       before do
         allow(item).to receive(:collection_ids=)
+        allow(item).to receive(:rightsMetadata).and_return(
+          instance_double(Dor::RightsMetadataDS, ng_xml_will_change!: nil)
+        )
         allow(content_metadata).to receive(:contentType=)
         allow(Cocina::ToFedora::Identity).to receive(:apply)
         allow(AdministrativeTags).to receive(:create)
         allow(content_metadata).to receive(:ng_xml)
+        allow(Cocina::ToFedora::RightsMetadataGenerator).to receive(:generate)
       end
 
       context 'when structural has changed' do
@@ -465,6 +469,7 @@ RSpec.describe Cocina::ObjectUpdater do
           expect(content_metadata).not_to have_received(:ng_xml)
           expect(Cocina::ToFedora::Identity).to have_received(:apply)
           expect(AdministrativeTags).to have_received(:create)
+          expect(Cocina::ToFedora::RightsMetadataGenerator).to have_received(:generate)
         end
       end
 
@@ -475,6 +480,7 @@ RSpec.describe Cocina::ObjectUpdater do
           expect(content_metadata).not_to have_received(:contentType=)
           expect(Cocina::ToFedora::Identity).not_to have_received(:apply)
           expect(AdministrativeTags).not_to have_received(:create)
+          expect(Cocina::ToFedora::RightsMetadataGenerator).not_to have_received(:generate)
         end
       end
     end
@@ -482,11 +488,15 @@ RSpec.describe Cocina::ObjectUpdater do
     context 'when updating structural with a contains block' do
       before do
         allow(item).to receive(:collection_ids=)
+        allow(item).to receive(:rightsMetadata).and_return(
+          instance_double(Dor::RightsMetadataDS, ng_xml_will_change!: nil)
+        )
         allow(content_metadata).to receive(:content=)
         allow(content_metadata).to receive(:contentType=)
         allow(content_metadata).to receive(:ng_xml)
         allow(Cocina::ToFedora::Identity).to receive(:apply)
         allow(AdministrativeTags).to receive(:create)
+        allow(Cocina::ToFedora::RightsMetadataGenerator).to receive(:generate)
       end
 
       let(:cocina_attrs) do
@@ -505,6 +515,7 @@ RSpec.describe Cocina::ObjectUpdater do
         expect(content_metadata).not_to have_received(:ng_xml)
         expect(Cocina::ToFedora::Identity).to have_received(:apply)
         expect(AdministrativeTags).to have_received(:create)
+        expect(Cocina::ToFedora::RightsMetadataGenerator).to have_received(:generate)
       end
     end
 

--- a/spec/services/cocina/to_fedora/rights_metadata_generator_spec.rb
+++ b/spec/services/cocina/to_fedora/rights_metadata_generator_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 
 RSpec.describe Cocina::ToFedora::RightsMetadataGenerator do
   subject(:generate) do
-    described_class.generate(rights: rights, access: access)
+    described_class.generate(rights: rights, access: access, structural: structural)
   end
 
-  let(:access) { Cocina::Models::DROAccess.new(JSON.parse(cocina)) }
+  let(:access) { Cocina::Models::DROAccess.new(JSON.parse(cocina_access)) }
   let(:item) { instantiate_fixture('druid:hj097bm8879', Dor::Item) }
   let(:rights) { item.rightsMetadata }
   let(:rights_statements) do
@@ -24,263 +24,15 @@ RSpec.describe Cocina::ToFedora::RightsMetadataGenerator do
       </copyright>
     XML
   end
+  let(:structural) { nil }
 
-  context 'when citation-only' do
-    let(:cocina) do
-      <<~JSON
-        {
-          "access": "citation-only",
-          "download": "none"
-        }
-      JSON
-    end
-
-    it 'maps rights metadata as expected' do
-      expect(generate).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <none/>
-            </machine>
-          </access>
-          #{rights_statements}
-        </rightsMetadata>
-      XML
-    end
-  end
-
-  context 'when controlled digital lending' do
-    let(:cocina) do
-      <<~JSON
-        {
-          "access": "stanford",
-          "controlledDigitalLending": true,
-          "download": "none"
-        }
-      JSON
-    end
-
-    it 'maps rights metadata as expected' do
-      expect(generate).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <cdl>
-                <group rule="no-download">stanford</group>
-              </cdl>
-            </machine>
-          </access>
-          #{rights_statements}
-        </rightsMetadata>
-      XML
-    end
-  end
-
-  context 'when dark' do
-    let(:cocina) do
-      <<~JSON
-        {
-          "access": "dark",
-          "download": "none"
-        }
-      JSON
-    end
-
-    it 'maps rights metadata as expected' do
-      expect(generate).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <none/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <none/>
-            </machine>
-          </access>
-          #{rights_statements}
-        </rightsMetadata>
-      XML
-    end
-  end
-
-  context 'when stanford' do
-    let(:cocina) do
-      <<~JSON
-        {
-          "access": "stanford",
-          "download": "stanford"
-        }
-      JSON
-    end
-
-    it 'maps rights metadata as expected' do
-      expect(generate).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <group>stanford</group>
-            </machine>
-          </access>
-          #{rights_statements}
-        </rightsMetadata>
-      XML
-    end
-  end
-
-  context 'when stanford (no-download)' do
-    let(:cocina) do
-      <<~JSON
-        {
-          "access": "stanford",
-          "download": "none"
-        }
-      JSON
-    end
-
-    it 'maps rights metadata as expected' do
-      expect(generate).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <group rule="no-download">stanford</group>
-            </machine>
-          </access>
-          #{rights_statements}
-        </rightsMetadata>
-      XML
-    end
-  end
-
-  context 'when stanford + world (no-download)' do
-    let(:cocina) do
-      <<~JSON
-        {
-          "access": "world",
-          "download": "stanford"
-        }
-      JSON
-    end
-
-    it 'maps rights metadata as expected' do
-      expect(generate).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <group>stanford</group>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <world rule="no-download"/>
-            </machine>
-          </access>
-          #{rights_statements}
-        </rightsMetadata>
-      XML
-    end
-  end
-
-  context 'when world' do
-    let(:cocina) do
-      <<~JSON
-        {
-          "access": "world",
-          "download": "world"
-        }
-      JSON
-    end
-
-    it 'maps rights metadata as expected' do
-      expect(generate).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          #{rights_statements}
-        </rightsMetadata>
-      XML
-    end
-  end
-
-  context 'when world (no-download)' do
-    let(:cocina) do
-      <<~JSON
-        {
-          "access": "world",
-          "download": "none"
-        }
-      JSON
-    end
-
-    it 'maps rights metadata as expected' do
-      expect(generate).to be_equivalent_to <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <world rule="no-download"/>
-            </machine>
-          </access>
-          #{rights_statements}
-        </rightsMetadata>
-      XML
-    end
-  end
-
-  ['ars', 'art', 'hoover', 'm&m', 'music', 'spec'].each do |location|
-    context "when location:#{location}" do
-      let(:cocina) do
+  describe 'object-level generation' do
+    context 'when citation-only' do
+      let(:cocina_access) do
         <<~JSON
           {
-            "access": "location-based",
-            "download": "location-based",
-            "readLocation": "#{location}"
+            "access": "citation-only",
+            "download": "none"
           }
         JSON
       end
@@ -296,7 +48,7 @@ RSpec.describe Cocina::ToFedora::RightsMetadataGenerator do
             </access>
             <access type="read">
               <machine>
-                <location>#{CGI.escapeHTML(location)}</location>
+                <none/>
               </machine>
             </access>
             #{rights_statements}
@@ -305,44 +57,13 @@ RSpec.describe Cocina::ToFedora::RightsMetadataGenerator do
       end
     end
 
-    context "when location:#{location} (no-download)" do
-      let(:cocina) do
-        <<~JSON
-          {
-            "access": "location-based",
-            "download": "none",
-            "readLocation": "#{location}"
-          }
-        JSON
-      end
-
-      it 'maps rights metadata as expected' do
-        expect(generate).to be_equivalent_to <<~XML
-          <?xml version="1.0"?>
-          <rightsMetadata>
-            <access type="discover">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <access type="read">
-              <machine>
-                <location rule="no-download">#{CGI.escapeHTML(location)}</location>
-              </machine>
-            </access>
-            #{rights_statements}
-          </rightsMetadata>
-        XML
-      end
-    end
-
-    context "when location:#{location} + stanford (no-download)" do
-      let(:cocina) do
+    context 'when controlled digital lending' do
+      let(:cocina_access) do
         <<~JSON
           {
             "access": "stanford",
-            "download": "location-based",
-            "readLocation": "#{location}"
+            "controlledDigitalLending": true,
+            "download": "none"
           }
         JSON
       end
@@ -358,7 +79,94 @@ RSpec.describe Cocina::ToFedora::RightsMetadataGenerator do
             </access>
             <access type="read">
               <machine>
-                <location>#{CGI.escapeHTML(location)}</location>
+                <cdl>
+                  <group rule="no-download">stanford</group>
+                </cdl>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+
+    context 'when dark' do
+      let(:cocina_access) do
+        <<~JSON
+          {
+            "access": "dark",
+            "download": "none"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <none/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <none/>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+
+    context 'when stanford' do
+      let(:cocina_access) do
+        <<~JSON
+          {
+            "access": "stanford",
+            "download": "stanford"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <group>stanford</group>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+
+    context 'when stanford (no-download)' do
+      let(:cocina_access) do
+        <<~JSON
+          {
+            "access": "stanford",
+            "download": "none"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
               </machine>
             </access>
             <access type="read">
@@ -372,13 +180,12 @@ RSpec.describe Cocina::ToFedora::RightsMetadataGenerator do
       end
     end
 
-    context "when location:#{location} + world (no-download)" do
-      let(:cocina) do
+    context 'when stanford + world (no-download)' do
+      let(:cocina_access) do
         <<~JSON
           {
             "access": "world",
-            "download": "location-based",
-            "readLocation": "#{location}"
+            "download": "stanford"
           }
         JSON
       end
@@ -394,7 +201,7 @@ RSpec.describe Cocina::ToFedora::RightsMetadataGenerator do
             </access>
             <access type="read">
               <machine>
-                <location>#{CGI.escapeHTML(location)}</location>
+                <group>stanford</group>
               </machine>
             </access>
             <access type="read">
@@ -405,6 +212,792 @@ RSpec.describe Cocina::ToFedora::RightsMetadataGenerator do
             #{rights_statements}
           </rightsMetadata>
         XML
+      end
+    end
+
+    context 'when world' do
+      let(:cocina_access) do
+        <<~JSON
+          {
+            "access": "world",
+            "download": "world"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+
+    context 'when world (no-download)' do
+      let(:cocina_access) do
+        <<~JSON
+          {
+            "access": "world",
+            "download": "none"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world rule="no-download"/>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+
+    ['ars', 'art', 'hoover', 'm&m', 'music', 'spec'].each do |location|
+      context "when location:#{location}" do
+        let(:cocina_access) do
+          <<~JSON
+            {
+              "access": "location-based",
+              "download": "location-based",
+              "readLocation": "#{location}"
+            }
+          JSON
+        end
+
+        it 'maps rights metadata as expected' do
+          expect(generate).to be_equivalent_to <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <location>#{CGI.escapeHTML(location)}</location>
+                </machine>
+              </access>
+              #{rights_statements}
+            </rightsMetadata>
+          XML
+        end
+      end
+
+      context "when location:#{location} (no-download)" do
+        let(:cocina_access) do
+          <<~JSON
+            {
+              "access": "location-based",
+              "download": "none",
+              "readLocation": "#{location}"
+            }
+          JSON
+        end
+
+        it 'maps rights metadata as expected' do
+          expect(generate).to be_equivalent_to <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <location rule="no-download">#{CGI.escapeHTML(location)}</location>
+                </machine>
+              </access>
+              #{rights_statements}
+            </rightsMetadata>
+          XML
+        end
+      end
+
+      context "when location:#{location} + stanford (no-download)" do
+        let(:cocina_access) do
+          <<~JSON
+            {
+              "access": "stanford",
+              "download": "location-based",
+              "readLocation": "#{location}"
+            }
+          JSON
+        end
+
+        it 'maps rights metadata as expected' do
+          expect(generate).to be_equivalent_to <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <location>#{CGI.escapeHTML(location)}</location>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <group rule="no-download">stanford</group>
+                </machine>
+              </access>
+              #{rights_statements}
+            </rightsMetadata>
+          XML
+        end
+      end
+
+      context "when location:#{location} + world (no-download)" do
+        let(:cocina_access) do
+          <<~JSON
+            {
+              "access": "world",
+              "download": "location-based",
+              "readLocation": "#{location}"
+            }
+          JSON
+        end
+
+        it 'maps rights metadata as expected' do
+          expect(generate).to be_equivalent_to <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <location>#{CGI.escapeHTML(location)}</location>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <world rule="no-download"/>
+                </machine>
+              </access>
+              #{rights_statements}
+            </rightsMetadata>
+          XML
+        end
+      end
+    end
+  end
+
+  describe 'file rights generation' do
+    let(:cocina_access) do
+      <<~JSON
+        {
+          "access": "world",
+          "download": "world"
+        }
+      JSON
+    end
+    # NOTE: We could test this with smaller filesets but it seemed wise to test
+    #       with multiple sets containing multiple files
+    let(:cocina_filesets) do
+      <<~JSON
+        [
+          {
+            "externalIdentifier": "http://cocina.sul.stanford.edu/fileSet/c8fc22e3-ba0b-4532-8536-f010d117415d",
+            "type": "http://cocina.sul.stanford.edu/models/resources/audio.jsonld",
+            "version": 1,
+            "structural": {
+              "contains": [
+                {
+                  "externalIdentifier": "http://cocina.sul.stanford.edu/file/260a7c04-be8f-43cb-a1ae-2c6082563daf",
+                  "type": "http://cocina.sul.stanford.edu/models/file.jsonld",
+                  "label": "gs491bt1345_sample_01_00_pm.wav",
+                  "filename": "gs491bt1345_sample_01_00_pm.wav",
+                  "size": 299569842,
+                  "version": 1,
+                  "hasMessageDigests": [
+                    {
+                      "type": "sha1",
+                      "digest": "ccde1331b5bc6c3dce0231c352c7a11f1fd3e77f"
+                    },
+                    {
+                      "type": "md5",
+                      "digest": "d46055f03b4a9dc30fcfdfebea473127"
+                    }
+                  ],
+                  "access": {
+                    "access": "world",
+                    "download": "world"
+                  },
+                  "administrative": {
+                    "publish": false,
+                    "sdrPreserve": true,
+                    "shelve": false
+                  },
+                  "hasMimeType": "audio/x-wav"
+                },
+                {
+                  "externalIdentifier": "http://cocina.sul.stanford.edu/file/7420f933-5be0-4462-bbe0-d2f8ddba08e1",
+                  "type": "http://cocina.sul.stanford.edu/models/file.jsonld",
+                  "label": "gs491bt1345_sample_01_00_sh.wav",
+                  "filename": "gs491bt1345_sample_01_00_sh.wav",
+                  "size": 91743738,
+                  "version": 1,
+                  "hasMessageDigests": [
+                    {
+                      "type": "sha1",
+                      "digest": "a9cb4668c42c5416a301759ff40fe365ea2467a3"
+                    },
+                    {
+                      "type": "md5",
+                      "digest": "188c0c972bc039c679bf984e75c7500e"
+                    }
+                  ],
+                  "access": {
+                    "access": "world",
+                    "download": "world"
+                  },
+                  "administrative": {
+                    "publish": false,
+                    "sdrPreserve": true,
+                    "shelve": false
+                  },
+                  "hasMimeType": "audio/x-wav"
+                },
+                {
+                  "externalIdentifier": "http://cocina.sul.stanford.edu/file/70c2f617-1235-46a4-a015-ab788a4847ee",
+                  "type": "http://cocina.sul.stanford.edu/models/file.jsonld",
+                  "label": "gs491bt1345_sample_01_00_sl.m4a",
+                  "filename": "gs491bt1345_sample_01_00_sl.m4a",
+                  "size": 16798755,
+                  "version": 1,
+                  "hasMessageDigests": [
+                    {
+                      "type": "sha1",
+                      "digest": "8d95b3b77f900b6d229ee32d05f927d75cbce032"
+                    },
+                    {
+                      "type": "md5",
+                      "digest": "b044b593d0d444180e82de064594339a"
+                    }
+                  ],
+                  "access": {
+                    "access": "world",
+                    "download": "world"
+                  },
+                  "administrative": {
+                    "publish": true,
+                    "sdrPreserve": true,
+                    "shelve": true
+                  },
+                  "hasMimeType": "audio/mp4"
+                }
+              ]
+            },
+           "label": "Audio file"
+          },
+          {
+            "externalIdentifier": "http://cocina.sul.stanford.edu/fileSet/91df0a5b-093b-458e-a30a-9874a57d8313",
+            "type": "http://cocina.sul.stanford.edu/models/resources/file.jsonld",
+            "version": 1,
+            "structural": {
+              "contains": [
+                {
+                  "externalIdentifier": "http://cocina.sul.stanford.edu/file/3be6c06c-453d-4291-ae44-59cec2da33e1",
+                  "type": "http://cocina.sul.stanford.edu/models/file.jsonld",
+                  "label": "gs491bt1345_sample_md.pdf",
+                  "filename": "gs491bt1345_sample_md.pdf",
+                  "size": 930089,
+                  "version": 1,
+                  "hasMessageDigests": [
+                    {
+                      "type": "sha1",
+                      "digest": "3b342f7b87f126997088720c1220122d41c8c159"
+                    },
+                    {
+                      "type": "md5",
+                      "digest": "6ed0004f39657ff81dff7b2b017fb9d9"
+                    }
+                  ],
+                  "access": #{cocina_file_access},
+                  "administrative": {
+                    "publish": true,
+                    "sdrPreserve": true,
+                    "shelve": true
+                  },
+                  "hasMimeType": "application/pdf"
+                }
+              ]
+            },
+            "label": "Program PDF"
+          }
+        ]
+      JSON
+    end
+    let(:structural) { Cocina::Models::DROStructural.new(contains: JSON.parse(cocina_filesets)) }
+
+    context 'when controlled digital lending' do
+      let(:cocina_file_access) do
+        <<~JSON
+          {
+            "access": "stanford",
+            "controlledDigitalLending": true,
+            "download": "none"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <file>gs491bt1345_sample_md.pdf</file>
+              <machine>
+                <cdl>
+                  <group rule="no-download">stanford</group>
+                </cdl>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+
+    context 'when dark' do
+      let(:cocina_file_access) do
+        <<~JSON
+          {
+            "access": "dark",
+            "download": "none"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <file>gs491bt1345_sample_md.pdf</file>
+              <machine>
+                <none/>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+
+    context 'when stanford' do
+      let(:cocina_file_access) do
+        <<~JSON
+          {
+            "access": "stanford",
+            "download": "stanford"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <file>gs491bt1345_sample_md.pdf</file>
+              <machine>
+                <group>stanford</group>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+
+    context 'when stanford (no-download)' do
+      let(:cocina_file_access) do
+        <<~JSON
+          {
+            "access": "stanford",
+            "download": "none"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <file>gs491bt1345_sample_md.pdf</file>
+              <machine>
+                <group rule="no-download">stanford</group>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+
+    context 'when stanford + world (no-download)' do
+      let(:cocina_file_access) do
+        <<~JSON
+          {
+            "access": "world",
+            "download": "stanford"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <file>gs491bt1345_sample_md.pdf</file>
+              <machine>
+                <group>stanford</group>
+              </machine>
+              <machine>
+                <world rule="no-download"/>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+
+    context 'when world' do
+      # NOTE: Added because when object and file accesses match, the file access is not inserted in the XML
+      let(:cocina_access) do
+        <<~JSON
+          {
+            "access": "stanford",
+            "download": "stanford"
+          }
+        JSON
+      end
+      let(:cocina_file_access) do
+        <<~JSON
+          {
+            "access": "world",
+            "download": "world"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <group>stanford</group>
+              </machine>
+            </access>
+            <access type="read">
+              <file>gs491bt1345_sample_01_00_pm.wav</file>
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <file>gs491bt1345_sample_01_00_sh.wav</file>
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <file>gs491bt1345_sample_01_00_sl.m4a</file>
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <file>gs491bt1345_sample_md.pdf</file>
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+
+    context 'when world (no-download)' do
+      let(:cocina_file_access) do
+        <<~JSON
+          {
+            "access": "world",
+            "download": "none"
+          }
+        JSON
+      end
+
+      it 'maps rights metadata as expected' do
+        expect(generate).to be_equivalent_to <<~XML
+          <?xml version="1.0"?>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <file>gs491bt1345_sample_md.pdf</file>
+              <machine>
+                <world rule="no-download"/>
+              </machine>
+            </access>
+            #{rights_statements}
+          </rightsMetadata>
+        XML
+      end
+    end
+
+    ['ars', 'art', 'hoover', 'm&m', 'music', 'spec'].each do |location|
+      context "with location:#{location}" do
+        let(:cocina_file_access) do
+          <<~JSON
+            {
+              "access": "location-based",
+              "download": "location-based",
+              "readLocation": "#{location}"
+            }
+          JSON
+        end
+
+        it 'maps rights metadata as expected' do
+          expect(generate).to be_equivalent_to <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <file>gs491bt1345_sample_md.pdf</file>
+                <machine>
+                  <location>#{CGI.escapeHTML(location)}</location>
+                </machine>
+              </access>
+              #{rights_statements}
+            </rightsMetadata>
+          XML
+        end
+      end
+
+      context "with location:#{location} (no-download)" do
+        let(:cocina_file_access) do
+          <<~JSON
+            {
+              "access": "location-based",
+              "download": "none",
+              "readLocation": "#{location}"
+            }
+          JSON
+        end
+
+        it 'maps rights metadata as expected' do
+          expect(generate).to be_equivalent_to <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <file>gs491bt1345_sample_md.pdf</file>
+                <machine>
+                  <location rule="no-download">#{CGI.escapeHTML(location)}</location>
+                </machine>
+              </access>
+              #{rights_statements}
+            </rightsMetadata>
+          XML
+        end
+      end
+
+      context "with location:#{location} + stanford (no-download)" do
+        let(:cocina_file_access) do
+          <<~JSON
+            {
+              "access": "stanford",
+              "download": "location-based",
+              "readLocation": "#{location}"
+            }
+          JSON
+        end
+
+        it 'maps rights metadata as expected' do
+          expect(generate).to be_equivalent_to <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <file>gs491bt1345_sample_md.pdf</file>
+                <machine>
+                  <location>#{CGI.escapeHTML(location)}</location>
+                </machine>
+                <machine>
+                  <group rule="no-download">stanford</group>
+                </machine>
+              </access>
+              #{rights_statements}
+            </rightsMetadata>
+          XML
+        end
+      end
+
+      context "with location:#{location} + world (no-download)" do
+        let(:cocina_file_access) do
+          <<~JSON
+            {
+              "access": "world",
+              "download": "location-based",
+              "readLocation": "#{location}"
+            }
+          JSON
+        end
+
+        it 'maps rights metadata as expected' do
+          expect(generate).to be_equivalent_to <<~XML
+            <?xml version="1.0"?>
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <file>gs491bt1345_sample_md.pdf</file>
+                <machine>
+                  <location>#{CGI.escapeHTML(location)}</location>
+                </machine>
+                <machine>
+                  <world rule="no-download"/>
+                </machine>
+              </access>
+              #{rights_statements}
+            </rightsMetadata>
+          XML
+        end
       end
     end
   end


### PR DESCRIPTION
**HOLD** until this can be thoroughly tested in QA/stage

Fixes sul-dlss/argo#2382

## Why was this change made?

These commits complete mapping file-level rights from Fedora to Cocina and back. This is the first SDR implementation of rights mapping at the file level.

## How was this change tested?

CI, and will be tested in QA/stage

## Which documentation and/or configurations were updated?

None

