### PR TITLE
allow lane medical barcodes to validate

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.59.0)
+    cocina-models (0.59.1)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -331,7 +331,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    psych (3.3.1)
+    psych (3.3.2)
     public_suffix (4.0.6)
     puma (3.12.6)
     racc (1.5.2)

--- a/openapi.yml
+++ b/openapi.yml
@@ -1418,6 +1418,7 @@ components:
       description: 'A barcode'
       oneOf:
         - $ref: '#/components/schemas/BusinessBarcode'
+        - $ref: '#/components/schemas/LaneMedicalBarcode'
         - $ref: '#/components/schemas/CatkeyBarcode'
         - $ref: '#/components/schemas/StandardBarcode'
     BusinessBarcode:
@@ -1425,6 +1426,11 @@ components:
       type: string
       pattern: '^2050[0-9]{7}$'
       example: 20503740296
+    LaneMedicalBarcode:
+      description: The barcode associated with a Lane Medical Library DRO object, prefixed with 245
+      type: string
+      pattern: '^245[0-9]{8}$'
+      example: 24503259768
     CatalogLink:
       type: object
       additionalProperties: false


### PR DESCRIPTION
## Why was this change made?

Fixes #2851 - validate lane medical barcodes

~~[HOLD] for sul-dlss/cocina-models#262 and updated version of the gem~~ 

## How was this change tested?



## Which documentation and/or configurations were updated?



