### PR TITLE
HydrusDefaultTitleBuilder: skip Titles.build for empty title related item

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/hydrus_default_title_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/hydrus_default_title_builder.rb
@@ -10,7 +10,12 @@ module Cocina
         # @return [Hash] a hash that can be mapped to a cocina model
         def self.build(resource_element:, notifier:, require_title: nil)
           titles = resource_element.xpath('mods:titleInfo/mods:title[string-length() > 0]', mods: DESC_METADATA_NS)
-          return [{ value: 'Hydrus' }] if titles.empty? && resource_element.name != 'relatedItem'
+
+          if titles.empty?
+            return [{ value: 'Hydrus' }] if resource_element.name != 'relatedItem'
+
+            return []
+          end
 
           Titles.build(resource_element: resource_element, notifier: notifier)
         end

--- a/spec/services/cocina/from_fedora/descriptive/hydrus_default_title_builder_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/hydrus_default_title_builder_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe Cocina::FromFedora::Descriptive::HydrusDefaultTitleBuilder do
 
       it 'returns empty' do
         expect(build).to be_empty
-        expect(notifier).to have_received(:warn).with('Empty title node')
-        expect(notifier).to have_received(:error).with('Missing title')
+        expect(notifier).not_to have_received(:warn)
+        expect(notifier).not_to have_received(:error)
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

A small refinement to existing behavior (which used a placeholder for empty-title Hydrus items and fell through to `Titles.build` for a `relatedItem`).  Prevents an unnecessary "Missing title" warning.

connects to #2759

(paired w/ @justinlittman, who suggested this approach to suppressing the warning)

## How was this change tested?

- [x] unit tests
- [x] `bin/validate-desc-cocina-roundtrip -s 100000` on sdr-deploy (results unchanged, 99.992% success, 0.008% different)
- [x] stage (to see whether it gets rid of the error in the real world)
  - _This seems like an improvement that didn't fix the issue entirely_: it prevented the `[DATA ERROR] Missing title` alert when `deposit_via_hydrus_spec.rb` deposits an item, but there's still a `Missing title` alert when the collection is created/opened.  This fix also seems prevent the `Missing title` alert that would occur when visiting this Hydrus item's Argo view page: https://argo-stage.stanford.edu/view/druid:bt639bc2787

## Which documentation and/or configurations were updated?

n/a

