### PR TITLE
Add a descriptive message in accessMetadata for new licenses

### DIFF
--- a/app/services/publish/license.rb
+++ b/app/services/publish/license.rb
@@ -3,114 +3,22 @@
 module Publish
   # This is the license entity used for translating a license URL into text on
   # to be added to the public descriptive metadata
-  #
-  # NOTE: be aware that mods_display parses the value of this node with a regex
-  # See: https://github.com/sul-dlss/mods_display/blob/36e5bf7247fd7aa7892247af48033afaee2fd76b/lib/mods_display/fields/access_condition.rb#L79
-  #
   class License
     attr_reader :description, :uri
 
     # Raised when the license provided is not valid
     class LegacyLicenseError < StandardError; end
 
-    def initialize(url:)
-      raise LegacyLicenseError unless LICENSES.key?(url)
-
-      attrs = LICENSES.fetch(url)
-      @uri = url
-      @description = attrs.fetch(:label)
+    def self.licenses
+      @licenses ||= Rails.application.config_for(:licenses, env: 'production')
     end
 
-    LICENSES = {
-      'https://www.gnu.org/licenses/agpl.txt' => {
-        label: 'AGPL-3.0-only GNU Affero General Public License'
-      },
-      'https://www.apache.org/licenses/LICENSE-2.0' => {
-        label: 'Apache-2.0'
-      },
-      'https://opensource.org/licenses/BSD-2-Clause' => {
-        label: 'BSD-2-Clause "Simplified" License'
-      },
-      'https://opensource.org/licenses/BSD-3-Clause' => {
-        label: 'BSD-3-Clause "New" or "Revised" License'
-      },
-      'https://creativecommons.org/licenses/by/4.0/legalcode' => {
-        label: 'CC BY: Attribution International'
-      },
-      'https://creativecommons.org/licenses/by-nc/4.0/legalcode' => {
-        label: 'CC BY-NC: Attribution-NonCommercial International'
-      },
-      'https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode' => {
-        label: 'CC BY-NC-ND: Attribution-NonCommercial-No Derivatives'
-      },
-      'https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode' => {
-        label: 'CC BY-NC-SA: Attribution-NonCommercial-Share Alike International'
-      },
-      'https://creativecommons.org/licenses/by-nd/4.0/legalcode' => {
-        label: 'CC BY-ND: Attribution-No Derivatives International'
-      },
-      'https://creativecommons.org/licenses/by-sa/4.0/legalcode' => {
-        label: 'CC BY-SA: Attribution-Share Alike International'
-      },
-      'https://creativecommons.org/publicdomain/zero/1.0/legalcode' => {
-        label: 'CC0 - 1.0'
-      },
-      'https://opensource.org/licenses/cddl1' => {
-        label: 'CDDL-1.1 Common Development and Distribution License'
-      },
-      'https://www.eclipse.org/legal/epl-2.0' => {
-        label: 'EPL-2.0 Eclipse Public License'
-      },
-      'https://www.gnu.org/licenses/gpl-3.0-standalone.html' => {
-        label: 'GPL-3.0-only GNU General Public License'
-      },
-      'https://www.isc.org/downloads/software-support-policy/isc-license/' => {
-        label: 'ISC License'
-      },
-      'https://www.gnu.org/licenses/lgpl-3.0-standalone.html' => {
-        label: 'LGPL-3.0-only Lesser GNU Public License'
-      },
-      'https://opensource.org/licenses/MIT' => {
-        label: 'MIT License'
-      },
-      'https://www.mozilla.org/MPL/2.0/' => {
-        label: 'MPL-2.0 Mozilla Public License'
-      },
-      'https://opendatacommons.org/licenses/by/1-0/' => {
-        label: 'ODC odc-by: ODC-By-1.0 Attribution License'
-      },
-      'http://opendatacommons.org/licenses/odbl/1.0/' => {
-        # This is a non-canonical url found in some existing data. It redirects to
-        # https://opendatacommons.org/licenses/odbl/1-0/
-        label: 'ODC odbl: ODbL-1.0 Open Database License'
-      },
-      'https://opendatacommons.org/licenses/odbl/1-0/' => {
-        label: 'ODC odbl: ODbL-1.0 Open Database License'
-      },
-      'https://creativecommons.org/publicdomain/mark/1.0/' => {
-        label: 'CC pdm: Creative Commons Public Domain Mark 1.0'
-      },
-      'https://opendatacommons.org/licenses/pddl/1-0/' => {
-        label: 'ODC pddl: Open Data Commons Public Domain Dedication and License (PDDL-1.0)'
-      },
-      'https://creativecommons.org/licenses/by/3.0/legalcode' => {
-        label: 'CC by: Attribution 3.0 Unported License'
-      },
-      'https://creativecommons.org/licenses/by-sa/3.0/legalcode' => {
-        label: 'CC by-sa: Attribution Share Alike 3.0 Unported License'
-      },
-      'https://creativecommons.org/licenses/by-nd/3.0/legalcode' => {
-        label: 'CC by-nd: Attribution No Derivatives 3.0 Unported License'
-      },
-      'https://creativecommons.org/licenses/by-nc/3.0/legalcode' => {
-        label: 'CC by-nc: Attribution-NonCommercial 3.0 Unported License'
-      },
-      'https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode' => {
-        label: 'CC by-nc-sa: Attribution-NonCommercial-Share Alike 3.0 Unported License'
-      },
-      'https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode' => {
-        label: 'CC by-nc-nd: Attribution-NonCommercial-No Derivative Works 3.0 Unported License'
-      }
-    }.freeze
+    def initialize(url:)
+      raise LegacyLicenseError unless License.licenses.key?(url)
+
+      attrs = License.licenses.fetch(url)
+      @uri = url
+      @description = attrs.fetch('description')
+    end
   end
 end

--- a/config/licenses.yml
+++ b/config/licenses.yml
@@ -1,0 +1,60 @@
+production:
+  https://www.apache.org/licenses/LICENSE-2.0:
+    description: 'This work is licensed under an Apache License 2.0.'
+  https://opensource.org/licenses/BSD-2-Clause:
+    description: 'This work is licensed under a BSD 2-Clause "Simplified" License.'
+  https://opensource.org/licenses/BSD-3-Clause:
+    description: 'This work is licensed under a BSD 3-Clause "New" or "Revised" License.'
+  https://creativecommons.org/licenses/by/3.0/legalcode:
+    description: 'This work is licensed under a Creative Commons Attribution 3.0 Unported license (CC BY).'
+  https://creativecommons.org/licenses/by/4.0/legalcode:
+    description: 'This work is licensed under a Creative Commons Attribution 4.0 International license (CC BY).'
+  https://creativecommons.org/licenses/by-nc/3.0/legalcode:
+    description: 'This work is licensed under a Creative Commons Attribution Non Commercial 3.0 Unported license (CC BY-NC).'
+  https://creativecommons.org/licenses/by-nc/4.0/legalcode:
+    description: 'This work is licensed under a Creative Commons Attribution Non Commercial 4.0 International license (CC BY-NC).'
+  https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode:
+    description: 'This work is licensed under a Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported license (CC BY-NC-ND).'
+  https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode:
+    description: 'This work is licensed under a Creative Commons Attribution Non Commercial No Derivatives 4.0 International license (CC BY-NC-ND).'
+  https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode:
+    description: 'This work is licensed under a Creative Commons Attribution Non Commercial Share Alike 3.0 Unported license (CC BY-NC-SA).'
+  https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode:
+    description: 'his work is licensed under a Creative Commons Attribution Non Commercial Share Alike 4.0 International license (CC BY-NC-SA).'
+  https://creativecommons.org/licenses/by-nd/4.0/legalcode:
+    description: 'This work is licensed under a Creative Commons Attribution No Derivatives 4.0 International license (CC BY-ND).'
+  https://creativecommons.org/licenses/by-sa/3.0/legalcode:
+    description: 'This work is licensed under a Creative Commons Attribution Share Alike 3.0 Unported license (CC BY-SA).'
+  https://creativecommons.org/licenses/by-sa/4.0/legalcode:
+    description: 'This work is licensed under a Creative Commons Attribution Share Alike 4.0 International license (CC BY-SA).'
+  https://creativecommons.org/licenses/by-nd/3.0/legalcode:
+    description: 'This work is licensed under a Creative Commons Attribution No Derivatives 3.0 Unported license (CC BY-ND).'
+  https://creativecommons.org/publicdomain/zero/1.0/legalcode:
+    description: 'This work is licensed under a Creative Commons Zero v1.0 Universal license (CC0).'
+  https://opensource.org/licenses/cddl1:
+    description: 'This work is licensed under a Common Development and Distribution License 1.0.'
+  https://www.eclipse.org/legal/epl-2.0:
+    description: 'This work is licensed under an Eclipse Public License 2.0.'
+  https://www.gnu.org/licenses/agpl.txt:
+    description: 'This work is licensed under a GNU Affero General Public License v3.0 only.'
+  https://www.gnu.org/licenses/gpl-3.0-standalone.html:
+    description: 'This work is licensed under a GNU General Public License v3.0 only.'
+  https://www.gnu.org/licenses/lgpl-3.0-standalone.html:
+    description: 'This work is licensed under a GNU Lesser General Public License v3.0 only.'
+  https://www.isc.org/downloads/software-support-policy/isc-license/:
+    description: 'This work is licensed under an ISC License.'
+  https://opensource.org/licenses/MIT:
+    description: 'This work is licensed under an MIT License.'
+  https://www.mozilla.org/MPL/2.0/:
+    description: 'This work is licensed under a Mozilla Public License 2.0.'
+  https://opendatacommons.org/licenses/by/1-0/:
+    description: 'This work is licensed under an Open Data Commons Attribution License v1.0.'
+  http://opendatacommons.org/licenses/odbl/1.0/:
+    # This is a non-canonical url found in some existing data. It redirects to  # https://opendatacommons.org/licenses/odbl/1-0/
+    description: 'This work is licensed under an Open Data Commons Open Database License v1.0.'
+  https://opendatacommons.org/licenses/odbl/1-0/:
+    description: 'This work is licensed under an Open Data Commons Open Database License v1.0.'
+  https://opendatacommons.org/licenses/pddl/1-0/:
+    description: 'This work is licensed under an Open Data Commons Public Domain Dedication & License 1.0.'
+  https://creativecommons.org/publicdomain/mark/1.0/:
+    description: 'This work has been identified as being free of known restrictions under copyright law, including all related and neighboring rights (Public Domain Mark 1.0).'

--- a/spec/services/publish/public_desc_metadata_service_spec.rb
+++ b/spec/services/publish/public_desc_metadata_service_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Publish::PublicDescMetadataService do
         end
         expect(doc.xpath('//mods:accessCondition[@type="useAndReproduction"]').text).to match(/yada/)
         expect(doc.xpath('//mods:accessCondition[@type="copyright"]').text).to match(/Property rights reside with/)
-        expect(doc.xpath('//mods:accessCondition[@type="license"]').text).to eq 'CC by-nc: Attribution-NonCommercial 3.0 Unported License'
+        expect(doc.xpath('//mods:accessCondition[@type="license"]').text).to eq 'This work is licensed under a Creative Commons Attribution Non Commercial 3.0 Unported license (CC BY-NC).'
       end
     end
 
@@ -160,7 +160,7 @@ RSpec.describe Publish::PublicDescMetadataService do
         end
         expect(doc.xpath('//xmlns:accessCondition[@type="useAndReproduction"]').text).to match(/yada/)
         expect(doc.xpath('//xmlns:accessCondition[@type="copyright"]').text).to match(/Property rights reside with/)
-        expect(doc.xpath('//xmlns:accessCondition[@type="license"]').text).to eq 'CC by-nc: Attribution-NonCommercial 3.0 Unported License'
+        expect(doc.xpath('//xmlns:accessCondition[@type="license"]').text).to eq 'This work is licensed under a Creative Commons Attribution Non Commercial 3.0 Unported license (CC BY-NC).'
       end
     end
   end
@@ -222,7 +222,7 @@ RSpec.describe Publish::PublicDescMetadataService do
 
     it 'adds license accessCondtitions based on creativeCommons or openDataCommons statements' do
       expect(public_mods.xpath('//mods:accessCondition[@type="license"]').size).to eq 1
-      expect(license_node.text).to match(/by-nc: Attribution-NonCommercial 3.0 Unported/)
+      expect(license_node.text).to eq 'This work is licensed under a Creative Commons Attribution Non Commercial 3.0 Unported license (CC BY-NC).'
       expect(public_mods.root.namespaces).to include('xmlns:xlink')
       expect(license_node['xlink:href']).to eq 'https://creativecommons.org/licenses/by-nc/3.0/legalcode'
     end
@@ -256,7 +256,7 @@ RSpec.describe Publish::PublicDescMetadataService do
       end
 
       it 'adds license accessConditions' do
-        expect(license_node.text).to eq 'CC BY-ND: Attribution-No Derivatives International'
+        expect(license_node.text).to eq 'This work is licensed under a Creative Commons Attribution No Derivatives 4.0 International license (CC BY-ND).'
         expect(license_node['xlink:href']).to eq 'https://creativecommons.org/licenses/by-nd/4.0/legalcode'
       end
     end
@@ -276,7 +276,7 @@ RSpec.describe Publish::PublicDescMetadataService do
       end
 
       it 'adds license accessConditions' do
-        expect(license_node.text).to eq 'CC by-nc-nd: Attribution-NonCommercial-No Derivative Works 3.0 Unported License'
+        expect(license_node.text).to eq 'This work is licensed under a Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported license (CC BY-NC-ND).'
         expect(license_node['xlink:href']).to eq 'https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode'
         expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] https://creativecommons.org/licenses/by-nc-nd/3.0/ is not a supported license')
       end
@@ -294,7 +294,7 @@ RSpec.describe Publish::PublicDescMetadataService do
       end
 
       it 'adds license accessConditions' do
-        expect(license_node.text).to eq 'ODC odc-by: ODC-By-1.0 Attribution License'
+        expect(license_node.text).to eq 'This work is licensed under an Open Data Commons Attribution License v1.0.'
         expect(license_node['xlink:href']).to eq 'https://opendatacommons.org/licenses/by/1-0/'
       end
     end


### PR DESCRIPTION


## Why was this change made?
This was requested by the access team in 2021-06-09 to support new licenses, so they don't need to maintain a lookup table.


## How was this change tested?



## Which documentation and/or configurations were updated?



