### PR TITLE
Support normalization in validate-cocina-roundtrip and check datastre…

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Normalizers
+    # Normalizes a Fedora object content metadata datastream, accounting for differences between Fedora rights and cocina rights that are valid but different
+    # when round-tripping.
+    class ContentMetadataNormalizer
+      include Cocina::Normalizers::Base
+
+      # @param [Nokogiri::Document] content_ng_xml content metadata XML to be normalized
+      # @return [Nokogiri::Document] normalized content metadata xml
+      def self.normalize(content_ng_xml:)
+        new(content_ng_xml: content_ng_xml).normalize
+      end
+
+      def initialize(content_ng_xml:)
+        @ng_xml = content_ng_xml.dup
+        @ng_xml.encoding = 'UTF-8' if @ng_xml.respond_to?(:encoding=) # sometimes it's a String (?)
+      end
+
+      def normalize
+        remove_resource_id
+        normalize_object_id
+
+        regenerate_ng_xml(ng_xml.to_s)
+      end
+
+      private
+
+      attr_reader :ng_xml
+
+      def remove_resource_id
+        ng_xml.root.xpath('//resource[@id]').each { |resource_node| resource_node.delete('id') }
+      end
+
+      def normalize_object_id
+        object_id = ng_xml.root['objectId']
+        return if object_id.nil? || object_id.start_with?('druid:')
+
+        ng_xml.root['objectId'] = "druid:#{object_id}"
+      end
+    end
+  end
+end

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -171,7 +171,7 @@ module Cocina
     # rubocop:enable Style/GuardClause
 
     def update_descriptive?
-      Settings.enabled_features.update_descriptive
+      Settings.enabled_features.update_descriptive || trial
     end
 
     def client_attempted_metadata_update?

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -45,10 +45,14 @@ def write_result(druid, orig_cocina_hash, roundtrip_cocina_hash, diff_datastream
     end
 
     diff_datastreams.each_pair do |dsid, ng_xmls|
-      orig_ds_ng_xml, ds_ng_xml = ng_xmls
-
+      orig_datastream_ng_xml, norm_orig_datatream_ng_xml, roundtrip_datastream_ng_xml, norm_roundtrip_datastream_ng_xml = ng_xmls
+      file.write("Difference found for #{dsid}\n")
       file.write("Diff for #{dsid}:\n")
-      file.write(Diffy::Diff.new("#{orig_ds_ng_xml.to_xml}\n", "#{ds_ng_xml.to_xml}\n"))
+      file.write(Diffy::Diff.new("#{norm_orig_datatream_ng_xml.to_xml}\n", "#{norm_roundtrip_datastream_ng_xml.to_xml}\n\n"))
+      file.write("\nOriginal XML for #{dsid}:\n#{orig_datastream_ng_xml.to_xml}\n")
+      file.write("\nNormalized original XML for #{dsid}:\n#{norm_orig_datatream_ng_xml.to_xml}\n") if orig_datastream_ng_xml != norm_orig_datatream_ng_xml
+      file.write("\nRoundtripped XML for #{dsid}:\n#{roundtrip_datastream_ng_xml.to_xml}\n")
+      file.write("\nNormalized roundtripped XML for #{dsid}:\n#{norm_roundtrip_datastream_ng_xml.to_xml}\n") if roundtrip_datastream_ng_xml != norm_roundtrip_datastream_ng_xml
       file.write("\n\n")
     end
   end
@@ -71,6 +75,57 @@ def ng_xml_for(xml)
   Nokogiri::XML(xml) { |config| config.default_xml.noblanks }
 end
 
+def norm_orig_datastream_ng_xml_for(dsid, orig_datastream_ng_xml, druid, label)
+  case dsid
+  # Additional normalizers to go here.
+  when 'descMetadata'
+    Cocina::Normalizers::ModsNormalizer.normalize(mods_ng_xml: orig_datastream_ng_xml, druid: druid, label: label)
+  when 'rightsMetadata'
+    Cocina::Normalizers::RightsNormalizer.normalize(rights_ng_xml: orig_datastream_ng_xml)
+  when 'contentMetadata'
+    Cocina::Normalizers::ContentMetadataNormalizer.normalize(content_ng_xml: orig_datastream_ng_xml)
+  else
+    orig_datastream_ng_xml
+  end
+end
+
+def norm_roundtrip_datastream_ng_xml_for(dsid, roundtrip_datastream_ng_xml, orig_datastream_ng_xml)
+  case dsid
+    # Additional normalizers to go here.
+  when 'rightsMetadata'
+    Cocina::Normalizers::RightsNormalizer.normalize_roundtrip(rights_ng_xml: roundtrip_datastream_ng_xml, original_ng_xml: orig_datastream_ng_xml)
+  when 'contentMetadata'
+    Cocina::Normalizers::ContentMetadataNormalizer.normalize(content_ng_xml: roundtrip_datastream_ng_xml)
+  else
+    roundtrip_datastream_ng_xml
+  end
+end
+
+def equivalent?(dsid, orig_datastream_ng_xml, roundtrip_ng_xml)
+  if dsid == 'descMetadata'
+    ModsEquivalentService.equivalent?(orig_datastream_ng_xml, roundtrip_ng_xml)
+  else
+    EquivalentXml.equivalent?(orig_datastream_ng_xml, roundtrip_ng_xml, { element_order: false, normalize_whitespace: false })
+  end
+end
+
+def diff_datatreams_for(druid, label, orig_datastreams, fedora_obj)
+  diff_datastreams = {}
+  orig_datastreams.each_pair do |dsid, orig_datastream|
+    next if orig_datastream.nil?
+
+    orig_datastream_ng_xml = ng_xml_for(orig_datastream)
+    norm_orig_datastream_ng_xml = norm_orig_datastream_ng_xml_for(dsid, orig_datastream_ng_xml, druid, label)
+
+    roundtrip_datastream_ng_xml = ng_xml_for(fedora_obj.datastreams[dsid].content)
+    norm_roundtrip_datastream_ng_xml = norm_roundtrip_datastream_ng_xml_for(dsid, roundtrip_datastream_ng_xml, orig_datastream_ng_xml)
+    next if equivalent?(dsid, norm_orig_datastream_ng_xml, norm_roundtrip_datastream_ng_xml)
+
+    diff_datastreams[dsid] = [orig_datastream_ng_xml, norm_orig_datastream_ng_xml, roundtrip_datastream_ng_xml, norm_roundtrip_datastream_ng_xml]
+  end
+  diff_datastreams
+end
+
 def validate_druid(druid, loader)
   return :missing unless loader.cached?(druid)
 
@@ -85,6 +140,7 @@ def validate_druid(druid, loader)
 
   orig_datastreams = {}
   FedoraCache::DATASTREAMS.each { |dsid| orig_datastreams[dsid] = fedora_obj.datastreams[dsid]&.content }
+  label = fedora_obj.label
 
   begin
     orig_cocina_obj = Cocina::Mapper.build(fedora_obj, notifier: DataErrorNotifier.new)
@@ -103,43 +159,38 @@ def validate_druid(druid, loader)
   end
   roundtrip_cocina_hash = roundtrip_cocina_obj.to_h
 
-  diff_datastreams = {}
-  orig_datastreams.each_pair do |dsid, orig_datastream|
-    next if orig_datastream.nil?
-
-    orig_datastream_ng_xml = ng_xml_for(orig_datastream)
-
-    datastream_ng_xml = ng_xml_for(fedora_obj.datastreams[dsid].content)
-    next if EquivalentXml.equivalent?(orig_datastream_ng_xml, datastream_ng_xml, { element_order: false, normalize_whitespace: false })
-
-    diff_datastreams[dsid] = [orig_datastream_ng_xml, datastream_ng_xml]
+  begin
+    diff_datastreams = diff_datatreams_for(druid, label, orig_datastreams, fedora_obj)
+  rescue StandardError => e
+    write_error(druid, e)
+    return :normalization_error
   end
 
-  return :success if DeepEqual.match?(normalize_orig(orig_cocina_hash), normalize(roundtrip_cocina_hash))
-
-  # && diff_datastreams.empty?
-  # Currently only determining success based on cocina.
-  # However, in future might want to also check datastreams. This would require normalization.
+  return :success if DeepEqual.match?(normalize_orig_cocina(orig_cocina_hash), normalize_roundtrip_cocina(roundtrip_cocina_hash)) && diff_datastreams.empty?
 
   write_result(druid, orig_cocina_hash, roundtrip_cocina_hash, diff_datastreams)
   :different
 end
 
-def normalize_orig(cocina_hash)
+def normalize_orig_cocina(cocina_hash)
   # Remove space from source id, e.g., "sul: M0443_S2_D-K_B9_F33_011"
   source_id = cocina_hash.dig(:identification, :sourceId)
   cocina_hash[:identification][:sourceId] = source_id.gsub(/ *: */, ':') if source_id
 
-  normalize(cocina_hash)
+  normalize_roundtrip_cocina(cocina_hash)
 end
 
-def normalize(cocina_hash)
+def normalize_external_identifiers(cocina_hash)
   # Remove file and fileSet externalIdentifiers, since usually regenerated.
   Array(cocina_hash.dig(:structural, :contains)).each do |file_set|
     file_set.delete(:externalIdentifier)
     Array(file_set.dig(:structural, :contains)).each { |file| file.delete(:externalIdentifier) }
   end
   cocina_hash
+end
+
+def normalize_roundtrip_cocina(cocina_hash)
+  normalize_external_identifiers(cocina_hash)
 end
 
 def percentage(raw_num, denom)
@@ -162,7 +213,7 @@ end
 results = Parallel.map(druids, progress: 'Testing') do |druid|
   validate_druid(druid, loader)
 end
-counts = { different: 0, success: 0, mapping_error: 0, update_error: 0, missing: 0, unmapped: 0, bad_cache: 0 }
+counts = { different: 0, success: 0, mapping_error: 0, update_error: 0, normalization_error: 0, missing: 0, unmapped: 0, bad_cache: 0 }
 results.each { |result| counts[result] += 1 }
 
 denom = druids.size - counts[:missing] - counts[:unmapped] - counts[:bad_cache]
@@ -172,6 +223,7 @@ puts "  Success:   #{counts[:success]} (#{percentage(counts[:success], denom)}%)
 puts "  Different: #{counts[:different]} (#{percentage(counts[:different], denom)}%)"
 puts "  Mapping error:     #{counts[:mapping_error]} (#{percentage(counts[:mapping_error], denom)}%)"
 puts "  Update error:     #{counts[:update_error]} (#{percentage(counts[:update_error], denom)}%)"
+puts "  Normalization error:     #{counts[:normalization_error]} (#{percentage(counts[:normalization_error], denom)}%)"
 puts "  Missing:     #{counts[:missing]} (#{(100 * counts[:missing].to_f / druids.size).round(3)}%)"
 puts "  Unmapped:     #{counts[:unmapped]} (#{(100 * counts[:unmapped].to_f / druids.size).round(3)}%)"
 puts "  Bad cache:     #{counts[:bad_cache]} (#{(100 * counts[:bad_cache].to_f / druids.size).round(3)}%)"

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -17,6 +17,7 @@ parser = OptionParser.new do |option_parser|
 
   option_parser.on('-sSAMPLE', '--sample SAMPLE', Integer, 'Sample size, otherwise all druids.')
   option_parser.on('-r', '--random', 'Select random druids.')
+  option_parser.on('-f', '--fast', 'Without content metadata.')
   option_parser.on('-dDRUIDS', '--druids DRUIDS', Array, 'List of druids (instead of druids.txt).')
   option_parser.on('-h', '--help', 'Displays help.') do
     puts option_parser
@@ -126,7 +127,7 @@ def diff_datatreams_for(druid, label, orig_datastreams, fedora_obj)
   diff_datastreams
 end
 
-def validate_druid(druid, loader)
+def validate_druid(druid, loader, fast: false)
   return :missing unless loader.cached?(druid)
 
   begin
@@ -137,6 +138,8 @@ def validate_druid(druid, loader)
   rescue FedoraLoader::Unmapped
     return :unmapped
   end
+
+  fedora_obj.contentMetadata.content = "<contentMetadata type='#{fedora_obj.contentMetadata.contentType.first}' />" if fast && fedora_obj.datastreams.include?('contentMetadata')
 
   orig_datastreams = {}
   FedoraCache::DATASTREAMS.each { |dsid| orig_datastreams[dsid] = fedora_obj.datastreams[dsid]&.content }
@@ -197,10 +200,8 @@ def percentage(raw_num, denom)
   (100 * raw_num.to_f / denom).round(3)
 end
 
-unless options[:fast]
-  FileUtils.rm_rf('results')
-  FileUtils.mkdir_p('results')
-end
+FileUtils.rm_rf('results')
+FileUtils.mkdir_p('results')
 
 if options[:druids].empty?
   druids = File.read('druids.txt').split
@@ -211,7 +212,7 @@ else
 end
 
 results = Parallel.map(druids, progress: 'Testing') do |druid|
-  validate_druid(druid, loader)
+  validate_druid(druid, loader, fast: options[:fast])
 end
 counts = { different: 0, success: 0, mapping_error: 0, update_error: 0, normalization_error: 0, missing: 0, unmapped: 0, bad_cache: 0 }
 results.each { |result| counts[result] += 1 }

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
+  let(:normalized_ng_xml) { described_class.normalize(content_ng_xml: Nokogiri::XML(original_xml)) }
+
+  context 'when normalizing resource ids' do
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata objectId="druid:bk689jd2364" type="file">
+          <resource id="bk689jd2364_1" sequence="1" type="file">
+            <file id="Decision.Record_6-30-03_signed.pdf" preserve="yes" publish="yes" shelve="yes" mimetype="application/pdf" size="102937">
+              <checksum type="md5">50d5fc2730503a98bc2dda643064ae5b</checksum>
+              <checksum type="sha1">df31b2f415d8e0806fa283db4e2c7fda690d1b02</checksum>
+            </file>
+          </resource>
+        </contentMetadata>
+      XML
+    end
+
+    it 'removes the ids' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <contentMetadata objectId="druid:bk689jd2364" type="file">
+            <resource sequence="1" type="file">
+              <file id="Decision.Record_6-30-03_signed.pdf" preserve="yes" publish="yes" shelve="yes" mimetype="application/pdf" size="102937">
+                <checksum type="md5">50d5fc2730503a98bc2dda643064ae5b</checksum>
+                <checksum type="sha1">df31b2f415d8e0806fa283db4e2c7fda690d1b02</checksum>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      )
+    end
+  end
+
+  context 'when normalizing objectId' do
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata objectId="bk689jd2364" type="file" />
+      XML
+    end
+
+    it 'prefixes with druid:' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <contentMetadata objectId="druid:bk689jd2364" type="file" />
+        XML
+      )
+    end
+  end
+end


### PR DESCRIPTION
…am diffs.

## Why was this change made?
Progress towards roundtrip testing for all datastreams. This adds a normalizer for content metadata and provides the ability to adds others as necessary.


## How was this change tested?
Unit, local


## Which documentation and/or configurations were updated?
NA


