### PR TITLE
Roundtrip identification mapping specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,9 +70,10 @@ Rails/Exit:
 RSpec/DescribeClass:
   Exclude:
     - 'spec/requests/**/*'
-    - 'spec/services/cocina/mapping/descriptive/**/*'
-    - 'spec/services/cocina/mapping/administrative/**/*'
     - 'spec/services/cocina/mapping/access/**/*'
+    - 'spec/services/cocina/mapping/administrative/**/*'
+    - 'spec/services/cocina/mapping/descriptive/**/*'
+    - 'spec/services/cocina/mapping/identification/**/*'
 
 RSpec/ExampleLength:
   Max: 8

--- a/app/services/cocina/from_fedora/administrative.rb
+++ b/app/services/cocina/from_fedora/administrative.rb
@@ -2,34 +2,34 @@
 
 module Cocina
   module FromFedora
-    # Creates Cocina Administrative objects from Fedora objects
+    # Creates Cocina::Administrative object properties from Fedora objects
     class Administrative
-      # @param [Dor::Item,Dor::Etd] item
-      # @return [Hash] a hash that can be mapped to a cocina administrative model
-      def self.props(item)
-        new(item).props
+      # @param [Dor::Item,Dor::Etd,Dor::Collection] fedora_object
+      # @return [Hash] a hash that can be mapped to a Cocina::Administrative object
+      def self.props(fedora_object)
+        new(fedora_object).props
       end
 
-      def initialize(item)
-        @item = item
+      def initialize(fedora_object)
+        @fedora_object = fedora_object
       end
 
       def props
         {}.tap do |admin|
-          admin[:hasAdminPolicy] = item.admin_policy_object_id if item.admin_policy_object_id
+          admin[:hasAdminPolicy] = fedora_object.admin_policy_object_id if fedora_object.admin_policy_object_id
           release_tags = build_release_tags
           admin[:releaseTags] = release_tags unless release_tags.empty?
-          projects = AdministrativeTags.project(pid: item.id)
+          projects = AdministrativeTags.project(pid: fedora_object.id)
           admin[:partOfProject] = projects.first if projects.any?
         end
       end
 
       private
 
-      attr_reader :item
+      attr_reader :fedora_object
 
       def build_release_tags
-        item.identityMetadata.ng_xml.xpath('//release').map do |node|
+        fedora_object.identityMetadata.ng_xml.xpath('//release').map do |node|
           {
             to: node.attributes['to'].value,
             what: node.attributes['what'].value,

--- a/app/services/cocina/from_fedora/collection.rb
+++ b/app/services/cocina/from_fedora/collection.rb
@@ -2,41 +2,41 @@
 
 module Cocina
   module FromFedora
-    # Creates Cocina Collection objects from Fedora objects
+    # Creates Cocina::Collection object properties from Fedora objects
     class Collection
-      # @param [Dor::Item,Dor::Etd] item
+      # @param [Dor::Collection] fedora_collection
       # @param [Cocina::FromFedora::DataErrorNotifier] notifier
-      # @return [Hash] a hash that can be mapped to a cocina model
-      def self.props(item, notifier: nil)
-        new(item, notifier: notifier).props
+      # @return [Hash] a hash that can be mapped to a Cocina::Collection object
+      def self.props(fedora_collection, notifier: nil)
+        new(fedora_collection, notifier: notifier).props
       end
 
-      def initialize(item, notifier: nil)
-        @item = item
+      def initialize(fedora_collection, notifier: nil)
+        @fedora_collection = fedora_collection
         @notifier = notifier
       end
 
       def props
         {
-          externalIdentifier: item.pid,
+          externalIdentifier: fedora_collection.pid,
           type: Cocina::Models::Vocab.collection,
-          label: item.label,
-          version: item.current_version.to_i,
-          administrative: FromFedora::Administrative.props(item),
-          access: CollectionAccess.props(item.rightsMetadata)
+          label: fedora_collection.label,
+          version: fedora_collection.current_version.to_i,
+          administrative: FromFedora::Administrative.props(fedora_collection),
+          access: CollectionAccess.props(fedora_collection.rightsMetadata)
         }.tap do |props|
-          title_builder = FromFedora::Descriptive::TitleBuilderStrategy.find(label: item.label)
-          description = FromFedora::Descriptive.props(title_builder: title_builder, mods: item.descMetadata.ng_xml, druid: item.pid, notifier: notifier)
+          title_builder = FromFedora::Descriptive::TitleBuilderStrategy.find(label: fedora_collection.label)
+          description = FromFedora::Descriptive.props(title_builder: title_builder, mods: fedora_collection.descMetadata.ng_xml, druid: fedora_collection.pid, notifier: notifier)
           props[:description] = description unless description.nil?
-          identification = FromFedora::Identification.props(item)
-          identification[:catalogLinks] = [{ catalog: 'symphony', catalogRecordId: item.catkey }] if item.catkey
+          identification = FromFedora::Identification.props(fedora_collection)
+          identification[:catalogLinks] = [{ catalog: 'symphony', catalogRecordId: fedora_collection.catkey }] if fedora_collection.catkey
           props[:identification] = identification unless identification.empty?
         end
       end
 
       private
 
-      attr_reader :item, :notifier
+      attr_reader :fedora_collection, :notifier
     end
   end
 end

--- a/app/services/cocina/from_fedora/dro.rb
+++ b/app/services/cocina/from_fedora/dro.rb
@@ -2,23 +2,23 @@
 
 module Cocina
   module FromFedora
-    # Creates Cocina DRO objects from Fedora objects
+    # Creates Cocina::DRO object properties from Fedora objects
     class DRO
-      # @param [Dor::Item,Dor::Etd] item
+      # @param [Dor::Item,Dor::Etd,Dor::Agreement] fedora_item
       # @param [Cocina::FromFedora::DataErrorNotifier] notifier
-      # @return [Hash] a hash that can be mapped to a cocina model
-      def self.props(item, notifier: nil)
-        new(item, notifier: notifier).props
+      # @return [Hash] a hash that can be mapped to a Cocina::DRO object
+      def self.props(fedora_item, notifier: nil)
+        new(fedora_item, notifier: notifier).props
       end
 
-      # @param [Dor::Item,Dor::Etd] item
-      # @return [String] item's type
-      def self.dro_type(item)
-        return Cocina::Models::Vocab.agreement if item.is_a? Dor::Agreement
+      # @param [Dor::Item,Dor::Etd,Dor::Agreement] fedora_item
+      # @return [String] fedora_item's type
+      def self.dro_type(fedora_item)
+        return Cocina::Models::Vocab.agreement if fedora_item.is_a? Dor::Agreement
 
-        case item.contentMetadata.contentType.first
+        case fedora_item.contentMetadata.contentType.first
         when 'image'
-          if /^Manuscript/.match?(AdministrativeTags.content_type(pid: item.pid).first)
+          if /^Manuscript/.match?(AdministrativeTags.content_type(pid: fedora_item.pid).first)
             Cocina::Models::Vocab.manuscript
           else
             Cocina::Models::Vocab.image
@@ -40,38 +40,38 @@ module Cocina
         when 'file', nil
           Cocina::Models::Vocab.object
         else
-          raise "Unknown content type #{item.contentMetadata.contentType.first}"
+          raise "Unknown content type #{fedora_item.contentMetadata.contentType.first}"
         end
       end
 
-      def initialize(item, notifier: nil)
-        @item = item
+      def initialize(fedora_item, notifier: nil)
+        @fedora_item = fedora_item
         @notifier = notifier
       end
 
       # @raises [SolrConnectionError]
       # rubocop:disable Metrics/AbcSize
       def props
-        type = DRO.dro_type(item)
+        type = DRO.dro_type(fedora_item)
         {
-          externalIdentifier: item.pid,
+          externalIdentifier: fedora_item.pid,
           type: type,
           # Label may have been truncated, so prefer objectLabel.
-          label: item.objectLabel.first || item.label,
-          version: item.current_version.to_i,
-          administrative: FromFedora::Administrative.props(item),
-          access: DROAccess.props(item.rightsMetadata, item.embargoMetadata),
-          structural: DroStructural.props(item, type: type)
+          label: fedora_item.objectLabel.first || fedora_item.label,
+          version: fedora_item.current_version.to_i,
+          administrative: FromFedora::Administrative.props(fedora_item),
+          access: DROAccess.props(fedora_item.rightsMetadata, fedora_item.embargoMetadata),
+          structural: DroStructural.props(fedora_item, type: type)
         }.tap do |props|
-          title_builder = FromFedora::Descriptive::TitleBuilderStrategy.find(label: item.label)
+          title_builder = FromFedora::Descriptive::TitleBuilderStrategy.find(label: fedora_item.label)
           description = FromFedora::Descriptive.props(title_builder: title_builder,
-                                                      mods: item.descMetadata.ng_xml,
-                                                      druid: item.pid,
+                                                      mods: fedora_item.descMetadata.ng_xml,
+                                                      druid: fedora_item.pid,
                                                       notifier: notifier)
           props[:description] = description unless description.nil?
-          props[:geographic] = { iso19139: item.geoMetadata.content } if type == Cocina::Models::Vocab.geo
-          identification = FromFedora::Identification.props(item)
-          identification[:catalogLinks] = [{ catalog: 'symphony', catalogRecordId: item.catkey }] if item.catkey
+          props[:geographic] = { iso19139: fedora_item.geoMetadata.content } if type == Cocina::Models::Vocab.geo
+          identification = FromFedora::Identification.props(fedora_item)
+          identification[:catalogLinks] = [{ catalog: 'symphony', catalogRecordId: fedora_item.catkey }] if fedora_item.catkey
           props[:identification] = identification unless identification.empty?
         end
       end
@@ -79,7 +79,7 @@ module Cocina
 
       private
 
-      attr_reader :item, :notifier
+      attr_reader :fedora_item, :notifier
     end
   end
 end

--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -13,12 +13,12 @@ module Cocina
         'Manuscript (ltr)' => 'left-to-right'
       }.freeze
 
-      def self.props(item, type:)
-        new(item, type: type).props
+      def self.props(fedora_item, type:)
+        new(fedora_item, type: type).props
       end
 
-      def initialize(item, type:)
-        @item = item
+      def initialize(fedora_item, type:)
+        @fedora_item = fedora_item
         @type = type
       end
 
@@ -30,17 +30,18 @@ module Cocina
           # To build file sets, we need to consider both content metadata and
           # rights metadata, the latter of which is used to map file-specific
           # access/rights.
-          contains = FileSets.build(item.contentMetadata,
-                                    rights_metadata: item.rightsMetadata,
-                                    version: item.current_version.to_i,
+          contains = FileSets.build(fedora_item.contentMetadata,
+                                    rights_metadata: fedora_item.rightsMetadata,
+                                    version: fedora_item.current_version.to_i,
                                     ignore_resource_type_errors: project_phoenix?)
           structural[:contains] = contains if contains.present?
 
-          structural[:hasAgreement] = item.identityMetadata.agreementId.first unless item.identityMetadata.agreementId.empty?
+          structural[:hasAgreement] = fedora_item.identityMetadata.agreementId.first unless fedora_item.identityMetadata.agreementId.empty?
 
           begin
-            # Note that there is a bug with item.collection_ids that returns [] until item.collections is called. Below side-steps this.
-            structural[:isMemberOf] = item.collections.map(&:id) if item.collections.present?
+            # Note that there is a bug with fedora_item.collection_ids that returns [] until fedora_item.collections is called.
+            # Below side-steps this.
+            structural[:isMemberOf] = fedora_item.collections.map(&:id) if fedora_item.collections.present?
           rescue RSolr::Error::ConnectionRefused
             # ActiveFedora calls RSolr to lookup collections, but sometimes that call fails.
             raise SolrConnectionError, 'unable to connect to solr to resolve collections'
@@ -50,15 +51,15 @@ module Cocina
 
       private
 
-      attr_reader :item, :type
+      attr_reader :fedora_item, :type
 
       def project_phoenix?
-        AdministrativeTags.for(pid: item.id).include?('Google Book : GBS VIEW_FULL')
+        AdministrativeTags.for(pid: fedora_item.id).include?('Google Book : GBS VIEW_FULL')
       end
 
       def build_has_member_orders
         member_orders = create_member_order if type == Cocina::Models::Vocab.book
-        sequence = build_sequence(item.contentMetadata)
+        sequence = build_sequence(fedora_item.contentMetadata)
         if sequence.present?
           member_orders ||= [{}]
           member_orders.first[:members] = sequence
@@ -67,7 +68,7 @@ module Cocina
       end
 
       def create_member_order
-        reading_direction = item.contentMetadata.ng_xml.xpath('//bookData/@readingOrder').first&.value
+        reading_direction = fedora_item.contentMetadata.ng_xml.xpath('//bookData/@readingOrder').first&.value
         # See https://consul.stanford.edu/pages/viewpage.action?spaceKey=chimera&title=DOR+content+types%2C+resource+types+and+interpretive+metadata
         case reading_direction
         when 'ltr'
@@ -77,7 +78,7 @@ module Cocina
         else
           # Fallback to using tags.  Some books don't have bookData nodes in contentMetadata XML.
           # When we migrate from Fedora 3, we don't need to look this up from AdministrativeTags
-          content_type = AdministrativeTags.content_type(pid: item.id).first
+          content_type = AdministrativeTags.content_type(pid: fedora_item.id).first
           [{ viewingDirection: VIEWING_DIRECTION_FOR_CONTENT_TYPE[content_type] }] if VIEWING_DIRECTION_FOR_CONTENT_TYPE[content_type]
         end
       end

--- a/app/services/cocina/from_fedora/identification.rb
+++ b/app/services/cocina/from_fedora/identification.rb
@@ -2,39 +2,39 @@
 
 module Cocina
   module FromFedora
-    # Creates Cocina Identification objects from Fedora objects
+    # Creates Cocina::Identification object properties from Fedora objects
     class Identification
-      # @param [Dor::Item,Dor::Collection,Dor::Etd] item
-      # @return [Hash] a hash that can be mapped to a cocina administrative model
+      # @param [Dor::Item,Dor::Collection,Dor::Etd] fedora_object
+      # @return [Hash] a hash that can be mapped to a Cocina::Identification object
       # @raises [Mapper::MissingSourceID]
-      def self.props(item)
-        new(item).props
+      def self.props(fedora_object)
+        new(fedora_object).props
       end
 
-      def initialize(item)
-        @item = item
+      def initialize(fedora_object)
+        @fedora_object = fedora_object
       end
 
       def props
         {
           sourceId: source_id,
-          barcode: item.identityMetadata.barcode
+          barcode: fedora_object.identityMetadata.barcode
         }.compact
       end
 
       private
 
-      attr_reader :item
+      attr_reader :fedora_object
 
       def source_id
-        if item.source_id
-          item.source_id
-        elsif item.is_a? Dor::Collection
+        if fedora_object.source_id
+          fedora_object.source_id
+        elsif fedora_object.is_a? Dor::Collection
           nil
         else
           # ETDs post Summer 2020 have a source id, but legacy ones don't.  In that case look for a dissertation_id.
-          dissertation = item.otherId.find { |id| id.start_with?('dissertationid:') }
-          raise Mapper::MissingSourceID, "unable to resolve a sourceId for #{item.pid}" unless dissertation
+          dissertation = fedora_object.otherId.find { |id| id.start_with?('dissertationid:') }
+          raise Mapper::MissingSourceID, "unable to resolve a sourceId for #{fedora_object.pid}" unless dissertation
 
           dissertation
         end

--- a/app/services/cocina/to_fedora/identity.rb
+++ b/app/services/cocina/to_fedora/identity.rb
@@ -2,8 +2,7 @@
 
 module Cocina
   module ToFedora
-    # This transforms the DRO.access schema to the
-    # Fedora 3 data model identityMetadata
+    # This transforms the DRO.identification schema to the Fedora 3 data model identityMetadata
     class Identity
       # @param [String] agreement_id (nil) the identifier for the agreement. Note that only items have an agreement.
       def self.apply(item, label:, agreement_id: nil)

--- a/app/services/cocina/to_fedora/identity.rb
+++ b/app/services/cocina/to_fedora/identity.rb
@@ -2,16 +2,18 @@
 
 module Cocina
   module ToFedora
-    # This transforms the DRO.identification schema to the Fedora 3 data model identityMetadata
+    # This transforms the cocina identification information to the Fedora 3 data model identityMetadata
     class Identity
-      # @param [String] agreement_id (nil) the identifier for the agreement. Note that only items have an agreement.
-      def self.apply(item, label:, agreement_id: nil)
-        item.objectId = item.pid
-        item.objectCreator = 'DOR'
-        # May have already been set when setting descriptive metadata.
-        item.objectLabel = label if item.objectLabel.empty?
-        item.objectType = item.object_type # This comes from the class definition in dor-services
-        item.identityMetadata.agreementId = agreement_id if agreement_id
+      # @param [Dor::Item,Dor::Collection,Dor::Etd,Dor::AdminPolicyObject] fedora_object
+      # @param [String] label the label for the cocina object.
+      # @param [String] agreement_id (nil) the identifier for the agreement. Note that only apos and items may have an agreement.
+      def self.apply(fedora_object, label:, agreement_id: nil)
+        fedora_object.objectId = fedora_object.pid
+        fedora_object.objectCreator = 'DOR'
+        # Label may have already been set when setting descriptive metadata.
+        fedora_object.objectLabel = label if fedora_object.objectLabel.empty?
+        fedora_object.objectType = fedora_object.object_type # This comes from the class definition in dor-services
+        fedora_object.identityMetadata.agreementId = agreement_id if agreement_id
       end
     end
   end

--- a/spec/services/cocina/mapping/identification/agreement_spec.rb
+++ b/spec/services/cocina/mapping/identification/agreement_spec.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_examples 'Agreement Object Identification Fedora Cocina mapping' do
+  # Required: agreement_id, label, admin_policy_id, collection_ids, identity_metadata_xml, cocina_props
+  # Optional: catkey, source_id_source, source_id, other_id_name, other_id, roundtrip_identity_metadata_xml
+
+  # Normalization notes for later:
+  #  otherId of type uuid -> normalize out (keep catkey, barcode ...)  shelfseq, callseq? dissertationid (YES?)?,
+  #  tags (non-release) -> normalize out
+  #  adminPolicy -> normalize out (we use RELS-EXT)
+  #  sourceId -> we need to KEEP - every item should have a sourceId, as should agreements
+  #  releaseTag -> we need to KEEP
+  #  missing collections OK -- don't produce cocina with nil druid for collection
+
+  let(:namespaced_source_id) { defined?(source_id) && defined?(source_id_source) ? "#{source_id_source}:#{source_id}" : nil }
+  let(:namespaced_other_ids) do
+    other_id_nodes = Nokogiri::XML(identity_metadata_xml).xpath('//identityMetadata/otherId')
+    other_id_nodes.map { |other_id_node| "#{other_id_node['name']}:#{other_id_node.text}" }
+  end
+  let(:mods_xml) do
+    <<~XML
+      <mods #{MODS_ATTRIBUTES}>
+        <titleInfo>
+          <title>agreement title</title>
+        </titleInfo>
+      </mods>
+    XML
+  end
+  # using a mock rather than every example having all relevant datastreams
+  let(:fedora_agreement_mock) do
+    instance_double(Dor::Agreement,
+                    pid: agreement_id,
+                    id: agreement_id, # see app/services/cocina/from_fedora/administrative.rb:22
+                    objectLabel: [label],
+                    label: label,
+                    current_version: '1',
+                    admin_policy_object_id: defined?(admin_policy_id) ? admin_policy_id : nil,
+                    catkey: defined?(catkey) ? catkey : nil,
+                    source_id: namespaced_source_id, # see app/services/cocina/from_fedora/identification.rb:30
+                    otherId: namespaced_other_ids, # see app/services/cocina/from_fedora/identification.rb:36
+                    collections: collection_ids.map { |id| Dor::Collection.new(pid: id) },
+                    identityMetadata: Dor::IdentityMetadataDS.from_xml(identity_metadata_xml),
+                    descMetadata: Dor::DescMetadataDS.from_xml(mods_xml),
+                    embargoMetadata: Dor::EmbargoMetadataDS.new,
+                    contentMetadata: Dor::ContentMetadataDS.new,
+                    rightsMetadata: Dor::RightsMetadataDS.new)
+  end
+  let(:mapped_cocina_props) { Cocina::FromFedora::DRO.props(fedora_agreement_mock) }
+  let(:roundtrip_identity_md_xml) { defined?(roundtrip_identity_metadata_xml) ? roundtrip_identity_metadata_xml : identity_metadata_xml }
+  let(:roundtrip_fedora_agreement) do
+    cocina_dro = Cocina::Models::DRO.new(mapped_cocina_props)
+    fedora_agreement = Dor::Agreement.new(pid: cocina_dro.externalIdentifier,
+                                          source_id: cocina_dro.identification.sourceId,
+                                          catkey: Cocina::ObjectCreator.new.send(:catkey_for, cocina_dro),
+                                          label: Cocina::ObjectCreator.new.send(:truncate_label, cocina_dro.label))
+    Cocina::ToFedora::Identity.apply(fedora_agreement, label: cocina_dro.label, agreement_id: cocina_dro.structural&.hasAgreement)
+    fedora_agreement.identityMetadata.barcode = cocina_dro.identification.barcode
+    fedora_agreement
+  end
+  let(:mapped_roundtrip_identity_xml) do
+    Cocina::ToFedora::Identity.apply(roundtrip_fedora_agreement, label: mapped_cocina_props[:label])
+    roundtrip_fedora_agreement.identityMetadata.to_xml
+  end
+
+  before do
+    allow(fedora_agreement_mock).to receive(:is_a?).with(Dor::Agreement).and_return(true)
+  end
+
+  context 'when mapping from Fedora to Cocina' do
+    it 'cocina hash produces valid Cocina Descriptive model' do
+      expect { Cocina::Models::DRO.new(cocina_props) }.not_to raise_error
+    end
+
+    it 'Fedora maps to expected Cocina' do
+      expect(mapped_cocina_props).to be_deep_equal(cocina_props)
+    end
+  end
+
+  context 'when mapping from Cocina to (roundtrip) Fedora' do
+    it 'identityMetadata roundtrips thru cocina model to original identityMetadata.xml' do
+      expect(mapped_roundtrip_identity_xml).to be_equivalent_to(roundtrip_identity_md_xml)
+    end
+  end
+
+  context 'when mapping from roundtrip Fedora to (roundtrip) Cocina' do
+    let(:roundtrip_catkey) do
+      catalog_link = mapped_cocina_props[:identification][:catalogLinks]&.find { |clink| clink[:catalog] == 'symphony' }
+      catalog_link[:catalogRecordId] if catalog_link
+    end
+    let(:roundtrip_namespaced_other_ids) do
+      other_id_nodes = Nokogiri::XML(mapped_roundtrip_identity_xml).xpath('//identityMetadata/otherId')
+      other_id_nodes.map { |other_id_node| "#{other_id_node['name']}:#{other_id_node.text}" }
+    end
+    let(:roundtrip_collections) do
+      mapped_cocina_props[:structural][:isMemberOf]&.map do |collection_id|
+        instance_double(Dor::Collection,
+                        pid: collection_id,
+                        id: collection_id)
+      end
+    end
+    # using a mock rather than every example having all relevant datastreams
+    let(:roundtrip_fedora_agreement_mock) do
+      instance_double(Dor::Agreement,
+                      pid: mapped_cocina_props[:externalIdentifier],
+                      id: mapped_cocina_props[:externalIdentifier], # see app/services/cocina/from_fedora/administrative.rb:22
+                      objectLabel: [label],
+                      label: mapped_cocina_props[:label],
+                      current_version: '1',
+                      admin_policy_object_id: mapped_cocina_props[:administrative][:hasAdminPolicy],
+                      collections: roundtrip_collections,
+                      catkey: roundtrip_catkey,
+                      source_id: mapped_cocina_props[:identification][:sourceId],
+                      otherId: namespaced_other_ids, # see app/services/cocina/from_fedora/identification.rb:36
+                      identityMetadata: Dor::IdentityMetadataDS.from_xml(mapped_roundtrip_identity_xml),
+                      descMetadata: Dor::DescMetadataDS.from_xml(mods_xml),
+                      embargoMetadata: Dor::EmbargoMetadataDS.new,
+                      contentMetadata: Dor::ContentMetadataDS.new,
+                      rightsMetadata: Dor::RightsMetadataDS.new)
+    end
+    let(:roundtrip_cocina_props) { Cocina::FromFedora::DRO.props(roundtrip_fedora_agreement_mock) }
+
+    before do
+      allow(roundtrip_fedora_agreement_mock).to receive(:is_a?).with(Dor::Agreement).and_return(true)
+    end
+
+    it 'roundtrip Fedora maps to expected Cocina props' do
+      expect(roundtrip_cocina_props).to be_deep_equal(cocina_props)
+    end
+  end
+end
+
+RSpec.describe 'Agreement Object Fedora identityMetadata <--> Cocina Identification mappings' do
+  # NOTE: access tested in mapping/access/dro_access_spec.rb
+  let(:access_props) do
+    {
+      access: 'dark',
+      download: 'none'
+    }
+  end
+  # NOTE: description tested in mapping/descriptive/mods
+  let(:description_props) do
+    {
+      title: [
+        value: 'agreement title'
+      ],
+      purl: "http://purl.stanford.edu/#{agreement_id.split(':').last}",
+      access: {
+        digitalRepository: [
+          {
+            value: 'Stanford Digital Repository'
+          }
+        ]
+      }
+    }
+  end
+
+  context 'with agreement object' do
+    it_behaves_like 'Agreement Object Identification Fedora Cocina mapping' do
+      let(:agreement_id) { 'druid:bq655xb7335' }
+      let(:label) { 'Gale hText agreement' }
+      let(:admin_policy_id) { 'druid:hv992ry2431' } # from RELS-EXT
+      let(:collection_ids) { [] } # no collection ids from RELS-EXT
+      let(:source_id_source) { 'Hydrus' }
+      let(:source_id) { 'item-hfrost-2014-03-17T21:29:12.331Z' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{agreement_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>agreement</objectType>
+            <otherId name="uuid">2f05815a-ae1b-11e3-8209-0050569b3c6e</otherId>
+            <tag>Remediated By : 5.11.0</tag>
+          </identityMetadata>
+        XML
+      end
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{agreement_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>agreement</objectType>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: agreement_id,
+          type: Cocina::Models::Vocab.agreement,
+          label: label,
+          version: 1,
+          identification: {
+            sourceId: "#{source_id_source}:#{source_id}"
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id
+          },
+          structural: {},
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+end

--- a/spec/services/cocina/mapping/identification/apo_spec.rb
+++ b/spec/services/cocina/mapping/identification/apo_spec.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_examples 'APO Identification Fedora Cocina mapping' do
+  # Required: pid, label, identity_metadata_xml, cocina_props
+  # Optional: admin_policy_id, agreement_object_id, roundtrip_identity_metadata_xml
+
+  # Normalization notes:
+  #  otherId of type uuid -> normalize out
+  #  tags -> normalize out
+  #  agreementId, adminPolicy -> normalize out (we use RELS-EXT)
+  #  sourceId -> we need to KEEP
+
+  let(:mods_ng_xml) do
+    Nokogiri::XML <<~XML
+      <mods #{MODS_ATTRIBUTES}>
+        <titleInfo>
+          <title>APO title</title>
+        </titleInfo>
+      </mods>
+    XML
+  end
+  # NOTE: tested in mapping/administrative/apo_administrative_spec.rb
+  let(:default_object_rights_xml) do
+    <<~XML
+      <rightsMetadata/>
+    XML
+  end
+  # NOTE: tested in mapping/administrative/apo_administrative_spec.rb
+  let(:administrative_metadata_xml) do
+    <<~XML
+      <administrativeMetadata/>
+    XML
+  end
+  let(:admin_policy_id) { defined?(admin_policy_id) ? admin_policy_id : nil }
+  let(:agreement_object_id) { defined?(agreement_object_id) ? agreement_object_id : nil }
+  let(:fedora_apo_mock) do
+    instance_double(Dor::AdminPolicyObject,
+                    pid: pid,
+                    label: label,
+                    current_version: '1',
+                    admin_policy_object_id: admin_policy_id,
+                    agreement_object_id: agreement_object_id,
+                    descMetadata: instance_double(Dor::DescMetadataDS, ng_xml: mods_ng_xml),
+                    defaultObjectRights: instance_double(Dor::DefaultObjectRightsDS, content: default_object_rights_xml),
+                    administrativeMetadata: Dor::AdministrativeMetadataDS.from_xml(administrative_metadata_xml),
+                    roleMetadata: instance_double(Dor::RoleMetadataDS, find_by_xpath: []))
+  end
+  let(:mapped_cocina_props) { Cocina::FromFedora::APO.props(fedora_apo_mock) }
+  let(:roundtrip_identity_metadata_xml) { defined?(roundtrip_identity_metadata_xml) ? roundtrip_identity_metadata_xml : identity_metadata_xml }
+
+  context 'when mapping from Fedora to Cocina' do
+    it 'cocina hash produces valid Cocina Descriptive model' do
+      expect { Cocina::Models::AdminPolicy.new(cocina_props) }.not_to raise_error
+    end
+
+    it 'Fedora maps to expected Cocina' do
+      expect(mapped_cocina_props).to be_deep_equal(cocina_props)
+    end
+  end
+
+  context 'when mapping from Cocina to (roundtrip) Fedora' do
+    let(:mapped_fedora_apo) do
+      Dor::AdminPolicyObject.new(pid: mapped_cocina_props[:externalIdentifier],
+                                 admin_policy_object_id: mapped_cocina_props[:administrative][:hasAdminPolicy],
+                                 agreement_object_id: mapped_cocina_props[:administrative][:referencesAgreement],
+                                 # source_id: cocina_admin_policy.identification.sourceId,
+                                 label: mapped_cocina_props[:label])
+    end
+    let(:mapped_roundtrip_identity_xml) do
+      Cocina::ToFedora::Identity.apply(mapped_fedora_apo, label: mapped_cocina_props[:label], agreement_id: mapped_cocina_props[:agreement_object_id])
+      mapped_fedora_apo.identityMetadata.to_xml
+    end
+
+    it 'identityMetadata roundtrips thru cocina model to original identityMetadata.xml' do
+      expect(mapped_roundtrip_identity_xml).to be_equivalent_to(roundtrip_identity_metadata_xml)
+    end
+  end
+
+  context 'when mapping from roundtrip Fedora to Cocina' do
+    let(:roundtrip_fedora_apo_mock) do
+      instance_double(Dor::AdminPolicyObject,
+                      pid: mapped_cocina_props[:externalIdentifier],
+                      label: mapped_cocina_props[:label],
+                      current_version: '1',
+                      admin_policy_object_id: mapped_cocina_props[:administrative][:hasAdminPolicy],
+                      agreement_object_id: mapped_cocina_props[:administrative][:referencesAgreement],
+                      descMetadata: instance_double(Dor::DescMetadataDS, ng_xml: mods_ng_xml),
+                      defaultObjectRights: instance_double(Dor::DefaultObjectRightsDS, content: default_object_rights_xml),
+                      administrativeMetadata: Dor::AdministrativeMetadataDS.from_xml(administrative_metadata_xml),
+                      roleMetadata: instance_double(Dor::RoleMetadataDS, find_by_xpath: []))
+    end
+    let(:roundtrip_cocina_props) { Cocina::FromFedora::APO.props(roundtrip_fedora_apo_mock) }
+
+    it 'roundtrip Fedora maps to expected Cocina props' do
+      expect(roundtrip_cocina_props).to be_deep_equal(cocina_props)
+    end
+  end
+end
+
+RSpec.describe 'APO Fedora identityMetadata <--> Cocina Identification mappings' do
+  # NOTE: tested in mapping/administrative/apo_administrative_spec.rb
+  let(:default_access_props) do
+    {
+      access: 'dark',
+      download: 'none'
+    }
+  end
+  # NOTE: tested in mapping/administrative/apo_administrative_spec.rb
+  let(:default_object_rights_xml) { "<rightsMetadata/>\n" }
+  # NOTE: tested in mapping/descriptive/mods
+  let(:description_props) do
+    {
+      title: [
+        value: 'APO title'
+      ],
+      purl: "http://purl.stanford.edu/#{pid.split(':').last}",
+      access: {
+        digitalRepository: [
+          {
+            value: 'Stanford Digital Repository'
+          }
+        ]
+      }
+    }
+  end
+
+  context 'without adminPolicy, without referencesAgreement in identityMetadata.xml (in RELS_EXT)' do
+    it_behaves_like 'APO Identification Fedora Cocina mapping' do
+      let(:pid) { 'druid:zd878cf9993' }
+      let(:label) { 'Fondo Lanciani' }
+      let(:admin_policy_id) { 'druid:hv992ry2431' }
+      let(:agreement_object_id) { 'druid:zh747vq3919' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{pid}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>adminPolicy</objectType>
+            <otherId name="uuid">5844f566-282e-11e6-8872-005056a7ed61</otherId>
+            <tag>Registered By : caster</tag>
+            <tag>Remediated By : 5.10.0</tag>
+          </identityMetadata>
+        XML
+      end
+
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{pid}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>adminPolicy</objectType>
+          </identityMetadata>
+        XML
+      end
+
+      let(:cocina_props) do
+        {
+          externalIdentifier: pid,
+          type: Cocina::Models::Vocab.admin_policy,
+          label: label,
+          version: 1,
+          administrative: {
+            hasAdminPolicy: admin_policy_id,
+            referencesAgreement: agreement_object_id,
+            defaultAccess: default_access_props,
+            defaultObjectRights: default_object_rights_xml,
+            roles: []
+          },
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with agreementID, adminPolicy in identityMetadata.xml (Parker APO) (also in RELS_EXT)' do
+    it_behaves_like 'APO Identification Fedora Cocina mapping' do
+      let(:pid) { 'druid:bm077td6448' }
+      let(:label) { 'Parker Manuscripts' }
+      let(:admin_policy_id) { 'druid:nt592gh9590' }
+      let(:agreement_object_id) { 'druid:tx617qp8040' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectLabel>#{label}</objectLabel>
+            <adminPolicy>#{admin_policy_id}</adminPolicy>
+            <agreementId>#{agreement_object_id}</agreementId>
+            <objectType>adminPolicy</objectType>
+            <otherId name="uuid">6abe4356-a584-bc4d-5256-aaaefdba2400</otherId>
+            <objectId>#{pid}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <tag>Remediated By : 5.11.0</tag>
+          </identityMetadata>
+        XML
+      end
+
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>adminPolicy</objectType>
+            <objectId>#{pid}</objectId>
+            <objectCreator>DOR</objectCreator>
+          </identityMetadata>
+        XML
+      end
+
+      let(:cocina_props) do
+        {
+          externalIdentifier: pid,
+          type: Cocina::Models::Vocab.admin_policy,
+          label: label,
+          version: 1,
+          administrative: {
+            hasAdminPolicy: admin_policy_id,
+            referencesAgreement: agreement_object_id,
+            defaultAccess: default_access_props,
+            defaultObjectRights: default_object_rights_xml,
+            roles: []
+          },
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with sourceId, without agreementId in identityMetadata.xml (CS Tech Reports) (agreementId in RELS_EXT)' do
+    # it_behaves_like 'APO Identification Fedora Cocina mapping' do
+    xit 'to be implemented: APO objects do need support sourceId' do
+      let(:pid) { 'druid:bk068fh4950' }
+      let(:label) { 'APO for Stanford University, Department of Computer Science, Technical Reports' }
+      let(:admin_policy_id) { 'druid:zw306xn5593' }
+      let(:agreement_object_id) { 'druid:mc322hh4254' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="Hydrus">adminPolicy-dhartwig-2013-06-10T18:11:42.520Z</sourceId>
+            <objectId>#{pid}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>adminPolicy</objectType>
+            <adminPolicy>#{admin_policy_id}</adminPolicy>
+            <otherId name="uuid">341b275c-d1f9-11e2-ba42-0050569b3c6e</otherId>
+            <tag>Project : Hydrus</tag>
+            <tag>Remediated By : 4.6.6.2</tag>
+          </identityMetadata>
+        XML
+      end
+
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="Hydrus">adminPolicy-dhartwig-2013-06-10T18:11:42.520Z</sourceId>
+            <objectId>#{pid}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>adminPolicy</objectType>
+          </identityMetadata>
+        XML
+      end
+
+      let(:cocina_props) do
+        {
+          externalIdentifier: pid,
+          type: Cocina::Models::Vocab.admin_policy,
+          label: label,
+          version: 1,
+          administrative: {
+            hasAdminPolicy: admin_policy_id,
+            referencesAgreement: agreement_object_id,
+            defaultAccess: default_access_props,
+            defaultObjectRights: default_object_rights_xml,
+            roles: []
+          },
+          description: description_props
+        }
+      end
+    end
+  end
+end

--- a/spec/services/cocina/mapping/identification/collection_spec.rb
+++ b/spec/services/cocina/mapping/identification/collection_spec.rb
@@ -1,0 +1,508 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_examples 'Collection Identification Fedora Cocina mapping' do
+  # Required: collection_id, label, admin_policy_id, identity_metadata_xml, cocina_props
+  # Optional: catkey, source_id_source, source_id, other_id_name, other_id, roundtrip_identity_metadata_xml
+
+  # Normalization notes for later:
+  #  otherId of type uuid -> normalize out (keep catkey, barcode ...)
+  #  tags -> normalize out
+  #  agreementId, adminPolicy -> normalize out (we use RELS-EXT)
+  #  sourceId -> we need to KEEP
+  #  releaseTag -> we need to KEEP
+  #  multiple objectType -> can drop set type and keep collection type
+  #  displayType -> normalize out
+
+  let(:namespaced_source_id) { defined?(source_id) && defined?(source_id_source) ? "#{source_id_source}:#{source_id}" : nil }
+  let(:namespaced_other_id) { defined?(other_id) && defined?(other_id_name) ? "#{other_id_name}:#{other_id}" : nil }
+  let(:mods_xml) do
+    <<~XML
+      <mods #{MODS_ATTRIBUTES}>
+        <titleInfo>
+          <title>collection title</title>
+        </titleInfo>
+      </mods>
+    XML
+  end
+  # NOTE: rightsMetadata mappings are tested elsewhere
+  let(:rights_metadata_xml) do
+    <<~XML
+      <rightsMetadata/>
+    XML
+  end
+  let(:fedora_collection_mock) do
+    instance_double(Dor::Collection,
+                    pid: collection_id,
+                    id: collection_id, # see app/services/cocina/from_fedora/administrative.rb:22
+                    label: label,
+                    current_version: '1',
+                    admin_policy_object_id: defined?(admin_policy_id) ? admin_policy_id : nil,
+                    catkey: defined?(catkey) ? catkey : nil,
+                    source_id: namespaced_source_id,
+                    otherId: [namespaced_other_id],
+                    identityMetadata: Dor::IdentityMetadataDS.from_xml(identity_metadata_xml),
+                    descMetadata: Dor::DescMetadataDS.from_xml(mods_xml),
+                    rightsMetadata: Dor::RightsMetadataDS.from_xml(rights_metadata_xml))
+  end
+  let(:mapped_cocina_props) { Cocina::FromFedora::Collection.props(fedora_collection_mock) }
+  let(:roundtrip_identity_md_xml) { defined?(roundtrip_identity_metadata_xml) ? roundtrip_identity_metadata_xml : identity_metadata_xml }
+  let(:mapped_fedora_collection) do
+    cocina_collection = Cocina::Models::Collection.new(mapped_cocina_props)
+    Dor::Collection.new(pid: cocina_collection.externalIdentifier,
+                        admin_policy_object_id: cocina_collection.administrative.hasAdminPolicy,
+                        source_id: cocina_collection.identification&.sourceId,
+                        catkey: Cocina::ObjectCreator.new.send(:catkey_for, cocina_collection),
+                        label: Cocina::ObjectCreator.new.send(:truncate_label, cocina_collection.label))
+  end
+  let(:mapped_roundtrip_identity_xml) do
+    Cocina::ToFedora::Identity.apply(mapped_fedora_collection, label: mapped_cocina_props[:label])
+    mapped_fedora_collection.identityMetadata.to_xml
+  end
+
+  before do
+    allow(fedora_collection_mock).to receive(:is_a?).with(Dor::Collection).and_return(true)
+  end
+
+  context 'when mapping from Fedora to Cocina' do
+    it 'cocina hash produces valid Cocina Descriptive model' do
+      expect { Cocina::Models::Collection.new(cocina_props) }.not_to raise_error
+    end
+
+    it 'Fedora maps to expected Cocina' do
+      expect(mapped_cocina_props).to be_deep_equal(cocina_props)
+    end
+  end
+
+  context 'when mapping from Cocina to (roundtrip) Fedora' do
+    it 'identityMetadata roundtrips thru cocina model to original identityMetadata.xml' do
+      expect(mapped_roundtrip_identity_xml).to be_equivalent_to(roundtrip_identity_md_xml)
+    end
+  end
+
+  context 'when mapping from roundtrip Fedora to (roundtrip) Cocina' do
+    let(:roundtrip_catkey) do
+      catalog_link = mapped_cocina_props[:identification][:catalogLinks]&.find { |clink| clink[:catalog] == 'symphony' }
+      catalog_link[:catalogRecordId] if catalog_link
+    end
+    let(:roundtrip_fedora_collection_mock) do
+      instance_double(Dor::Collection,
+                      pid: mapped_cocina_props[:externalIdentifier],
+                      id: mapped_cocina_props[:externalIdentifier], # see app/services/cocina/from_fedora/administrative.rb:22
+                      label: mapped_cocina_props[:label],
+                      current_version: '1',
+                      admin_policy_object_id: mapped_cocina_props[:administrative][:hasAdminPolicy],
+                      catkey: roundtrip_catkey,
+                      source_id: mapped_cocina_props[:identification][:sourceId],
+                      identityMetadata: Dor::IdentityMetadataDS.from_xml(mapped_roundtrip_identity_xml),
+                      descMetadata: Dor::DescMetadataDS.from_xml(mods_xml),
+                      rightsMetadata: Dor::RightsMetadataDS.from_xml(rights_metadata_xml))
+    end
+    let(:roundtrip_cocina_props) { Cocina::FromFedora::Collection.props(roundtrip_fedora_collection_mock) }
+
+    before do
+      allow(roundtrip_fedora_collection_mock).to receive(:is_a?).with(Dor::Collection).and_return(true)
+    end
+
+    it 'roundtrip Fedora maps to expected Cocina props' do
+      expect(roundtrip_cocina_props).to be_deep_equal(cocina_props)
+    end
+  end
+end
+
+RSpec.describe 'Collection Fedora identityMetadata <--> Cocina Identification mappings' do
+  # NOTE: access tested in mapping/access/collection_access_spec.rb
+  let(:access_props) do
+    {
+      access: 'dark'
+    }
+  end
+  # NOTE: description tested in mapping/descriptive/mods
+  let(:description_props) do
+    {
+      title: [
+        value: 'collection title'
+      ],
+      purl: "http://purl.stanford.edu/#{collection_id.split(':').last}",
+      access: {
+        digitalRepository: [
+          {
+            value: 'Stanford Digital Repository'
+          }
+        ]
+      }
+    }
+  end
+
+  describe 'Hydrus collection' do
+    context 'with release tags' do
+      # it_behaves_like 'Collection Identification Fedora Cocina mapping' do
+      xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+        let(:collection_id) { 'druid:ds247vz0452' }
+        let(:label) { 'Undergraduate Theses, Department of Physics' }
+        let(:admin_policy_id) { 'druid:dx569vq3421' } # from RELS-EXT
+        let(:source_id_source) { 'Hydrus' }
+        let(:source_id) { 'collection-hfrost-2013-02-21T21:28:38.119Z' }
+        let(:other_id_name) { 'uuid' }
+        let(:other_id) { 'a7b70ac8-7c6d-11e2-9a96-0050569b3c6e' }
+        let(:identity_metadata_xml) do
+          <<~XML
+            <identityMetadata>
+              <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+              <objectId>#{collection_id}</objectId>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>#{label}</objectLabel>
+              <objectType>collection</objectType>
+              <adminPolicy>#{admin_policy_id}</adminPolicy>
+              <otherId name="#{other_id_name}">#{other_id}</otherId>
+              <tag>Project : Hydrus</tag>
+              <objectType>set</objectType>
+              <release displayType="file" release="true" to="Searchworks" what="self" when="2015-07-27T18:43:32Z" who="lauraw15">true</release>
+              <release displayType="file" release="true" to="Searchworks" what="self" when="2015-10-25T21:12:42Z" who="blalbrit">true</release>
+              <tag>Remediated By : 4.22.3</tag>
+              <displayType>file</displayType>
+              <release displayType="file" release="true" to="Searchworks" what="self" when="2016-07-15T23:44:01Z" who="blalbrit">true</release>
+            </identityMetadata>
+          XML
+        end
+        let(:roundtrip_identity_metadata_xml) do
+          <<~XML
+            <identityMetadata>
+              <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+              <objectId>#{collection_id}</objectId>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>#{label}</objectLabel>
+              <objectType>collection</objectType>
+              <release displayType="file" release="true" to="Searchworks" what="self" when="2015-07-27T18:43:32Z" who="lauraw15">true</release>
+              <release displayType="file" release="true" to="Searchworks" what="self" when="2015-10-25T21:12:42Z" who="blalbrit">true</release>
+              <release displayType="file" release="true" to="Searchworks" what="self" when="2016-07-15T23:44:01Z" who="blalbrit">true</release>
+            </identityMetadata>
+          XML
+        end
+        let(:cocina_props) do
+          {
+            externalIdentifier: collection_id,
+            type: Cocina::Models::Vocab.collection,
+            label: label,
+            version: 1,
+            identification: {
+              sourceId: "#{source_id_source}:#{source_id}"
+            },
+            access: access_props,
+            administrative: {
+              hasAdminPolicy: admin_policy_id,
+              releaseTags: [
+                {
+                  to: 'Searchworks',
+                  what: 'self',
+                  date: '2015-07-27T18:43:32Z',
+                  who: 'lauraw15',
+                  release: true
+                },
+                {
+                  to: 'Searchworks',
+                  what: 'self',
+                  date: '2015-10-25T21:12:42Z',
+                  who: 'blalbrit',
+                  release: true
+                },
+                {
+                  to: 'Searchworks',
+                  what: 'self',
+                  date: '2016-07-15T23:44:01Z',
+                  who: 'blalbrit',
+                  release: true
+                }
+              ]
+            },
+            description: description_props
+          }
+        end
+      end
+    end
+
+    context 'without release tags' do
+      it_behaves_like 'Collection Identification Fedora Cocina mapping' do
+        let(:collection_id) { 'druid:bh036kv6092' }
+        let(:label) { 'Enlace' }
+        let(:admin_policy_id) { 'druid:wp142hh6543' } # from RELS-EXT
+        let(:source_id_source) { 'Hydrus' }
+        let(:source_id) { 'collection-dhartwig-2013-03-19T16:43:27.792Z' }
+        let(:other_id_name) { 'uuid' }
+        let(:other_id) { '1fe81744-90b4-11e2-be35-0050569b3c6e' }
+        let(:identity_metadata_xml) do
+          <<~XML
+            <identityMetadata>
+              <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+              <objectId>#{collection_id}</objectId>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>#{label}</objectLabel>
+              <objectType>collection</objectType>
+              <adminPolicy>#{admin_policy_id}</adminPolicy>
+              <otherId name="#{other_id_name}">#{other_id}</otherId>
+              <tag>Project : Hydrus</tag>
+              <objectType>set</objectType>
+              <tag>Remediated By : 5.11.0</tag>
+            </identityMetadata>
+          XML
+        end
+        let(:roundtrip_identity_metadata_xml) do
+          <<~XML
+            <identityMetadata>
+              <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+              <objectId>#{collection_id}</objectId>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>#{label}</objectLabel>
+              <objectType>collection</objectType>
+            </identityMetadata>
+          XML
+        end
+        let(:cocina_props) do
+          {
+            externalIdentifier: collection_id,
+            type: Cocina::Models::Vocab.collection,
+            label: label,
+            version: 1,
+            identification: {
+              sourceId: "#{source_id_source}:#{source_id}"
+            },
+            access: access_props,
+            administrative: {
+              hasAdminPolicy: admin_policy_id
+            },
+            description: description_props
+          }
+        end
+      end
+    end
+
+    context 'with recent collection' do
+      it_behaves_like 'Collection Identification Fedora Cocina mapping' do
+        let(:collection_id) { 'druid:rs370pv0174' }
+        let(:label) { 'Stanford University, University Architect / Campus Planning and Design, records' }
+        let(:admin_policy_id) { 'druid:wp142hh6543' } # from RELS-EXT
+        let(:source_id_source) { 'Hydrus' }
+        let(:source_id) { 'collection-jschne-2018-02-08T16:42:44.515Z' }
+        let(:other_id_name) { 'uuid' }
+        let(:other_id) { '166c6046-0cef-11e8-9809-0050562259df' }
+        let(:identity_metadata_xml) do
+          <<~XML
+            <identityMetadata>
+              <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+              <objectId>#{collection_id}</objectId>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>#{label}</objectLabel>
+              <objectType>collection</objectType>
+              <otherId name="#{other_id_name}">#{other_id}</otherId>
+              <tag>Project : Hydrus</tag>
+              <objectType>set</objectType>
+            </identityMetadata>
+          XML
+        end
+        let(:roundtrip_identity_metadata_xml) do
+          <<~XML
+            <identityMetadata>
+              <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+              <objectId>#{collection_id}</objectId>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>#{label}</objectLabel>
+              <objectType>collection</objectType>
+            </identityMetadata>
+          XML
+        end
+        let(:cocina_props) do
+          {
+            externalIdentifier: collection_id,
+            type: Cocina::Models::Vocab.collection,
+            label: label,
+            version: 1,
+            identification: {
+              sourceId: "#{source_id_source}:#{source_id}"
+            },
+            access: access_props,
+            administrative: {
+              hasAdminPolicy: admin_policy_id
+            },
+            description: description_props
+          }
+        end
+      end
+    end
+
+    context 'with ckey and release tags' do
+      # it_behaves_like 'Collection Identification Fedora Cocina mapping' do
+      xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+        let(:collection_id) { 'druid:bc225xg9715' }
+        let(:label) { 'Generation Anthropocene' }
+        let(:admin_policy_id) { 'druid:yp636tj5357' } # from RELS-EXT
+        let(:source_id_source) { 'Hydrus' }
+        let(:source_id) { 'collection-amyhodge-2013-03-15T18:27:56.741Z' }
+        let(:other_id_name) { 'uuid' }
+        let(:other_id) { '0ed6a40c-8d9e-11e2-998c-0050569b3c6e' }
+        let(:identity_metadata_xml) do
+          <<~XML
+            <identityMetadata>
+              <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+              <objectId>#{collection_id}</objectId>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>#{label}</objectLabel>
+              <objectType>collection</objectType>
+              <adminPolicy>#{admin_policy_id}</adminPolicy>
+              <otherId name="#{other_id_name}">#{other_id}</otherId>
+              <tag>Project : Hydrus</tag>
+              <objectType>set</objectType>
+              <release displayType="file" release="true" to="Searchworks" what="self" when="2016-10-03T21:55:25Z" who="blalbrit">true</release>
+              <tag>Remediated By : 5.11.0</tag>
+            </identityMetadata>
+          XML
+        end
+        let(:roundtrip_identity_metadata_xml) do
+          <<~XML
+            <identityMetadata>
+              <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+              <objectId>#{collection_id}</objectId>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>#{label}</objectLabel>
+              <objectType>collection</objectType>
+              <release displayType="file" release="true" to="Searchworks" what="self" when="2016-10-03T21:55:25Z" who="blalbrit">true</release>
+            </identityMetadata>
+          XML
+        end
+        let(:cocina_props) do
+          {
+            externalIdentifier: collection_id,
+            type: Cocina::Models::Vocab.collection,
+            label: label,
+            version: 1,
+            identification: {
+              sourceId: "#{source_id_source}:#{source_id}"
+            },
+            access: access_props,
+            administrative: {
+              hasAdminPolicy: admin_policy_id,
+              releaseTags: [
+                {
+                  to: 'Searchworks',
+                  what: 'self',
+                  date: '2016-10-03T21:55:25Z',
+                  who: 'blalbrit',
+                  release: true
+                }
+              ]
+            },
+            description: description_props
+          }
+        end
+      end
+    end
+  end
+
+  context 'with non-hydrus collection with catkey and uuid' do
+    # it_behaves_like 'Collection Identification Fedora Cocina mapping' do
+    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+      let(:collection_id) { 'druid:dj477pz3643' }
+      let(:label) { 'Casa Zapata murals collection, 1984-1995' }
+      let(:admin_policy_id) { 'druid:yf767bj4831' } # from RELS-EXT
+      let(:catkey) { '7618375' }
+      let(:other_id_name) { 'uuid' }
+      let(:other_id) { 'f88d41aa-a8ef-11e9-a9e1-005056a7edb9' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{collection_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>collection</objectType>
+            <otherId name="catkey">#{catkey}</otherId>
+            <otherId name="#{other_id_name}">#{other_id}</otherId>
+            <release what="collection" to="Searchworks" who="dhartwig" when="2019-07-19T19:40:30Z">true</release>
+          </identityMetadata>
+        XML
+      end
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{collection_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>collection</objectType>
+            <otherId name="catkey">#{catkey}</otherId>
+            <release what="collection" to="Searchworks" who="dhartwig" when="2019-07-19T19:40:30Z">true</release>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: collection_id,
+          type: Cocina::Models::Vocab.collection,
+          label: label,
+          version: 1,
+          identification: {
+            catalogLinks: [
+              {
+                catalog: 'symphony',
+                catalogRecordId: catkey
+              }
+            ]
+          },
+          access: access_props,
+          administrative: {
+            hasAdminPolicy: admin_policy_id,
+            releaseTags: [
+              {
+                to: 'Searchworks',
+                what: 'collection',
+                date: '2019-07-19T19:40:30Z',
+                who: 'dhartwig',
+                release: true
+              }
+            ]
+          },
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with recent non-hydrus collection with catkey' do
+    it_behaves_like 'Collection Identification Fedora Cocina mapping' do
+      let(:collection_id) { 'druid:jm134xy3910' }
+      let(:label) { 'Stanford Power2Act, Records' }
+      let(:admin_policy_id) { 'druid:yf767bj4831' } # from RELS-EXT
+      let(:catkey) { '13678509' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <otherId name="catkey">#{catkey}</otherId>
+            <objectLabel>#{label}</objectLabel>
+            <objectId>#{collection_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectType>collection</objectType>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: collection_id,
+          type: Cocina::Models::Vocab.collection,
+          label: label,
+          version: 1,
+          identification: {
+            catalogLinks: [
+              {
+                catalog: 'symphony',
+                catalogRecordId: catkey
+              }
+            ]
+          },
+          access: access_props,
+          administrative: {
+            hasAdminPolicy: admin_policy_id
+          },
+          description: description_props
+        }
+      end
+    end
+  end
+end

--- a/spec/services/cocina/mapping/identification/dro_spec.rb
+++ b/spec/services/cocina/mapping/identification/dro_spec.rb
@@ -1,0 +1,1390 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_examples 'DRO Identification Fedora Cocina mapping' do
+  # Required: item_id, label, admin_policy_id, collection_ids, identity_metadata_xml, cocina_props
+  # Optional: catkey, source_id_source, source_id, other_id_name, other_id, roundtrip_identity_metadata_xml
+
+  # Normalization notes for later:
+  #  otherId of type uuid -> normalize out (keep catkey, barcode ...)  shelfseq, callseq? dissertationid (YES?)?,
+  #  tags (non-release) -> normalize out
+  #  adminPolicy -> normalize out (we use RELS-EXT)
+  #  sourceId -> we need to KEEP - every item should have a sourceId, as should agreements
+  #  releaseTag -> we need to KEEP
+  #  displayType -> normalize out
+  #  missing collections OK -- don't produce cocina with nil druid for collection
+  #  citationTitle, citationCreator -> normalize out
+  #  agreementId?  -> normalize out -> should only be for APOs
+  # multiple collections -> ok
+  #  objectAdminClass -> normalize out
+
+  let(:namespaced_source_id) { defined?(source_id) && defined?(source_id_source) ? "#{source_id_source}:#{source_id}" : nil }
+  let(:namespaced_other_ids) do
+    other_id_nodes = Nokogiri::XML(identity_metadata_xml).xpath('//identityMetadata/otherId')
+    other_id_nodes.map { |other_id_node| "#{other_id_node['name']}:#{other_id_node.text}" }
+  end
+  let(:mods_xml) do
+    <<~XML
+      <mods #{MODS_ATTRIBUTES}>
+        <titleInfo>
+          <title>item title</title>
+        </titleInfo>
+      </mods>
+    XML
+  end
+  # using a mock rather than every example having all relevant datastreams
+  let(:fedora_item_mock) do
+    instance_double(Dor::Item,
+                    pid: item_id,
+                    id: item_id, # see app/services/cocina/from_fedora/administrative.rb:22
+                    objectLabel: [label],
+                    label: label,
+                    current_version: '1',
+                    admin_policy_object_id: defined?(admin_policy_id) ? admin_policy_id : nil,
+                    catkey: defined?(catkey) ? catkey : nil,
+                    source_id: namespaced_source_id, # see app/services/cocina/from_fedora/identification.rb:30
+                    otherId: namespaced_other_ids, # see app/services/cocina/from_fedora/identification.rb:36
+                    collections: collection_ids.map { |id| Dor::Collection.new(pid: id) },
+                    identityMetadata: Dor::IdentityMetadataDS.from_xml(identity_metadata_xml),
+                    descMetadata: Dor::DescMetadataDS.from_xml(mods_xml),
+                    embargoMetadata: Dor::EmbargoMetadataDS.new,
+                    geoMetadata: Dor::GeoMetadataDS.new,
+                    contentMetadata: Dor::ContentMetadataDS.new,
+                    rightsMetadata: Dor::RightsMetadataDS.new)
+  end
+  let(:mapped_cocina_props) { Cocina::FromFedora::DRO.props(fedora_item_mock) }
+  let(:roundtrip_identity_md_xml) { defined?(roundtrip_identity_metadata_xml) ? roundtrip_identity_metadata_xml : identity_metadata_xml }
+  let(:roundtrip_fedora_item) do
+    cocina_dro = Cocina::Models::DRO.new(mapped_cocina_props)
+    fedora_item = Dor::Item.new(pid: cocina_dro.externalIdentifier,
+                                source_id: cocina_dro.identification.sourceId,
+                                catkey: Cocina::ObjectCreator.new.send(:catkey_for, cocina_dro),
+                                label: Cocina::ObjectCreator.new.send(:truncate_label, cocina_dro.label))
+    Cocina::ToFedora::Identity.apply(fedora_item, label: cocina_dro.label, agreement_id: cocina_dro.structural&.hasAgreement)
+    fedora_item.identityMetadata.barcode = cocina_dro.identification.barcode
+    fedora_item
+  end
+  let(:mapped_roundtrip_identity_xml) do
+    Cocina::ToFedora::Identity.apply(roundtrip_fedora_item, label: mapped_cocina_props[:label])
+    roundtrip_fedora_item.identityMetadata.to_xml
+  end
+
+  context 'when mapping from Fedora to Cocina' do
+    it 'cocina hash produces valid Cocina Descriptive model' do
+      expect { Cocina::Models::DRO.new(cocina_props) }.not_to raise_error
+    end
+
+    it 'Fedora maps to expected Cocina' do
+      expect(mapped_cocina_props).to be_deep_equal(cocina_props)
+    end
+  end
+
+  context 'when mapping from Cocina to (roundtrip) Fedora' do
+    it 'identityMetadata roundtrips thru cocina model to original identityMetadata.xml' do
+      expect(mapped_roundtrip_identity_xml).to be_equivalent_to(roundtrip_identity_md_xml)
+    end
+  end
+
+  context 'when mapping from roundtrip Fedora to (roundtrip) Cocina' do
+    let(:roundtrip_catkey) do
+      catalog_link = mapped_cocina_props[:identification][:catalogLinks]&.find { |clink| clink[:catalog] == 'symphony' }
+      catalog_link[:catalogRecordId] if catalog_link
+    end
+    let(:roundtrip_namespaced_other_ids) do
+      other_id_nodes = Nokogiri::XML(mapped_roundtrip_identity_xml).xpath('//identityMetadata/otherId')
+      other_id_nodes.map { |other_id_node| "#{other_id_node['name']}:#{other_id_node.text}" }
+    end
+    let(:roundtrip_collections) do
+      mapped_cocina_props[:structural][:isMemberOf]&.map do |collection_id|
+        instance_double(Dor::Collection,
+                        pid: collection_id,
+                        id: collection_id)
+      end
+    end
+    # using a mock rather than every example having all relevant datastreams
+    let(:roundtrip_fedora_item_mock) do
+      instance_double(Dor::Item,
+                      pid: mapped_cocina_props[:externalIdentifier],
+                      id: mapped_cocina_props[:externalIdentifier], # see app/services/cocina/from_fedora/administrative.rb:22
+                      objectLabel: [label],
+                      label: mapped_cocina_props[:label],
+                      current_version: '1',
+                      admin_policy_object_id: mapped_cocina_props[:administrative][:hasAdminPolicy],
+                      collections: roundtrip_collections,
+                      catkey: roundtrip_catkey,
+                      source_id: mapped_cocina_props[:identification][:sourceId],
+                      otherId: namespaced_other_ids, # see app/services/cocina/from_fedora/identification.rb:36
+                      identityMetadata: Dor::IdentityMetadataDS.from_xml(mapped_roundtrip_identity_xml),
+                      descMetadata: Dor::DescMetadataDS.from_xml(mods_xml),
+                      embargoMetadata: Dor::EmbargoMetadataDS.new,
+                      geoMetadata: Dor::GeoMetadataDS.new,
+                      contentMetadata: Dor::ContentMetadataDS.new,
+                      rightsMetadata: Dor::RightsMetadataDS.new)
+    end
+    let(:roundtrip_cocina_props) { Cocina::FromFedora::DRO.props(roundtrip_fedora_item_mock) }
+
+    before do
+      allow(roundtrip_fedora_item_mock).to receive(:is_a?).with(Dor::Agreement).and_return(false)
+      allow(roundtrip_fedora_item_mock).to receive(:is_a?).with(Dor::Item).and_return(true)
+    end
+
+    it 'roundtrip Fedora maps to expected Cocina props' do
+      expect(roundtrip_cocina_props).to be_deep_equal(cocina_props)
+    end
+  end
+end
+
+RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mappings' do
+  # NOTE: access tested in mapping/access/dro_access_spec.rb
+  let(:access_props) do
+    {
+      access: 'dark',
+      download: 'none'
+    }
+  end
+  # NOTE: description tested in mapping/descriptive/mods
+  let(:description_props) do
+    {
+      title: [
+        value: 'item title'
+      ],
+      purl: "http://purl.stanford.edu/#{item_id.split(':').last}",
+      access: {
+        digitalRepository: [
+          {
+            value: 'Stanford Digital Repository'
+          }
+        ]
+      }
+    }
+  end
+
+  context 'with simple example (even tho geo)' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+      let(:item_id) { 'druid:bb053zc5914' }
+      let(:label) { 'L15_1655E_1008N' }
+      let(:admin_policy_id) { 'druid:bc198wr8388' } # from RELS-EXT
+      let(:collection_ids) { ['druid:hh178mz6257'] } # from RELS-EXT
+      let(:source_id_source) { 'branner' }
+      let(:source_id) { 'drainagecanalsSEAsia_L15_1655E_1008N.tif' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: label,
+          version: 1,
+          identification: {
+            sourceId: "#{source_id_source}:#{source_id}"
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id
+          },
+          structural: {
+            isMemberOf: collection_ids
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with simple example with catkey and no collection' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+      let(:item_id) { 'druid:bb010dx6027' }
+      let(:label) { 'The rite of spring' }
+      let(:catkey) { '8501137' }
+      let(:admin_policy_id) { 'druid:bz845pv2292' } # from RELS-EXT
+      let(:collection_ids) { [] } # not in RELS-EXT
+      let(:source_id_source) { 'sul' }
+      let(:source_id) { 'naxos_nac_8.557501' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <otherId name="catkey">#{catkey}</otherId>
+            <objectLabel>#{label}</objectLabel>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectType>item</objectType>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: label,
+          version: 1,
+          identification: {
+            sourceId: "#{source_id_source}:#{source_id}",
+            catalogLinks: [
+              {
+                catalog: 'symphony',
+                catalogRecordId: catkey
+              }
+            ]
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id
+          },
+          structural: {},
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with empty otherId with name' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+      let(:item_id) { 'druid:bb274jy1491' }
+      let(:label) { 'Cashews, Harvested Area Data Quality, 1997-2003' }
+      let(:admin_policy_id) { 'druid:mh095yb8404' } # from RELS-EXT
+      let(:collection_ids) { ['druid:tz390fn8810'] } # from RELS-EXT
+      let(:source_id_source) { 'branner' }
+      let(:source_id) { 'EStat_cashew_DataQuality_HarvestedArea.tif' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+            <otherId name="label"/>
+            <otherId name="uuid">bc466ea0-e358-11e7-917d-0050569b2d90</otherId>
+            <tag>Process : Content Type : File</tag>
+            <tag>Registered By : kdurante</tag>
+            <tag>Dataset : GIS</tag>
+          </identityMetadata>
+        XML
+      end
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: label,
+          version: 1,
+          identification: {
+            sourceId: "#{source_id_source}:#{source_id}"
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id
+          },
+          structural: {
+            isMemberOf: collection_ids
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with googlebooks item (with release tags)' do
+    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+      let(:item_id) { 'druid:bb000jd2736' }
+      let(:label) { 'The life of Goethe' }
+      let(:catkey) { '2003938' }
+      let(:admin_policy_id) { 'druid:dx569vq3421' } # from RELS-EXT
+      let(:collection_ids) { ['druid:yh583fk3400'] } # from RELS-EXT
+      let(:source_id_source) { 'googlebooks' }
+      let(:source_id) { 'stanford_36105010362304' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <otherId name="catkey">#{catkey}</otherId>
+            <objectLabel>#{label}</objectLabel>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectType>item</objectType>
+            <release what="self" to="Searchworks" who="cspitzer" when="2021-02-18T21:46:35Z">true</release>
+            <release what="self" to="Searchworks" who="bergeraj" when="2021-03-05T08:42:18Z">false</release>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: label,
+          version: 1,
+          identification: {
+            sourceId: "#{source_id_source}:#{source_id}",
+            catalogLinks: [
+              {
+                catalog: 'symphony',
+                catalogRecordId: catkey
+              }
+            ]
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id,
+            releaseTags: [
+              {
+                who: 'cspitzer',
+                what: 'self',
+                date: '2021-02-18T21:46:35Z',
+                to: 'Searchworks',
+                release: true
+              },
+              {
+                who: 'bergeraj',
+                what: 'self',
+                date: '2021-03-05T08:42:18Z',
+                to: 'Searchworks',
+                release: false
+              }
+            ]
+          },
+          structural: {
+            isMemberOf: collection_ids
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with project phoenix item; no collection, has agreement, has barcode' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+      let(:item_id) { 'druid:bb005bg5914' }
+      let(:label) { 'Google Scanned Book, barcode 36105014928126' }
+      let(:catkey) { '405984' }
+      let(:barcode) { '36105014928126' }
+      let(:admin_policy_id) { 'druid:rp029yq2361' } # from RELS-EXT
+      let(:collection_ids) { [] } # not in RELS-EXT
+      let(:source_id_source) { 'google' }
+      let(:source_id) { 'STANFORD_36105014928126' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{item_id}</objectId>
+            <objectType>item</objectType>
+            <objectAdminClass>GoogleBooks</objectAdminClass>
+            <objectLabel>#{label}</objectLabel>
+            <objectCreator>DOR</objectCreator>
+            <citationTitle>Proceedings</citationTitle>
+            <citationCreator>Somersetshire Archaeological and Natural History Society</citationCreator>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <otherId name="catkey">#{catkey}</otherId>
+            <otherId name="shelfseq">DA 000670 .S49 S55 V.000045-000046 001899-001900</otherId>
+            <otherId name="barcode">#{barcode}</otherId>
+            <otherId name="callseq">29</otherId>
+            <otherId name="uuid">6d408a7d-46c1-446c-ad4c-e5b0633830eb</otherId>
+            <agreementId>druid:zn292gq7284</agreementId>
+            <tag>Book : Multi-volume work</tag>
+            <tag>Google Book : GBS VIEW_FULL</tag>
+            <tag>Book : Non-US pre-1891</tag>
+            <tag>Google Book : Scan source STANFORD</tag>
+            <tag>Remediated By : 3.6.2</tag>
+          </identityMetadata>
+        XML
+      end
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{item_id}</objectId>
+            <objectType>item</objectType>
+            <objectLabel>#{label}</objectLabel>
+            <objectCreator>DOR</objectCreator>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <otherId name="catkey">#{catkey}</otherId>
+            <otherId name="barcode">#{barcode}</otherId>
+            <agreementId>druid:zn292gq7284</agreementId>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: label,
+          version: 1,
+          identification: {
+            barcode: barcode,
+            catalogLinks: [
+              {
+                catalog: 'symphony',
+                catalogRecordId: catkey
+              }
+            ],
+            sourceId: 'google:STANFORD_36105014928126'
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id
+          },
+          structural: {
+            hasAgreement: 'druid:zn292gq7284'
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with early ETD, empty objectLabel, no sourceID ... (with release tags)' do
+    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+      let(:item_id) { 'druid:px901zd6069' }
+      let(:label) { '' }
+      let(:catkey) { '8537171' }
+      let(:admin_policy_id) { 'druid:bx911tp9024' } # from RELS-EXT
+      let(:collection_ids) { [] } # not in RELS-EXT
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{item_id}</objectId>
+            <objectType>item</objectType>
+            <objectLabel/>
+            <objectCreator>DOR</objectCreator>
+            <citationTitle>The design and implementation of dynamic information flow tracking systems for software security: 2009, c2010</citationTitle>
+            <citationCreator>Dalton, Michael</citationCreator>
+            <otherId name="dissertationid">0000000001</otherId>
+            <otherId name="catkey">#{catkey}</otherId>
+            <otherId name="uuid">aefeb8c0-632e-11e1-b86c-0800200c9a66</otherId>
+            <agreementId>druid:ct692vv3660</agreementId>
+            <objectAdminClass>ETDs</objectAdminClass>
+            <tag>ETD : Term 1102</tag>
+            <tag>ETD : Dissertation</tag>
+            <release to="Searchworks" what="self" when="2017-02-07T10:45:17Z" who="blalbrit">true</release>
+            <tag>Remediated By : 5.11.0</tag>
+          </identityMetadata>
+        XML
+      end
+      # NOTE: dissertationid becomes sourceId
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{item_id}</objectId>
+            <objectType>item</objectType>
+            <objectLabel/>
+            <objectCreator>DOR</objectCreator>
+            <sourceId source="dissertationid">0000000001</sourceId>
+            <otherId name="catkey">#{catkey}</otherId>
+            <agreementId>druid:ct692vv3660</agreementId>
+            <release to="Searchworks" what="self" when="2017-02-07T10:45:17Z" who="blalbrit">true</release>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: '',
+          version: 1,
+          identification: {
+            sourceId: 'dissertationid:0000000001',
+            catalogLinks: [
+              {
+                catalog: 'symphony',
+                catalogRecordId: catkey
+              }
+            ]
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id,
+            releaseTags: [
+              {
+                who: 'blalbrit',
+                what: 'self',
+                date: '2017-02-07T10:45:17Z',
+                to: 'Searchworks',
+                release: true
+              }
+            ]
+          },
+          structural: {
+            hasAgreement: 'druid:ct692vv3660'
+            # isMemberOf: [
+            #   nil
+            # ]
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with ETD with 2 catkeys' do
+    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+    xit 'to be implemented: what to do with 2 catkeys; release tags need to roundtrip back into identityMetadata.xml' do
+      let(:item_id) { 'druid:zw844wz5427' }
+      let(:label) { '' }
+      let(:catkey) { '8652337' }
+      let(:admin_policy_id) { 'druid:bx911tp9024' } # from RELS-EXT
+      let(:collection_ids) { [] } # not in RELS-EXT
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{item_id}</objectId>
+            <objectType>item</objectType>
+            <objectLabel/>
+            <objectCreator>DOR</objectCreator>
+            <citationTitle>Multiphoton interactions with transparent tissues: applications to imaging and surgery</citationTitle>
+            <citationCreator>Toytman, Ilya</citationCreator>
+            <otherId name="dissertationid">0000000296</otherId>
+            <otherId name="catkey">#{catkey}</otherId>
+            <otherId name="uuid">bb8e629e-6328-11e1-9378-022c4a816c60</otherId>
+            <agreementId>druid:ct692vv3660</agreementId>
+            <tag>ETD : Term 1106</tag>
+            <tag>ETD : Dissertation</tag>
+            <tag>Remediated By : 4.20.1</tag>
+            <release to="Searchworks" who="blalbrit" what="self" when="2017-02-07T11:07:41Z">true</release>
+            <release to="Searchworks" who="blalbrit" what="self" when="2017-02-07T15:15:41Z">true</release>
+            <otherId name="catkey">12303517</otherId>
+            <release to="Searchworks" who="cebraj" what="self" when="2018-05-14T23:26:59Z">true</release>
+          </identityMetadata>
+        XML
+      end
+      # NOTE: dissertationid becomes sourceId
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{item_id}</objectId>
+            <objectType>item</objectType>
+            <objectLabel/>
+            <objectCreator>DOR</objectCreator>
+            <sourceId source="dissertationid">0000000296</sourceId>
+            <otherId name="catkey">#{catkey}</otherId>
+            <agreementId>druid:ct692vv3660</agreementId>
+            <release to="Searchworks" who="blalbrit" what="self" when="2017-02-07T11:07:41Z">true</release>
+            <release to="Searchworks" who="blalbrit" what="self" when="2017-02-07T15:15:41Z">true</release>
+            <otherId name="catkey">12303517</otherId>
+            <release to="Searchworks" who="cebraj" what="self" when="2018-05-14T23:26:59Z">true</release>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: '',
+          version: 1,
+          identification: {
+            sourceId: 'dissertationid:0000000296',
+            catalogLinks: [
+              {
+                catalog: 'symphony',
+                catalogRecordId: catkey
+              }
+            ]
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id,
+            releaseTags: [
+              {
+                who: 'blalbrit',
+                what: 'self',
+                date: '2017-02-07T11:07:41Z',
+                to: 'Searchworks',
+                release: true
+              },
+              {
+                who: 'blalbrit',
+                what: 'self',
+                date: '2017-02-07T15:15:41Z',
+                to: 'Searchworks',
+                release: true
+              },
+              {
+                who: 'cebraj',
+                what: 'self',
+                date: '2018-05-14T23:26:59Z',
+                to: 'Searchworks',
+                release: true
+              }
+            ]
+          },
+          structural: {
+            hasAgreement: 'druid:ct692vv3660'
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with ETD with empty citation elements' do
+    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+      let(:item_id) { 'druid:mr401cc4586' }
+      let(:label) { '' }
+      let(:catkey) { '10327542' }
+      let(:admin_policy_id) { 'druid:bx911tp9024' } # from RELS-EXT
+      let(:collection_ids) { [] } # not in RELS-EXT
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{item_id}</objectId>
+            <objectType>item</objectType>
+            <objectLabel/>
+            <objectCreator>DOR</objectCreator>
+            <citationTitle/>
+            <citationCreator/>
+            <otherId name="dissertationid">0000002905</otherId>
+            <otherId name="catkey">#{catkey}</otherId>
+            <otherId name="uuid">f8493238-61a8-11e3-922e-0050569b52d5</otherId>
+            <agreementId>druid:ct692vv3660</agreementId>
+            <objectAdminClass>ETDs</objectAdminClass>
+            <tag>ETD : Dissertation</tag>
+            <tag>Remediated By : 4.17.1</tag>
+            <release to="Searchworks" what="self" when="2017-02-07T10:01:59Z" who="blalbrit">true</release>
+          </identityMetadata>
+        XML
+      end
+      # NOTE: dissertationid becomes sourceId
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{item_id}</objectId>
+            <objectType>item</objectType>
+            <objectLabel/>
+            <objectCreator>DOR</objectCreator>
+            <sourceId source="dissertationid">0000002905</sourceId>
+            <otherId name="catkey">#{catkey}</otherId>
+            <agreementId>druid:ct692vv3660</agreementId>
+            <release to="Searchworks" what="self" when="2017-02-07T10:01:59Z" who="blalbrit">true</release>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: '',
+          version: 1,
+          identification: {
+            sourceId: 'dissertationid:0000002905',
+            catalogLinks: [
+              {
+                catalog: 'symphony',
+                catalogRecordId: catkey
+              }
+            ]
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id,
+            releaseTags: [
+              {
+                who: 'blalbrit',
+                what: 'self',
+                date: '2017-02-07T10:01:59Z',
+                to: 'Searchworks',
+                release: true
+              }
+            ]
+          },
+          structural: {
+            hasAgreement: 'druid:ct692vv3660'
+            # isMemberOf: [
+            #   nil
+            # ]
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with ETD without citation elements' do
+    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+      let(:item_id) { 'druid:xs522rn2310' }
+      let(:label) { '' }
+      let(:catkey) { '12684953' }
+      let(:admin_policy_id) { 'druid:bx911tp9024' } # from RELS-EXT
+      let(:collection_ids) { [] } # not in RELS-EXT
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{item_id}</objectId>
+            <objectType>item</objectType>
+            <objectLabel/>
+            <objectCreator>DOR</objectCreator>
+            <otherId name="dissertationid">0000006152</otherId>
+            <otherId name="catkey">#{catkey}</otherId>
+            <otherId name="uuid">2f3dc52e-7487-11e8-ae3a-005056a7d1e9</otherId>
+            <agreementId>druid:ct692vv3660</agreementId>
+            <objectAdminClass>ETDs</objectAdminClass>
+            <tag>ETD : Dissertation</tag>
+            <release to="Searchworks" what="self" when="2018-10-19T17:37:18Z" who="arcadia">true</release>
+          </identityMetadata>
+        XML
+      end
+      # NOTE: dissertationid becomes sourceId
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{item_id}</objectId>
+            <objectType>item</objectType>
+            <objectLabel/>
+            <objectCreator>DOR</objectCreator>
+            <sourceId source="dissertationid">0000006152</sourceId>
+            <otherId name="catkey">#{catkey}</otherId>
+            <agreementId>druid:ct692vv3660</agreementId>
+            <release to="Searchworks" what="self" when="2018-10-19T17:37:18Z" who="arcadia">true</release>
+          </identityMetadata>
+        XML
+      end
+
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: '',
+          version: 1,
+          identification: {
+            sourceId: 'dissertationid:0000006152',
+            catalogLinks: [
+              {
+                catalog: 'symphony',
+                catalogRecordId: catkey
+              }
+            ]
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id,
+            releaseTags: [
+              {
+                who: 'arcadia',
+                what: 'self',
+                date: '2018-10-19T17:37:18Z',
+                to: 'Searchworks',
+                release: true
+              }
+            ]
+          },
+          structural: {
+            hasAgreement: 'druid:ct692vv3660'
+            # isMemberOf: [
+            #   nil
+            # ]
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with Bassi-Verati item' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+      let(:item_id) { 'druid:bn012fy8818' }
+      let(:label) { '"Al marito impareggiabile della signora Laura Maria Catterina Bassi", Sonetto di M.D.G.L., s.d.' }
+      let(:admin_policy_id) { 'druid:wq307yk9043' } # from RELS-EXT
+      let(:collection_ids) { ['druid:nx585yw5390'] } # from RELS-EXT
+      let(:source_id_source) { 'Archiginnasio' }
+      let(:source_id) { 'Bassi_Box6_Folder6_Item2' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+            <adminPolicy>#{admin_policy_id}</adminPolicy>
+            <otherId name="uuid">037df272-d787-11e1-9eae-0016034322e2</otherId>
+            <tag>Project : Bassi Veratti</tag>
+            <tag>Registered By : mgolson</tag>
+            <tag>Remediated By : 3.17.13</tag>
+          </identityMetadata>
+        XML
+      end
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: label,
+          version: 1,
+          identification: {
+            sourceId: "#{source_id_source}:#{source_id}"
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id
+          },
+          structural: {
+            isMemberOf: collection_ids
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with SPEC (special collections) item' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+      let(:item_id) { 'druid:fn010kg7712' }
+      let(:label) { 'Mainichi Shinbun, Japanese, shichigatsu 21' }
+      let(:admin_policy_id) { 'druid:ww057vk7675' } # from RELS-EXT
+      let(:collection_ids) { ['druid:hh178mz6257'] } # from RELS-EXT
+      let(:source_id_source) { 'sul' }
+      let(:source_id) { 'ARmoonlanding_i4' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+            <adminPolicy>#{admin_policy_id}</adminPolicy>
+            <otherId name="uuid">da9c0b9a-dfe8-11e1-a037-0016034322e2</otherId>
+            <tag>Project : Digitization Request</tag>
+            <tag>JIRA : DIGREQ-427</tag>
+            <tag>DPG : Digitization Request</tag>
+            <tag>DPG : Access Services</tag>
+            <tag>DPG : Purnell</tag>
+            <tag>Registered By : astrids</tag>
+            <tag>Remediated By : 3.25.3</tag>
+          </identityMetadata>
+        XML
+      end
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: label,
+          version: 1,
+          identification: {
+            sourceId: "#{source_id_source}:#{source_id}"
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id
+          },
+          structural: {
+            isMemberOf: collection_ids
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with source id namespace trailing space, id has multiple leading spaces' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+      let(:item_id) { 'druid:bb077vq3166' }
+      let(:label) { '16152_24A_SM' }
+      let(:admin_policy_id) { 'druid:qp256sh2346' } # from RELS-EXT
+      let(:collection_ids) { ['druid:vx796zh5418'] } # from RELS-EXT
+      let(:source_id_source) { 'sul ' }
+      let(:source_id) { '  16152_24A_SM' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+            <adminPolicy>druid:qp256sh2346</adminPolicy>
+            <otherId name="label"/>
+            <otherId name="uuid">f8621178-2317-11e4-9677-0050569b3c3c</otherId>
+            <tag>Process : Content Type : Image</tag>
+            <tag>Project : Menuez</tag>
+            <tag>Project : Menuez : Batch2</tag>
+            <tag>Registered By : blalbrit</tag>
+            <tag>Remediated By : 4.6.6.2</tag>
+          </identityMetadata>
+        XML
+      end
+      # NOTE: source and source_id values stripped of leading and trailing whitespace
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source.strip}">#{source_id.strip}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: label,
+          version: 1,
+          identification: {
+            sourceId: "#{source_id_source}:#{source_id}"
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id
+          },
+          structural: {
+            isMemberOf: collection_ids
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with displayType (Hydrus item)' do
+    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+      let(:item_id) { 'druid:gj077jb7878' }
+      let(:label) { 'Open Science Perspective' }
+      let(:admin_policy_id) { 'druid:sn486kf1487' } # from RELS-EXT
+      let(:collection_ids) { ['druid:ck552zg2217'] } # from RELS-EXT
+      let(:source_id_source) { 'Hydrus' }
+      let(:source_id) { 'item-amyhodge-2013-12-19T23:04:19.236Z' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+            <adminPolicy>#{admin_policy_id}</adminPolicy>
+            <otherId name="uuid">e44a8574-6901-11e3-a6d0-0050569b3c6e</otherId>
+            <tag>Project : Hydrus</tag>
+            <tag>Remediated By : 3.25.3</tag>
+            <displayType>file</displayType>
+            <release displayType="file" release="true" to="Searchworks" what="self" when="2015-10-25T21:29:13Z" who="blalbrit">true</release>
+          </identityMetadata>
+        XML
+      end
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+            <release displayType="file" release="true" to="Searchworks" what="self" when="2015-10-25T21:29:13Z" who="blalbrit">true</release>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: label,
+          version: 1,
+          identification: {
+            sourceId: "#{source_id_source}:#{source_id}"
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id,
+            releaseTags: [
+              {
+                who: 'blalbrit',
+                what: 'self',
+                date: '2015-10-25T21:29:13Z',
+                to: 'Searchworks',
+                release: true
+              }
+            ]
+          },
+          structural: {
+            isMemberOf: collection_ids
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with web archive seed (old)' do
+    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+      let(:item_id) { 'druid:bj731rx4986' }
+      let(:label) { 'http://nippongenkikai.jp/' }
+      let(:admin_policy_id) { 'druid:xt299pt7593' } # from RELS-EXT
+      let(:collection_ids) { ['druid:sr233xh9483'] } # from RELS-EXT
+      let(:source_id_source) { 'sul' }
+      let(:source_id) { 'ARCHIVEIT-EAL-8001-nippongenkikai.jp/' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+            <otherId name="uuid">49bc073a-e1e8-11e7-95c6-005056a7edb9</otherId>
+            <tag>webarchive : seed</tag>
+            <release to="Searchworks" who="reganmk" what="self" when="2018-05-21T21:40:51Z">true</release>
+            <release to="Searchworks" who="cebraj" what="self" when="2018-07-19T21:35:44Z">true</release>
+          </identityMetadata>
+        XML
+      end
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+            <release to="Searchworks" who="reganmk" what="self" when="2018-05-21T21:40:51Z">true</release>
+            <release to="Searchworks" who="cebraj" what="self" when="2018-07-19T21:35:44Z">true</release>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: label,
+          version: 1,
+          identification: {
+            sourceId: "#{source_id_source}:#{source_id}"
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id,
+            releaseTags: [
+              {
+                who: 'reganmk',
+                what: 'self',
+                date: '2018-05-21T21:40:51Z',
+                to: 'Searchworks',
+                release: true
+              },
+              {
+                who: 'cebraj',
+                what: 'self',
+                date: '2018-07-19T21:35:44Z',
+                to: 'Searchworks',
+                release: true
+              }
+            ]
+          },
+          structural: {
+            isMemberOf: collection_ids
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with web archive seed (new)' do
+    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+      let(:item_id) { 'druid:bb143kr5856' }
+      let(:label) { 'http://cheme.stanford.edu/' }
+      let(:admin_policy_id) { 'druid:xt299pt7593' } # from RELS-EXT
+      let(:collection_ids) { ['druid:xs048zp7815'] } # from RELS-EXT
+      let(:source_id_source) { 'sul' }
+      let(:source_id) { 'ARCHIVEIT-UA-5591-http://cheme.stanford.edu' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+            <release what="self" to="Searchworks" who="pchan3" when="2020-10-28T23:53:05Z">false</release>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: label,
+          version: 1,
+          identification: {
+            sourceId: "#{source_id_source}:#{source_id}"
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id,
+            releaseTags: [
+              {
+                who: 'pchan3',
+                what: 'self',
+                date: '2020-10-28T23:53:05Z',
+                to: 'Searchworks',
+                release: false
+              }
+            ]
+          },
+          structural: {
+            isMemberOf: collection_ids
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with 2 collections and objectLabel with xml encoding' do
+    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+    xit 'to be implemented: do not double XML escape ampersands in objectLabel' do
+      let(:item_id) { 'druid:bb001zc5754' }
+      let(:label) { 'French Grand Prix &amp; 12 Hour Rheims 7/4/1954' }
+      let(:admin_policy_id) { 'druid:qv648vd4392' } # from RELS-EXT
+      let(:collection_ids) { ['druid:nt028fd5773', 'druid:wy149zp6932'] } # from RELS-EXT
+      let(:source_id_source) { 'Revs' }
+      let(:source_id) { '2006-001PHIL-1954-b1_29.1_0021' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+            <adminPolicy>#{admin_policy_id}</adminPolicy>
+            <otherId name="uuid">b9af2444-2525-11e2-a4c7-0050569b52d5</otherId>
+            <tag>Project : Revs</tag>
+            <tag>Remediated By : 4.23.0</tag>
+          </identityMetadata>
+        XML
+      end
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: label,
+          version: 1,
+          identification: {
+            sourceId: "#{source_id_source}:#{source_id}"
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id
+          },
+          structural: {
+            isMemberOf: [
+              'druid:nt028fd5773',
+              'druid:wy149zp6932'
+            ]
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with objectAdminClass (EEMS) and same catkey twice, no collection' do
+    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+      let(:item_id) { 'druid:bb029vy9696' }
+      let(:label) { 'EEMs: Finite State Continuous-Time Markov Decision Processes with Applications to a Class of Optimization Problems in Queueing Theory' }
+      let(:catkey) { '10208128' }
+      let(:admin_policy_id) { 'druid:jj305hm5259' } # from RELS-EXT
+      let(:collection_ids) { [] } # none in RELS-EXT
+      let(:source_id_source) { 'eems' }
+      let(:source_id) { 'eems_src_00001' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{item_id}</objectId>
+            <objectType>item</objectType>
+            <objectLabel>#{label}</objectLabel>
+            <objectAdminClass>EEMs</objectAdminClass>
+            <agreementId>druid:fn200hb6598</agreementId>
+            <tag>EEM : 1.0</tag>
+            <otherId name="catkey">#{catkey}</otherId>
+            <tag>Remediated By : 5.8.1</tag>
+            <release to="Searchworks" what="self" when="2016-11-22T19:21:08Z" who="blalbrit">true</release>
+            <release to="Searchworks" what="self" when="2016-11-22T21:35:46Z" who="blalbrit">true</release>
+            <otherId name="catkey">#{catkey}</otherId>
+            <release to="Searchworks" what="self" when="2018-05-15T00:31:17Z" who="cebraj">true</release>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+          </identityMetadata>
+        XML
+      end
+      # NOTE: missing objectCreator added
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{item_id}</objectId>
+            <objectType>item</objectType>
+            <objectLabel>#{label}</objectLabel>
+            <objectCreator>DOR</objectCreator>
+            <agreementId>druid:fn200hb6598</agreementId>
+            <otherId name="catkey">#{catkey}</otherId>
+            <release to="Searchworks" what="self" when="2016-11-22T19:21:08Z" who="blalbrit">true</release>
+            <release to="Searchworks" what="self" when="2016-11-22T21:35:46Z" who="blalbrit">true</release>
+            <release to="Searchworks" what="self" when="2018-05-15T00:31:17Z" who="cebraj">true</release>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: label,
+          version: 1,
+          identification: {
+            sourceId: "#{source_id_source}:#{source_id}",
+            catalogLinks: [
+              {
+                catalog: 'symphony',
+                catalogRecordId: catkey
+              }
+            ]
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id,
+            releaseTags: [
+              {
+                who: 'blalbrit',
+                what: 'self',
+                date: '2016-11-22T19:21:08Z',
+                to: 'Searchworks',
+                release: true
+              },
+              {
+                who: 'blalbrit',
+                what: 'self',
+                date: '2016-11-22T21:35:46Z',
+                to: 'Searchworks',
+                release: true
+              },
+              {
+                who: 'cebraj',
+                what: 'self',
+                date: '2018-05-15T00:31:17Z',
+                to: 'Searchworks',
+                release: true
+              }
+            ]
+          },
+          structural: {
+            hasAgreement: 'druid:fn200hb6598'
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with &#x escaped chars in objectLabel (FRDA)' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+      let(:item_id) { 'druid:bb016nw8128' }
+      let(:label) { 'E&#x301;ve&#x301;nement du 19 fevrier 1790' }
+      let(:admin_policy_id) { 'druid:ht275vw4351' } # from RELS-EXT
+      let(:collection_ids) { ['druid:jh957jy1101'] } # from RELS-EXT
+      let(:source_id_source) { 'French Revolution Digital Archive' }
+      let(:source_id) { 'BNF:06944651' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{label}</objectLabel>
+            <objectType>item</objectType>
+            <adminPolicy>druid:ht275vw4351</adminPolicy>
+            <otherId name="uuid">c2c9b4f6-4bac-11e2-b8ce-0050569b52d5</otherId>
+            <tag>Project : French Revolution Digital Archive</tag>
+            <tag>Remediated By : 3.25.3</tag>
+          </identityMetadata>
+        XML
+      end
+      # NOTE: label: xml escapes ampersands in unicode hex characters
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>E&amp;#x301;ve&amp;#x301;nement du 19 fevrier 1790</objectLabel>
+            <objectType>item</objectType>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: label,
+          version: 1,
+          identification: {
+            sourceId: "#{source_id_source}:#{source_id}"
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id
+          },
+          structural: {
+            isMemberOf: collection_ids
+          },
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,7 +97,7 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = :random
+  config.order = :random if config.files_to_run.one?
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,7 +97,7 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = :random if config.files_to_run.one?
+  config.order = :random unless config.files_to_run.one?
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce


### PR DESCRIPTION
Part of #2703, this PR presents four new spec files that are focused on the mapping code (from_fedora, to_fedora) that affects identityMetadata.xml for Fedora objects, and Cocina::Identification models.

There is a teeny bit of refactoring included -- trying to get more of the code to follow the naming conventions we agreed on in an infradev meeting ("fedora_collection" "cocina_dro" etc.)


## How was this change tested?

it adds specs.


## Which documentation and/or configurations were updated?



