### PR TITLE
Add missing xlink namespace on publish

### DIFF
--- a/app/services/publish/access_conditions.rb
+++ b/app/services/publish/access_conditions.rb
@@ -55,6 +55,13 @@ module Publish
     def add_license
       return unless license?
 
+      # Add the xlink namespace in case it doesn't exist.  Many items that were
+      # Registered via dor-services-app do not because this namespace was not
+      # configured here:
+      # https://github.com/sul-dlss/dor-services/blob/ef7cd8c8d787e4b9781e5d00282d1d112d0e1f4f/lib/dor/datastreams/desc_metadata_ds.rb#L9-L14
+      # We use this namespace when we add accessCondition
+      public_mods.root.add_namespace_definition 'xlink', 'http://www.w3.org/1999/xlink'
+
       last_element.add_next_sibling public_mods.create_element('accessCondition', license.description,
                                                                type: 'license', 'xlink:href' => license_url)
     end

--- a/spec/services/publish/public_desc_metadata_service_spec.rb
+++ b/spec/services/publish/public_desc_metadata_service_spec.rb
@@ -223,7 +223,25 @@ RSpec.describe Publish::PublicDescMetadataService do
     it 'adds license accessCondtitions based on creativeCommons or openDataCommons statements' do
       expect(public_mods.xpath('//mods:accessCondition[@type="license"]').size).to eq 1
       expect(license_node.text).to match(/by-nc: Attribution-NonCommercial 3.0 Unported/)
+      expect(public_mods.root.namespaces).to include('xmlns:xlink')
       expect(license_node['xlink:href']).to eq 'https://creativecommons.org/licenses/by-nc/3.0/legalcode'
+    end
+
+    context 'when source MODS does not have xlink namespace' do
+      let(:mods) do
+        <<~XML
+          <mods:mods xmlns:mods="http://www.loc.gov/mods/v3">
+            <mods:titleInfo>
+                <mods:title type="main">Slides, IA, Geodesic Domes [1 of 2]</mods:title>
+            </mods:titleInfo>
+          </mods:mods>
+        XML
+      end
+
+      it 'adds license accessCondtitions based on creativeCommons or openDataCommons statements' do
+        expect(public_mods.root.namespaces).to include('xmlns:xlink')
+        expect(license_node['xlink:href']).to eq 'https://creativecommons.org/licenses/by-nc/3.0/legalcode'
+      end
     end
 
     context 'when a license node is present in rightsMetadata' do


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



