### PR TITLE
EventsController: return event list sorted by creation date (newest first)

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,6 +9,6 @@ class EventsController < ApplicationController
   end
 
   def index
-    @events = Event.where(druid: params[:object_id])
+    @events = Event.where(druid: params[:object_id]).order(created_at: :desc)
   end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :event do
+    druid { 'druid:xz456jk0987' }
+    event_type { 'important_action_completed' }
+    data { { other: 'useful info specific to the event/occurrence' } }
+  end
+end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -32,5 +32,21 @@ RSpec.describe 'Add and retrieve events' do
       expect(json[0]['data']).to eq('description' => 'stuff', 'size' => 1900)
       expect(json[0]).to have_key 'created_at'
     end
+
+    context 'when there are multiple events' do
+      before do
+        create(:event, druid: druid, event_type: 'publish')
+        create(:event, druid: druid, event_type: 'unpublish')
+      end
+
+      it 'returns events in chronological order, newest first' do
+        get "/v1/objects/#{druid}/events",
+            headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json[0]['event_type']).to eq 'unpublish'
+        expect(json[1]['event_type']).to eq 'publish'
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?

I got confused when i went looking for a replication event on a test object that I'd versioned this morning, and the newest event seemed to be 26 days old.  Turns out the latest events were at the bottom, so i figured there was a SQL query that might need an `order by`.

I guess the consumer of the list could sort it (Argo for example just displays the list in the order it comes back, AFAICT).  But this seems like a fine deterministic default for most consumers, and it was slightly easier to make and test this change here, so I went ahead and sorted in DSA.

Compare this random QA object to this random prod object:

<img width="903" alt="Screen Shot 2021-05-24 at 7 28 16 PM" src="https://user-images.githubusercontent.com/7741604/119433382-f84acf00-bcca-11eb-876c-8aa0f85f678b.png">
<img width="948" alt="Screen Shot 2021-05-24 at 7 28 30 PM" src="https://user-images.githubusercontent.com/7741604/119433384-f8e36580-bcca-11eb-8b2f-dace2c98a3f0.png">
<img width="854" alt="Screen Shot 2021-05-24 at 7 55 15 PM" src="https://user-images.githubusercontent.com/7741604/119433458-24665000-bccb-11eb-8dfe-e8059ef92bb3.png">
<img width="689" alt="Screen Shot 2021-05-24 at 8 03 17 PM" src="https://user-images.githubusercontent.com/7741604/119433461-24fee680-bccb-11eb-818f-3da2867fad89.png">


I suspect we mostly get a consistent sort by chance, because SQL results often return in creation order if no other order is specified (but of course, that's not guaranteed).

## How was this change tested?



## Which documentation and/or configurations were updated?



