### PR TITLE
identityMetadata.xml mapping "unit" specs: wire in identity_normalizer

### DIFF
--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -27,8 +27,6 @@ module Cocina
                                     ignore_resource_type_errors: project_phoenix?)
           structural[:contains] = contains if contains.present?
 
-          structural[:hasAgreement] = fedora_item.identityMetadata.agreementId.first unless fedora_item.identityMetadata.agreementId.empty?
-
           begin
             # Note that there is a bug with fedora_item.collection_ids that returns [] until fedora_item.collections is called.
             # Below side-steps this.

--- a/app/services/cocina/normalizers/identity_normalizer.rb
+++ b/app/services/cocina/normalizers/identity_normalizer.rb
@@ -19,20 +19,97 @@ module Cocina
       end
 
       def normalize
-        normalize_source_id
+        normalize_dissertation_id_to_source_id
+        normalize_out_uuid
+        normalize_out_admin_tags
+        normalize_out_admin_policy
+        normalize_out_agreement_id
+        normalize_out_set_object_type
+        normalize_out_display_type
+        normalize_out_object_admin_class
+        normalize_out_citation_elements
+        normalize_out_call_sequence_ids
+        normalize_out_empty_other_ids
+        normalize_source_id_whitespace
 
-        regenerate_ng_xml(ng_xml.to_s)
+        regenerate_ng_xml(ng_xml.to_xml)
       end
 
       private
 
       attr_reader :ng_xml
 
-      def normalize_source_id
+      def normalize_source_id_whitespace
         ng_xml.root.xpath('//sourceId').each do |source_node|
           source_node['source'] = source_node['source']&.strip
           source_node.content = source_node.content&.strip
         end
+      end
+
+      # if there is no sourceId, but there is an otherId with name dissertationid, convert the dissertationid to a sourceId
+      #   (obviously only applies to (old) ETDs)
+      def normalize_dissertation_id_to_source_id
+        return if ng_xml.root.xpath('//sourceId').present?
+
+        diss_id_nodes = ng_xml.root.xpath('//otherId[@name="dissertationid"]')
+        return if diss_id_nodes.first&.content.blank?
+
+        new_source_id_node = Nokogiri::XML::Node.new('sourceId', ng_xml)
+        new_source_id_node.content = diss_id_nodes.first.content
+        new_source_id_node['source'] = 'dissertationid'
+        diss_id_nodes.first.parent.add_child(new_source_id_node)
+        diss_id_nodes.first.remove
+      end
+
+      # we don't care about uuids
+      def normalize_out_uuid
+        ng_xml.root.xpath('//otherId[@name="uuid"]').each(&:remove)
+      end
+
+      # administrative tags are stored by the administrative_tag service
+      def normalize_out_admin_tags
+        ng_xml.root.xpath('//tag').each(&:remove)
+      end
+
+      # adminPolicy id is retrieved from RELS-EXT
+      def normalize_out_admin_policy
+        ng_xml.root.xpath('//adminPolicy').each(&:remove)
+      end
+
+      # agreementId is retrieved from RELS-EXT
+      def normalize_out_agreement_id
+        ng_xml.root.xpath('//agreementId').each(&:remove)
+      end
+
+      #  keep objectType collection and drop set (set is vestigial early SDR junk)
+      def normalize_out_set_object_type
+        ng_xml.root.xpath('//objectType[text() = "set"]').each(&:remove) if ng_xml.root.xpath('//objectType[text() = "collection"]').present?
+      end
+
+      # displayType is vestigial early SDR junk
+      def normalize_out_display_type
+        ng_xml.root.xpath('//displayType').each(&:remove)
+      end
+
+      # objectAdminClass is vestigial early SDR junk
+      def normalize_out_object_admin_class
+        ng_xml.root.xpath('//objectAdminClass').each(&:remove)
+      end
+
+      # citationTitle, citationCreator are vestigial early SDR/ETD junk
+      def normalize_out_citation_elements
+        ng_xml.root.xpath('//citationTitle').each(&:remove)
+        ng_xml.root.xpath('//citationCreator').each(&:remove)
+      end
+
+      def normalize_out_empty_other_ids
+        ng_xml.root.xpath('//otherId').select { |el| el.content.blank? }.each(&:remove)
+      end
+
+      # these appear in project phoenix and they are vestigial early SDR junk
+      def normalize_out_call_sequence_ids
+        ng_xml.root.xpath('//otherId[@name="callseq"]').each(&:remove)
+        ng_xml.root.xpath('//otherId[@name="shelfseq"]').each(&:remove)
       end
     end
   end

--- a/app/services/cocina/to_fedora/identity.rb
+++ b/app/services/cocina/to_fedora/identity.rb
@@ -13,7 +13,6 @@ module Cocina
         # Label may have already been set when setting descriptive metadata.
         fedora_object.objectLabel = label if fedora_object.objectLabel.empty?
         fedora_object.objectType = fedora_object.object_type # This comes from the class definition in dor-services
-        fedora_object.identityMetadata.agreementId = agreement_id if agreement_id
       end
     end
   end

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Create object' do
     let(:label) { 'This is my label' }
     let(:title) { 'This is my title' }
     let(:expected_label) { label }
-    let(:expected_structural) { { hasAgreement: 'druid:bc777df7777' } }
+    let(:expected_structural) { {} }
     let(:access) { 'world' }
     let(:expected) do
       Cocina::Models::DRO.new(type: Cocina::Models::Vocab.image,
@@ -65,17 +65,13 @@ RSpec.describe 'Create object' do
           "structural":#{structural.to_json}}
       JSON
     end
-
     let(:identification) do
       {
         sourceId: 'googlebooks:999999',
         barcode: '36105036289127'
       }
     end
-
-    let(:structural) do
-      { hasAgreement: 'druid:bc777df7777' }
-    end
+    let(:structural) { {} }
 
     context 'when the service is disabled' do
       before do

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -50,8 +50,7 @@ RSpec.describe 'Update object' do
       hasMemberOrders: [
         { viewingDirection: 'right-to-left' }
       ],
-      isMemberOf: ['druid:xx888xx7777'],
-      hasAgreement: 'druid:cd777df7777'
+      isMemberOf: ['druid:xx888xx7777']
     }
   end
   let(:cocina_structural) { Cocina::Models::DROStructural.new(structural) }
@@ -327,8 +326,7 @@ RSpec.describe 'Update object' do
           "identification":#{identification.to_json},
           "structural":{
             "hasMemberOrders":[{"viewingDirection":"right-to-left"}],
-            "isMemberOf":["druid:xx888xx7777"],
-            "hasAgreement":"druid:cd777df7777"
+            "isMemberOf":["druid:xx888xx7777"]
           }
         }
       JSON

--- a/spec/services/cocina/normalizers/identity_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/identity_normalizer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Cocina::Normalizers::IdentityNormalizer do
   let(:normalized_ng_xml) { described_class.normalize(identity_ng_xml: Nokogiri::XML(original_xml)) }
 
-  context 'when normalizing sourceId' do
+  context 'when #normalize_source_id_whitespace' do
     let(:original_xml) do
       <<~XML
         <identityMetadata>
@@ -22,6 +22,452 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
           </identityMetadata>
         XML
       )
+    end
+  end
+
+  describe '#normalize_dissertation_id_to_source_id' do
+    context 'when there is an existing sourceId' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+             <sourceId source="foo">bar</sourceId>
+             <otherId name="dissertationid">0000000666</otherId>
+          </identityMetadata>
+        XML
+      end
+
+      it 'does nothing' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <sourceId source="foo">bar</sourceId>
+              <otherId name="dissertationid">0000000666</otherId>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+
+    context 'when no sourceId and there is otherId[@name=disserationid]' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+             <otherId name="dissertationid">0000000666</otherId>
+          </identityMetadata>
+        XML
+      end
+
+      it 'creates the new sourceId node and removes the otherId node' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <sourceId source="dissertationid">0000000666</sourceId>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+
+    context 'when no sourceId and there are many otherId nodes' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>foo</objectId>
+            <objectType>item</objectType>
+            <objectLabel>bar</objectLabel>
+            <objectCreator>DOR</objectCreator>
+            <otherId name="dissertationid">0000000666</otherId>
+            <otherId name="catkey">666</otherId>
+            <otherId name="uuid">bb8e629e-6328-11e1-9378-022c4a816c60</otherId>
+          </identityMetadata>
+        XML
+      end
+
+      it 'creates the new sourceId node from dissertationid node and removes the correct otherId node' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectId>foo</objectId>
+              <objectType>item</objectType>
+              <objectLabel>bar</objectLabel>
+              <objectCreator>DOR</objectCreator>
+              <sourceId source="dissertationid">0000000666</sourceId>
+              <otherId name="catkey">666</otherId>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+  end
+
+  describe '#normalize_out_uuid' do
+    context 'when there is an otherId with name uuid' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <otherId name="catkey">666</otherId>
+            <otherId name="uuid">bb8e629e-6328-11e1-9378-022c4a816c60</otherId>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes it' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <otherId name="catkey">666</otherId>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+  end
+
+  describe '#normalize_out_admin_tags' do
+    context 'when there is one administrative tag' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>foo</objectId>
+            <tag>fa la la felafel</tag>
+            <otherId name="catkey">666</otherId>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes it' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectId>foo</objectId>
+              <otherId name="catkey">666</otherId>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+
+    context 'when there are multiple administrative tags' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>foo</objectId>
+            <tag>ETD : Term 1106</tag>
+            <tag>ETD : Dissertation</tag>
+            <tag>Remediated By : 4.20.1</tag>
+            <otherId name="catkey">666</otherId>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes it' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectId>foo</objectId>
+              <otherId name="catkey">666</otherId>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+  end
+
+  describe '#normalize_out_adminPolicy' do
+    context 'when adminPolicy is present' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>foo</objectId>
+            <adminPolicy>druid:wq307yk9043</adminPolicy>
+            <otherId name="catkey">666</otherId>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes it' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectId>foo</objectId>
+              <otherId name="catkey">666</otherId>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+  end
+
+  describe '#normalize_out_agreementId' do
+    context 'when agreementId is present' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>foo</objectId>
+            <agreementId>druid:ct692vv3660</agreementId>
+            <otherId name="catkey">666</otherId>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes it' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectId>foo</objectId>
+              <otherId name="catkey">666</otherId>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+  end
+
+  describe '#normalize_out_set_object_type' do
+    context 'when objectType set and collection are both present' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectCreator>DOR</objectCreator>
+            <objectType>set</objectType>
+            <objectLabel>foo</objectLabel>
+            <objectType>collection</objectType>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes objectType set' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>foo</objectLabel>
+              <objectType>collection</objectType>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+
+    context 'when objectType set is present alone' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectCreator>DOR</objectCreator>
+            <objectType>set</objectType>
+            <objectLabel>foo</objectLabel>
+          </identityMetadata>
+        XML
+      end
+
+      it 'does not remove objectType set' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectCreator>DOR</objectCreator>
+              <objectType>set</objectType>
+              <objectLabel>foo</objectLabel>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+  end
+
+  describe '#normalize_out_display_type' do
+    context 'when displayType is present' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>foo</objectLabel>
+            <displayType>file</displayType>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes it' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>foo</objectLabel>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+  end
+
+  describe '#normalize_out_object_admin_class' do
+    context 'when objectAdminClass is present' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>foo</objectLabel>
+            <objectAdminClass>EEMs</objectAdminClass>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes it' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>foo</objectLabel>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+  end
+
+  describe '#normalize_out_citation_elements' do
+    context 'when citationTitle alone is present' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>foo</objectLabel>
+            <citationTitle>Proceedings</citationTitle>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes it' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>foo</objectLabel>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+
+    context 'when citationCreator alone is present' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>foo</objectLabel>
+            <citationCreator>Dalton, Michael</citationCreator>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes it' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>foo</objectLabel>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+
+    context 'when both citationTitle and citationCreator are present' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>foo</objectLabel>
+            <citationTitle>Proceedings</citationTitle>
+            <citationCreator>Dalton, Michael</citationCreator>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes them' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>foo</objectLabel>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+
+    context 'when empty citationTitle and citationCreator are present' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>foo</objectLabel>
+            <citationTitle/>
+            <citationCreator></citationCreator>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes them' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>foo</objectLabel>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+  end
+
+  describe '#normalize_out_empty_other_ids' do
+    context 'when otherId[@name="label"] is present but empty' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>foo</objectLabel>
+            <otherId name=\"label\"/>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes it' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>foo</objectLabel>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+  end
+
+  describe '#normalize_out_call_sequence_ids' do
+    context 'when otherId[@name="shelfseq"] and otherId[@name="callseq"] are present' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>foo</objectLabel>
+            <otherId name="shelfseq">DA 000670 .S49 S55 V.000045-000046 001899-001900</otherId>
+            <otherId name="callseq">29</otherId>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes them' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>foo</objectLabel>
+            </identityMetadata>
+          XML
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

- to keep future changes to identity_normalizer from inadvertently breaking other expected identityMetadata.xml mappings
- to ensure our mapping tests are aligned with current identity_normalizer code

Closes #2814
Part of #2703

## How was this change tested?

it's all specs; wiring in the unit tests found some errors in the identity_normalizer and mapping code, which are fixed and included here.

## Which documentation and/or configurations were updated?



