### PR TITLE
Handle leading and trailing spaces in source id.

### DIFF
--- a/app/services/cocina/from_fedora/identification.rb
+++ b/app/services/cocina/from_fedora/identification.rb
@@ -28,7 +28,7 @@ module Cocina
 
       def source_id
         if fedora_object.source_id
-          fedora_object.source_id
+          fedora_object.source_id.strip.sub(/ *: */, ':')
         elsif fedora_object.is_a? Dor::Collection
           nil
         else

--- a/app/services/cocina/normalizers/identity_normalizer.rb
+++ b/app/services/cocina/normalizers/identity_normalizer.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Normalizers
+    # Normalizes a Fedora object identity metadata datastream, accounting for differences between Fedora rights and cocina rights that are valid but different
+    # when round-tripping.
+    class IdentityNormalizer
+      include Cocina::Normalizers::Base
+
+      # @param [Nokogiri::Document] identity_ng_xml identity metadata XML to be normalized
+      # @return [Nokogiri::Document] normalized identity metadata xml
+      def self.normalize(identity_ng_xml:)
+        new(identity_ng_xml: identity_ng_xml).normalize
+      end
+
+      def initialize(identity_ng_xml:)
+        @ng_xml = identity_ng_xml.dup
+        @ng_xml.encoding = 'UTF-8' if @ng_xml.respond_to?(:encoding=) # sometimes it's a String (?)
+      end
+
+      def normalize
+        normalize_source_id
+
+        regenerate_ng_xml(ng_xml.to_s)
+      end
+
+      private
+
+      attr_reader :ng_xml
+
+      def normalize_source_id
+        ng_xml.root.xpath('//sourceId').each do |source_node|
+          source_node['source'] = source_node['source']&.strip
+          source_node.content = source_node.content&.strip
+        end
+      end
+    end
+  end
+end

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -85,6 +85,8 @@ def norm_orig_datastream_ng_xml_for(dsid, orig_datastream_ng_xml, druid, label)
     Cocina::Normalizers::RightsNormalizer.normalize(rights_ng_xml: orig_datastream_ng_xml)
   when 'contentMetadata'
     Cocina::Normalizers::ContentMetadataNormalizer.normalize(druid: druid, content_ng_xml: orig_datastream_ng_xml)
+  when 'identityMetadata'
+    Cocina::Normalizers::IdentityNormalizer.normalize(identity_ng_xml: orig_datastream_ng_xml)
   else
     orig_datastream_ng_xml
   end
@@ -169,18 +171,10 @@ def validate_druid(druid, loader, fast: false)
     return :normalization_error
   end
 
-  return :success if DeepEqual.match?(normalize_orig_cocina(orig_cocina_hash), normalize_roundtrip_cocina(roundtrip_cocina_hash)) && diff_datastreams.empty?
+  return :success if DeepEqual.match?(normalize_cocina(orig_cocina_hash), normalize_cocina(roundtrip_cocina_hash)) && diff_datastreams.empty?
 
   write_result(druid, orig_cocina_hash, roundtrip_cocina_hash, diff_datastreams)
   :different
-end
-
-def normalize_orig_cocina(cocina_hash)
-  # Remove space from source id, e.g., "sul: M0443_S2_D-K_B9_F33_011"
-  source_id = cocina_hash.dig(:identification, :sourceId)
-  cocina_hash[:identification][:sourceId] = source_id.gsub(/ *: */, ':') if source_id
-
-  normalize_roundtrip_cocina(cocina_hash)
 end
 
 def normalize_external_identifiers(cocina_hash)
@@ -192,7 +186,7 @@ def normalize_external_identifiers(cocina_hash)
   cocina_hash
 end
 
-def normalize_roundtrip_cocina(cocina_hash)
+def normalize_cocina(cocina_hash)
   normalize_external_identifiers(cocina_hash)
 end
 

--- a/spec/services/cocina/mapping/identification/dro_spec.rb
+++ b/spec/services/cocina/mapping/identification/dro_spec.rb
@@ -963,7 +963,7 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
           label: label,
           version: 1,
           identification: {
-            sourceId: "#{source_id_source}:#{source_id}"
+            sourceId: "#{source_id_source.strip}:#{source_id.strip}"
           },
           administrative: {
             hasAdminPolicy: admin_policy_id

--- a/spec/services/cocina/normalizers/identity_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/identity_normalizer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::Normalizers::IdentityNormalizer do
+  let(:normalized_ng_xml) { described_class.normalize(identity_ng_xml: Nokogiri::XML(original_xml)) }
+
+  context 'when normalizing sourceId' do
+    let(:original_xml) do
+      <<~XML
+        <identityMetadata>
+           <sourceId source=" sul "> M0443_S2_D-K_B9_F33_011 </sourceId>
+        </identityMetadata>
+      XML
+    end
+
+    it 'removes spaces' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <identityMetadata>
+             <sourceId source="sul">M0443_S2_D-K_B9_F33_011</sourceId>
+          </identityMetadata>
+        XML
+      )
+    end
+  end
+end


### PR DESCRIPTION
closes #2804

## Why was this change made?
Handle bad data when mapping,


## How was this change tested?
Unit, local


## Which documentation and/or configurations were updated?
NA


