### PR TITLE
Publish a RabbitMQ message when an embargo is lifted on an object

### DIFF
--- a/app/services/notifications/embargo_lifted.rb
+++ b/app/services/notifications/embargo_lifted.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Notifications
+  # Send a message to a RabbitMQ exchange that an embargo has been removed from an item.
+  # The primary use case here is that h2 needs to log a message when this happens
+  class EmbargoLifted
+    def self.publish(model:)
+      Rails.logger.debug "Publishing Rabbitmq Message for embargo #{model.externalIdentifier}"
+      new(model: model, channel: RabbitChannel.instance).publish
+      Rails.logger.debug "Published Rabbitmq Message for embargo #{model.externalIdentifier}"
+    end
+
+    def initialize(model:, channel:)
+      @model = model
+      @channel = channel
+    end
+
+    def publish
+      message = { model: model.to_h }
+      exchange.publish(message.to_json, routing_key: routing_key)
+    end
+
+    private
+
+    attr_reader :model, :channel
+
+    def exchange
+      channel.topic('sdr.objects.embargo_lifted')
+    end
+
+    # Using the project as a routing key because listeners may only care about their projects.
+    def routing_key
+      model.is_a?(Cocina::Models::AdminPolicy) ? 'SDR' : model.administrative.partOfProject
+    end
+  end
+end

--- a/spec/services/embargo_release_service_spec.rb
+++ b/spec/services/embargo_release_service_spec.rb
@@ -244,12 +244,21 @@ RSpec.describe EmbargoReleaseService do
       end
 
       context 'when it is openable' do
+        before do
+          allow(Notifications::EmbargoLifted).to receive(:publish)
+          allow(Settings.rabbitmq).to receive(:enabled).and_return(true)
+          allow(Cocina::Mapper).to receive(:build).and_return(model)
+        end
+
+        let(:model) { instance_double(Cocina::Models::DRO) }
+
         it 'is successful' do
           release_items
           expect(VersionService).to have_received(:can_open?).with(item)
           expect(VersionService).to have_received(:open).with(item, event_factory)
           expect(item).to have_received(:save!)
           expect(VersionService).to have_received(:close).with(item, close_params, event_factory)
+          expect(Notifications::EmbargoLifted).to have_received(:publish).with(model: model)
         end
       end
 

--- a/spec/services/notifications/embargo_lifted_spec.rb
+++ b/spec/services/notifications/embargo_lifted_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Notifications::EmbargoLifted do
+  subject(:publish) { described_class.publish(model: model) }
+
+  let(:data) { { data: '455' } }
+  let(:administrative) do
+    instance_double(Cocina::Models::Administrative, partOfProject: 'h2')
+  end
+
+  let(:channel) { instance_double(Notifications::RabbitChannel, topic: topic) }
+  let(:topic) { instance_double(Bunny::Exchange, publish: true) }
+
+  before do
+    allow(Notifications::RabbitChannel).to receive(:instance).and_return(channel)
+  end
+
+  context 'when called with a DRO' do
+    let(:model) do
+      instance_double(Cocina::Models::DRO,
+                      externalIdentifier: 'druid:123', administrative: administrative, to_h: data)
+    end
+
+    it 'is successful' do
+      publish
+      expect(topic).to have_received(:publish).with('{"model":{"data":"455"}}', routing_key: 'h2')
+    end
+  end
+
+  context 'when called with an AdminPolicy' do
+    let(:model) do
+      Cocina::Models::AdminPolicy.new(externalIdentifier: 'druid:bc123dg9393',
+                                      administrative: {
+                                        hasAdminPolicy: 'druid:gg123vx9393'
+                                      },
+                                      version: 1,
+                                      label: 'just an apo',
+                                      type: Cocina::Models::Vocab.admin_policy)
+    end
+
+    before do
+      allow(model).to receive(:to_h).and_return(data)
+    end
+
+    it 'is successful' do
+      publish
+      expect(topic).to have_received(:publish).with('{"model":{"data":"455"}}', routing_key: 'SDR')
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?
So that h2 can log that the embargo was lifted.
Ref https://github.com/sul-dlss/happy-heron/issues/1347

## How was this change tested?



## Which documentation and/or configurations were updated?



