### PR TITLE
Avoid empty use elements.

### DIFF
--- a/app/services/cocina/normalizers/rights_normalizer.rb
+++ b/app/services/cocina/normalizers/rights_normalizer.rb
@@ -62,6 +62,7 @@ module Cocina
           ng_xml.root.xpath("//use/machine[@type='#{license_type}' and text()]").each(&:remove)
           ng_xml.root.xpath("//use/human[@type='#{license_type}' and text()]").each(&:remove)
         end
+        ng_xml.root.xpath('//use[count(*) = 0]').each(&:remove)
       end
 
       def remove_embargo_release_date

--- a/app/services/cocina/to_fedora/license.rb
+++ b/app/services/cocina/to_fedora/license.rb
@@ -34,10 +34,11 @@ module Cocina
         datastream.ng_xml.xpath('/rightsMetadata/use/machine[@type="creativeCommons"]').each(&:remove)
         datastream.ng_xml.xpath('/rightsMetadata/use/human[@type="openDataCommons"]').each(&:remove)
         datastream.ng_xml.xpath('/rightsMetadata/use/human[@type="creativeCommons"]').each(&:remove)
+        datastream.ng_xml.xpath('/rightsMetadata/use[count(*) = 0]').each(&:remove)
       end
 
       def use_node
-        datastream.ng_xml.xpath('/rightsMetadata/use').first
+        datastream.ng_xml.xpath('/rightsMetadata/use').first || datastream.ng_xml.root.add_child('<use/>').first
       end
 
       def initialize_use_node!

--- a/spec/services/cocina/normalizers/rights_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/rights_normalizer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Cocina::Normalizers::RightsNormalizer do
   let(:normalized_roundtrip_ng_xml) { described_class.normalize_roundtrip(rights_ng_xml: roundtrip_ng_xml, original_ng_xml: original_ng_xml) }
 
   context 'when normalizing rights' do
-    context 'when dealing with licenses' do
+    context 'when dealing with licenses that share a use with use and reproduction' do
       let(:original_ng_xml) do
         Nokogiri::XML <<~XML
           <rightsMetadata>
@@ -60,6 +60,50 @@ RSpec.describe Cocina::Normalizers::RightsNormalizer do
       it 'leaves use and reproduction statement in all cases' do
         expect(normalized_original_ng_xml.root.xpath("//use/human[@type='useAndReproduction']").first.text).to eq('Use at will.')
         expect(normalized_roundtrip_ng_xml.root.xpath("//use/human[@type='useAndReproduction']").first.text).to eq('Use at will.')
+      end
+    end
+
+    context 'when dealing with licenses in own use' do
+      let(:original_ng_xml) do
+        Nokogiri::XML <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world rule="no-download"/>
+              </machine>
+            </access>
+            <use>
+              <human type="creativeCommons">CC BY-NC Attribution-NonCommercial</human>
+              <machine type="creativeCommons">by-nc</machine>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+
+      let(:roundtrip_ng_xml) do
+        Nokogiri::XML <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world rule="no-download"/>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'removes createCommons licenses from original rights xml' do
+        expect(normalized_original_ng_xml).to be_equivalent_to(roundtrip_ng_xml)
       end
     end
   end

--- a/spec/services/cocina/to_fedora/license_spec.rb
+++ b/spec/services/cocina/to_fedora/license_spec.rb
@@ -6,17 +6,83 @@ RSpec.describe Cocina::ToFedora::License do
   subject(:apply) { described_class.update(datastream, uri) }
 
   let(:datastream) do
-    Dor::DefaultObjectRightsDS.new
+    Dor::DefaultObjectRightsDS.new.tap { |ds| ds.content = datastream_xml }
   end
 
   context 'with cc0' do
     let(:uri) { 'https://creativecommons.org/share-your-work/public-domain/cc0/' }
+
+    let(:datastream_xml) do
+      <<~XML
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <world rule="no-download"/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction"/>
+            <human type="creativeCommons"/>
+            <machine type="creativeCommons" uri=""/>
+            <human type="openDataCommons"/>
+            <machine type="openDataCommons" uri=""/>
+          </use>
+          <copyright>
+            <human/>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
 
     it 'writes the XML' do
       apply
       expect(datastream.ng_xml.xpath('//use')).to be_equivalent_to <<~XML
         <use>
            <human type="useAndReproduction"/>
+           <license>https://creativecommons.org/share-your-work/public-domain/cc0/</license>
+        </use>
+      XML
+    end
+  end
+
+  context 'with use without use and reproduction' do
+    let(:uri) { 'https://creativecommons.org/share-your-work/public-domain/cc0/' }
+
+    let(:datastream_xml) do
+      <<~XML
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <world rule="no-download"/>
+            </machine>
+          </access>
+          <use>
+            <human type="creativeCommons"/>
+            <machine type="creativeCommons" uri=""/>
+            <human type="openDataCommons"/>
+            <machine type="openDataCommons" uri=""/>
+          </use>
+          <copyright>
+            <human/>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'writes the XML' do
+      apply
+      expect(datastream.ng_xml.xpath('//use')).to be_equivalent_to <<~XML
+        <use>
            <license>https://creativecommons.org/share-your-work/public-domain/cc0/</license>
         </use>
       XML


### PR DESCRIPTION
closes #2803

## Why was this change made?
Empty use statements are an error.


## How was this change tested?
Unit, local


## Which documentation and/or configurations were updated?
NA


