### PR TITLE
Add embargo metadata to cached datastreams.

### DIFF
--- a/lib/fedora_cache.rb
+++ b/lib/fedora_cache.rb
@@ -8,7 +8,7 @@ class FedoraCache
   include Rubydora::FedoraUrlHelpers
   include Dry::Monads[:result]
 
-  DATASTREAMS = %w[descMetadata identityMetadata rightsMetadata contentMetadata geoMetadata RELS-EXT].freeze
+  DATASTREAMS = %w[descMetadata identityMetadata rightsMetadata contentMetadata geoMetadata embargoMetadata RELS-EXT].freeze
 
   def initialize(overwrite: false, cache_dir: nil)
     @overwrite = overwrite


### PR DESCRIPTION
refs #2700

## Why was this change made?
To test embargo mapping, need to change embargo datastream.


## How was this change tested?
NA


## Which documentation and/or configurations were updated?
NA


