### PR TITLE
mapping/access/dro_access_spec: add to it and remove duplication elsewhere

### DIFF
--- a/spec/services/cocina/from_fedora/dro_access_spec.rb
+++ b/spec/services/cocina/from_fedora/dro_access_spec.rb
@@ -16,112 +16,12 @@ RSpec.describe Cocina::FromFedora::DROAccess do
     allow(item).to receive(:rightsMetadata).and_return(rights_metadata_ds)
   end
 
-  context 'with useAndReproduction and no copyright' do
-    # From https://argo.stanford.edu/view/druid:bb000kg4251
-    let(:xml) do
-      <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <use>
-            <human type="useAndReproduction">Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Public Services Librarian of the Dept. of Special Collections (http://library.stanford.edu/spc).</human>
-          </use>
-        </rightsMetadata>
-      XML
-    end
-
-    it 'builds the hash' do
-      expect(access).to eq(access: 'world',
-                           download: 'world',
-                           useAndReproductionStatement: 'Property rights reside with the repository. '\
-                           'Literary rights reside with the creators of the documents or their heirs. ' \
-                           'To obtain permission to publish or reproduce, please contact the Public ' \
-                           'Services Librarian of the Dept. of Special Collections ' \
-                           '(http://library.stanford.edu/spc).')
-    end
-  end
-
-  describe 'with copyright' do
-    # from https://argo.stanford.edu/view/druid:bb003dn0409
-    let(:xml) do
-      <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <use>
-            <human type="useAndReproduction">Official WTO documents are free for public use.</human>
-            <human type="creativeCommons"/>
-            <machine type="creativeCommons"/>
-          </use>
-          <copyright>
-            <human>Copyright &#xA9; World Trade Organization</human>
-          </copyright>
-        </rightsMetadata>
-      XML
-    end
-
-    it 'builds the hash' do
-      expect(access).to eq(access: 'world',
-                           download: 'world',
-                           copyright: 'Copyright © World Trade Organization',
-                           useAndReproductionStatement: 'Official WTO documents are free for public use.')
-    end
-  end
-
-  describe 'with copyright but no use statement (contrived example)' do
-    let(:xml) do
-      <<~XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <world/>
-            </machine>
-          </access>
-          <copyright>
-            <human>Copyright &#xA9; DLSS</human>
-          </copyright>
-        </rightsMetadata>
-      XML
-    end
-
-    it 'builds the hash' do
-      expect(access).to eq(access: 'world',
-                           download: 'world',
-                           copyright: 'Copyright © DLSS')
-    end
-  end
-
   context 'with an embargo' do
     let(:embargo) { Cocina::FromFedora::Embargo.props(item.embargoMetadata) }
     # from https://argo.stanford.edu/view/druid:bb003dn0409
 
     let(:xml) do
       <<~XML
-        <?xml version="1.0"?>
         <rightsMetadata>
           <access type="discover">
             <machine>
@@ -149,86 +49,10 @@ RSpec.describe Cocina::FromFedora::DROAccess do
     end
   end
 
-  context 'with an ODC license' do
-    let(:xml) do
-      <<~XML
-        <rightsMetadata>
-          <use>
-            <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
-            <machine type="openDataCommons">odc-by</machine>
-          </use>
-        </rightsMetadata>
-      XML
-    end
-
-    it 'builds the hash' do
-      expect(access).to include(license: 'http://opendatacommons.org/licenses/by/1.0/')
-    end
-  end
-
-  context 'with a CC license' do
-    let(:xml) do
-      <<~XML
-        <rightsMetadata>
-          <use>
-            <human type="creativeCommons">Attribution Non-Commercial, No Derivatives 3.0 Unported</human>
-            <machine type="creativeCommons">by-nc-nd</machine>
-          </use>
-        </rightsMetadata>
-      XML
-    end
-
-    it 'builds the hash' do
-      expect(access).to include(license: 'https://creativecommons.org/licenses/by-nc-nd/3.0/')
-    end
-  end
-
-  context 'with a "none" license' do
-    let(:xml) do
-      <<~XML
-        <rightsMetadata>
-          <use>
-            <human type="creativeCommons">no Creative Commons (CC) license</human>
-            <machine type="creativeCommons">none</machine>
-          </use>
-        </rightsMetadata>
-      XML
-    end
-
-    it 'builds the hash' do
-      expect(access).to include(license: 'http://cocina.sul.stanford.edu/licenses/none')
-    end
-  end
-
   describe 'access and download rights' do
-    context 'when citation-only' do
-      let(:xml) do
-        <<~XML
-          <?xml version="1.0"?>
-          <rightsMetadata>
-            <access type="discover">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <access type="read">
-              <machine>
-                <none/>
-              </machine>
-            </access>
-          </rightsMetadata>
-        XML
-      end
-
-      it 'specifies access as citation-only w/ no download' do
-        expect(access).to eq(access: 'citation-only', download: 'none')
-      end
-    end
-
     context 'when controlled digital lending' do
       let(:xml) do
         <<~XML
-          <?xml version="1.0"?>
           <rightsMetadata>
             <access type="discover">
               <machine>
@@ -248,54 +72,6 @@ RSpec.describe Cocina::FromFedora::DROAccess do
 
       it 'specifies access as stanford with cdl = true and no download' do
         expect(access).to eq(access: 'stanford', controlledDigitalLending: true, download: 'none')
-      end
-    end
-
-    context 'when dark' do
-      let(:xml) do
-        <<~XML
-          <?xml version="1.0"?>
-          <rightsMetadata>
-            <access type="discover">
-              <machine>
-                <none/>
-              </machine>
-            </access>
-            <access type="read">
-              <machine>
-                <none/>
-              </machine>
-            </access>
-          </rightsMetadata>
-        XML
-      end
-
-      it 'specifies access as dark with no download' do
-        expect(access).to eq(access: 'dark', download: 'none')
-      end
-    end
-
-    context 'when stanford' do
-      let(:xml) do
-        <<~XML
-          <?xml version="1.0"?>
-          <rightsMetadata>
-            <access type="discover">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <access type="read">
-              <machine>
-                <group>stanford</group>
-              </machine>
-            </access>
-          </rightsMetadata>
-        XML
-      end
-
-      it 'specifies access and download as stanford' do
-        expect(access).to eq(access: 'stanford', download: 'stanford')
       end
     end
 
@@ -328,58 +104,6 @@ RSpec.describe Cocina::FromFedora::DROAccess do
       end
     end
 
-    context 'when stanford + world (no-download)' do
-      let(:xml) do
-        <<~XML
-          <rightsMetadata>
-            <access type="discover">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <access type="read">
-              <machine>
-                <group>stanford</group>
-              </machine>
-            </access>
-            <access type="read">
-              <machine>
-                <world rule="no-download"/>
-              </machine>
-            </access>
-          </rightsMetadata>
-        XML
-      end
-
-      it 'specifies access as world with stanford download' do
-        expect(access).to eq(access: 'world', download: 'stanford')
-      end
-    end
-
-    context 'when world' do
-      let(:xml) do
-        <<~XML
-          <?xml version="1.0"?>
-          <rightsMetadata>
-            <access type="discover">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <access type="read">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-          </rightsMetadata>
-        XML
-      end
-
-      it 'specifies access and download as world' do
-        expect(access).to eq(access: 'world', download: 'world')
-      end
-    end
-
     context 'when world (no-download)' do
       let(:xml) do
         <<~XML
@@ -406,114 +130,6 @@ RSpec.describe Cocina::FromFedora::DROAccess do
 
       it 'specifies access as world with no download' do
         expect(access).to eq(access: 'world', download: 'none')
-      end
-    end
-
-    ['ars', 'art', 'hoover', 'm&m', 'music', 'spec'].each do |location|
-      context "with location:#{location}" do
-        let(:xml) do
-          <<~XML
-            <?xml version="1.0"?>
-            <rightsMetadata>
-              <access type="discover">
-                <machine>
-                  <world/>
-                </machine>
-              </access>
-              <access type="read">
-                <machine>
-                  <location>#{CGI.escapeHTML(location)}</location>
-                </machine>
-              </access>
-            </rightsMetadata>
-          XML
-        end
-
-        it "specifies access and download as location-based for #{location}" do
-          expect(access).to eq(access: 'location-based', readLocation: location, download: 'location-based')
-        end
-      end
-
-      context "with location:#{location} (no-download)" do
-        let(:xml) do
-          <<~XML
-            <?xml version="1.0"?>
-            <rightsMetadata>
-              <access type="discover">
-                <machine>
-                  <world/>
-                </machine>
-              </access>
-              <access type="read">
-                <machine>
-                  <location rule="no-download">#{CGI.escapeHTML(location)}</location>
-                </machine>
-              </access>
-            </rightsMetadata>
-          XML
-        end
-
-        it "specifies access as location-based for #{location} with no download" do
-          expect(access).to eq(access: 'location-based', readLocation: location, download: 'none')
-        end
-      end
-
-      context "with location:#{location} + stanford (no-download)" do
-        let(:xml) do
-          <<~XML
-            <?xml version="1.0"?>
-            <rightsMetadata>
-              <access type="discover">
-                <machine>
-                  <world/>
-                </machine>
-              </access>
-              <access type="read">
-                <machine>
-                  <location>#{CGI.escapeHTML(location)}</location>
-                </machine>
-              </access>
-              <access type="read">
-                <machine>
-                  <group rule="no-download">stanford</group>
-                </machine>
-              </access>
-            </rightsMetadata>
-          XML
-        end
-
-        it "specifies access as stanford and download as location-based for #{location}" do
-          expect(access).to eq(access: 'stanford', readLocation: location, download: 'location-based')
-        end
-      end
-
-      context "with location:#{location} + world (no-download)" do
-        let(:xml) do
-          <<~XML
-            <?xml version="1.0"?>
-            <rightsMetadata>
-              <access type="discover">
-                <machine>
-                  <world/>
-                </machine>
-              </access>
-              <access type="read">
-                <machine>
-                  <location>#{CGI.escapeHTML(location)}</location>
-                </machine>
-              </access>
-              <access type="read">
-                <machine>
-                  <world rule="no-download"/>
-                </machine>
-              </access>
-            </rightsMetadata>
-          XML
-        end
-
-        it "specifies access as world and download as location-based for #{location}" do
-          expect(access).to eq(access: 'world', readLocation: location, download: 'location-based')
-        end
       end
     end
   end

--- a/spec/services/cocina/mapping/access/dro_access_spec.rb
+++ b/spec/services/cocina/mapping/access/dro_access_spec.rb
@@ -145,6 +145,70 @@ RSpec.describe 'Fedora item rights/statements/licenses <--> Cocina DRO access ma
     end
   end
 
+  context 'with full example from https://github.com/sul-dlss/cocina-models/issues/236' do
+    # from bb001xb8305
+    it_behaves_like 'DRO Access Fedora Cocina mapping' do
+      let(:rights_xml) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <use>
+              <human type="creativeCommons">Public Domain Mark 1.0</human>
+              <machine type="creativeCommons" uri="https://creativecommons.org/publicdomain/mark/1.0/">pdm</machine>
+              <human type="useAndReproduction">hrrm hoo hum</human>
+            </use>
+            <copyright>
+              <human>Public Domain.</human>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      let(:roundtrip_rights_xml) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <use>
+              <license>https://creativecommons.org/publicdomain/mark/1.0/</license>
+              <human type="useAndReproduction">hrrm hoo hum</human>
+            </use>
+            <copyright>
+              <human>Public Domain.</human>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      let(:cocina_access_props) do
+        {
+          access: 'world',
+          copyright: 'Public Domain.',
+          download: 'world',
+          license: 'https://creativecommons.org/publicdomain/mark/1.0/',
+          useAndReproductionStatement: 'hrrm hoo hum'
+        }
+      end
+    end
+  end
+
   context 'with new style license specification (world access)' do
     it_behaves_like 'DRO Access Fedora Cocina mapping' do
       let(:rights_xml) do
@@ -209,63 +273,6 @@ RSpec.describe 'Fedora item rights/statements/licenses <--> Cocina DRO access ma
           download: 'world',
           useAndReproductionStatement: 'baroque',
           license: 'https://creativecommons.org/licenses/pdm/????'
-        }
-      end
-    end
-  end
-
-  context 'with CC 4.0 license' do
-    # based on bd324jt9731
-    it_behaves_like 'DRO Access Fedora Cocina mapping' do
-      let(:rights_xml) do
-        <<~XML
-          <rightsMetadata>
-            <access type="discover">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <access type="read">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <use>
-              <human type="creativeCommons">CC-BY SA 4.0</human>
-              <machine type="creativeCommons" uri="https://creativecommons.org/licenses/by-sa/4.0/">by-sa</machine>
-              <human type="useAndReproduction">we are all one</human>
-            </use>
-          </rightsMetadata>
-        XML
-      end
-
-      let(:roundtrip_rights_xml) do
-        <<~XML
-          <rightsMetadata>
-            <access type="discover">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <access type="read">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <use>
-              <license>https://creativecommons.org/licenses/by-sa/4.0/</license>
-              <human type="useAndReproduction">we are all one</human>
-            </use>
-          </rightsMetadata>
-        XML
-      end
-
-      let(:cocina_access_props) do
-        {
-          access: 'world',
-          download: 'world',
-          useAndReproductionStatement: 'we are all one',
-          license: 'https://creativecommons.org/licenses/by-sa/4.0/'
         }
       end
     end
@@ -419,7 +426,7 @@ RSpec.describe 'Fedora item rights/statements/licenses <--> Cocina DRO access ma
   end
 
   describe 'license types' do
-    context 'with an ODC license' do
+    context 'with an ODC license (default access = dark)' do
       it_behaves_like 'DRO Access Fedora Cocina mapping' do
         let(:rights_xml) do
           <<~XML
@@ -462,7 +469,7 @@ RSpec.describe 'Fedora item rights/statements/licenses <--> Cocina DRO access ma
       end
     end
 
-    context 'with a CC license' do
+    context 'with a CC license (default access = dark)' do
       it_behaves_like 'DRO Access Fedora Cocina mapping' do
         let(:rights_xml) do
           <<~XML
@@ -505,7 +512,64 @@ RSpec.describe 'Fedora item rights/statements/licenses <--> Cocina DRO access ma
       end
     end
 
-    context 'with a "none" license' do
+    context 'with CC 4.0 license' do
+      # based on bd324jt9731
+      it_behaves_like 'DRO Access Fedora Cocina mapping' do
+        let(:rights_xml) do
+          <<~XML
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <use>
+                <human type="creativeCommons">CC-BY SA 4.0</human>
+                <machine type="creativeCommons" uri="https://creativecommons.org/licenses/by-sa/4.0/">by-sa</machine>
+                <human type="useAndReproduction">we are all one</human>
+              </use>
+            </rightsMetadata>
+          XML
+        end
+
+        let(:roundtrip_rights_xml) do
+          <<~XML
+            <rightsMetadata>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <use>
+                <license>https://creativecommons.org/licenses/by-sa/4.0/</license>
+                <human type="useAndReproduction">we are all one</human>
+              </use>
+            </rightsMetadata>
+          XML
+        end
+
+        let(:cocina_access_props) do
+          {
+            access: 'world',
+            download: 'world',
+            useAndReproductionStatement: 'we are all one',
+            license: 'https://creativecommons.org/licenses/by-sa/4.0/'
+          }
+        end
+      end
+    end
+
+    context 'with a "none" license (default access = dark)' do
       it_behaves_like 'DRO Access Fedora Cocina mapping' do
         let(:rights_xml) do
           <<~XML
@@ -543,6 +607,48 @@ RSpec.describe 'Fedora item rights/statements/licenses <--> Cocina DRO access ma
             access: 'dark',
             download: 'none',
             license: 'http://cocina.sul.stanford.edu/licenses/none'
+          }
+        end
+      end
+    end
+
+    context 'with cc0 (default access = dark)' do
+      it_behaves_like 'DRO Access Fedora Cocina mapping' do
+        let(:rights_xml) do
+          <<~XML
+            <rightsMetadata>
+              <use>
+                <license>https://creativecommons.org/share-your-work/public-domain/cc0/</license>
+              </use>
+            </rightsMetadata>
+          XML
+        end
+
+        let(:roundtrip_rights_xml) do
+          <<~XML
+            <rightsMetadata>
+              <use>
+                <license>https://creativecommons.org/share-your-work/public-domain/cc0/</license>
+              </use>
+              <access type="discover">
+                <machine>
+                  <none/>
+                </machine>
+              </access>
+              <access type="read">
+                <machine>
+                  <none/>
+                </machine>
+              </access>
+            </rightsMetadata>
+          XML
+        end
+
+        let(:cocina_access_props) do
+          {
+            access: 'dark',
+            download: 'none',
+            license: 'https://creativecommons.org/share-your-work/public-domain/cc0/'
           }
         end
       end

--- a/spec/services/cocina/to_fedora/dro_access_spec.rb
+++ b/spec/services/cocina/to_fedora/dro_access_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Cocina::ToFedora::DROAccess do
 
     before do
       item.rightsMetadata.content = <<~XML
-        <?xml version="1.0"?>
         <rightsMetadata>
           <access type="discover">
             <machine>
@@ -42,7 +41,6 @@ RSpec.describe Cocina::ToFedora::DROAccess do
     it 'builds the xml' do
       apply
       expect(item.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
-        <?xml version="1.0"?>
         <rightsMetadata>
           <access type="discover">
             <machine>
@@ -60,140 +58,6 @@ RSpec.describe Cocina::ToFedora::DROAccess do
           </use>
           <copyright>
             <human>New Copyright Statement</human>
-          </copyright>
-        </rightsMetadata>
-      XML
-    end
-  end
-
-  context 'with cdl access' do
-    let(:access) do
-      Cocina::Models::DROAccess.new(access: 'citation-only', controlledDigitalLending: true, download: 'none')
-    end
-
-    it 'builds the xml' do
-      apply
-      expect(item.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
-        <?xml version="1.0"?>
-          <rightsMetadata>
-            <access type="discover">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <access type="read">
-              <machine>
-                <cdl>
-                  <group rule="no-download">stanford</group>
-                </cdl>
-              </machine>
-            </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <human type="creativeCommons"/>
-              <machine type="creativeCommons" uri=""/>
-              <human type="openDataCommons"/>
-              <machine type="openDataCommons" uri=""/>
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
-          </rightsMetadata>
-        </xml>
-      XML
-    end
-  end
-
-  context 'with a CC license' do
-    let(:access) do
-      Cocina::Models::DROAccess.new(license: 'https://creativecommons.org/licenses/by-nc-nd/3.0/')
-    end
-
-    it 'builds the xml' do
-      apply
-      expect(item.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <none/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <none/>
-            </machine>
-          </access>
-          <use>
-            <human type="useAndReproduction"/>
-            <license>https://creativecommons.org/licenses/by-nc-nd/3.0/</license>
-          </use>
-          <copyright>
-            <human/>
-          </copyright>
-        </rightsMetadata>
-      XML
-    end
-  end
-
-  context 'with an ODC license' do
-    let(:access) do
-      Cocina::Models::DROAccess.new(license: 'http://opendatacommons.org/licenses/by/1.0/')
-    end
-
-    it 'builds the xml' do
-      apply
-      expect(item.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <none/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <none/>
-            </machine>
-          </access>
-          <use>
-            <human type="useAndReproduction"/>
-            <license>http://opendatacommons.org/licenses/by/1.0/</license>
-          </use>
-          <copyright>
-            <human/>
-          </copyright>
-        </rightsMetadata>
-      XML
-    end
-  end
-
-  context 'with a "none" license' do
-    let(:access) do
-      Cocina::Models::DROAccess.new(license: 'http://cocina.sul.stanford.edu/licenses/none')
-    end
-
-    it 'builds the xml' do
-      apply
-      expect(item.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
-        <?xml version="1.0"?>
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <none/>
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <none/>
-            </machine>
-          </access>
-          <use>
-            <human type="useAndReproduction"/>
-            <license>http://cocina.sul.stanford.edu/licenses/none</license>
-          </use>
-          <copyright>
-            <human/>
           </copyright>
         </rightsMetadata>
       XML


### PR DESCRIPTION
## Why was this change made?

- Adds a couple specs to mapping/access/dro_access_spec
- removes duplicate specs as promised in PR #2753.

I left the from_fedora and to_fedora license specs alone because they appear to be appropriate unit tests for that code ("what if the license is in the XML _this_ way?  _that_ way?  will it find all these cases?)

This adds the example from sul-dlss/cocina-models/issues/236, and thus:

Closes sul-dlss/cocina-models/issues/236

I'm not closing #2701 as I think work in progress in #2744 and #2748 may impact that ticket.

## How was this change tested?

it's a spec.

## Which documentation and/or configurations were updated?



