### PR TITLE
block for map should use 'next' instead of 'return'

### DIFF
--- a/bin/validate-to-desc-cocina
+++ b/bin/validate-to-desc-cocina
@@ -92,7 +92,7 @@ results = Parallel.map(druids, progress: 'Testing') do |druid|
   notifier = DataErrorNotifier.new
 
   result = cache.label_and_desc_metadata(druid)
-  return Result.new(druid, 'Missing', :missing) if result.failure?
+  next Result.new(druid, 'Missing', :missing) if result.failure?
 
   label, mods_xml = result.value!
   mods_ng_xml = Nokogiri::XML(mods_xml)


### PR DESCRIPTION
## Why was this change made?

that's the (ruby) way to have a block provide a result and short circuit the rest of its code

fixes #2745

## How was this change tested?

using this branch, i ran `bin/validate-to-desc-cocina` and `bin/validate-to-desc-cocina -s 1000`, and both completed without error (before this change, the latter was consistently crashing as described in the issue).

## Which documentation and/or configurations were updated?

n/a