### PR TITLE
Set the query_hash_key for committee

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,9 +33,15 @@ end
 module DorServices
   class Application < Rails::Application
     accept_proc = proc { |request| request.path.start_with?('/v1') }
-    config.middleware.use Committee::Middleware::RequestValidation, schema_path: 'openapi.yml', strict: true,
-                                                                    error_class: JSONAPIError, accept_request_filter: accept_proc,
-                                                                    parse_response_by_content_type: false
+    config.middleware.use(
+      Committee::Middleware::RequestValidation,
+      schema_path: 'openapi.yml',
+      strict: true,
+      error_class: JSONAPIError,
+      accept_request_filter: accept_proc,
+      parse_response_by_content_type: false,
+      query_hash_key: 'action_dispatch.request.query_parameters'
+    )
 
     # TODO: we can uncomment this at a later date to ensure we are passing back valid responses
     # config.middleware.use Committee::Middleware::ResponseValidation, schema: schema


### PR DESCRIPTION


## Why was this change made?

This avoids a deprecation notice.  Copied from the example at https://github.com/interagent/committee/blob/master/examples/openapi3_rails/config/application.rb#L44



## How was this change tested?



## Which documentation and/or configurations were updated?



