### PR TITLE
rightsMetadata.xml mapping "unit" specs: wire in rights_normalizer

### DIFF
--- a/spec/services/cocina/normalizers/rights_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/rights_normalizer_spec.rb
@@ -4,12 +4,12 @@ require 'rails_helper'
 
 RSpec.describe Cocina::Normalizers::RightsNormalizer do
   let(:normalized_original_ng_xml) { described_class.normalize(datastream: object_rights_ds) }
-  let(:object_rights_ds) { Dor::DefaultObjectRightsDS.new }
+  let(:object_rights_ds) { Dor::RightsMetadataDS.new }
 
   before { allow(object_rights_ds).to receive(:ng_xml).and_return(original_ng_xml) }
 
-  context 'when normalizing rights' do
-    context 'when dealing with licenses that share a use with use and reproduction' do
+  describe '#normalize_license_to_uri' do
+    context 'when use element contains more than human and machine license info' do
       let(:original_ng_xml) do
         Nokogiri::XML <<~XML
           <rightsMetadata>
@@ -48,7 +48,7 @@ RSpec.describe Cocina::Normalizers::RightsNormalizer do
       end
     end
 
-    context 'when dealing with licenses in own use' do
+    context 'when use element contains human and machine license info only' do
       let(:original_ng_xml) do
         Nokogiri::XML <<~XML
           <rightsMetadata>
@@ -73,6 +73,62 @@ RSpec.describe Cocina::Normalizers::RightsNormalizer do
       it 'removes createCommons licenses from original rights xml and adds license URI' do
         expect(normalized_original_ng_xml.root.xpath("//use/machine[@type='creativeCommons' and text()]").size).to eq(0)
         expect(normalized_original_ng_xml.root.xpath("//use/human[@type='creativeCommons' and text()]").size).to eq(0)
+        expect(normalized_original_ng_xml.root.xpath('//use/license').size).to eq(1)
+        expect(normalized_original_ng_xml.root.xpath('//use/license').first.text).to eq('https://creativecommons.org/licenses/by-nc/3.0/')
+      end
+    end
+
+    context 'when use element contains only license' do
+      let(:original_ng_xml) do
+        Nokogiri::XML <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world rule="no-download"/>
+              </machine>
+            </access>
+            <use>
+              <license>https://creativecommons.org/licenses/by-nc/3.0/</license>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'keeps the license URI' do
+        expect(normalized_original_ng_xml.root.xpath('//use/license').size).to eq(1)
+        expect(normalized_original_ng_xml.root.xpath('//use/license').first.text).to eq('https://creativecommons.org/licenses/by-nc/3.0/')
+      end
+    end
+
+    context 'when use element contains license and useAndReproduction' do
+      let(:original_ng_xml) do
+        Nokogiri::XML <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world rule="no-download"/>
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction">Use at will.</human>
+              <license>https://creativecommons.org/licenses/by-nc/3.0/</license>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'keeps the license URI' do
+        expect(normalized_original_ng_xml.root.xpath('//use/human').size).to eq(1)
         expect(normalized_original_ng_xml.root.xpath('//use/license').size).to eq(1)
         expect(normalized_original_ng_xml.root.xpath('//use/license').first.text).to eq('https://creativecommons.org/licenses/by-nc/3.0/')
       end


### PR DESCRIPTION
## Why was this change made?

- to keep future changes to rights_normalizer from inadvertently breaking other expected rightsMetadata.xml mappings
- to ensure our mapping tests are aligned with current rights_normalizer code

part of #2701

## How was this change tested?

it's all unit tests;  wiring in the unit tests found an error in the rights_normalizer code, which is fixed and included here.


## Which documentation and/or configurations were updated?



