### PR TITLE
adjust rights normalization for licenses

### DIFF
--- a/app/services/cocina/normalizers/rights_normalizer.rb
+++ b/app/services/cocina/normalizers/rights_normalizer.rb
@@ -9,6 +9,8 @@ module Cocina
 
       # @param [Nokogiri::Document] the rights datastream to be normalized
       # @return [Nokogiri::Document] normalized rights xml
+      # Note: this is different than other normalizers in that it takes in a datastream as a parameter instead of the XML
+      #  because we use an existing class below to fetch the license URI and this class requires a datastream
       def self.normalize(datastream:)
         new(datastream: datastream).normalize
       end
@@ -44,7 +46,7 @@ module Cocina
         end
         # now add new <license> node
         license_uri = Cocina::FromFedora::Access::License.find(datastream)
-        new_license_node = Nokogiri::XML::Node.new('license', Nokogiri::XML(nil))
+        new_license_node = Nokogiri::XML::Node.new('license', ng_xml)
         new_license_node.content = license_uri
         ng_xml.at('//use') << new_license_node if license_uri.present?
         ng_xml.root.xpath('//use[count(*) = 0]').each(&:remove)

--- a/app/services/cocina/normalizers/rights_normalizer.rb
+++ b/app/services/cocina/normalizers/rights_normalizer.rb
@@ -7,25 +7,20 @@ module Cocina
     class RightsNormalizer
       include Cocina::Normalizers::Base
 
-      # @param [Nokogiri::Document] rights_ng_xml rights XML to be normalized
+      # @param [Nokogiri::Document] the rights datastream to be normalized
       # @return [Nokogiri::Document] normalized rights xml
-      def self.normalize(rights_ng_xml:)
-        new(rights_ng_xml: rights_ng_xml).normalize
+      def self.normalize(datastream:)
+        new(datastream: datastream).normalize
       end
 
-      # @param [Nokogiri::Document] roundtripped rights_ng_xml rights XML to be normalized
-      # @return [Nokogiri::Document] normalized roundtripped rights xml
-      def self.normalize_roundtrip(rights_ng_xml:, original_ng_xml:)
-        new(rights_ng_xml: rights_ng_xml).normalize_roundtrip(original_ng_xml)
-      end
-
-      def initialize(rights_ng_xml:)
-        @ng_xml = rights_ng_xml.dup
+      def initialize(datastream:)
+        @datastream = datastream
+        @ng_xml = datastream.ng_xml.dup
         @ng_xml.encoding = 'UTF-8' if @ng_xml.respond_to?(:encoding=) # sometimes it's a String (?)
       end
 
       def normalize
-        remove_license
+        normalize_license_to_uri
         remove_embargo_release_date
         normalize_group
         normalize_use_and_reproduction
@@ -33,35 +28,25 @@ module Cocina
         regenerate_ng_xml(ng_xml.to_s)
       end
 
-      def normalize_roundtrip(original_ng_xml)
-        normalize_roundtrip_ng_xml(original_ng_xml)
-        regenerate_ng_xml(ng_xml.to_s)
-      end
-
       private
 
-      attr_reader :ng_xml
-
-      def normalize_roundtrip_ng_xml(original_ng_xml)
-        if license_nodes(original_ng_xml).blank?
-          license_nodes(ng_xml).each do |license_node|
-            use_node = license_node.parent
-            license_node.remove
-            use_node.remove if use_node.children.empty?
-          end
-        end
-        regenerate_ng_xml(ng_xml.to_s)
-      end
+      attr_reader :ng_xml, :datastream
 
       def license_nodes(xml)
         xml.root.xpath('//license')
       end
 
-      def remove_license
+      def normalize_license_to_uri
+        # first remove old style license nodes
         ['openDataCommons', 'creativeCommons'].each do |license_type|
           ng_xml.root.xpath("//use/machine[@type='#{license_type}' and text()]").each(&:remove)
           ng_xml.root.xpath("//use/human[@type='#{license_type}' and text()]").each(&:remove)
         end
+        # now add new <license> node
+        license_uri = Cocina::FromFedora::Access::License.find(datastream)
+        new_license_node = Nokogiri::XML::Node.new('license', Nokogiri::XML(nil))
+        new_license_node.content = license_uri
+        ng_xml.at('//use') << new_license_node if license_uri.present?
         ng_xml.root.xpath('//use[count(*) = 0]').each(&:remove)
       end
 

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -81,13 +81,13 @@ def ng_xml_for(xml)
   Nokogiri::XML(xml) { |config| config.default_xml.noblanks }
 end
 
-def norm_orig_datastream_ng_xml_for(dsid, orig_datastream_ng_xml, druid, label)
+def norm_orig_datastream_ng_xml_for(dsid, orig_datastream_ng_xml, druid, label, fedora_obj)
   case dsid
   # Additional normalizers to go here.
   when 'descMetadata'
     Cocina::Normalizers::ModsNormalizer.normalize(mods_ng_xml: orig_datastream_ng_xml, druid: druid, label: label)
   when 'rightsMetadata'
-    Cocina::Normalizers::RightsNormalizer.normalize(rights_ng_xml: orig_datastream_ng_xml)
+    Cocina::Normalizers::RightsNormalizer.normalize(datastream: fedora_obj.datastreams['rightsMetadata'])
   when 'contentMetadata'
     Cocina::Normalizers::ContentMetadataNormalizer.normalize(druid: druid, content_ng_xml: orig_datastream_ng_xml)
   when 'identityMetadata'
@@ -97,11 +97,9 @@ def norm_orig_datastream_ng_xml_for(dsid, orig_datastream_ng_xml, druid, label)
   end
 end
 
-def norm_roundtrip_datastream_ng_xml_for(dsid, roundtrip_datastream_ng_xml, orig_datastream_ng_xml)
+def norm_roundtrip_datastream_ng_xml_for(dsid, roundtrip_datastream_ng_xml)
   case dsid
     # Additional normalizers to go here.
-  when 'rightsMetadata'
-    Cocina::Normalizers::RightsNormalizer.normalize_roundtrip(rights_ng_xml: roundtrip_datastream_ng_xml, original_ng_xml: orig_datastream_ng_xml)
   when 'contentMetadata'
     Cocina::Normalizers::ContentMetadataNormalizer.normalize_roundtrip(content_ng_xml: roundtrip_datastream_ng_xml)
   else
@@ -123,10 +121,10 @@ def diff_datatreams_for(druid, label, orig_datastreams, fedora_obj)
     next if orig_datastream.nil?
 
     orig_datastream_ng_xml = ng_xml_for(orig_datastream)
-    norm_orig_datastream_ng_xml = norm_orig_datastream_ng_xml_for(dsid, orig_datastream_ng_xml, druid, label)
+    norm_orig_datastream_ng_xml = norm_orig_datastream_ng_xml_for(dsid, orig_datastream_ng_xml, druid, label, fedora_obj)
 
     roundtrip_datastream_ng_xml = ng_xml_for(fedora_obj.datastreams[dsid].content)
-    norm_roundtrip_datastream_ng_xml = norm_roundtrip_datastream_ng_xml_for(dsid, roundtrip_datastream_ng_xml, orig_datastream_ng_xml)
+    norm_roundtrip_datastream_ng_xml = norm_roundtrip_datastream_ng_xml_for(dsid, roundtrip_datastream_ng_xml)
     next if equivalent?(dsid, norm_orig_datastream_ng_xml, norm_roundtrip_datastream_ng_xml)
 
     diff_datastreams[dsid] = [orig_datastream_ng_xml, norm_orig_datastream_ng_xml, roundtrip_datastream_ng_xml, norm_roundtrip_datastream_ng_xml]

--- a/bin/validate-rights-cocina-roundtrip
+++ b/bin/validate-rights-cocina-roundtrip
@@ -29,21 +29,18 @@ loader = FedoraLoader.new(cache: cache)
 Dor::Services::Client.configure(url: Settings.dor_services.url,
                                 token: Settings.dor_services.token)
 
-# rubocop:disable Metrics/ParameterLists
-def write_result(druid, original_ng_xml, normalized_original_ng_xml, roundtrip_ng_xml, normalized_roundtrip_ng_xml, cocina)
+def write_result(druid, original_ng_xml, normalized_original_ng_xml, roundtrip_ng_xml, cocina)
   File.open("results/#{druid}.txt", 'w') do |file|
     file.write("Druid: #{druid}\n\n")
 
-    file.write("Difference:\n#{Diffy::Diff.new("#{normalized_original_ng_xml.to_xml}\n", "#{normalized_roundtrip_ng_xml.to_xml}\n")}\n")
+    file.write("Difference:\n#{Diffy::Diff.new("#{normalized_original_ng_xml.to_xml}\n", "#{roundtrip_ng_xml.to_xml}\n")}\n")
 
     file.write("\nOriginal XML:\n#{format_xml(original_ng_xml)}\n")
-    file.write("Roundtripped XML:\n#{format_xml(roundtrip_ng_xml)}\n")
     file.write("\nNormalized original XML:\n#{format_xml(normalized_original_ng_xml)}\n")
-    file.write("Normalized roundtripped XML:\n#{format_xml(normalized_roundtrip_ng_xml)}\n")
+    file.write("Roundtripped XML:\n#{format_xml(roundtrip_ng_xml)}\n")
     file.write("Cocina:\n#{JSON.pretty_generate(cocina)}\n\n")
   end
 end
-# rubocop:enable Metrics/ParameterLists
 
 def write_error(druid, original_ng_xml, cocina, error)
   File.open("results/#{druid}.txt", 'w') do |file|
@@ -102,20 +99,18 @@ def validate_druid(druid, loader)
   end
 
   begin
-    normalized_original_ng_xml = Cocina::Normalizers::RightsNormalizer.normalize(rights_ng_xml: original_ng_xml)
-    normalized_roundtrip_ng_xml = Cocina::Normalizers::RightsNormalizer.normalize_roundtrip(rights_ng_xml: roundtrip_ng_xml, original_ng_xml: original_ng_xml)
+    normalized_original_ng_xml = Cocina::Normalizers::RightsNormalizer.normalize(datastream: fedora_obj.datastreams['rightsMetadata'])
   rescue StandardError => e
-    write_error(druid, original_ng_xml, cocina_props, e)
+    write_error(druid, original_ng_xml, cocina_access_props, e)
     return :rights_normalizer_error
   end
 
-  return :success if EquivalentXml.equivalent?(normalized_original_ng_xml, normalized_roundtrip_ng_xml)
+  return :success if EquivalentXml.equivalent?(normalized_original_ng_xml, roundtrip_ng_xml)
 
   write_result(druid,
                original_ng_xml,
                normalized_original_ng_xml,
                roundtrip_ng_xml,
-               normalized_roundtrip_ng_xml,
                cocina_access_props)
   :different
 end

--- a/spec/services/cocina/normalizers/rights_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/rights_normalizer_spec.rb
@@ -3,8 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::Normalizers::RightsNormalizer do
-  let(:normalized_original_ng_xml) { described_class.normalize(rights_ng_xml: original_ng_xml) }
-  let(:normalized_roundtrip_ng_xml) { described_class.normalize_roundtrip(rights_ng_xml: roundtrip_ng_xml, original_ng_xml: original_ng_xml) }
+  let(:normalized_original_ng_xml) { described_class.normalize(datastream: object_rights_ds) }
+  let(:object_rights_ds) { Dor::DefaultObjectRightsDS.new }
+
+  before { allow(object_rights_ds).to receive(:ng_xml).and_return(original_ng_xml) }
 
   context 'when normalizing rights' do
     context 'when dealing with licenses that share a use with use and reproduction' do
@@ -30,36 +32,19 @@ RSpec.describe Cocina::Normalizers::RightsNormalizer do
         XML
       end
 
-      let(:roundtrip_ng_xml) do
-        Nokogiri::XML <<~XML
-          <rightsMetadata>
-            <access type="discover">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <access type="read">
-              <machine>
-                <world rule="no-download"/>
-              </machine>
-            </access>
-            <use>
-              <human type="useAndReproduction">Use at will.</human>
-            </use>
-          </rightsMetadata>
-        XML
-      end
-
-      it 'removes createCommons licenses from original rights xml' do
+      it 'removes createCommons licenses from original rights xml and adds correct license URI' do
         expect(original_ng_xml.root.xpath("//use/machine[@type='creativeCommons' and text()]").size).to eq(1)
         expect(original_ng_xml.root.xpath("//use/human[@type='creativeCommons' and text()]").size).to eq(1)
+        expect(original_ng_xml.root.xpath('//use/license').size).to eq(0)
         expect(normalized_original_ng_xml.root.xpath("//use/machine[@type='creativeCommons' and text()]").size).to eq(0)
         expect(normalized_original_ng_xml.root.xpath("//use/human[@type='creativeCommons' and text()]").size).to eq(0)
+        expect(normalized_original_ng_xml.root.xpath('//use/license').size).to eq(1)
+        expect(normalized_original_ng_xml.root.xpath('//use/license').first.text).to eq('https://creativecommons.org/licenses/by-nc/3.0/')
       end
 
       it 'leaves use and reproduction statement in all cases' do
+        expect(original_ng_xml.root.xpath("//use/human[@type='useAndReproduction']").first.text).to eq('Use at will.')
         expect(normalized_original_ng_xml.root.xpath("//use/human[@type='useAndReproduction']").first.text).to eq('Use at will.')
-        expect(normalized_roundtrip_ng_xml.root.xpath("//use/human[@type='useAndReproduction']").first.text).to eq('Use at will.')
       end
     end
 
@@ -85,25 +70,11 @@ RSpec.describe Cocina::Normalizers::RightsNormalizer do
         XML
       end
 
-      let(:roundtrip_ng_xml) do
-        Nokogiri::XML <<~XML
-          <rightsMetadata>
-            <access type="discover">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <access type="read">
-              <machine>
-                <world rule="no-download"/>
-              </machine>
-            </access>
-          </rightsMetadata>
-        XML
-      end
-
-      it 'removes createCommons licenses from original rights xml' do
-        expect(normalized_original_ng_xml).to be_equivalent_to(roundtrip_ng_xml)
+      it 'removes createCommons licenses from original rights xml and adds license URI' do
+        expect(normalized_original_ng_xml.root.xpath("//use/machine[@type='creativeCommons' and text()]").size).to eq(0)
+        expect(normalized_original_ng_xml.root.xpath("//use/human[@type='creativeCommons' and text()]").size).to eq(0)
+        expect(normalized_original_ng_xml.root.xpath('//use/license').size).to eq(1)
+        expect(normalized_original_ng_xml.root.xpath('//use/license').first.text).to eq('https://creativecommons.org/licenses/by-nc/3.0/')
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

Fixes #2797 - adjust rights normalization to deal with license code style differences

1. remove the "roundtrip" normalizer (which used to normalize the XML that came back from the roundtrip), which is no longer necessary, and eliminate some methods called by it
2. change the normalizer to take in a datastream as a parameter instead of xml, since the method I am calling to convert to license URIs takes a datastream

## How was this change tested?

Updated tests and tested on sdr-deploy for 100 objects

## Which documentation and/or configurations were updated?



