### PR TITLE
allow publish to continue with HB data error for invalid license URL

### DIFF
--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -13,6 +13,7 @@ class PublishJob < ApplicationJob
     workflow_process = workflow == 'releaseWF' ? 'release-publish' : 'publish'
     begin
       item = Dor.find(druid)
+      Honeybadger.context({ pid: druid }) # add the druid to any HB alerts having to do with publishing
 
       # Disabling validation until pre-assembly and WAS handle this correctly.
       # validator = validator_for?(item)

--- a/app/services/publish/access_conditions.rb
+++ b/app/services/publish/access_conditions.rb
@@ -68,9 +68,13 @@ module Publish
     end
 
     def license
+      # The "none" licnese URI is a valid value in SDR (for legacy ETDs), but we don't want to publish that to PURL.
+      return if license_url == Cocina::FromFedora::Access::License::NONE_LICENSE_URI
+
       @license ||= License.new(url: license_url)
     rescue License::LegacyLicenseError
-      Honeybadger.notify("[DATA ERROR] #{license_url} is not a supported license in object #{pid}")
+      Honeybadger.notify("[DATA ERROR] #{license_url} is not a supported license",
+                         context: { druid: pid })
       if license_url.include?('creativecommons.org')
         # Try to find a workable license:
         @license = License.new(url: "#{license_url}legalcode")

--- a/app/services/publish/access_conditions.rb
+++ b/app/services/publish/access_conditions.rb
@@ -5,14 +5,13 @@ module Publish
   # These are derived from the rightsMetadata and are consumed by the
   # Searchworks item view via the mods_display gem.
   class AccessConditions
-    def self.add(public_mods:, rights_md:, pid:)
-      new(public_mods: public_mods, rights_md: rights_md, pid: pid).add
+    def self.add(public_mods:, rights_md:)
+      new(public_mods: public_mods, rights_md: rights_md).add
     end
 
-    def initialize(public_mods:, rights_md:, pid:)
+    def initialize(public_mods:, rights_md:)
       @public_mods = public_mods
       @rights_md = rights_md
-      @pid = pid
     end
 
     def add
@@ -24,7 +23,7 @@ module Publish
 
     private
 
-    attr_reader :rights_md, :public_mods, :pid
+    attr_reader :rights_md, :public_mods
 
     def rights
       @rights ||= rights_md.ng_xml
@@ -73,8 +72,7 @@ module Publish
 
       @license ||= License.new(url: license_url)
     rescue License::LegacyLicenseError
-      Honeybadger.notify("[DATA ERROR] #{license_url} is not a supported license",
-                         context: { druid: pid })
+      Honeybadger.notify("[DATA ERROR] #{license_url} is not a supported license")
       if license_url.include?('creativecommons.org')
         # Try to find a workable license:
         @license = License.new(url: "#{license_url}legalcode")

--- a/app/services/publish/public_desc_metadata_service.rb
+++ b/app/services/publish/public_desc_metadata_service.rb
@@ -25,7 +25,7 @@ module Publish
     def ng_xml(include_access_conditions: true)
       @ng_xml ||= begin
         add_collection_reference!
-        AccessConditions.add(public_mods: doc, rights_md: object.rightsMetadata) if include_access_conditions
+        AccessConditions.add(public_mods: doc, rights_md: object.rightsMetadata, pid: object.pid) if include_access_conditions
         add_constituent_relations!
         strip_comments!
 

--- a/app/services/publish/public_desc_metadata_service.rb
+++ b/app/services/publish/public_desc_metadata_service.rb
@@ -25,7 +25,7 @@ module Publish
     def ng_xml(include_access_conditions: true)
       @ng_xml ||= begin
         add_collection_reference!
-        AccessConditions.add(public_mods: doc, rights_md: object.rightsMetadata, pid: object.pid) if include_access_conditions
+        AccessConditions.add(public_mods: doc, rights_md: object.rightsMetadata) if include_access_conditions
         add_constituent_relations!
         strip_comments!
 

--- a/spec/services/publish/access_conditions_spec.rb
+++ b/spec/services/publish/access_conditions_spec.rb
@@ -3,9 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Publish::AccessConditions do
-  subject(:access) { described_class.new(public_mods: public_mods, rights_md: Dor::RightsMetadataDS.from_xml(rights_md), pid: pid) }
+  subject(:access) { described_class.new(public_mods: public_mods, rights_md: Dor::RightsMetadataDS.from_xml(rights_md)) }
 
-  let(:pid) { 'druid:bc123df4567' }
   let(:mods) do
     <<~XML
       <mods:mods xmlns:mods="http://www.loc.gov/mods/v3">

--- a/spec/services/publish/access_conditions_spec.rb
+++ b/spec/services/publish/access_conditions_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Publish::AccessConditions do
+  subject(:access) { described_class.new(public_mods: public_mods, rights_md: Dor::RightsMetadataDS.from_xml(rights_md), pid: pid) }
+
+  let(:pid) { 'druid:bc123df4567' }
+  let(:mods) do
+    <<~XML
+      <mods:mods xmlns:mods="http://www.loc.gov/mods/v3">
+        <mods:titleInfo>
+            <mods:title type="main">Some Excellent Title</mods:title>
+        </mods:titleInfo>
+      </mods:mods>
+    XML
+  end
+  let(:public_mods) { Dor::DescMetadataDS.from_xml(mods).ng_xml }
+
+  before { allow(Honeybadger).to receive(:notify) }
+
+  describe '#add' do
+    context 'when special NONE license url' do
+      let(:rights_md) do
+        <<~XML
+          <rightsMetadata>
+            <use>
+              <machine type="creativeCommons">none</machine>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'does not alert HB and does not add a license to public mods' do
+        access.add
+        expect(public_mods.xpath('//mods:accessCondition[@type="license"]').size).to eq 0
+        expect(Honeybadger).not_to have_received(:notify)
+      end
+    end
+
+    context 'when bogus license url' do
+      let(:rights_md) do
+        <<~XML
+          <rightsMetadata>
+            <use>
+              <license>https://some.unknown.license</license>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'alerts HB and does not add a license to public mods' do
+        access.add
+        expect(public_mods.xpath('//mods:accessCondition[@type="license"]').size).to eq 0
+        expect(Honeybadger).to have_received(:notify)
+      end
+    end
+
+    context 'when known license url that maps' do
+      let(:rights_md) do
+        <<~XML
+          <rightsMetadata>
+            <use>
+              <license>https://www.gnu.org/licenses/agpl.txt</license>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'does not alert HB and adds a license to public mods' do
+        access.add
+        expect(public_mods.xpath('//mods:accessCondition[@type="license"]').text).to eq 'AGPL-3.0-only GNU Affero General Public License'
+        expect(Honeybadger).not_to have_received(:notify)
+      end
+    end
+
+    context 'when we do not have a license url' do
+      let(:rights_md) do
+        <<~XML
+          <rightsMetadata>
+            <use>
+              <nada>no license url here</nada>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'does not alert HB and does not add a license to public mods' do
+        expect(public_mods.xpath('//mods:accessCondition[@type="license"]').size).to eq 0
+        expect(Honeybadger).not_to have_received(:notify)
+      end
+    end
+  end
+end

--- a/spec/services/publish/public_desc_metadata_service_spec.rb
+++ b/spec/services/publish/public_desc_metadata_service_spec.rb
@@ -281,7 +281,8 @@ RSpec.describe Publish::PublicDescMetadataService do
       it 'adds license accessConditions' do
         expect(license_node.text).to eq 'CC by-nc-nd: Attribution-NonCommercial-No Derivative Works 3.0 Unported License'
         expect(license_node['xlink:href']).to eq 'https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode'
-        expect(Honeybadger).to have_received(:notify).with("[DATA ERROR] https://creativecommons.org/licenses/by-nc-nd/3.0/ is not a supported license in object #{pid}")
+        expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] https://creativecommons.org/licenses/by-nc-nd/3.0/ is not a supported license',
+                                                           { context: { druid: 'druid:bc123df4567' } })
       end
     end
 
@@ -313,8 +314,9 @@ RSpec.describe Publish::PublicDescMetadataService do
         XML
       end
 
-      it 'does not add license accessConditions' do
+      it 'does not add license accessConditions and does not alert HB' do
         expect(license_node).to be_nil
+        expect(Honeybadger).not_to receive(:notify)
       end
     end
 

--- a/spec/services/publish/public_desc_metadata_service_spec.rb
+++ b/spec/services/publish/public_desc_metadata_service_spec.rb
@@ -281,8 +281,7 @@ RSpec.describe Publish::PublicDescMetadataService do
       it 'adds license accessConditions' do
         expect(license_node.text).to eq 'CC by-nc-nd: Attribution-NonCommercial-No Derivative Works 3.0 Unported License'
         expect(license_node['xlink:href']).to eq 'https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode'
-        expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] https://creativecommons.org/licenses/by-nc-nd/3.0/ is not a supported license',
-                                                           { context: { druid: 'druid:bc123df4567' } })
+        expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] https://creativecommons.org/licenses/by-nc-nd/3.0/ is not a supported license')
       end
     end
 

--- a/spec/services/publish/public_desc_metadata_service_spec.rb
+++ b/spec/services/publish/public_desc_metadata_service_spec.rb
@@ -5,7 +5,10 @@ require 'rails_helper'
 RSpec.describe Publish::PublicDescMetadataService do
   subject(:service) { described_class.new(obj) }
 
-  let(:obj) { instantiate_fixture('druid:bc123df4567', Dor::Item) }
+  let(:pid) { 'druid:bc123df4567' }
+  let(:obj) { instantiate_fixture(pid, Dor::Item) }
+
+  before { allow(obj).to receive(:pid).and_return(pid) }
 
   describe '#ng_xml' do
     subject(:doc) { service.ng_xml }
@@ -278,7 +281,7 @@ RSpec.describe Publish::PublicDescMetadataService do
       it 'adds license accessConditions' do
         expect(license_node.text).to eq 'CC by-nc-nd: Attribution-NonCommercial-No Derivative Works 3.0 Unported License'
         expect(license_node['xlink:href']).to eq 'https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode'
-        expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] https://creativecommons.org/licenses/by-nc-nd/3.0/ is not a supported license')
+        expect(Honeybadger).to have_received(:notify).with("[DATA ERROR] https://creativecommons.org/licenses/by-nc-nd/3.0/ is not a supported license in object #{pid}")
       end
     end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #2872 -- do not error out in the publish step when an invalid license URL is found and also provide the druid in the HB data error alert

## How was this change tested?

Existing tests


## Which documentation and/or configurations were updated?



