### PR TITLE
Only normalize reading order when resources are present.

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -57,6 +57,7 @@ module Cocina
       def normalize_reading_order(druid)
         return if ng_xml.root['type'] != 'book'
         return if ng_xml.root.xpath('//bookData[@readingOrder]').present?
+        return if ng_xml.root.xpath('//resource').empty?
 
         reading_direction = Cocina::FromFedora::ViewingDirectionHelper.viewing_direction(druid: druid, content_ng_xml: ng_xml)
         return unless reading_direction

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -85,10 +85,28 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       end
     end
 
-    context 'when reading missing' do
+    context 'when no resources' do
       let(:original_xml) do
         <<~XML
           <contentMetadata objectId="druid:bb035tg0974" type="book" />
+        XML
+      end
+
+      before do
+        allow(AdministrativeTags).to receive(:content_type).and_return(['Book (ltr)'])
+      end
+
+      it 'does nothing' do
+        expect(normalized_ng_xml).to be_equivalent_to(original_xml)
+      end
+    end
+
+    context 'when reading missing' do
+      let(:original_xml) do
+        <<~XML
+          <contentMetadata objectId="druid:bb035tg0974" type="book">
+            <resource sequence="1" type="page" />
+          </contentMetadata>
         XML
       end
 
@@ -101,6 +119,7 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
           <<~XML
             <contentMetadata objectId="druid:bb035tg0974" type="book">
               <bookData readingOrder="ltr"/>
+              <resource sequence="1" type="page" />
             </contentMetadata>
           XML
         )


### PR DESCRIPTION
## Why was this change made?
Better map the mapping code.


## How was this change tested?
Unit, local


## Which documentation and/or configurations were updated?
NA


