### PR TITLE
Maps release tags from cocina to fedora.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,7 @@ Metrics/ClassLength:
     - 'app/services/cocina/from_fedora/descriptive/access.rb'
     - 'app/services/cocina/to_fedora/descriptive/related_resource.rb'
     - 'app/services/cocina/object_updater.rb'
+    - 'app/services/cocina/object_creator.rb'
 
 Performance/CollectionLiteralInLoop:
   Enabled: true

--- a/app/services/cocina/normalizers/identity_normalizer.rb
+++ b/app/services/cocina/normalizers/identity_normalizer.rb
@@ -31,6 +31,7 @@ module Cocina
         normalize_out_call_sequence_ids
         normalize_out_empty_other_ids
         normalize_source_id_whitespace
+        normalize_release_tags
 
         regenerate_ng_xml(ng_xml.to_xml)
       end
@@ -110,6 +111,13 @@ module Cocina
       def normalize_out_call_sequence_ids
         ng_xml.root.xpath('//otherId[@name="callseq"]').each(&:remove)
         ng_xml.root.xpath('//otherId[@name="shelfseq"]').each(&:remove)
+      end
+
+      def normalize_release_tags
+        ng_xml.root.xpath('//release').each do |release_node|
+          release_node.delete('displayType')
+          release_node.delete('release')
+        end
       end
     end
   end

--- a/app/services/cocina/to_fedora/identity.rb
+++ b/app/services/cocina/to_fedora/identity.rb
@@ -5,15 +5,52 @@ module Cocina
     # This transforms the cocina identification information to the Fedora 3 data model identityMetadata
     class Identity
       # @param [Dor::Item,Dor::Collection,Dor::Etd,Dor::AdminPolicyObject] fedora_object
+      def self.initialize_identity(fedora_object)
+        new(fedora_object).initialize_identity
+      end
+
+      # @param [Dor::Item,Dor::Collection,Dor::Etd,Dor::AdminPolicyObject] fedora_object
       # @param [String] label the label for the cocina object.
-      # @param [String] agreement_id (nil) the identifier for the agreement. Note that only apos and items may have an agreement.
-      def self.apply(fedora_object, label:, agreement_id: nil)
+      def self.apply_label(fedora_object, label:)
+        new(fedora_object).apply_label(label)
+      end
+
+      # @param [Dor::Item,Dor::Collection,Dor::Etd,Dor::AdminPolicyObject] fedora_object
+      # @param [Array<Cocina::Model::ReleaseTag>] release_tags for collections and items.
+      def self.apply_release_tags(fedora_object, release_tags:)
+        new(fedora_object).apply_release_tags(release_tags)
+      end
+
+      def initialize(fedora_object)
+        @fedora_object = fedora_object
+      end
+
+      def initialize_identity
         fedora_object.objectId = fedora_object.pid
         fedora_object.objectCreator = 'DOR'
-        # Label may have already been set when setting descriptive metadata.
-        fedora_object.objectLabel = label if fedora_object.objectLabel.empty?
         fedora_object.objectType = fedora_object.object_type # This comes from the class definition in dor-services
       end
+
+      def apply_label(label)
+        return unless fedora_object.objectLabel.empty?
+
+        fedora_object.objectLabel = label
+      end
+
+      def apply_release_tags(release_tags)
+        return if release_tags.blank?
+
+        release_tags.each do |release_tag|
+          attrs = release_tag.to_h
+          release = attrs.delete(:release)
+          attrs[:when] = attrs.delete(:date) || Time.now.utc.iso8601 # add the timestamp
+          fedora_object.identityMetadata.add_value(:release, release.to_s, attrs)
+        end
+      end
+
+      private
+
+      attr_reader :fedora_object
     end
   end
 end

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -562,10 +562,7 @@ RSpec.describe 'Update object' do
         expect(response.status).to eq 200
 
         # Identity metadata set correctly.
-        expect(item.objectId).to eq(druid)
-        expect(item.objectCreator.first).to eq('DOR')
         expect(item.objectLabel.first).to eq(expected_label)
-        expect(item.objectType.first).to eq('item')
       end
     end
 

--- a/spec/services/cocina/mapping/identification/agreement_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/agreement_identity_spec.rb
@@ -61,12 +61,14 @@ RSpec.shared_examples 'Agreement Object Identification Fedora Cocina mapping' do
                                           source_id: cocina_dro.identification.sourceId,
                                           catkey: Cocina::ObjectCreator.new.send(:catkey_for, cocina_dro),
                                           label: Cocina::ObjectCreator.new.send(:truncate_label, cocina_dro.label))
-    Cocina::ToFedora::Identity.apply(fedora_agreement, label: cocina_dro.label, agreement_id: cocina_dro.structural&.hasAgreement)
+    Cocina::ToFedora::Identity.initialize_identity(fedora_agreement)
+    Cocina::ToFedora::Identity.apply_label(fedora_agreement, label: cocina_dro.label)
     fedora_agreement.identityMetadata.barcode = cocina_dro.identification.barcode
     fedora_agreement
   end
   let(:mapped_roundtrip_identity_xml) do
-    Cocina::ToFedora::Identity.apply(roundtrip_fedora_agreement, label: mapped_cocina_props[:label])
+    Cocina::ToFedora::Identity.initialize_identity(roundtrip_fedora_agreement)
+    Cocina::ToFedora::Identity.apply_label(roundtrip_fedora_agreement, label: mapped_cocina_props[:label])
     roundtrip_fedora_agreement.identityMetadata.to_xml
   end
 

--- a/spec/services/cocina/mapping/identification/apo_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/apo_identity_spec.rb
@@ -76,7 +76,9 @@ RSpec.shared_examples 'APO Identification Fedora Cocina mapping' do
                                  label: mapped_cocina_props[:label])
     end
     let(:mapped_roundtrip_identity_xml) do
-      Cocina::ToFedora::Identity.apply(mapped_fedora_apo, label: mapped_cocina_props[:label], agreement_id: mapped_cocina_props[:agreement_object_id])
+      Cocina::ToFedora::Identity.initialize_identity(mapped_fedora_apo)
+      Cocina::ToFedora::Identity.apply_label(mapped_fedora_apo, label: mapped_cocina_props[:label])
+      Cocina::ToFedora::Identity.apply_release_tags(mapped_fedora_apo, release_tags: mapped_cocina_props.dig(:administrative, :releaseTags))
       mapped_fedora_apo.identityMetadata.to_xml
     end
 

--- a/spec/services/cocina/mapping/identification/collection_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/collection_identity_spec.rb
@@ -63,7 +63,9 @@ RSpec.shared_examples 'Collection Identification Fedora Cocina mapping' do
                         label: Cocina::ObjectCreator.new.send(:truncate_label, cocina_collection.label))
   end
   let(:mapped_roundtrip_identity_xml) do
-    Cocina::ToFedora::Identity.apply(mapped_fedora_collection, label: mapped_cocina_props[:label])
+    Cocina::ToFedora::Identity.initialize_identity(mapped_fedora_collection)
+    Cocina::ToFedora::Identity.apply_label(mapped_fedora_collection, label: mapped_cocina_props[:label])
+    Cocina::ToFedora::Identity.apply_release_tags(mapped_fedora_collection, release_tags: mapped_cocina_props.dig(:administrative, :releaseTags))
     mapped_fedora_collection.identityMetadata.to_xml
   end
 
@@ -174,8 +176,7 @@ RSpec.describe 'Fedora Collection identityMetadata <--> Cocina Collection Identi
 
   describe 'Hydrus collection' do
     context 'with release tags' do
-      # it_behaves_like 'Collection Identification Fedora Cocina mapping' do
-      xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+      it_behaves_like 'Collection Identification Fedora Cocina mapping' do
         let(:collection_id) { 'druid:ds247vz0452' }
         let(:label) { 'Undergraduate Theses, Department of Physics' }
         let(:admin_policy_id) { 'druid:dx569vq3421' } # from RELS-EXT
@@ -199,7 +200,7 @@ RSpec.describe 'Fedora Collection identityMetadata <--> Cocina Collection Identi
               <release displayType="file" release="true" to="Searchworks" what="self" when="2015-10-25T21:12:42Z" who="blalbrit">true</release>
               <tag>Remediated By : 4.22.3</tag>
               <displayType>file</displayType>
-              <release displayType="file" release="true" to="Searchworks" what="self" when="2016-07-15T23:44:01Z" who="blalbrit">true</release>
+              <release displayType="file" release="false" to="Searchworks" what="self" when="2016-07-15T23:44:01Z" who="blalbrit">false</release>
             </identityMetadata>
           XML
         end
@@ -211,9 +212,9 @@ RSpec.describe 'Fedora Collection identityMetadata <--> Cocina Collection Identi
               <objectCreator>DOR</objectCreator>
               <objectLabel>#{label}</objectLabel>
               <objectType>collection</objectType>
-              <release displayType="file" release="true" to="Searchworks" what="self" when="2015-07-27T18:43:32Z" who="lauraw15">true</release>
-              <release displayType="file" release="true" to="Searchworks" what="self" when="2015-10-25T21:12:42Z" who="blalbrit">true</release>
-              <release displayType="file" release="true" to="Searchworks" what="self" when="2016-07-15T23:44:01Z" who="blalbrit">true</release>
+              <release to="Searchworks" what="self" when="2015-07-27T18:43:32Z" who="lauraw15">true</release>
+              <release to="Searchworks" what="self" when="2015-10-25T21:12:42Z" who="blalbrit">true</release>
+              <release to="Searchworks" what="self" when="2016-07-15T23:44:01Z" who="blalbrit">false</release>
             </identityMetadata>
           XML
         end
@@ -249,7 +250,7 @@ RSpec.describe 'Fedora Collection identityMetadata <--> Cocina Collection Identi
                   what: 'self',
                   date: '2016-07-15T23:44:01Z',
                   who: 'blalbrit',
-                  release: true
+                  release: false
                 }
               ]
             },
@@ -368,8 +369,7 @@ RSpec.describe 'Fedora Collection identityMetadata <--> Cocina Collection Identi
     end
 
     context 'with ckey and release tags' do
-      # it_behaves_like 'Collection Identification Fedora Cocina mapping' do
-      xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+      it_behaves_like 'Collection Identification Fedora Cocina mapping' do
         let(:collection_id) { 'druid:bc225xg9715' }
         let(:label) { 'Generation Anthropocene' }
         let(:admin_policy_id) { 'druid:yp636tj5357' } # from RELS-EXT
@@ -402,7 +402,7 @@ RSpec.describe 'Fedora Collection identityMetadata <--> Cocina Collection Identi
               <objectCreator>DOR</objectCreator>
               <objectLabel>#{label}</objectLabel>
               <objectType>collection</objectType>
-              <release displayType="file" release="true" to="Searchworks" what="self" when="2016-10-03T21:55:25Z" who="blalbrit">true</release>
+              <release to="Searchworks" what="self" when="2016-10-03T21:55:25Z" who="blalbrit">true</release>
             </identityMetadata>
           XML
         end
@@ -436,8 +436,7 @@ RSpec.describe 'Fedora Collection identityMetadata <--> Cocina Collection Identi
   end
 
   context 'with non-hydrus collection with catkey and uuid' do
-    # it_behaves_like 'Collection Identification Fedora Cocina mapping' do
-    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+    it_behaves_like 'Collection Identification Fedora Cocina mapping' do
       let(:collection_id) { 'druid:dj477pz3643' }
       let(:label) { 'Casa Zapata murals collection, 1984-1995' }
       let(:admin_policy_id) { 'druid:yf767bj4831' } # from RELS-EXT

--- a/spec/services/cocina/mapping/identification/dro_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/dro_identity_spec.rb
@@ -67,7 +67,9 @@ RSpec.shared_examples 'DRO Identification Fedora Cocina mapping' do
                                 source_id: cocina_dro.identification.sourceId,
                                 catkey: Cocina::ObjectCreator.new.send(:catkey_for, cocina_dro),
                                 label: Cocina::ObjectCreator.new.send(:truncate_label, cocina_dro.label))
-    Cocina::ToFedora::Identity.apply(fedora_item, label: cocina_dro.label, agreement_id: cocina_dro.structural&.hasAgreement)
+    Cocina::ToFedora::Identity.initialize_identity(fedora_item)
+    Cocina::ToFedora::Identity.apply_label(fedora_item, label: cocina_dro.label)
+    Cocina::ToFedora::Identity.apply_release_tags(fedora_item, release_tags: mapped_cocina_props.dig(:administrative, :releaseTags))
     fedora_item.identityMetadata.barcode = cocina_dro.identification.barcode
     fedora_item
   end
@@ -84,7 +86,7 @@ RSpec.shared_examples 'DRO Identification Fedora Cocina mapping' do
 
   context 'when mapping from Cocina to (roundtrip) Fedora' do
     before do
-      Cocina::ToFedora::Identity.apply(roundtrip_fedora_item, label: mapped_cocina_props[:label])
+      Cocina::ToFedora::Identity.apply_label(roundtrip_fedora_item, label: mapped_cocina_props[:label])
     end
 
     it 'identityMetadata roundtrips thru cocina model to expected roundtrip identityMetadata.xml' do
@@ -106,7 +108,7 @@ RSpec.shared_examples 'DRO Identification Fedora Cocina mapping' do
       catalog_link[:catalogRecordId] if catalog_link
     end
     let(:mapped_roundtrip_identity_xml) do
-      Cocina::ToFedora::Identity.apply(roundtrip_fedora_item, label: mapped_cocina_props[:label])
+      Cocina::ToFedora::Identity.apply_label(roundtrip_fedora_item, label: mapped_cocina_props[:label])
       roundtrip_fedora_item.identityMetadata.to_xml
     end
     let(:roundtrip_namespaced_other_ids) do
@@ -144,6 +146,7 @@ RSpec.shared_examples 'DRO Identification Fedora Cocina mapping' do
 
     before do
       allow(roundtrip_fedora_item_mock).to receive(:is_a?).with(Dor::Agreement).and_return(false)
+      # allow(roundtrip_fedora_item_mock).to receive(:is_a?).with(Dor::Collection).and_return(false)
       allow(roundtrip_fedora_item_mock).to receive(:is_a?).with(Dor::Item).and_return(true)
     end
 
@@ -181,6 +184,7 @@ RSpec.shared_examples 'DRO Identification Fedora Cocina mapping' do
 
     before do
       allow(normalized_orig_fedora_item_mock).to receive(:is_a?).with(Dor::Agreement).and_return(false)
+      allow(normalized_orig_fedora_item_mock).to receive(:is_a?).with(Dor::Collection).and_return(false)
       allow(normalized_orig_fedora_item_mock).to receive(:is_a?).with(Dor::Item).and_return(true)
     end
 
@@ -361,8 +365,7 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
   end
 
   context 'with googlebooks item (with release tags)' do
-    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
-    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
       let(:item_id) { 'druid:bb000jd2736' }
       let(:label) { 'The life of Goethe' }
       let(:catkey) { '2003938' }
@@ -504,13 +507,14 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
   end
 
   context 'with early ETD, empty objectLabel, no sourceID ... (with release tags)' do
-    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
-    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
       let(:item_id) { 'druid:px901zd6069' }
       let(:label) { '' }
       let(:catkey) { '8537171' }
       let(:admin_policy_id) { 'druid:bx911tp9024' } # from RELS-EXT
       let(:collection_ids) { [] } # not in RELS-EXT
+      let(:source_id) { '0000000001' }
+      let(:source_id_source) { 'dissertationid' }
       let(:identity_metadata_xml) do
         <<~XML
           <identityMetadata>
@@ -542,7 +546,6 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             <objectCreator>DOR</objectCreator>
             <sourceId source="dissertationid">0000000001</sourceId>
             <otherId name="catkey">#{catkey}</otherId>
-            <agreementId>druid:ct692vv3660</agreementId>
             <release to="Searchworks" what="self" when="2017-02-07T10:45:17Z" who="blalbrit">true</release>
           </identityMetadata>
         XML
@@ -574,12 +577,7 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
               }
             ]
           },
-          structural: {
-            hasAgreement: 'druid:ct692vv3660'
-            # isMemberOf: [
-            #   nil
-            # ]
-          },
+          structural: {},
           access: access_props,
           description: description_props
         }
@@ -589,7 +587,7 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
 
   context 'with ETD with 2 catkeys' do
     # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
-    xit 'to be implemented: what to do with 2 catkeys; release tags need to roundtrip back into identityMetadata.xml' do
+    xit 'to be implemented: what to do with 2 catkeys' do
       let(:item_id) { 'druid:zw844wz5427' }
       let(:label) { '' }
       let(:catkey) { '8652337' }
@@ -688,13 +686,14 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
   end
 
   context 'with ETD with empty citation elements' do
-    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
-    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
       let(:item_id) { 'druid:mr401cc4586' }
       let(:label) { '' }
       let(:catkey) { '10327542' }
       let(:admin_policy_id) { 'druid:bx911tp9024' } # from RELS-EXT
       let(:collection_ids) { [] } # not in RELS-EXT
+      let(:source_id) { '0000002905' }
+      let(:source_id_source) { 'dissertationid' }
       let(:identity_metadata_xml) do
         <<~XML
           <identityMetadata>
@@ -725,7 +724,6 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             <objectCreator>DOR</objectCreator>
             <sourceId source="dissertationid">0000002905</sourceId>
             <otherId name="catkey">#{catkey}</otherId>
-            <agreementId>druid:ct692vv3660</agreementId>
             <release to="Searchworks" what="self" when="2017-02-07T10:01:59Z" who="blalbrit">true</release>
           </identityMetadata>
         XML
@@ -757,12 +755,7 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
               }
             ]
           },
-          structural: {
-            hasAgreement: 'druid:ct692vv3660'
-            # isMemberOf: [
-            #   nil
-            # ]
-          },
+          structural: {},
           access: access_props,
           description: description_props
         }
@@ -771,13 +764,14 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
   end
 
   context 'with ETD without citation elements' do
-    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
-    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
       let(:item_id) { 'druid:xs522rn2310' }
       let(:label) { '' }
       let(:catkey) { '12684953' }
       let(:admin_policy_id) { 'druid:bx911tp9024' } # from RELS-EXT
       let(:collection_ids) { [] } # not in RELS-EXT
+      let(:source_id) { '0000006152' }
+      let(:source_id_source) { 'dissertationid' }
       let(:identity_metadata_xml) do
         <<~XML
           <identityMetadata>
@@ -805,7 +799,6 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             <objectCreator>DOR</objectCreator>
             <sourceId source="dissertationid">0000006152</sourceId>
             <otherId name="catkey">#{catkey}</otherId>
-            <agreementId>druid:ct692vv3660</agreementId>
             <release to="Searchworks" what="self" when="2018-10-19T17:37:18Z" who="arcadia">true</release>
           </identityMetadata>
         XML
@@ -838,12 +831,7 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
               }
             ]
           },
-          structural: {
-            hasAgreement: 'druid:ct692vv3660'
-            # isMemberOf: [
-            #   nil
-            # ]
-          },
+          structural: {},
           access: access_props,
           description: description_props
         }
@@ -1031,8 +1019,7 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
   end
 
   context 'with displayType (Hydrus item)' do
-    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
-    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
       let(:item_id) { 'druid:gj077jb7878' }
       let(:label) { 'Open Science Perspective' }
       let(:admin_policy_id) { 'druid:sn486kf1487' } # from RELS-EXT
@@ -1064,7 +1051,7 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             <objectCreator>DOR</objectCreator>
             <objectLabel>#{label}</objectLabel>
             <objectType>item</objectType>
-            <release displayType="file" release="true" to="Searchworks" what="self" when="2015-10-25T21:29:13Z" who="blalbrit">true</release>
+            <release to="Searchworks" what="self" when="2015-10-25T21:29:13Z" who="blalbrit">true</release>
           </identityMetadata>
         XML
       end
@@ -1100,8 +1087,7 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
   end
 
   context 'with web archive seed (old)' do
-    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
-    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
       let(:item_id) { 'druid:bj731rx4986' }
       let(:label) { 'http://nippongenkikai.jp/' }
       let(:admin_policy_id) { 'druid:xt299pt7593' } # from RELS-EXT
@@ -1175,8 +1161,7 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
   end
 
   context 'with web archive seed (new)' do
-    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
-    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
       let(:item_id) { 'druid:bb143kr5856' }
       let(:label) { 'http://cheme.stanford.edu/' }
       let(:admin_policy_id) { 'druid:xt299pt7593' } # from RELS-EXT
@@ -1288,7 +1273,7 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
 
   context 'with objectAdminClass (EEMS) and same catkey twice, no collection' do
     # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
-    xit 'to be implemented: release tags need to roundtrip back into identityMetadata.xml' do
+    xit 'to be implemented: what to do with 2 catkeys' do
       let(:item_id) { 'druid:bb029vy9696' }
       let(:label) { 'EEMs: Finite State Continuous-Time Markov Decision Processes with Applications to a Class of Optimization Problems in Queueing Theory' }
       let(:catkey) { '10208128' }

--- a/spec/services/cocina/object_updater_spec.rb
+++ b/spec/services/cocina/object_updater_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Cocina::ObjectUpdater do
     context 'when updating label' do
       before do
         allow(item).to receive(:label=)
-        allow(Cocina::ToFedora::Identity).to receive(:apply)
+        allow(Cocina::ToFedora::Identity).to receive(:apply_label)
       end
 
       context 'when label has changed' do
@@ -70,7 +70,7 @@ RSpec.describe Cocina::ObjectUpdater do
         it 'updates label' do
           update
           expect(item).to have_received(:label=).with('new label')
-          expect(Cocina::ToFedora::Identity).to have_received(:apply)
+          expect(Cocina::ToFedora::Identity).to have_received(:apply_label)
         end
       end
 
@@ -78,7 +78,7 @@ RSpec.describe Cocina::ObjectUpdater do
         it 'does not update label' do
           update
           expect(item).not_to have_received(:label=)
-          expect(Cocina::ToFedora::Identity).not_to have_received(:apply)
+          expect(Cocina::ToFedora::Identity).not_to have_received(:apply_label)
         end
       end
     end
@@ -328,13 +328,13 @@ RSpec.describe Cocina::ObjectUpdater do
 
       before do
         allow(item).to receive(:label=)
-        allow(Cocina::ToFedora::Identity).to receive(:apply)
+        allow(Cocina::ToFedora::Identity).to receive(:apply_label)
       end
 
       it 'updates label' do
         update
         expect(item).to have_received(:label=).with('new label')
-        expect(Cocina::ToFedora::Identity).to have_received(:apply)
+        expect(Cocina::ToFedora::Identity).to have_received(:apply_label)
       end
     end
 
@@ -446,7 +446,6 @@ RSpec.describe Cocina::ObjectUpdater do
           instance_double(Dor::RightsMetadataDS, ng_xml_will_change!: nil)
         )
         allow(content_metadata).to receive(:contentType=)
-        allow(Cocina::ToFedora::Identity).to receive(:apply)
         allow(AdministrativeTags).to receive(:create)
         allow(content_metadata).to receive(:ng_xml)
         allow(Cocina::ToFedora::DROAccess).to receive(:apply)
@@ -467,7 +466,6 @@ RSpec.describe Cocina::ObjectUpdater do
           expect(item).to have_received(:collection_ids=)
           expect(content_metadata).to have_received(:contentType=)
           expect(content_metadata).not_to have_received(:ng_xml)
-          expect(Cocina::ToFedora::Identity).to have_received(:apply)
           expect(AdministrativeTags).to have_received(:create)
           expect(Cocina::ToFedora::DROAccess).to have_received(:apply)
         end
@@ -478,7 +476,6 @@ RSpec.describe Cocina::ObjectUpdater do
           update
           expect(item).not_to have_received(:collection_ids=)
           expect(content_metadata).not_to have_received(:contentType=)
-          expect(Cocina::ToFedora::Identity).not_to have_received(:apply)
           expect(AdministrativeTags).not_to have_received(:create)
           expect(Cocina::ToFedora::DROAccess).not_to have_received(:apply)
         end
@@ -494,7 +491,6 @@ RSpec.describe Cocina::ObjectUpdater do
         allow(content_metadata).to receive(:content=)
         allow(content_metadata).to receive(:contentType=)
         allow(content_metadata).to receive(:ng_xml)
-        allow(Cocina::ToFedora::Identity).to receive(:apply)
         allow(AdministrativeTags).to receive(:create)
         allow(Cocina::ToFedora::DROAccess).to receive(:apply)
       end
@@ -513,7 +509,6 @@ RSpec.describe Cocina::ObjectUpdater do
         expect(content_metadata).to have_received(:content=)
         expect(content_metadata).not_to have_received(:contentType=)
         expect(content_metadata).not_to have_received(:ng_xml)
-        expect(Cocina::ToFedora::Identity).to have_received(:apply)
         expect(AdministrativeTags).to have_received(:create)
         expect(Cocina::ToFedora::DROAccess).to have_received(:apply)
       end
@@ -624,7 +619,7 @@ RSpec.describe Cocina::ObjectUpdater do
       allow(item).to receive(:catkey=)
       allow(item).to receive(:collection_ids=)
       allow(item).to receive(:save!)
-      allow(Cocina::ToFedora::Identity).to receive(:apply)
+      allow(Cocina::ToFedora::Identity).to receive(:apply_label)
       allow(desc_metadata).to receive(:content=)
       allow(desc_metadata).to receive(:content_will_change!)
       allow(Cocina::ToFedora::Descriptive).to receive(:transform).and_return(Nokogiri::XML::Builder.new)
@@ -633,7 +628,6 @@ RSpec.describe Cocina::ObjectUpdater do
       allow(content_metadata).to receive(:ng_xml).and_return(content_metadata_ng_xml)
       allow(content_metadata_ng_xml).to receive(:xpath).and_return([book_data_node])
       allow(book_data_node).to receive(:remove)
-      allow(Cocina::ToFedora::Identity).to receive(:apply)
       allow(Cocina::ToFedora::DROAccess).to receive(:apply)
       allow(identity_metadata).to receive(:barcode=)
     end
@@ -649,14 +643,13 @@ RSpec.describe Cocina::ObjectUpdater do
       expect(item).to have_received(:source_id=)
       expect(item).to have_received(:catkey=)
       expect(item).to have_received(:collection_ids=)
-      expect(Cocina::ToFedora::Identity).to have_received(:apply)
+      expect(Cocina::ToFedora::Identity).to have_received(:apply_label)
       expect(desc_metadata).to have_received(:content=)
       expect(desc_metadata).to have_received(:content_will_change!)
       expect(Cocina::ToFedora::Descriptive).to have_received(:transform)
       expect(content_metadata).to have_received(:contentType=)
       allow(content_metadata).to receive(:ng_xml).and_return(content_metadata_ng_xml)
       allow(content_metadata_ng_xml).to receive(:xpath).and_return([book_data_node])
-      expect(Cocina::ToFedora::Identity).to have_received(:apply)
       expect(Cocina::ToFedora::DROAccess).to have_received(:apply)
       expect(identity_metadata).to have_received(:barcode=)
     end


### PR DESCRIPTION
closes #2834

## Why was this change made?
Complete roundtrip mapping.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


