### PR TITLE
Add support for roundtrip validation using object create.

### DIFF
--- a/app/services/cocina/normalizers/embargo_normalizer.rb
+++ b/app/services/cocina/normalizers/embargo_normalizer.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Normalizers
+    # Normalizes a Fedora object embargo metadata datastream
+    class EmbargoNormalizer
+      include Cocina::Normalizers::Base
+
+      # @param [Nokogiri::Document] embargo_ng_xml embargo metadata XML to be normalized
+      # @return [Nokogiri::Document] normalized embargo metadata xml
+      def self.normalize(embargo_ng_xml:)
+        new(embargo_ng_xml: embargo_ng_xml).normalize
+      end
+
+      def initialize(embargo_ng_xml:)
+        @ng_xml = embargo_ng_xml.dup
+        @ng_xml.encoding = 'UTF-8' if @ng_xml.respond_to?(:encoding=) # sometimes it's a String (?)
+      end
+
+      def normalize
+        normalize_empty
+
+        regenerate_ng_xml(ng_xml.to_xml)
+      end
+
+      private
+
+      attr_reader :ng_xml
+
+      def normalize_empty
+        ng_xml.root.xpath('*[count(*) = 0]').each(&:remove)
+        ng_xml.root.remove if ng_xml.root.xpath('*').empty?
+      end
+    end
+  end
+end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -5,47 +5,56 @@ module Cocina
   class ObjectCreator
     # @raises SymphonyReader::ResponseError if symphony connection failed
     def self.create(cocina_object, event_factory: EventFactory, persister: ActiveFedoraPersister)
-      new.create(cocina_object, event_factory: event_factory, persister: persister)
+      _fedora_object, cocina_object = new.create(cocina_object, event_factory: event_factory, persister: persister)
+      cocina_object
+    end
+
+    def self.trial_create(cocina_object, notifier:)
+      new.create(cocina_object, event_factory: nil, persister: nil, trial: true, notifier: notifier)
     end
 
     # @param [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAdminPolicy] cocina_object
     # @raises SymphonyReader::ResponseError if symphony connection failed
-    def create(cocina_object, event_factory:, persister:)
+    def create(cocina_object, event_factory:, persister:, trial: false, notifier: nil)
       ensure_ur_admin_policy_exists if Settings.enabled_features.create_ur_admin_policy && cocina_object.administrative.hasAdminPolicy == Settings.ur_admin_policy.druid
 
-      validate(cocina_object)
+      validate(cocina_object) unless trial
 
-      af_model = create_from_model(cocina_object, persister: persister)
-      # Fedora 3 has no unique constrains, so
-      # index right away to reduce the likelyhood of duplicate sourceIds
-      SynchronousIndexer.reindex_remotely(af_model.pid)
+      fedora_object = create_from_model(cocina_object, trial: trial)
 
-      event_factory.create(druid: af_model.pid, event_type: 'registration', data: cocina_object.to_h)
+      unless trial
+        persister.store(fedora_object)
+
+        # Fedora 3 has no unique constrains, so
+        # index right away to reduce the likelyhood of duplicate sourceIds
+        SynchronousIndexer.reindex_remotely(fedora_object.pid)
+
+        event_factory.create(druid: fedora_object.pid, event_type: 'registration', data: cocina_object.to_h)
+      end
 
       # This will rebuild the cocina model from fedora, which shows we are only returning persisted data
-      Mapper.build(af_model)
+      roundtrip_cocina_object = Mapper.build(fedora_object, notifier: notifier)
+
+      [fedora_object, roundtrip_cocina_object]
     end
 
     private
 
-    # @param [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAdminPolicy] cocina_object
-    # @param [#store] persister the service responsible for persisting the model
+    # @param [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAdminPolicy,
+    #   Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy] cocina_object
     # @return [Dor::Abstract] a persisted ActiveFedora model
     # @raises SymphonyReader::ResponseError if symphony connection failed
-    def create_from_model(cocina_object, persister:)
-      af_object = case cocina_object
-                  when Cocina::Models::RequestAdminPolicy
-                    create_apo(cocina_object)
-                  when Cocina::Models::RequestDRO
-                    create_dro(cocina_object)
-                  when Cocina::Models::RequestCollection
-                    create_collection(cocina_object)
-                  else
-                    raise "unsupported type #{cocina_object.type}"
-                  end
-
-      persister.store(af_object)
-      af_object
+    def create_from_model(cocina_object, trial:)
+      case cocina_object
+      when Cocina::Models::RequestAdminPolicy, Cocina::Models::AdminPolicy
+        create_apo(cocina_object, trial: trial)
+      when Cocina::Models::RequestDRO, Cocina::Models::DRO
+        create_dro(cocina_object, trial: trial)
+      when Cocina::Models::RequestCollection, Cocina::Models::Collection
+        create_collection(cocina_object, trial: trial)
+      else
+        raise "unsupported type #{cocina_object.type}"
+      end
     end
 
     # If an object references the Ur-AdminPolicy, it has to exist first.
@@ -54,16 +63,16 @@ module Cocina
       Dor::AdminPolicyObject.exists?(Settings.ur_admin_policy.druid) || UrAdminPolicyFactory.create
     end
 
-    # @param [Cocina::Models::RequestAdminPolicy] cocina_admin_policy
+    # @param [Cocina::Models::RequestAdminPolicy,Cocina::Models::AdminPolicy] cocina_admin_policy
     # @return [Dor::AdminPolicyObject] a persisted APO model
-    def create_apo(cocina_admin_policy)
-      pid = Dor::SuriService.mint_id
+    def create_apo(cocina_admin_policy, trial:)
+      pid = trial ? cocina_admin_policy.externalIdentifier : Dor::SuriService.mint_id
       Dor::AdminPolicyObject.new(pid: pid,
                                  admin_policy_object_id: cocina_admin_policy.administrative.hasAdminPolicy,
                                  agreement_object_id: cocina_admin_policy.administrative.referencesAgreement,
                                  # source_id: cocina_admin_policy.identification.sourceId,
                                  label: cocina_admin_policy.label).tap do |fedora_apo|
-        add_description(fedora_apo, cocina_admin_policy)
+        add_description(fedora_apo, cocina_admin_policy, trial: trial)
 
         Cocina::ToFedora::DefaultRights.write(fedora_apo.defaultObjectRights, cocina_admin_policy.administrative.defaultAccess) if cocina_admin_policy.administrative.defaultAccess
         Cocina::ToFedora::AdministrativeMetadata.write(fedora_apo.administrativeMetadata, cocina_admin_policy.administrative)
@@ -73,12 +82,12 @@ module Cocina
       end
     end
 
-    # @param [Cocina::Models::RequestDRO] cocina_item
+    # @param [Cocina::Models::RequestDRO,Cocina::Models::DRO] cocina_item
     # @return [Dor::Item] a persisted Item model
     # @raises SymphonyReader::ResponseError if symphony connection failed
     # rubocop:disable Metrics/AbcSize
-    def create_dro(cocina_item)
-      pid = Dor::SuriService.mint_id
+    def create_dro(cocina_item, trial:)
+      pid = trial ? cocina_item.externalIdentifier : Dor::SuriService.mint_id
       klass = cocina_item.type == Cocina::Models::Vocab.agreement ? Dor::Agreement : Dor::Item
       klass.new(pid: pid,
                 admin_policy_object_id: cocina_item.administrative.hasAdminPolicy,
@@ -86,10 +95,13 @@ module Cocina
                 collection_ids: Array.wrap(cocina_item.structural&.isMemberOf).compact,
                 catkey: catkey_for(cocina_item),
                 label: truncate_label(cocina_item.label)).tap do |fedora_item|
-        add_description(fedora_item, cocina_item)
-        add_dro_tags(pid, cocina_item)
+        add_description(fedora_item, cocina_item, trial: trial)
 
-        apply_default_access(fedora_item)
+        unless trial
+          add_dro_tags(pid, cocina_item)
+          apply_default_access(fedora_item)
+        end
+
         Cocina::ToFedora::DROAccess.apply(fedora_item, cocina_item.access, cocina_item.structural) if cocina_item.access || cocina_item.structural
 
         fedora_item.contentMetadata.content = Cocina::ToFedora::ContentMetadataGenerator.generate(druid: pid, object: cocina_item)
@@ -102,18 +114,18 @@ module Cocina
     end
     # rubocop:enable Metrics/AbcSize
 
-    # @param [Cocina::Models::RequestCollection] cocina_collection
+    # @param [Cocina::Models::RequestCollection,Cocina::Models::Collection] cocina_collection
     # @return [Dor::Collection] a persisted Collection model
-    def create_collection(cocina_collection)
-      pid = Dor::SuriService.mint_id
+    def create_collection(cocina_collection, trial:)
+      pid = trial ? cocina_collection.externalIdentifier : Dor::SuriService.mint_id
       Dor::Collection.new(pid: pid,
                           admin_policy_object_id: cocina_collection.administrative.hasAdminPolicy,
                           source_id: cocina_collection.identification&.sourceId,
                           catkey: catkey_for(cocina_collection),
                           label: truncate_label(cocina_collection.label)).tap do |fedora_collection|
-        add_description(fedora_collection, cocina_collection)
-        add_collection_tags(pid, cocina_collection)
-        apply_default_access(fedora_collection)
+        add_description(fedora_collection, cocina_collection, trial: trial)
+        add_collection_tags(pid, cocina_collection) unless trial
+        apply_default_access(fedora_collection) unless trial
         Cocina::ToFedora::CollectionAccess.apply(fedora_collection, cocina_collection.access) if cocina_collection.access
         Cocina::ToFedora::Identity.initialize_identity(fedora_collection)
         Cocina::ToFedora::Identity.apply_label(fedora_collection, label: cocina_collection.label)
@@ -128,12 +140,12 @@ module Cocina
     # @param [Dor::[Item|Collection|APO]] fedora_object
     # @param [Cocina:Models::Request[DOR|Collection|xxx]] cocina_object
     # @raises SymphonyReader::ResponseError if symphony connection failed
-    def add_description(fedora_object, cocina_object)
+    def add_description(fedora_object, cocina_object, trial:)
       # Hydrus doesn't set description. See https://github.com/sul-dlss/hydrus/issues/421
       return if cocina_object.label == 'Hydrus'
 
       # Synch from symphony if a catkey is present
-      if fedora_object.catkey
+      if fedora_object.catkey && !trial
         RefreshMetadataAction.run(identifiers: ["catkey:#{fedora_object.catkey}"], fedora_object: fedora_object)
         label = MetadataService.label_from_mods(fedora_object.descMetadata.ng_xml)
         fedora_object.label = truncate_label(label)

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -11,11 +11,12 @@ require 'diffy'
 require 'dor/services/client'
 require 'equivalent-xml'
 
-options = { random: false, druids: [], fast: false }
+options = { random: false, druids: [], fast: false, create: false }
 parser = OptionParser.new do |option_parser|
   option_parser.banner = 'Usage: bin/validate-cocina-roundtrip [options]'
 
   option_parser.on('-sSAMPLE', '--sample SAMPLE', Integer, 'Sample size, otherwise all druids.')
+  option_parser.on('-c', '--create', 'Run object create instead of object update.')
   option_parser.on('-r', '--random', 'Select random druids.')
   option_parser.on('-f', '--fast', 'Without content metadata.')
   option_parser.on('-dDRUIDS', '--druids DRUIDS', Array, 'List of druids (instead of druids.txt).')
@@ -92,6 +93,8 @@ def norm_orig_datastream_ng_xml_for(dsid, orig_datastream_ng_xml, druid, label, 
     Cocina::Normalizers::ContentMetadataNormalizer.normalize(druid: druid, content_ng_xml: orig_datastream_ng_xml)
   when 'identityMetadata'
     Cocina::Normalizers::IdentityNormalizer.normalize(identity_ng_xml: orig_datastream_ng_xml)
+  when 'embargoMetadata'
+    Cocina::Normalizers::EmbargoNormalizer.normalize(embargo_ng_xml: orig_datastream_ng_xml)
   else
     orig_datastream_ng_xml
   end
@@ -132,7 +135,11 @@ def diff_datatreams_for(druid, label, orig_datastreams, fedora_obj)
   diff_datastreams
 end
 
-def validate_druid(druid, loader, fast: false)
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/CyclomaticComplexity
+# rubocop:disable Metrics/MethodLength
+# rubocop:disable Metrics/PerceivedComplexity
+def validate_druid(druid, loader, fast: false, create: false)
   return :missing unless loader.cached?(druid)
 
   begin
@@ -144,7 +151,13 @@ def validate_druid(druid, loader, fast: false)
     return :unmapped
   end
 
-  fedora_obj.contentMetadata.content = "<contentMetadata type='#{fedora_obj.contentMetadata.contentType.first}' />" if fast && fedora_obj.datastreams.include?('contentMetadata')
+  if fast && fedora_obj.datastreams.include?('contentMetadata')
+    fedora_obj.contentMetadata.content = if create
+                                           "<contentMetadata type='#{fedora_obj.contentMetadata.contentType.first}' objectId='#{druid}'/>"
+                                         else
+                                           "<contentMetadata type='#{fedora_obj.contentMetadata.contentType.first}' />"
+                                         end
+  end
 
   orig_datastreams = {}
   FedoraCache::DATASTREAMS.each { |dsid| orig_datastreams[dsid] = fedora_obj.datastreams[dsid]&.content }
@@ -159,16 +172,28 @@ def validate_druid(druid, loader, fast: false)
 
   orig_cocina_hash = orig_cocina_obj.to_h
 
-  begin
-    roundtrip_cocina_obj = Cocina::ObjectUpdater.run(fedora_obj, orig_cocina_obj, trial: true, notifier: DataErrorNotifier.new)
-  rescue StandardError => e
-    write_error(druid, e)
-    return :update_error
+  if create
+    begin
+      roundtrip_fedora_obj, roundtrip_cocina_obj = Cocina::ObjectCreator.trial_create(orig_cocina_obj, notifier: DataErrorNotifier.new)
+    rescue StandardError => e
+      write_error(druid, e)
+      return :create_error
+    end
+    # RELS-EXT is not present in created Fedora object, so remove from orig_datastreams.
+    orig_datastreams.delete('RELS-EXT')
+  else
+    begin
+      roundtrip_cocina_obj = Cocina::ObjectUpdater.run(fedora_obj, orig_cocina_obj, trial: true, notifier: DataErrorNotifier.new)
+      roundtrip_fedora_obj = fedora_obj
+    rescue StandardError => e
+      write_error(druid, e)
+      return :update_error
+    end
   end
   roundtrip_cocina_hash = roundtrip_cocina_obj.to_h
 
   begin
-    diff_datastreams = diff_datatreams_for(druid, label, orig_datastreams, fedora_obj)
+    diff_datastreams = diff_datatreams_for(druid, label, orig_datastreams, roundtrip_fedora_obj)
   rescue StandardError => e
     write_error(druid, e)
     return :normalization_error
@@ -179,6 +204,10 @@ def validate_druid(druid, loader, fast: false)
   write_result(druid, orig_cocina_hash, roundtrip_cocina_hash, diff_datastreams)
   :different
 end
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/CyclomaticComplexity
+# rubocop:enable Metrics/MethodLength
+# rubocop:enable Metrics/PerceivedComplexity
 
 def normalize_external_identifiers(cocina_hash)
   # Remove file and fileSet externalIdentifiers, since usually regenerated.
@@ -209,9 +238,9 @@ else
 end
 
 results = Parallel.map(druids, progress: 'Testing') do |druid|
-  validate_druid(druid, loader, fast: options[:fast])
+  validate_druid(druid, loader, fast: options[:fast], create: options[:create])
 end
-counts = { different: 0, success: 0, mapping_error: 0, update_error: 0, normalization_error: 0, missing: 0, unmapped: 0, bad_cache: 0 }
+counts = { different: 0, success: 0, mapping_error: 0, update_error: 0, create_error: 0, normalization_error: 0, missing: 0, unmapped: 0, bad_cache: 0 }
 results.each { |result| counts[result] += 1 }
 
 denom = druids.size - counts[:missing] - counts[:unmapped] - counts[:bad_cache]
@@ -220,7 +249,11 @@ puts "Status (n=#{druids.size}; not using Missing for success/different/error st
 puts "  Success:   #{counts[:success]} (#{percentage(counts[:success], denom)}%)"
 puts "  Different: #{counts[:different]} (#{percentage(counts[:different], denom)}%)"
 puts "  Mapping error:     #{counts[:mapping_error]} (#{percentage(counts[:mapping_error], denom)}%)"
-puts "  Update error:     #{counts[:update_error]} (#{percentage(counts[:update_error], denom)}%)"
+if options[:create]
+  puts "  Create error:     #{counts[:create_error]} (#{percentage(counts[:create_error], denom)}%)"
+else
+  puts "  Update error:     #{counts[:update_error]} (#{percentage(counts[:update_error], denom)}%)"
+end
 puts "  Normalization error:     #{counts[:normalization_error]} (#{percentage(counts[:normalization_error], denom)}%)"
 puts "  Missing:     #{counts[:missing]} (#{(100 * counts[:missing].to_f / druids.size).round(3)}%)"
 puts "  Unmapped:     #{counts[:unmapped]} (#{(100 * counts[:unmapped].to_f / druids.size).round(3)}%)"

--- a/spec/services/cocina/normalizers/embargo_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/embargo_normalizer_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::Normalizers::EmbargoNormalizer do
+  let(:normalized_ng_xml) { described_class.normalize(embargo_ng_xml: Nokogiri::XML(original_xml)) }
+
+  context 'when #normalize_empty' do
+    let(:original_xml) do
+      <<~XML
+        <embargoMetadata>
+          <status/>
+          <releaseDate/>
+          <releaseAccess/>
+          <twentyPctVisibilityStatus/>
+          <twentyPctVisibilityReleaseDate/>
+        </embargoMetadata>
+      XML
+    end
+
+    it 'removes empty elements' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+        XML
+      )
+    end
+  end
+end


### PR DESCRIPTION
closes #2837

## Why was this change made?
Object create will help find unmapped, existing data that object update does not.


## How was this change tested?
Unit, local


## Which documentation and/or configurations were updated?
NA


