### PR TITLE
Remove agreementId from identityMetadata fixtures

### DIFF
--- a/lib/tasks/seeds/druid:bx911tp9024.xml
+++ b/lib/tasks/seeds/druid:bx911tp9024.xml
@@ -837,7 +837,6 @@
           <objectLabel>ETDs</objectLabel>
           <objectCreator>DOR</objectCreator>
           <otherId name="uuid">89477060-bc79-11e0-962b-0800200c9a66</otherId>
-          <agreementId>druid:tx617qp8040</agreementId>
           <tag>Project : DOR</tag>
           <tag>Remediated By : 3.6.2</tag>
         </identityMetadata>
@@ -851,7 +850,6 @@
           <objectLabel>ETDs</objectLabel>
           <objectCreator>DOR</objectCreator>
           <otherId name="uuid">89477060-bc79-11e0-962b-0800200c9a66</otherId>
-          <agreementId>druid:tx617qp8040</agreementId>
           <tag>Project : DOR</tag>
           <tag>Remediated By : 3.25.0</tag>
         </identityMetadata>
@@ -865,7 +863,6 @@
           <objectLabel>ETDs</objectLabel>
           <objectCreator>DOR</objectCreator>
           <otherId name="uuid">89477060-bc79-11e0-962b-0800200c9a66</otherId>
-          <agreementId>druid:tx617qp8040</agreementId>
           <tag>Project : DOR</tag>
           <tag>Remediated By : 4.6.4</tag>
         </identityMetadata>
@@ -879,7 +876,6 @@
           <objectLabel>ETDs</objectLabel>
           <objectCreator>DOR</objectCreator>
           <otherId name="uuid">89477060-bc79-11e0-962b-0800200c9a66</otherId>
-          <agreementId>druid:tx617qp8040</agreementId>
           <tag>Project : DOR</tag>
           <tag>Remediated By : 4.6.6.2</tag>
         </identityMetadata>
@@ -893,7 +889,6 @@
           <objectLabel>ETDs</objectLabel>
           <objectCreator>DOR</objectCreator>
           <otherId name="uuid">89477060-bc79-11e0-962b-0800200c9a66</otherId>
-          <agreementId>druid:tx617qp8040</agreementId>
           <tag>Project : DOR</tag>
           <tag>Remediated By : 4.17.1</tag>
         </identityMetadata>

--- a/lib/tasks/seeds/druid:hv992ry2431.xml
+++ b/lib/tasks/seeds/druid:hv992ry2431.xml
@@ -1749,7 +1749,6 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   <objectLabel>Internal Objects</objectLabel>
   <objectDescription>Default Administrative Policy Object</objectDescription>
   <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
-  <agreementId>druid:tx617qp8040</agreementId>
   <tag>Remediated By : 3.6.2</tag>
 </identityMetadata>
 </foxml:xmlContent>
@@ -1762,7 +1761,6 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   <objectLabel>Default Admin Policy</objectLabel>
   <objectDescription>Default Administrative Policy Object</objectDescription>
   <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
-  <agreementId>druid:tx617qp8040</agreementId>
   <tag>Remediated By : 3.6.2</tag>
 </identityMetadata>
 </foxml:xmlContent>
@@ -1775,7 +1773,6 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   <objectLabel>Default Admin Policy</objectLabel>
   <objectDescription>Default Administrative Policy Object</objectDescription>
   <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
-  <agreementId>druid:tx617qp8040</agreementId>
 </identityMetadata>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
@@ -1845,7 +1842,6 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   <objectLabel>Internal Objects</objectLabel>
   <objectDescription>Default Administrative Policy Object</objectDescription>
   <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
-  <agreementId>druid:tx617qp8040</agreementId>
   <tag>Remediated By : 3.22.1</tag>
 </identityMetadata>
 </foxml:xmlContent>
@@ -1858,7 +1854,6 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   <objectLabel>[Internal System Objects]</objectLabel>
   <objectDescription>Default Administrative Policy Object</objectDescription>
   <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
-  <agreementId>druid:tx617qp8040</agreementId>
   <tag>Remediated By : 3.22.1</tag>
 </identityMetadata>
 </foxml:xmlContent>
@@ -1871,7 +1866,6 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   <objectLabel>[Internal System Objects]</objectLabel>
   <objectDescription>Default Administrative Policy Object</objectDescription>
   <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
-  <agreementId>druid:tx617qp8040</agreementId>
   <tag>Remediated By : 4.6.6.2</tag>
 </identityMetadata>
 </foxml:xmlContent>
@@ -1884,7 +1878,6 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   <objectLabel>[Internal System Objects]</objectLabel>
   <objectDescription>Default Administrative Policy Object</objectDescription>
   <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
-  <agreementId>druid:tx617qp8040</agreementId>
   <tag>Remediated By : 4.17.1</tag>
 </identityMetadata>
 </foxml:xmlContent>
@@ -1897,7 +1890,6 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   <objectLabel>[Internal System Objects]</objectLabel>
   <objectDescription>Default Administrative Policy Object</objectDescription>
   <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
-  <agreementId>druid:tx617qp8040</agreementId>
   <tag>Remediated By : 4.22.3</tag>
 </identityMetadata>
 </foxml:xmlContent>
@@ -1910,7 +1902,6 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   <objectLabel>[Internal System Objects]</objectLabel>
   <objectDescription>Default Administrative Policy Object</objectDescription>
   <otherId name="uuid">661e629a-24c8-2ef3-227e-883eb4e2c6d4</otherId>
-  <agreementId>druid:tx617qp8040</agreementId>
   <tag>Remediated By : 5.7.0</tag>
 </identityMetadata>
 </foxml:xmlContent>

--- a/spec/fixtures/apo_druid_fg890hx1234.xml
+++ b/spec/fixtures/apo_druid_fg890hx1234.xml
@@ -167,7 +167,6 @@
             <itemTag>AdminPolicy : Topographical Map</itemTag>
             <itemTag>Keyword : topographical</itemTag>
             <itemTag>Keyword : map</itemTag>
-            <agreementId>druid:wr729gb4199</agreementId>
             <workflow id="digitizationWF">
               <process id="initiate" lifecycle="registered" status="completed"/>
               <process id="digitize" status="waiting"/>

--- a/spec/fixtures/item_druid_qv648vd4392.xml
+++ b/spec/fixtures/item_druid_qv648vd4392.xml
@@ -45,7 +45,6 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
     <fedora-rel:isMemberOfCollection rdf:resource="info:fedora/druid:nt028fd5773"></fedora-rel:isMemberOfCollection>
   </relationships>
   <registration>
-    <agreementId>druid:xf765cv5573</agreementId>
     <workflow id="digitizationWF">
       <process lifecycle="registered" name="initiate" status="completed"></process>
       <process name="digitize" status="waiting"></process>
@@ -89,7 +88,6 @@ xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/
   <objectLabel>Revs Institute</objectLabel>
   <objectCreator>DOR</objectCreator>
   <otherId name="uuid">20d6c780-42eb-11e1-b86c-0800200c9a66</otherId>
-  <agreementId>druid:tx617qp8040</agreementId>
   <tag>Project : DOR</tag>
 </identityMetadata>
 </foxml:xmlContent>

--- a/spec/fixtures/item_druid_xh235dd9059.xml
+++ b/spec/fixtures/item_druid_xh235dd9059.xml
@@ -193,7 +193,6 @@ David Rumsey Map Collection at Stanford University Libraries
 <otherId name="uuid">43ea055e-6fbc-11e1-a721-02231e89cef0</otherId>
 <objectId>druid:xh235dd9059</objectId>
 <objectCreator>DOR</objectCreator>
-<agreementId>druid:xf765cv5573</agreementId>
 <tag>Remediated By : 3.6.2</tag>
 </identityMetadata>
 </foxml:xmlContent>
@@ -210,7 +209,6 @@ David Rumsey Map Collection at Stanford University Libraries
 <otherId name="uuid">43ea055e-6fbc-11e1-a721-02231e89cef0</otherId>
 <objectId>druid:xh235dd9059</objectId>
 <objectCreator>DOR</objectCreator>
-<agreementId>druid:xf765cv5573</agreementId>
 <tag>Remediated By : 4.20.1</tag>
 </identityMetadata>
 </foxml:xmlContent>
@@ -227,7 +225,6 @@ David Rumsey Map Collection at Stanford University Libraries
 <otherId name="uuid">43ea055e-6fbc-11e1-a721-02231e89cef0</otherId>
 <objectId>druid:xh235dd9059</objectId>
 <objectCreator>DOR</objectCreator>
-<agreementId>druid:xf765cv5573</agreementId>
 <tag>Remediated By : 4.20.1</tag>
 <displayType>image</displayType>
 <release displayType="image" release="true" to="Searchworks" what="collection" when="2015-08-14T21:49:29Z" who="lauraw15">true</release>

--- a/spec/fixtures/sdr_repo/dd116zh0343/v0001/data/metadata/identityMetadata.xml
+++ b/spec/fixtures/sdr_repo/dd116zh0343/v0001/data/metadata/identityMetadata.xml
@@ -12,7 +12,6 @@
   <otherId name="barcode">36105047816769</otherId>
   <otherId name="callseq">1</otherId>
   <otherId name="uuid">1ddfa648-79ce-4efa-b8e9-d521b0f07f71</otherId>
-  <agreementId>druid:zn292gq7284</agreementId>
   <tag>Google Book : GBS VIEW_FULL</tag>
   <tag>Google Book : Scan source STANFORD</tag>
   <tag>Remediated By : 3.6.2</tag>

--- a/spec/fixtures/sdr_repo/dd116zh0343/v0001/manifests/signatureCatalog.xml
+++ b/spec/fixtures/sdr_repo/dd116zh0343/v0001/manifests/signatureCatalog.xml
@@ -43,7 +43,7 @@
     <fileSignature size="3581" md5="b83c60b7f92c9f3de33205b6a7a180a1" sha1="14872a73e9aad29d859c79123b8deb5e418c3db6" sha256="dca666ba28dfdbc69b0d3464b605338c043e8a3b9f084abac571f0bc0863bd46"/>
   </entry>
   <entry originalVersion="1" groupId="metadata" storagePath="identityMetadata.xml">
-    <fileSignature size="880" md5="5a01eef164600fa9e46bd39c4e238ea3" sha1="c1968a2c9220485221bfec8bdf339df7d8e43fb1" sha256="78e4f4d21899cd21bf306119df20f81efdf75c2b4346edc35b0280bd90f0b032"/>
+    <fileSignature size="833" md5="8cab8095cad9028fb3151b0711aec27f" sha1="0a2d704da3ac78ec426612f2ae26053fc2cd3006" sha256="801d6f32166a16d9ad4fc96fdd7eb0ea3fa56ddb2285ba00a653dd75b77b6037"/>
   </entry>
   <entry originalVersion="1" groupId="metadata" storagePath="provenanceMetadata.xml">
     <fileSignature size="8532" md5="aa66f3aa50d78d4407e3bd70a056d080" sha1="5d3344d62c44890c1404e3e4a3f1bc505d7e766b" sha256="3025750e7d258ff149045a76e4c871a2809ea1247d9206e1632c755e9cb39335"/>

--- a/spec/fixtures/sdr_repo/jq937jp0017/v0001/data/metadata/identityMetadata.xml
+++ b/spec/fixtures/sdr_repo/jq937jp0017/v0001/data/metadata/identityMetadata.xml
@@ -1,6 +1,5 @@
 <identityMetadata>
   <objectAdminClass>GoogleBooks</objectAdminClass>
-  <agreementId>druid:zn292gq7284</agreementId>
   <objectType>item</objectType>
   <citationTitle>The poems of Robert Burns: A new edition</citationTitle>
   <citationCreator>Burns, Robert , 1759-1796</citationCreator>

--- a/spec/fixtures/workspace/dd/116/zh/0343/dd116zh0343/metadata/identityMetadata.xml
+++ b/spec/fixtures/workspace/dd/116/zh/0343/dd116zh0343/metadata/identityMetadata.xml
@@ -12,7 +12,6 @@
   <otherId name="barcode">36105047816769</otherId>
   <otherId name="callseq">1</otherId>
   <otherId name="uuid">1ddfa648-79ce-4efa-b8e9-d521b0f07f71</otherId>
-  <agreementId>druid:zn292gq7284</agreementId>
   <tag>Google Book : GBS VIEW_FULL</tag>
   <tag>Google Book : Scan source STANFORD</tag>
   <tag>Remediated By : 3.6.2</tag>

--- a/spec/services/cocina/mapping/identification/dro_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/dro_identity_spec.rb
@@ -454,7 +454,6 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             <otherId name="barcode">#{barcode}</otherId>
             <otherId name="callseq">29</otherId>
             <otherId name="uuid">6d408a7d-46c1-446c-ad4c-e5b0633830eb</otherId>
-            <agreementId>druid:zn292gq7284</agreementId>
             <tag>Book : Multi-volume work</tag>
             <tag>Google Book : GBS VIEW_FULL</tag>
             <tag>Book : Non-US pre-1891</tag>
@@ -523,7 +522,6 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             <otherId name="dissertationid">0000000001</otherId>
             <otherId name="catkey">#{catkey}</otherId>
             <otherId name="uuid">aefeb8c0-632e-11e1-b86c-0800200c9a66</otherId>
-            <agreementId>druid:ct692vv3660</agreementId>
             <objectAdminClass>ETDs</objectAdminClass>
             <tag>ETD : Term 1102</tag>
             <tag>ETD : Dissertation</tag>
@@ -542,7 +540,6 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             <objectCreator>DOR</objectCreator>
             <sourceId source="dissertationid">0000000001</sourceId>
             <otherId name="catkey">#{catkey}</otherId>
-            <agreementId>druid:ct692vv3660</agreementId>
             <release to="Searchworks" what="self" when="2017-02-07T10:45:17Z" who="blalbrit">true</release>
           </identityMetadata>
         XML
@@ -607,7 +604,6 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             <otherId name="dissertationid">0000000296</otherId>
             <otherId name="catkey">#{catkey}</otherId>
             <otherId name="uuid">bb8e629e-6328-11e1-9378-022c4a816c60</otherId>
-            <agreementId>druid:ct692vv3660</agreementId>
             <tag>ETD : Term 1106</tag>
             <tag>ETD : Dissertation</tag>
             <tag>Remediated By : 4.20.1</tag>
@@ -628,7 +624,6 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             <objectCreator>DOR</objectCreator>
             <sourceId source="dissertationid">0000000296</sourceId>
             <otherId name="catkey">#{catkey}</otherId>
-            <agreementId>druid:ct692vv3660</agreementId>
             <release to="Searchworks" who="blalbrit" what="self" when="2017-02-07T11:07:41Z">true</release>
             <release to="Searchworks" who="blalbrit" what="self" when="2017-02-07T15:15:41Z">true</release>
             <otherId name="catkey">12303517</otherId>
@@ -707,7 +702,6 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             <otherId name="dissertationid">0000002905</otherId>
             <otherId name="catkey">#{catkey}</otherId>
             <otherId name="uuid">f8493238-61a8-11e3-922e-0050569b52d5</otherId>
-            <agreementId>druid:ct692vv3660</agreementId>
             <objectAdminClass>ETDs</objectAdminClass>
             <tag>ETD : Dissertation</tag>
             <tag>Remediated By : 4.17.1</tag>
@@ -725,7 +719,6 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             <objectCreator>DOR</objectCreator>
             <sourceId source="dissertationid">0000002905</sourceId>
             <otherId name="catkey">#{catkey}</otherId>
-            <agreementId>druid:ct692vv3660</agreementId>
             <release to="Searchworks" what="self" when="2017-02-07T10:01:59Z" who="blalbrit">true</release>
           </identityMetadata>
         XML
@@ -788,7 +781,6 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             <otherId name="dissertationid">0000006152</otherId>
             <otherId name="catkey">#{catkey}</otherId>
             <otherId name="uuid">2f3dc52e-7487-11e8-ae3a-005056a7d1e9</otherId>
-            <agreementId>druid:ct692vv3660</agreementId>
             <objectAdminClass>ETDs</objectAdminClass>
             <tag>ETD : Dissertation</tag>
             <release to="Searchworks" what="self" when="2018-10-19T17:37:18Z" who="arcadia">true</release>
@@ -805,7 +797,6 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             <objectCreator>DOR</objectCreator>
             <sourceId source="dissertationid">0000006152</sourceId>
             <otherId name="catkey">#{catkey}</otherId>
-            <agreementId>druid:ct692vv3660</agreementId>
             <release to="Searchworks" what="self" when="2018-10-19T17:37:18Z" who="arcadia">true</release>
           </identityMetadata>
         XML
@@ -1303,7 +1294,6 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             <objectType>item</objectType>
             <objectLabel>#{label}</objectLabel>
             <objectAdminClass>EEMs</objectAdminClass>
-            <agreementId>druid:fn200hb6598</agreementId>
             <tag>EEM : 1.0</tag>
             <otherId name="catkey">#{catkey}</otherId>
             <tag>Remediated By : 5.8.1</tag>
@@ -1323,7 +1313,6 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             <objectType>item</objectType>
             <objectLabel>#{label}</objectLabel>
             <objectCreator>DOR</objectCreator>
-            <agreementId>druid:fn200hb6598</agreementId>
             <otherId name="catkey">#{catkey}</otherId>
             <release to="Searchworks" what="self" when="2016-11-22T19:21:08Z" who="blalbrit">true</release>
             <release to="Searchworks" what="self" when="2016-11-22T21:35:46Z" who="blalbrit">true</release>

--- a/spec/services/cocina/normalizers/identity_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/identity_normalizer_spec.rb
@@ -204,7 +204,6 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
         <<~XML
           <identityMetadata>
             <objectId>foo</objectId>
-            <agreementId>druid:ct692vv3660</agreementId>
             <otherId name="catkey">666</otherId>
           </identityMetadata>
         XML

--- a/spec/services/sdr_ingest_service_spec.rb
+++ b/spec/services/sdr_ingest_service_spec.rb
@@ -6,7 +6,11 @@ require 'fileutils'
 RSpec.describe SdrIngestService do
   let(:fixtures) { Pathname(File.dirname(__FILE__)).join('../fixtures') }
   let(:export_dir) { Pathname(Settings.sdr.local_export_home) }
-  let(:fixture_sig_cat_obj) { Moab::SignatureCatalog.parse(File.open(fixtures.join('sdr_repo/dd116zh0343/v0001/manifests/signatureCatalog.xml')).read) }
+  let(:fixture_sig_cat_obj) do
+    Moab::SignatureCatalog.parse(
+      File.open(fixtures.join('sdr_repo/dd116zh0343/v0001/manifests/signatureCatalog.xml')).read
+    )
+  end
 
   before do
     allow(Settings.sdr).to receive_messages(local_workspace_root: fixtures.join('workspace').to_s,


### PR DESCRIPTION


## Why was this change made?

This property has been deprecated and keeping it around in fixtures is confusing

## How was this change tested?



## Which documentation and/or configurations were updated?



