### PR TITLE
Rename test fixture to be a valid druid

### DIFF
--- a/spec/fixtures/apo_druid_fg890hx1234.xml
+++ b/spec/fixtures/apo_druid_fg890hx1234.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<foxml:digitalObject xmlns:foxml="info:fedora/fedora-system:def/foxml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" VERSION="1.1" PID="druid:fg890hi1234" xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+<foxml:digitalObject xmlns:foxml="info:fedora/fedora-system:def/foxml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" VERSION="1.1" PID="druid:fg890hx1234" xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
   <foxml:objectProperties>
     <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
     <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="Topographical Map"/>
@@ -11,7 +11,7 @@
       <foxml:xmlContent>
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
           <dc:title>Kitai Topographical Maps</dc:title>
-          <dc:identifier>druid:fg890hi1234</dc:identifier>
+          <dc:identifier>druid:fg890hx1234</dc:identifier>
         </oai_dc:dc>
       </foxml:xmlContent>
     </foxml:datastreamVersion>
@@ -19,7 +19,7 @@
       <foxml:xmlContent>
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
           <dc:title>Kitai Topographical Maps</dc:title>
-          <dc:identifier>druid:fg890hi1234</dc:identifier>
+          <dc:identifier>druid:fg890hx1234</dc:identifier>
           <dc:language>eng</dc:language>
         </oai_dc:dc>
       </foxml:xmlContent>
@@ -28,7 +28,7 @@
       <foxml:xmlContent>
         <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
           <dc:title>Topographical Maps</dc:title>
-          <dc:identifier>druid:fg890hi1234</dc:identifier>
+          <dc:identifier>druid:fg890hx1234</dc:identifier>
           <dc:language>eng</dc:language>
         </oai_dc:dc>
       </foxml:xmlContent>
@@ -37,7 +37,7 @@
       <foxml:xmlContent>
         <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
           <dc:title>Topographical Map</dc:title>
-          <dc:identifier>druid:fg890hi1234</dc:identifier>
+          <dc:identifier>druid:fg890hx1234</dc:identifier>
           <dc:language>eng</dc:language>
         </oai_dc:dc>
       </foxml:xmlContent>
@@ -47,7 +47,7 @@
     <foxml:datastreamVersion ID="identityMetadata.0" LABEL="Identity Metadata" CREATED="2011-04-18T18:45:37.109Z" MIMETYPE="text/xml" SIZE="353">
       <foxml:xmlContent>
         <identityMetadata>
-          <objectId>druid:fg890hi1234</objectId>
+          <objectId>druid:fg890hx1234</objectId>
           <objectType>adminPolicy</objectType>
           <objectLabel>Kitai Topographical Maps</objectLabel>
           <objectDescription>Kitai Topographical Map Collection</objectDescription>
@@ -59,7 +59,7 @@
     <foxml:datastreamVersion ID="identityMetadata.1" LABEL="Identity Metadata" CREATED="2011-05-23T17:04:04.652Z" MIMETYPE="text/xml" SIZE="335">
       <foxml:xmlContent>
         <identityMetadata>
-          <objectId>druid:fg890hi1234</objectId>
+          <objectId>druid:fg890hx1234</objectId>
           <objectType>adminPolicy</objectType>
           <objectLabel>Topographical Maps</objectLabel>
           <objectDescription>Topographical Maps</objectDescription>
@@ -71,7 +71,7 @@
     <foxml:datastreamVersion ID="identityMetadata.2" LABEL="Identity Metadata" CREATED="2011-05-23T17:04:31.969Z" MIMETYPE="text/xml" SIZE="344">
       <foxml:xmlContent>
         <identityMetadata>
-          <objectId>druid:fg890hi1234</objectId>
+          <objectId>druid:fg890hx1234</objectId>
           <objectType>adminPolicy</objectType>
           <objectLabel>Topographical Maps</objectLabel>
           <objectDescription>Topographical Maps</objectDescription>
@@ -83,7 +83,7 @@
     <foxml:datastreamVersion ID="identityMetadata.3" LABEL="Identity Metadata" CREATED="2011-05-23T17:07:15.558Z" MIMETYPE="text/xml" SIZE="341">
       <foxml:xmlContent>
         <identityMetadata>
-          <objectId>druid:fg890hi1234</objectId>
+          <objectId>druid:fg890hx1234</objectId>
           <objectType>adminPolicy</objectType>
           <objectLabel>Topographical Map</objectLabel>
           <objectDescription>Topographical Map</objectDescription>

--- a/spec/fixtures/item_druid_bc123df4567.xml
+++ b/spec/fixtures/item_druid_bc123df4567.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<foxml:digitalObject xmlns:foxml="info:fedora/fedora-system:def/foxml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PID="druid:ab123cd4567" VERSION="1.1" xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+<foxml:digitalObject xmlns:foxml="info:fedora/fedora-system:def/foxml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PID="druid:bc123df4567" VERSION="1.1" xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
   <foxml:objectProperties>
     <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
     <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="Foxml Test Object"/>
@@ -14,7 +14,7 @@
           <dc:identifier>barcode:36105049267078</dc:identifier>
           <dc:identifier>catkey:129483625</dc:identifier>
           <dc:identifier>uuid:7f3da130-7b02-11de-8a39-0800200c9a66</dc:identifier>
-          <dc:identifier>druid:ab123cd4567</dc:identifier>
+          <dc:identifier>druid:bc123df4567</dc:identifier>
         </oai_dc:dc>
       </foxml:xmlContent>
     </foxml:datastreamVersion>
@@ -48,11 +48,11 @@
   <foxml:datastream CONTROL_GROUP="X" ID="RELS-EXT" STATE="A">
     <foxml:datastreamVersion FORMAT_URI="info:fedora/fedora-system:FedoraRELSExt-1.0" ID="RELS-EXT.0" LABEL="RDF Statements about this object" MIMETYPE="application/rdf+xml">
       <foxml:xmlContent>
-        <rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+        <rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
           xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:hydra="http://projecthydra.org/ns/relations#">
-          <rdf:Description rdf:about="info:fedora/druid:ab123cd4567">
+          <rdf:Description rdf:about="info:fedora/druid:bc123df4567">
             <fedora-model:hasModel rdf:resource="info:fedora/testObject"/>
-            <hydra:isGovernedBy rdf:resource="info:fedora/druid:fg890hi1234"/>
+            <hydra:isGovernedBy rdf:resource="info:fedora/druid:fg890hx1234"/>
           </rdf:Description>
         </rdf:RDF>
       </foxml:xmlContent>

--- a/spec/services/item_query_service_spec.rb
+++ b/spec/services/item_query_service_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe ItemQueryService do
   subject(:service) { described_class }
 
-  let(:druid) { 'ab123cd4567' }
-  let(:item) { instantiate_fixture('druid:ab123cd4567', Dor::Item) }
+  let(:druid) { 'bc123df4567' }
+  let(:item) { instantiate_fixture('druid:bc123df4567', Dor::Item) }
   let(:workflow_client) { instance_double(Dor::Workflow::Client, workflow_routes: workflow_routes) }
   let(:workflow_routes) { instance_double(Dor::Workflow::Client::WorkflowRoutes, all_workflows: workflows_response) }
   let(:workflows_response) do
@@ -26,35 +26,35 @@ RSpec.describe ItemQueryService do
       let(:errors) { ['Net::ReadTimeout', 'Gremlins'] }
 
       it 'raises an error' do
-        expect { service.find_combinable_item('ab123cd4567') }.to raise_error(described_class::UncombinableItemError, 'Item druid:ab123cd4567 has workflow errors: Net::ReadTimeout; Gremlins')
+        expect { service.find_combinable_item('bc123df4567') }.to raise_error(described_class::UncombinableItemError, 'Item druid:bc123df4567 has workflow errors: Net::ReadTimeout; Gremlins')
       end
     end
 
     it 'raises error if object is neither open nor openable' do
       allow(VersionService).to receive(:can_open?).with(item).and_return(false)
       allow(VersionService).to receive(:open?).with(item).and_return(false)
-      expect { service.find_combinable_item('ab123cd4567') }.to raise_error(described_class::UncombinableItemError, 'Item druid:ab123cd4567 is not open or openable')
+      expect { service.find_combinable_item('bc123df4567') }.to raise_error(described_class::UncombinableItemError, 'Item druid:bc123df4567 is not open or openable')
     end
 
     it 'raises error if object is dark' do
       dra = instance_double(Dor::RightsAuth, dark?: true, citation_only?: false)
       rights_ds = instance_double(Dor::RightsMetadataDS, dra_object: dra)
       allow(item).to receive(:rightsMetadata).and_return(rights_ds)
-      expect { service.find_combinable_item('ab123cd4567') }.to raise_error(described_class::UncombinableItemError, 'Item druid:ab123cd4567 is dark')
+      expect { service.find_combinable_item('bc123df4567') }.to raise_error(described_class::UncombinableItemError, 'Item druid:bc123df4567 is dark')
     end
 
     it 'raises error if object is citation_only' do
       dra = instance_double(Dor::RightsAuth, dark?: false, citation_only?: true)
       rights_ds = instance_double(Dor::RightsMetadataDS, dra_object: dra)
       allow(item).to receive(:rightsMetadata).and_return(rights_ds)
-      expect { service.find_combinable_item('ab123cd4567') }.to raise_error(described_class::UncombinableItemError, 'Item druid:ab123cd4567 is citation_only')
+      expect { service.find_combinable_item('bc123df4567') }.to raise_error(described_class::UncombinableItemError, 'Item druid:bc123df4567 is citation_only')
     end
 
     it 'returns item otherwise' do
       dra = instance_double(Dor::RightsAuth, dark?: false, citation_only?: false)
       rights_ds = instance_double(Dor::RightsMetadataDS, dra_object: dra)
       allow(item).to receive(:rightsMetadata).and_return(rights_ds)
-      service.find_combinable_item('ab123cd4567')
+      service.find_combinable_item('bc123df4567')
     end
   end
 
@@ -89,8 +89,8 @@ RSpec.describe ItemQueryService do
       end
 
       it 'returns a single error' do
-        expect(service.validate_combinable_items(parent: 'druid:ab123cd4567', children: ['druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
-          'druid:ab123cd4567' => ['Item druid:ab123cd4567 has workflow errors: Boom']
+        expect(service.validate_combinable_items(parent: 'druid:bc123df4567', children: ['druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
+          'druid:bc123df4567' => ['Item druid:bc123df4567 has workflow errors: Boom']
         )
       end
     end
@@ -102,8 +102,8 @@ RSpec.describe ItemQueryService do
       end
 
       it 'returns a single error if one object does not allow modification' do
-        expect(service.validate_combinable_items(parent: 'druid:ab123cd4567', children: ['druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
-          'druid:ab123cd4567' => ['Item druid:ab123cd4567 is not open or openable']
+        expect(service.validate_combinable_items(parent: 'druid:bc123df4567', children: ['druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
+          'druid:bc123df4567' => ['Item druid:bc123df4567 is not open or openable']
         )
       end
     end
@@ -116,8 +116,8 @@ RSpec.describe ItemQueryService do
       end
 
       it 'returns errors if any objects are dark' do
-        expect(service.validate_combinable_items(parent: 'druid:ab123cd4567', children: ['druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
-          'druid:ab123cd4567' => ['Item druid:xh235dd9059 is dark', 'Item druid:hj097bm8879 is dark']
+        expect(service.validate_combinable_items(parent: 'druid:bc123df4567', children: ['druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
+          'druid:bc123df4567' => ['Item druid:xh235dd9059 is dark', 'Item druid:hj097bm8879 is dark']
         )
       end
     end
@@ -130,8 +130,8 @@ RSpec.describe ItemQueryService do
       end
 
       it 'raises error if any objects are citation_only' do
-        expect(service.validate_combinable_items(parent: 'druid:ab123cd4567', children: ['druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
-          'druid:ab123cd4567' => ['Item druid:ab123cd4567 is citation_only', 'Item druid:hj097bm8879 is citation_only']
+        expect(service.validate_combinable_items(parent: 'druid:bc123df4567', children: ['druid:xh235dd9059', 'druid:hj097bm8879'])).to eq(
+          'druid:bc123df4567' => ['Item druid:bc123df4567 is citation_only', 'Item druid:hj097bm8879 is citation_only']
         )
       end
     end
@@ -144,7 +144,7 @@ RSpec.describe ItemQueryService do
       end
 
       it 'returns an empty hash otherwise' do
-        expect(service.validate_combinable_items(parent: 'druid:ab123cd4567', children: ['druid:xh235dd9059', 'druid:hj097bm8879'])).to eq({})
+        expect(service.validate_combinable_items(parent: 'druid:bc123df4567', children: ['druid:xh235dd9059', 'druid:hj097bm8879'])).to eq({})
       end
     end
   end

--- a/spec/services/publish/dublin_core_service_spec.rb
+++ b/spec/services/publish/dublin_core_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Publish::DublinCoreService do
   subject(:service) { described_class.new(item) }
 
-  let(:item) { instantiate_fixture('druid:ab123cd4567', Dor::Item) }
+  let(:item) { instantiate_fixture('druid:bc123df4567', Dor::Item) }
 
   describe '#ng_xml' do
     subject(:xml) { service.ng_xml }

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Publish::MetadataTransferService do
   let(:item) do
-    instantiate_fixture('druid:ab123cd4567', Dor::Item).tap do |i|
+    instantiate_fixture('druid:bc123df4567', Dor::Item).tap do |i|
       i.contentMetadata.content = '<contentMetadata/>'
       i.rels_ext.content = rels
     end
@@ -14,7 +14,7 @@ RSpec.describe Publish::MetadataTransferService do
   let(:rels) do
     <<-EOXML
       <rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:hydra="http://projecthydra.org/ns/relations#">
-        <rdf:Description rdf:about="info:fedora/druid:ab123cd4567">
+        <rdf:Description rdf:about="info:fedora/druid:bc123df4567">
           <hydra:isGovernedBy rdf:resource="info:fedora/druid:789012"></hydra:isGovernedBy>
           <fedora-model:hasModel rdf:resource="info:fedora/hydra:commonMetadata"></fedora-model:hasModel>
           <fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"></fedora:isMemberOf>
@@ -27,7 +27,7 @@ RSpec.describe Publish::MetadataTransferService do
 
   describe '#publish' do
     before do
-      allow(OpenURI).to receive(:open_uri).with('https://purl-test.stanford.edu/ab123cd4567.xml').and_return('<xml/>')
+      allow(OpenURI).to receive(:open_uri).with('https://purl-test.stanford.edu/bc123df4567.xml').and_return('<xml/>')
     end
 
     context 'with no world discover access in rightsMetadata' do
@@ -35,7 +35,7 @@ RSpec.describe Publish::MetadataTransferService do
 
       before do
         item.rightsMetadata.content = <<-EOXML
-          <rightsMetadata objectId="druid:ab123cd4567">
+          <rightsMetadata objectId="druid:bc123df4567">
             <copyright>
               <human>(c) Copyright 2010 by Sebastian Jeremias Osterfeld</human>
             </copyright>
@@ -55,7 +55,7 @@ RSpec.describe Publish::MetadataTransferService do
         allow(Settings).to receive(:purl_services_url).and_return('http://example.com/purl')
         allow(Settings.stacks).to receive(:local_document_cache_root).and_return(purl_root)
 
-        stub_request(:delete, 'example.com/purl/purls/ab123cd4567')
+        stub_request(:delete, 'example.com/purl/purls/bc123df4567')
       end
 
       after do
@@ -69,7 +69,7 @@ RSpec.describe Publish::MetadataTransferService do
         File.open(File.join(druid1.path, 'tmpfile'), 'w') { |f| f.write 'junk' }
         service.publish
         expect(File).not_to exist(druid1.path) # it should now be gone
-        expect(WebMock).to have_requested(:delete, 'example.com/purl/purls/ab123cd4567')
+        expect(WebMock).to have_requested(:delete, 'example.com/purl/purls/bc123df4567')
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe Publish::MetadataTransferService do
                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                      version="3.3"
                      xsi:schemaLocation="http://www.loc.gov/mods/v3 http://cosimo.stanford.edu/standards/mods/v3/mods-3-3.xsd">
-            <mods:identifier type="local" displayLabel="SUL Resource ID">druid:ab123cd4567</mods:identifier>
+            <mods:identifier type="local" displayLabel="SUL Resource ID">druid:bc123df4567</mods:identifier>
           </mods:mods>
         EOXML
       end
@@ -120,7 +120,7 @@ RSpec.describe Publish::MetadataTransferService do
       end
 
       context 'with a collection object' do
-        let(:item) { instantiate_fixture('druid:ab123cd4567', Dor::Collection) }
+        let(:item) { instantiate_fixture('druid:bc123df4567', Dor::Collection) }
 
         before do
           item.descMetadata.content = mods
@@ -148,12 +148,12 @@ RSpec.describe Publish::MetadataTransferService do
       before do
         allow(Settings).to receive(:purl_services_url).and_return('http://example.com/purl')
 
-        stub_request(:post, 'example.com/purl/purls/ab123cd4567')
+        stub_request(:post, 'example.com/purl/purls/bc123df4567')
       end
 
       it 'notifies the purl service of the update' do
         notify
-        expect(WebMock).to have_requested(:post, 'example.com/purl/purls/ab123cd4567')
+        expect(WebMock).to have_requested(:post, 'example.com/purl/purls/bc123df4567')
       end
     end
 

--- a/spec/services/publish/public_desc_metadata_service_spec.rb
+++ b/spec/services/publish/public_desc_metadata_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Publish::PublicDescMetadataService do
   subject(:service) { described_class.new(obj) }
 
-  let(:obj) { instantiate_fixture('druid:ab123cd4567', Dor::Item) }
+  let(:obj) { instantiate_fixture('druid:bc123df4567', Dor::Item) }
 
   describe '#ng_xml' do
     subject(:doc) { service.ng_xml }
@@ -86,7 +86,7 @@ RSpec.describe Publish::PublicDescMetadataService do
       XML
     end
 
-    let(:collection) { instantiate_fixture('druid:ab123cd4567', Dor::Item) }
+    let(:collection) { instantiate_fixture('druid:bc123df4567', Dor::Item) }
 
     before do
       allow(obj).to receive(:relationships).with(:is_member_of).and_return(['info:fedora/druid:zb871zd0767'])
@@ -308,7 +308,7 @@ RSpec.describe Publish::PublicDescMetadataService do
   end
 
   describe 'add_collection_reference' do
-    let(:collection) { instantiate_fixture('druid:ab123cd4567', Dor::Item) }
+    let(:collection) { instantiate_fixture('druid:bc123df4567', Dor::Item) }
 
     before do
       allow(obj).to receive(:relationships).with(:is_member_of).and_return(['info:fedora/druid:zb871zd0767'])

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Publish::PublicXmlService do
 
   let(:release_tags) { {} }
 
-  let(:item) { instantiate_fixture('druid:ab123cd4567', Dor::Item) }
+  let(:item) { instantiate_fixture('druid:bc123df4567', Dor::Item) }
 
   describe '#to_xml' do
     subject(:xml) { service.to_xml }
@@ -15,7 +15,7 @@ RSpec.describe Publish::PublicXmlService do
     let(:rels) do
       <<-EOXML
             <rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:hydra="http://projecthydra.org/ns/relations#">
-              <rdf:Description rdf:about="info:fedora/druid:ab123cd4567">
+              <rdf:Description rdf:about="info:fedora/druid:bc123df4567">
                 <hydra:isGovernedBy rdf:resource="info:fedora/druid:789012"></hydra:isGovernedBy>
                 <fedora-model:hasModel rdf:resource="info:fedora/hydra:commonMetadata"></fedora-model:hasModel>
                 <fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"></fedora:isMemberOf>
@@ -28,7 +28,7 @@ RSpec.describe Publish::PublicXmlService do
 
     let(:rights) do
       <<~XML
-        <rightsMetadata objectId="druid:ab123cd4567">
+        <rightsMetadata objectId="druid:bc123df4567">
           <copyright>
             <human>(c) Copyright 2010 by Sebastian Jeremias Osterfeld</human>
           </copyright>
@@ -51,7 +51,7 @@ RSpec.describe Publish::PublicXmlService do
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    version="3.3"
                    xsi:schemaLocation="http://www.loc.gov/mods/v3 http://cosimo.stanford.edu/standards/mods/v3/mods-3-3.xsd">
-          <mods:identifier type="local" displayLabel="SUL Resource ID">druid:ab123cd4567</mods:identifier>
+          <mods:identifier type="local" displayLabel="SUL Resource ID">druid:bc123df4567</mods:identifier>
         </mods:mods>
       EOXML
 
@@ -60,7 +60,7 @@ RSpec.describe Publish::PublicXmlService do
       item.rightsMetadata.content  = rights
       item.rels_ext.content        = rels
       allow_any_instance_of(Publish::PublicDescMetadataService).to receive(:ng_xml).and_return(Nokogiri::XML(mods)) # calls Item.find and not needed in general tests
-      allow(OpenURI).to receive(:open_uri).with('https://purl-test.stanford.edu/ab123cd4567.xml').and_return('<xml/>')
+      allow(OpenURI).to receive(:open_uri).with('https://purl-test.stanford.edu/bc123df4567.xml').and_return('<xml/>')
       WebMock.disable_net_connect!
     end
 
@@ -84,7 +84,7 @@ RSpec.describe Publish::PublicXmlService do
     context 'with a licence node (new way)' do
       let(:rights) do
         <<~XML
-          <rightsMetadata objectId="druid:ab123cd4567">
+          <rightsMetadata objectId="druid:bc123df4567">
             <copyright>
               <human>(c) Copyright 2010 by Sebastian Jeremias Osterfeld</human>
             </copyright>
@@ -155,7 +155,7 @@ RSpec.describe Publish::PublicXmlService do
       end
 
       it 'an id attribute' do
-        expect(ng_xml.at_xpath('/publicObject/@id').value).to match(/^druid:ab123cd4567/)
+        expect(ng_xml.at_xpath('/publicObject/@id').value).to match(/^druid:bc123df4567/)
       end
 
       it 'a published attribute' do
@@ -178,7 +178,7 @@ RSpec.describe Publish::PublicXmlService do
         before do
           item.contentMetadata.content = <<-XML
             <?xml version="1.0"?>
-            <contentMetadata objectId="druid:ab123cd4567" type="file">
+            <contentMetadata objectId="druid:bc123df4567" type="file">
               <resource id="0001" sequence="1" type="file">
                 <file id="some_file.pdf" mimetype="file/pdf" publish="yes"/>
               </resource>
@@ -228,16 +228,16 @@ RSpec.describe Publish::PublicXmlService do
       it 'include a thumb node if a thumb is present' do
         item.contentMetadata.content = <<-XML
           <?xml version="1.0"?>
-          <contentMetadata objectId="druid:ab123cd4567" type="map">
+          <contentMetadata objectId="druid:bc123df4567" type="map">
             <resource id="0001" sequence="1" type="image">
-              <file id="ab123cd4567_05_0001.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
             </resource>
             <resource id="0002" sequence="2" thumb="yes" type="image">
-              <file id="ab123cd4567_05_0002.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_05_0002.jp2" mimetype="image/jp2"/>
             </resource>
           </contentMetadata>
         XML
-        expect(ng_xml.at_xpath('/publicObject/thumb').to_xml).to be_equivalent_to('<thumb>ab123cd4567/ab123cd4567_05_0002.jp2</thumb>')
+        expect(ng_xml.at_xpath('/publicObject/thumb').to_xml).to be_equivalent_to('<thumb>bc123df4567/bc123df4567_05_0002.jp2</thumb>')
       end
 
       context 'when there is content inside it' do
@@ -306,7 +306,7 @@ RSpec.describe Publish::PublicXmlService do
         end
 
         it 'raises an error' do
-          expect { xml }.to raise_error(Dor::DataError, 'The contentMetadata of druid:ab123cd4567 has an externalFile ' \
+          expect { xml }.to raise_error(Dor::DataError, 'The contentMetadata of druid:bc123df4567 has an externalFile ' \
             "reference to druid:cg767mn6478, cg767mn6478_1, but druid:cg767mn6478 doesn't have " \
             'a matching resource node in its contentMetadata')
         end
@@ -338,7 +338,7 @@ RSpec.describe Publish::PublicXmlService do
         end
 
         it 'raises an error' do
-          expect { xml }.to raise_error(Dor::DataError, 'Unable to find a file node with id="2542A.jp2" (child of druid:ab123cd4567)')
+          expect { xml }.to raise_error(Dor::DataError, 'Unable to find a file node with id="2542A.jp2" (child of druid:bc123df4567)')
         end
       end
 

--- a/spec/services/published_relationships_filter_spec.rb
+++ b/spec/services/published_relationships_filter_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe PublishedRelationshipsFilter do
   subject(:service) { described_class.new(obj) }
 
-  let(:obj) { instantiate_fixture('druid:ab123cd4567', Dor::Item) }
+  let(:obj) { instantiate_fixture('druid:bc123df4567', Dor::Item) }
 
   describe '#xml' do
     subject(:doc) { service.xml }
@@ -14,7 +14,7 @@ RSpec.describe PublishedRelationshipsFilter do
       let(:relationships) do
         <<~EOXML
           <rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:hydra="http://projecthydra.org/ns/relations#">
-            <rdf:Description rdf:about="info:fedora/druid:ab123cd4567">
+            <rdf:Description rdf:about="info:fedora/druid:bc123df4567">
               <hydra:isGovernedBy rdf:resource="info:fedora/druid:789012"></hydra:isGovernedBy>
               <fedora-model:hasModel rdf:resource="info:fedora/hydra:commonMetadata"></fedora-model:hasModel>
               <fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"></fedora:isMemberOf>
@@ -29,7 +29,7 @@ RSpec.describe PublishedRelationshipsFilter do
         <<~XML
           <?xml version="1.0"?>
             <rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:hydra="http://projecthydra.org/ns/relations#">
-              <rdf:Description rdf:about="info:fedora/druid:ab123cd4567">
+              <rdf:Description rdf:about="info:fedora/druid:bc123df4567">
                 <fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"/>
                 <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"/>
                 <fedora:isConstituentOf rdf:resource="info:fedora/druid:hj097bm8879"/>

--- a/spec/services/thumbnail_service_spec.rb
+++ b/spec/services/thumbnail_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ThumbnailService do
     subject { instance.thumb }
 
     context 'for a collection' do
-      let(:object) { instantiate_fixture('druid:ab123cd4567', Dor::Collection) }
+      let(:object) { instantiate_fixture('druid:bc123df4567', Dor::Collection) }
 
       it 'returns nil if there is no contentMetadata datastream' do
         expect(subject).to be_nil
@@ -17,7 +17,7 @@ RSpec.describe ThumbnailService do
     end
 
     context 'for an item' do
-      let(:object) { instantiate_fixture('druid:ab123cd4567', Dor::Item) }
+      let(:object) { instantiate_fixture('druid:bc123df4567', Dor::Item) }
 
       it 'returns nil if there is no contentMetadata' do
         object.contentMetadata.content = '<contentMetadata/>'
@@ -27,115 +27,115 @@ RSpec.describe ThumbnailService do
       it 'finds the first image as the thumb when no specific thumbs are specified' do
         object.contentMetadata.content = <<-XML
           <?xml version="1.0"?>
-          <contentMetadata objectId="druid:ab123cd4567" type="image">
+          <contentMetadata objectId="druid:bc123df4567" type="image">
             <resource id="0001" sequence="1" type="image">
-              <file id="ab123cd4567_05_0001.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
             </resource>
           </contentMetadata>
         XML
-        expect(subject).to eq('ab123cd4567/ab123cd4567_05_0001.jp2')
+        expect(subject).to eq('bc123df4567/bc123df4567_05_0001.jp2')
       end
 
       it 'finds a thumb resource marked as thumb with the thumb attribute first, even if it is listed second' do
         object.contentMetadata.content = <<-XML
           <?xml version="1.0"?>
-          <contentMetadata objectId="druid:ab123cd4567" type="map">
+          <contentMetadata objectId="druid:bc123df4567" type="map">
             <resource id="0001" sequence="1" type="image">
-              <file id="ab123cd4567_05_0001.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
             </resource>
             <resource id="0002" sequence="2" thumb="yes" type="thumb">
-              <file id="ab123cd4567_thumb.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_thumb.jp2" mimetype="image/jp2"/>
             </resource>
           </contentMetadata>
         XML
-        expect(subject).to eq('ab123cd4567/ab123cd4567_thumb.jp2')
+        expect(subject).to eq('bc123df4567/bc123df4567_thumb.jp2')
       end
 
       it 'finds a thumb resource marked as thumb without the thumb attribute first, even if it is listed second when there are no other thumbs specified' do
         object.contentMetadata.content = <<-XML
           <?xml version="1.0"?>
-          <contentMetadata objectId="druid:ab123cd4567" type="map">
+          <contentMetadata objectId="druid:bc123df4567" type="map">
             <resource id="0001" sequence="1" type="image">
-              <file id="ab123cd4567_05_0001.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
             </resource>
             <resource id="0002" sequence="2" type="thumb">
-              <file id="ab123cd4567_thumb.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_thumb.jp2" mimetype="image/jp2"/>
             </resource>
           </contentMetadata>
         XML
-        expect(subject).to eq('ab123cd4567/ab123cd4567_thumb.jp2')
+        expect(subject).to eq('bc123df4567/bc123df4567_thumb.jp2')
       end
 
       it 'finds a thumb resource marked as thumb with the thumb attribute first, even if it is listed second and there is another image marked as thumb first' do
         object.contentMetadata.content = <<-XML
           <?xml version="1.0"?>
-          <contentMetadata objectId="druid:ab123cd4567" type="map">
+          <contentMetadata objectId="druid:bc123df4567" type="map">
             <resource id="0001" sequence="1" thumb="yes" type="image">
-              <file id="ab123cd4567_05_0001.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
             </resource>
             <resource id="0002" sequence="2" thumb="yes" type="thumb">
-              <file id="ab123cd4567_thumb.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_thumb.jp2" mimetype="image/jp2"/>
             </resource>
           </contentMetadata>
         XML
-        expect(subject).to eq('ab123cd4567/ab123cd4567_thumb.jp2')
+        expect(subject).to eq('bc123df4567/bc123df4567_thumb.jp2')
       end
 
       it 'finds an image resource marked as thumb with the thumb attribute when there is no resource thumb specified' do
         object.contentMetadata.content = <<-XML
           <?xml version="1.0"?>
-          <contentMetadata objectId="druid:ab123cd4567" type="map">
+          <contentMetadata objectId="druid:bc123df4567" type="map">
             <resource id="0001" sequence="1" type="image">
-              <file id="ab123cd4567_05_0001.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
             </resource>
             <resource id="0002" sequence="2" thumb="yes" type="image">
-              <file id="ab123cd4567_05_0002.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_05_0002.jp2" mimetype="image/jp2"/>
             </resource>
           </contentMetadata>
         XML
-        expect(subject).to eq('ab123cd4567/ab123cd4567_05_0002.jp2')
+        expect(subject).to eq('bc123df4567/bc123df4567_05_0002.jp2')
       end
 
       it 'finds an image resource marked as thumb with the thumb attribute when there is a resource thumb specified but not the thumb attribute' do
         object.contentMetadata.content = <<-XML
           <?xml version="1.0"?>
-          <contentMetadata objectId="druid:ab123cd4567" type="book">
+          <contentMetadata objectId="druid:bc123df4567" type="book">
             <resource id="0001" sequence="1" type="thumb">
-              <file id="ab123cd4567_05_0001.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
             </resource>
             <resource id="0002" sequence="2" thumb="yes" type="image">
-              <file id="ab123cd4567_05_0002.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_05_0002.jp2" mimetype="image/jp2"/>
             </resource>
           </contentMetadata>
         XML
-        expect(subject).to eq('ab123cd4567/ab123cd4567_05_0002.jp2')
+        expect(subject).to eq('bc123df4567/bc123df4567_05_0002.jp2')
       end
 
       it 'finds a page resource marked as thumb with the thumb attribute when there is a resource thumb specified but not the thumb attribute' do
         object.contentMetadata.content = <<-XML
           <?xml version="1.0"?>
-          <contentMetadata objectId="druid:ab123cd4567" type="file">
+          <contentMetadata objectId="druid:bc123df4567" type="file">
             <resource id="0001" sequence="1" type="thumb">
-              <file id="ab123cd4567_05_0001.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
               <file id="extra_ignored_image" mimetype="image/jp2"/>
             </resource>
             <resource id="0002" sequence="2" thumb="yes" type="page">
-              <file id="ab123cd4567_05_0002.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_05_0002.jp2" mimetype="image/jp2"/>
             </resource>
             <resource id="0003" sequence="3" type="page">
               <externalFile fileId="2542A.jp2" mimetype="image/jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1">
             </resource>
           </contentMetadata>
         XML
-        expect(subject).to eq('ab123cd4567/ab123cd4567_05_0002.jp2')
+        expect(subject).to eq('bc123df4567/bc123df4567_05_0002.jp2')
       end
 
       it 'finds an externalFile image resource when there are no other images' do
         object.contentMetadata.content = <<-XML
           <?xml version="1.0"?>
-          <contentMetadata objectId="druid:ab123cd4567" type="file">
+          <contentMetadata objectId="druid:bc123df4567" type="file">
             <resource id="0001" sequence="1" type="file">
-              <file id="ab123cd4567_05_0001.pdf" mimetype="file/pdf"/>
+              <file id="bc123df4567_05_0001.pdf" mimetype="file/pdf"/>
             </resource>
             <resource id="0002" sequence="2" type="image">
               <externalFile fileId="2542A.jp2" mimetype="image/jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1">
@@ -148,9 +148,9 @@ RSpec.describe ThumbnailService do
       it 'finds an externalFile page resource when there are no other images, even if objectId attribute is missing druid prefix' do
         object.contentMetadata.content = <<-XML
           <?xml version="1.0"?>
-          <contentMetadata objectId="druid:ab123cd4567" type="file">
+          <contentMetadata objectId="druid:bc123df4567" type="file">
             <resource id="0001" sequence="1" type="file">
-              <file id="ab123cd4567_05_0001.pdf" mimetype="file/pdf"/>
+              <file id="bc123df4567_05_0001.pdf" mimetype="file/pdf"/>
             </resource>
             <resource id="0002" sequence="2" type="page">
               <externalFile fileId="2542A.jp2" mimetype="image/jp2" objectId="cg767mn6478" resourceId="cg767mn6478_1">
@@ -163,9 +163,9 @@ RSpec.describe ThumbnailService do
       it 'finds an explicit externalFile thumb resource before another image resource, and encode the space' do
         object.contentMetadata.content = <<-XML
           <?xml version="1.0"?>
-          <contentMetadata objectId="druid:ab123cd4567" type="file">
+          <contentMetadata objectId="druid:bc123df4567" type="file">
             <resource id="0001" sequence="1" type="image">
-              <file id="ab123cd4567_05_0001.jp2" mimetype="image/jp2"/>
+              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
             </resource>
             <resource id="0002" sequence="2" thumb="yes" type="page">
               <externalFile fileId="2542A withspace.jp2" mimetype="image/jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1">
@@ -178,7 +178,7 @@ RSpec.describe ThumbnailService do
       it 'returns nil if no thumb is identified' do
         object.contentMetadata.content = <<-XML
           <?xml version="1.0"?>
-          <contentMetadata objectId="druid:ab123cd4567" type="file">
+          <contentMetadata objectId="druid:bc123df4567" type="file">
             <resource id="0001" sequence="1" type="file">
               <file id="some_file.pdf" mimetype="file/pdf"/>
             </resource>


### PR DESCRIPTION
This only affects test code

## Why was this change made?

This will get in our way as we move toward using cocina models, which doesn't tolerate invalid druids.


## How was this change tested?



## Which documentation and/or configurations were updated?



