### PR TITLE
Test for purlness of urls by using the configured base url

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/access.rb
+++ b/app/services/cocina/from_fedora/descriptive/access.rb
@@ -107,7 +107,7 @@ module Cocina
         end
 
         def all_purl_nodes
-          @all_purl_nodes ||= all_url_nodes.select { |url_node| Purl.purl?(url_node) }
+          @all_purl_nodes ||= all_url_nodes.select { |url_node| ::Purl.purl?(url_node.text) }
         end
 
         def all_url_nodes
@@ -119,7 +119,7 @@ module Cocina
         end
 
         def url_nodes
-          @url_nodes ||= all_url_nodes.reject { |url_node| Purl.purl?(url_node) }
+          @url_nodes ||= all_url_nodes.reject { |url_node| ::Purl.purl?(url_node.text) }
         end
 
         def purl_note

--- a/app/services/cocina/from_fedora/descriptive/purl.rb
+++ b/app/services/cocina/from_fedora/descriptive/purl.rb
@@ -5,14 +5,8 @@ module Cocina
     class Descriptive
       # Support for PURLs.
       class Purl
-        PURL_REGEX = %r{^https?://purl.stanford.edu/}.freeze
-
-        def self.purl?(node)
-          PURL_REGEX.match(node.text)
-        end
-
         def self.primary_purl_node(resource_element, purl)
-          purl_nodes = resource_element.xpath('mods:location/mods:url', mods: DESC_METADATA_NS).select { |url_node| purl?(url_node) }
+          purl_nodes = resource_element.xpath('mods:location/mods:url', mods: DESC_METADATA_NS).select { |url_node| ::Purl.purl?(url_node.text) }
 
           return purl_nodes.find { |purl_node| purl_node.content == purl } if purl
 

--- a/app/services/cocina/from_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/from_fedora/descriptive/related_resource.rb
@@ -84,7 +84,7 @@ module Cocina
 
         def related_purls
           primary_purl_node = Descriptive::Purl.primary_purl_node(resource_element, purl)
-          purl_nodes = resource_element.xpath('mods:location/mods:url', mods: DESC_METADATA_NS).select { |url_node| Purl.purl?(url_node) && url_node != primary_purl_node }
+          purl_nodes = resource_element.xpath('mods:location/mods:url', mods: DESC_METADATA_NS).select { |url_node| ::Purl.purl?(url_node.text) && url_node != primary_purl_node }
           purl_nodes.map do |purl_node|
             {
               purl: purl_node.content,

--- a/app/services/cocina/normalizers/mods_normalizer.rb
+++ b/app/services/cocina/normalizers/mods_normalizer.rb
@@ -140,14 +140,14 @@ module Cocina
       end
 
       def purl_nodes(base_node)
-        base_node.xpath('mods:location/mods:url', mods: MODS_NS).select { |url_node| Cocina::FromFedora::Descriptive::Purl.purl?(url_node) }
+        base_node.xpath('mods:location/mods:url', mods: MODS_NS).select { |url_node| ::Purl.purl?(url_node.text) }
       end
 
       def primary_url_node_for(base_node, purl)
         primary_purl_nodes, primary_url_nodes = base_node.xpath('mods:location/mods:url[@usage="primary display"]', mods: MODS_NS)
-                                                         .partition { |url_node| Cocina::FromFedora::Descriptive::Purl.purl?(url_node) }
+                                                         .partition { |url_node| ::Purl.purl?(url_node.text) }
         all_purl_nodes = base_node.xpath('mods:location/mods:url', mods: MODS_NS)
-                                  .select { |url_node| Cocina::FromFedora::Descriptive::Purl.purl?(url_node) }
+                                  .select { |url_node| ::Purl.purl?(url_node.text) }
 
         this_purl_node = purl ? all_purl_nodes.find { |purl_node| purl_node.content == purl } : nil
 

--- a/app/services/purl.rb
+++ b/app/services/purl.rb
@@ -5,6 +5,19 @@ class Purl
   def self.for(druid:)
     return nil if druid.nil?
 
-    "#{Settings.release.purl_base_url}/#{druid.delete_prefix('druid:')}"
+    "#{base_url}/#{druid.delete_prefix('druid:')}"
+  end
+
+  def self.purl?(node)
+    node.start_with?("https://#{host}") || node.start_with?("http://#{host}")
+  end
+
+  # the purl without the protocol part
+  def self.host
+    @host ||= base_url.sub(%r{^https?://}, '')
+  end
+
+  def self.base_url
+    Settings.release.purl_base_url
   end
 end


### PR DESCRIPTION

## Why was this change made?

previously it was using a hardcoded regex, which works for production, but not for staging. It was causing the h2 object that were reaccessioned to fail round trip testing


## How was this change tested?



## Which documentation and/or configurations were updated?



