### PR TITLE
Handle blank valueURIs.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/value_uri.rb
+++ b/app/services/cocina/from_fedora/descriptive/value_uri.rb
@@ -12,7 +12,7 @@ module Cocina
         def self.sniff(uri, notifier)
           notifier.warn('Value URI has unexpected value', { uri: uri }) if uri.present? && !uri.starts_with?(*SUPPORTED_PREFIXES)
 
-          uri
+          uri.presence
         end
       end
     end

--- a/spec/services/cocina/from_fedora/descriptive/value_uri_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/value_uri_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe Cocina::FromFedora::Descriptive::ValueURI do
       end
     end
 
+    context 'with a blank uri' do
+      let(:uri) { '' }
+
+      it 'returns nil and does not warn' do
+        expect(described_class.sniff(uri, notifier)).to be_nil
+        expect(notifier).not_to have_received(:warn)
+      end
+    end
+
     context 'with a string uri that starts with supported prefix' do
       let(:uri) { 'http://foo.example.edu' }
 


### PR DESCRIPTION
closes #2451

## Why was this change made?
Handle bad data.


## How was this change tested?
Unit, sdr-deploy


## Which documentation and/or configurations were updated?
NA


