### PR TITLE
Normalize marcgac codes

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -131,7 +131,6 @@ module Cocina
           return nil if code.nil?
 
           notifier.warn('Subject has unknown authority code', { code: code }) unless SubjectAuthorityCodes::SUBJECT_AUTHORITY_CODES.include?(code)
-
           code
         end
 
@@ -262,7 +261,9 @@ module Cocina
           when 'titleInfo'
             title(node, attrs, orig_attrs)
           when 'geographicCode'
-            attrs.merge(code: node.text, type: 'place')
+            code = node.text
+            code = normalized_marcgac(code) if attrs.dig(:source, :code) == 'marcgac'
+            attrs.merge(code: code, type: 'place')
           when 'cartographics'
             # Cartographics are built separately
             nil
@@ -273,6 +274,11 @@ module Cocina
             node_type = node_type_for(node, attrs[:displayLabel])
             attrs.merge(value: node.text, type: node_type) if node_type
           end
+        end
+
+        # Strip any trailing dashes
+        def normalized_marcgac(code)
+          code.sub(/-+$/, '')
         end
 
         def title(node, attrs, orig_attrs)

--- a/app/services/cocina/normalizers/mods/subject_normalizer.rb
+++ b/app/services/cocina/normalizers/mods/subject_normalizer.rb
@@ -19,6 +19,7 @@ module Cocina
         def normalize
           normalize_xlink_href
           normalize_empty_geographic
+          normalize_marcgac
           normalize_empty_temporal
           normalize_subject
           normalize_subject_children
@@ -35,6 +36,12 @@ module Cocina
         private
 
         attr_reader :ng_xml
+
+        def normalize_marcgac
+          ng_xml.root.xpath('//mods:geographicCode', mods: ModsNormalizer::MODS_NS).each do |node|
+            node.content = node.content.sub(/-+$/, '')
+          end
+        end
 
         # rubocop:disable Metrics/PerceivedComplexity
         # rubocop:disable Metrics/CyclomaticComplexity

--- a/spec/services/cocina/mapping/descriptive/mods/subject_geographic_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_geographic_spec.rb
@@ -185,6 +185,40 @@ RSpec.describe 'MODS subject geographic <--> cocina mappings' do
     end
   end
 
+  describe 'marc geographic area code subject with trailing dashes' do
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <subject>
+            <geographicCode authority="marcgac">n-us---</geographicCode>
+          </subject>
+        XML
+      end
+
+      let(:roundtrip_mods) do
+        <<~XML
+          <subject authority="marcgac">
+            <geographicCode>n-us</geographicCode>
+          </subject>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          subject: [
+            {
+              code: 'n-us',
+              type: 'place',
+              source: {
+                code: 'marcgac'
+              }
+            }
+          ]
+        }
+      end
+    end
+  end
+
   describe 'Geographic code and term' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do


### PR DESCRIPTION
## Why was this change made?
Currently the MARC standard is to pad out this code to seven digits with dash, however, the lookup table that LOC publishes does not have any padding.
Fixes #2805 


## How was this change tested?

```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99371 (99.996%)
  Different: 4 (0.004%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     625 (0.625%)
```



## Which documentation and/or configurations were updated?



