### PR TITLE
Allow the purl base to be configured

### DIFF
--- a/app/services/cocina/add_purl_to_description.rb
+++ b/app/services/cocina/add_purl_to_description.rb
@@ -10,17 +10,12 @@ module Cocina
 
       notes = description.note.map do |note|
         if note.type == 'preferred citation'
-          note.new(value: note.value.gsub(/:link:/, purl_link(pid)))
+          note.new(value: note.value.gsub(/:link:/, Purl.for(druid: pid)))
         else
           note
         end
       end
       description.new(note: notes)
     end
-
-    def self.purl_link(pid)
-      "#{Settings.release.purl_base_url}/#{pid.delete_prefix('druid:')}"
-    end
-    private_class_method :purl_link
   end
 end

--- a/app/services/cocina/from_fedora/descriptive.rb
+++ b/app/services/cocina/from_fedora/descriptive.rb
@@ -32,7 +32,7 @@ module Cocina
         DescriptiveBuilder.build(title_builder: title_builder,
                                  resource_element: ng_xml.root,
                                  notifier: notifier,
-                                 purl: druid ? Purl.purl_for(druid) : nil)
+                                 purl: druid ? ::Purl.for(druid: druid) : nil)
       end
 
       private
@@ -73,10 +73,6 @@ module Cocina
       end
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/PerceivedComplexity
-
-      def purl
-        "http://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
-      end
 
       def check_version
         match = /MODS version (\d\.\d)/.match(ng_xml.root.at('//mods:recordInfo/mods:recordOrigin', mods: DESC_METADATA_NS)&.content)

--- a/app/services/cocina/from_fedora/descriptive/access.rb
+++ b/app/services/cocina/from_fedora/descriptive/access.rb
@@ -115,7 +115,7 @@ module Cocina
         end
 
         def primary_purl_node
-          @primary_purl_node ||= Purl.primary_purl_node(resource_element, purl)
+          @primary_purl_node ||= Descriptive::Purl.primary_purl_node(resource_element, purl)
         end
 
         def url_nodes

--- a/app/services/cocina/from_fedora/descriptive/descriptive_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/descriptive_builder.rb
@@ -41,7 +41,7 @@ module Cocina
           title_result = @title_builder.build(resource_element: resource_element, require_title: require_title, notifier: notifier)
           cocina_description[:title] = title_result if title_result.present?
 
-          purl_value = purl || Purl.primary_purl_node(resource_element, purl)&.content&.presence
+          purl_value = purl || Descriptive::Purl.primary_purl_node(resource_element, purl)&.content&.presence
           cocina_description[:purl] = purl_value if purl_value
 
           BUILDERS.each do |descriptive_property, builder|

--- a/app/services/cocina/from_fedora/descriptive/purl.rb
+++ b/app/services/cocina/from_fedora/descriptive/purl.rb
@@ -39,12 +39,6 @@ module Cocina
           end
           notes
         end
-
-        def self.purl_for(druid)
-          return nil if druid.nil?
-
-          "http://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
-        end
       end
     end
   end

--- a/app/services/cocina/from_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/from_fedora/descriptive/related_resource.rb
@@ -83,7 +83,7 @@ module Cocina
         end
 
         def related_purls
-          primary_purl_node = Purl.primary_purl_node(resource_element, purl)
+          primary_purl_node = Descriptive::Purl.primary_purl_node(resource_element, purl)
           purl_nodes = resource_element.xpath('mods:location/mods:url', mods: DESC_METADATA_NS).select { |url_node| Purl.purl?(url_node) && url_node != primary_purl_node }
           purl_nodes.map do |purl_node|
             {

--- a/app/services/cocina/normalizers/mods_normalizer.rb
+++ b/app/services/cocina/normalizers/mods_normalizer.rb
@@ -103,7 +103,7 @@ module Cocina
       end
 
       def normalize_purl
-        normalize_purl_for(ng_xml.root, purl: Cocina::FromFedora::Descriptive::Purl.purl_for(druid))
+        normalize_purl_for(ng_xml.root, purl: Purl.for(druid: druid))
         ng_xml.root.xpath('mods:relatedItem', mods: MODS_NS).each { |related_item_node| normalize_purl_for(related_item_node) }
       end
 

--- a/app/services/purl.rb
+++ b/app/services/purl.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Utility methods for generating purl links
+class Purl
+  def self.for(druid:)
+    return nil if druid.nil?
+
+    "#{Settings.release.purl_base_url}/#{druid.delete_prefix('druid:')}"
+  end
+end


### PR DESCRIPTION


## Why was this change made?

This allows us to accept items in test where the purl link is https://purl-test.stanford.edu and not get a roundtripping error.

Ref https://app.honeybadger.io/projects/50568/faults/79355918

## How was this change tested?



## Which documentation and/or configurations were updated?



