### PR TITLE
Move the unpublish method to the class

### DIFF
--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -2,7 +2,7 @@
 
 # Unpublishes Druid from PURL
 class UnpublishService
-  def unpublish(druid:)
+  def self.unpublish(druid:)
     raise 'You have not configured purl-fetcher (Settings.purl_services_url).' unless Settings.purl_services_url
 
     id = druid.gsub(/^druid:/, '')

--- a/spec/services/unpublish_service_spec.rb
+++ b/spec/services/unpublish_service_spec.rb
@@ -3,8 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe UnpublishService do
-  let(:instance) { described_class.new }
-
   describe '#unpublish' do
     context 'with an object' do
       let(:druid) { 'druid:ab123cd4567' }
@@ -16,7 +14,7 @@ RSpec.describe UnpublishService do
       end
 
       it 'removes from purl' do
-        instance.unpublish(druid: druid)
+        described_class.unpublish(druid: druid)
         expect(WebMock).to have_requested(:delete, 'example.com/purl/purls/ab123cd4567')
       end
     end


### PR DESCRIPTION


## Why was this change made?
This prevents a NoMethodError when called from UnpublishJob
Fixes #2853

## How was this change tested?



## Which documentation and/or configurations were updated?



