### PR TITLE
Publish Cocina models to purl

### DIFF
--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -30,6 +30,7 @@ module Publish
 
     # @raise [Dor::DataError]
     def transfer_metadata(release_tags)
+      transfer_to_document_store(PublicCocinaService.create(item), 'cocina.json')
       transfer_to_document_store(PublicXmlService.new(item, released_for: release_tags).to_xml, 'public')
       transfer_to_document_store(PublicDescMetadataService.new(item).to_xml, 'mods')
     end

--- a/app/services/publish/public_cocina_service.rb
+++ b/app/services/publish/public_cocina_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Publish
+  # Filters out the non-public parts of cocina for publishing to purl
+  class PublicCocinaService
+    def self.create(item)
+      cocina = Cocina::Mapper.build(item)
+      new(cocina).build
+    end
+
+    def initialize(cocina)
+      @cocina = cocina
+    end
+
+    # remove any file that is not published
+    # remove any file_set that doesn't have at least one published file
+    # remove partOfProject (similar to how we remove tags from identityMetadata)
+    def build
+      return cocina.to_json unless cocina.dro?
+
+      build_structural
+
+      cocina.new(structural: build_structural,
+                 administrative: build_administrative).to_json
+    end
+
+    private
+
+    attr_reader :cocina
+
+    # remove partOfProject (similar to how we remove tags from identityMetadata)
+    def build_administrative
+      Cocina::Models::Administrative.new(cocina.administrative.to_h.except(:partOfProject))
+    end
+
+    def build_structural
+      file_sets = Array(cocina.structural.contains)
+      new_file_sets = file_sets.filter_map do |fs|
+        files = fs.structural.contains.select { |file| file.administrative.publish }
+        next if files.empty?
+
+        new_file_set_structural = fs.structural.new(contains: files)
+        fs.new(structural: new_file_set_structural)
+      end
+      cocina.structural.new(contains: new_file_sets)
+    end
+  end
+end

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe Publish::MetadataTransferService do
         </identityMetadata>
       XML
       i.rels_ext.content = rels
+      i.objectLabel = 'google download barcode 36105049267078'
+      i.source_id = 'STANFORD:342837261527'
+      i.barcode = '36105049267078'
+      i.catkey = '129483625'
+      i.admin_policy_object_id = 'druid:fg890hx1234'
+      i.descMetadata.mods_title = 'Fixture title'
     end
   end
   let(:service) { described_class.new(item) }
@@ -21,7 +27,7 @@ RSpec.describe Publish::MetadataTransferService do
     <<-EOXML
       <rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:hydra="http://projecthydra.org/ns/relations#">
         <rdf:Description rdf:about="info:fedora/druid:bc123df4567">
-          <hydra:isGovernedBy rdf:resource="info:fedora/druid:789012"></hydra:isGovernedBy>
+          <hydra:isGovernedBy rdf:resource="info:fedora/druid:fg890hx1234"></hydra:isGovernedBy>
           <fedora-model:hasModel rdf:resource="info:fedora/hydra:commonMetadata"></fedora-model:hasModel>
           <fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"></fedora:isMemberOf>
           <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"></fedora:isMemberOfCollection>
@@ -102,6 +108,7 @@ RSpec.describe Publish::MetadataTransferService do
 
       context 'with an item' do
         before do
+          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/{"type"/, 'cocina.json')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<publicObject/, 'public')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<mods:mods/, 'mods')
           expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(no_args)
@@ -126,7 +133,13 @@ RSpec.describe Publish::MetadataTransferService do
       end
 
       context 'with a collection object' do
-        let(:item) { Dor::Collection.new }
+        let(:item) do
+          Dor::Collection.new(pid: 'druid:wz243fg4151',
+                              label: 'Simple collection',
+                              admin_policy_object_id: 'druid:fg890hx1234').tap do |coll|
+                                coll.descMetadata.mods_title = 'Grand collection'
+                              end
+        end
 
         before do
           item.rightsMetadata.content = "<rightsMetadata><access type='discover'><machine><world/></machine></access></rightsMetadata>"
@@ -134,6 +147,7 @@ RSpec.describe Publish::MetadataTransferService do
         end
 
         before do
+          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/{"type"/, 'cocina.json')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<publicObject/, 'public')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<mods:mods/, 'mods')
           expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(no_args)

--- a/spec/services/publish/public_cocina_service_spec.rb
+++ b/spec/services/publish/public_cocina_service_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Publish::PublicCocinaService do
+  subject(:json) { JSON.parse(create) }
+
+  let(:create) { described_class.create(fedora_obj) }
+
+  let(:fedora_obj) do
+    Dor::Item.new(
+      pid: 'druid:hz651dj0129',
+      source_id: 'sul:50807230',
+      label: 'Census of India 1931',
+      admin_policy_object_id: 'druid:xk494bv8475'
+    ).tap do |i|
+      i.descMetadata.mods_title = 'Census of India, 1931'
+      i.contentMetadata.content = content_metadata
+    end
+  end
+
+  let(:content_metadata) do
+    <<~XML
+      <contentMetadata objectId="hz651dj0129" type="book">
+        <resource id="hz651dj0129_1" sequence="1" type="page">
+          <label>Page 1</label>
+          <file id="50807230_0001.tif" mimetype="image/tiff" size="56987913" preserve="yes" publish="no" shelve="no">
+            <checksum type="md5">6618d3d35e6adbc5625405cd244f6bda</checksum>
+            <checksum type="sha1">4af78fde7fd8099ac7e3fee3a58332b1d268d244</checksum>
+            <imageData width="3544" height="5360"/>
+          </file>
+          <file id="50807230_0001.jp2" mimetype="image/jp2" size="3575822" preserve="no" publish="no" shelve="no">
+            <checksum type="md5">c99fae3c4c53e40824e710440f08acb9</checksum>
+            <checksum type="sha1">0a089200032d209e9b3e7f7768dd35323a863fcc</checksum>
+            <imageData width="3544" height="5360"/>
+          </file>
+        </resource>
+        <resource id="hz651dj0129_2" sequence="2" type="page">
+          <label>Page 2</label>
+          <file id="50807230_0002.tif" mimetype="image/tiff" size="31525443" preserve="yes" publish="no" shelve="no">
+            <checksum type="md5">010f88d1e40a6f81badde34e00c4ab5d</checksum>
+            <checksum type="sha1">46308444f201bec15857ac9338c2b6060f518ca5</checksum>
+            <imageData width="5736" height="5496"/>
+          </file>
+          <file id="50807230_0002.jp2" mimetype="image/jp2" size="5920056" preserve="no" publish="yes" shelve="yes">
+            <checksum type="md5">08544fe844c45eebb552f280709af564</checksum>
+            <checksum type="sha1">4691466371691f774151574d1cf97ed73ba45d2c</checksum>
+            <imageData width="5736" height="5496"/>
+          </file>
+        </resource>
+        <resource id="hz651dj0129_3" sequence="3" type="page">
+          <label>Page 3</label>
+          <file id="50807230_0003.tif" mimetype="image/tiff" size="31525443" preserve="yes" publish="no" shelve="no">
+            <checksum type="md5">0b43cedb0c8beb030e7c0e87a7ae46ae</checksum>
+            <checksum type="sha1">6b1fc3618c2c195ccc99432491e3a864b2df02af</checksum>
+            <imageData width="5736" height="5496"/>
+          </file>
+          <file id="50807230_0003.jp2" mimetype="image/jp2" size="5920374" preserve="no" publish="yes" shelve="yes">
+            <checksum type="md5">a9acee40e54bc6da6cee1388f7cc33e9</checksum>
+            <checksum type="sha1">9c62ab0930a8e3540b7c151c3e52e8b7732e9c2e</checksum>
+            <imageData width="5736" height="5496"/>
+          </file>
+        </resource>
+      </contentMetadata>
+    XML
+  end
+
+  it 'discards the non-published filesets and files' do
+    expect(json.dig('structural', 'contains').size).to eq 2
+    expect(json.dig('structural', 'contains', 1, 'structural', 'contains').size).to eq 1
+    expect(json.dig('structural', 'contains', 1, 'structural', 'contains', 0, 'filename')).to eq '50807230_0003.jp2'
+  end
+end


### PR DESCRIPTION
## Why was this change made?

So that we can begin sharing the new Cocina models with the Access team.   This change sanitizes the structural by removing any non-published fileset/files just as is done in the public xml.

Fixes #734

## How was this change tested?

To be tested on stage.



## Which documentation and/or configurations were updated?



