### PR TITLE
Return a 400 bad request when catkey isn't found

### DIFF
--- a/app/controllers/marcxml_controller.rb
+++ b/app/controllers/marcxml_controller.rb
@@ -7,9 +7,13 @@ class MarcxmlController < ApplicationController #:nodoc:
 
   def catkey
     render plain: SymphonyReader.new(barcode: params[:barcode]).fetch_catkey
+  rescue SymphonyReader::NotFound => e
+    json_api_error(status: :bad_request, title: 'Catkey not found in Symphony', message: e.message)
   end
 
   def marcxml
     render xml: MarcxmlResource.new(barcode: params[:barcode], catkey: params[:catkey]).marcxml
+  rescue SymphonyReader::NotFound => e
+    json_api_error(status: :bad_request, title: 'Catkey not found in Symphony', message: e.message)
   end
 end

--- a/app/controllers/metadata_refresh_controller.rb
+++ b/app/controllers/metadata_refresh_controller.rb
@@ -15,6 +15,8 @@ class MetadataRefreshController < ApplicationController
     return render status: :internal_server_error, plain: "#{@item.pid} descMetadata missing required fields (<title>)" if missing_required_fields?
 
     @item.save!
+  rescue SymphonyReader::NotFound => e
+    json_api_error(status: :bad_request, title: 'Catkey not found in Symphony', message: e.message)
   end
 
   private

--- a/app/models/symphony_reader.rb
+++ b/app/models/symphony_reader.rb
@@ -4,6 +4,8 @@
 class SymphonyReader
   class ResponseError < StandardError; end
 
+  class NotFound < StandardError; end
+
   attr_reader :catkey, :barcode
 
   def self.client
@@ -72,9 +74,7 @@ class SymphonyReader
       validate_response(resp)
       return resp
     elsif resp.status == 404
-      # 404 received here is for the catkey, but this app cares about the druid
-      #   for the DOR object, hence raising 404 from here could be misleading
-      errmsg = "Record not found in Symphony. API call: #{url}"
+      raise NotFound, "Record not found in Symphony. Catkey: #{catkey}. API call: #{url}"
     else
       errmsg = "Got HTTP Status-Code #{resp.status} calling #{url}: #{resp.body}"
     end

--- a/spec/models/symphony_reader_spec.rb
+++ b/spec/models/symphony_reader_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SymphonyReader do
   let(:marc_reader) { described_class.new(catkey: catkey) }
   let(:barcode_reader) { described_class.new(barcode: barcode) }
 
-  let(:catkey) { 'catkey' }
+  let(:catkey) { '482660' }
   let(:barcode) { 'barcode' }
   let(:marc_url) { Settings.catalog.symphony.base_url + Settings.catalog.symphony.marcxml_path }
   let(:barcode_url) { Settings.catalog.symphony.base_url + Settings.catalog.symphony.barcode_path }
@@ -55,7 +55,7 @@ RSpec.describe SymphonyReader do
 
     it 'removes original 001 fields and puts catkey in 001 field' do
       expect(marc_reader.to_marc.fields('001').length).to eq 1
-      expect(marc_reader.to_marc.fields('001').first.value).to eq 'acatkey'
+      expect(marc_reader.to_marc.fields('001').first.value).to eq 'a482660'
     end
 
     it 'parses data fields' do
@@ -112,7 +112,7 @@ RSpec.describe SymphonyReader do
         let(:headers) { { 'Content-Length': 268 } }
 
         it 'raises ResponseError and notifies Honeybadger' do
-          msg = 'Incomplete response received from Symphony for catkey - expected 268 bytes but got 394'
+          msg = 'Incomplete response received from Symphony for 482660 - expected 268 bytes but got 394'
           allow(Honeybadger).to receive(:notify)
           expect { marc_reader.to_marc }.to raise_error(SymphonyReader::ResponseError, msg)
           expect(Honeybadger).to have_received(:notify).with(msg)
@@ -124,10 +124,10 @@ RSpec.describe SymphonyReader do
           stub_request(:get, format(marc_url, catkey: catkey)).to_return(status: 404)
         end
 
-        it 'raises ResponseError and does not notify Honeybadger' do
-          msg = 'Record not found in Symphony. API call: https://sirsi.example.com/symws/catalog/bib/key/catkey?includeFields=bib'
+        it 'raises NotFound and does not notify Honeybadger' do
+          msg = 'Record not found in Symphony. Catkey: 482660. API call: https://sirsi.example.com/symws/catalog/bib/key/482660?includeFields=bib'
           allow(Honeybadger).to receive(:notify)
-          expect { marc_reader.to_marc }.to raise_error(SymphonyReader::ResponseError, msg)
+          expect { marc_reader.to_marc }.to raise_error(SymphonyReader::NotFound, msg)
           expect(Honeybadger).not_to have_received(:notify).with(msg)
         end
       end
@@ -149,7 +149,7 @@ RSpec.describe SymphonyReader do
         end
 
         it 'raises ResponseError' do
-          msg_regex = %r{Got HTTP Status-Code 403 calling https://sirsi.example.com/symws/catalog/bib/key/catkey\?includeFields=bib:.*Something somewhere went wrong.}
+          msg_regex = %r{Got HTTP Status-Code 403 calling https://sirsi.example.com/symws/catalog/bib/key/482660\?includeFields=bib:.*Something somewhere went wrong.}
           expect { marc_reader.to_marc }.to raise_error(SymphonyReader::ResponseError, msg_regex)
         end
       end
@@ -162,7 +162,7 @@ RSpec.describe SymphonyReader do
         end
 
         it 'raises ResponseError and notifies Honeybadger' do
-          msg_regex = %r{^Timeout for Symphony response for API call https://sirsi.example.com/symws/catalog/bib/key/catkey\?includeFields=bib: #{faraday_msg}}
+          msg_regex = %r{^Timeout for Symphony response for API call https://sirsi.example.com/symws/catalog/bib/key/482660\?includeFields=bib: #{faraday_msg}}
           allow(Honeybadger).to receive(:notify)
           expect { marc_reader.to_marc }.to raise_error(SymphonyReader::ResponseError, msg_regex)
           expect(Honeybadger).to have_received(:notify).with(msg_regex)

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -159,6 +159,21 @@ RSpec.describe 'Create object' do
           expect(response.status).to eq 502
         end
       end
+
+      context 'when symphony returns a 404' do
+        before do
+          allow(MetadataService).to receive(:fetch).and_raise(SymphonyReader::NotFound, 'unable to find catkey')
+        end
+
+        it 'draws an error message' do
+          post '/v1/objects',
+               params: data,
+               headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+          expect(response.body).to eq '{"errors":[{"status":"400","title":"Catkey not found in Symphony",' \
+            '"detail":"unable to find catkey"}]}'
+          expect(response.status).to eq 400
+        end
+      end
     end
 
     context 'when catkey is not provided' do

--- a/spec/requests/get_catkey_spec.rb
+++ b/spec/requests/get_catkey_spec.rb
@@ -55,11 +55,12 @@ RSpec.describe "Looking up an item's catkey by it's barcode" do
   context 'when barcode not found' do
     let(:bogus_value) { 'bogus' }
 
-    it 'returns a 500 error when looking up catkey by barcode' do
+    it 'returns a 400 error when looking up catkey by barcode' do
       stub_request(:get, format(barcode_url, barcode: bogus_value)).to_return(status: 404)
       get "/v1/catalog/catkey?barcode=#{bogus_value}", headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response.status).to eq(500)
-      expect(response.body).to eq("Record not found in Symphony. API call: https://sirsi.example.com/symws/catalog/item/barcode/#{bogus_value}")
+      expect(response).to have_http_status(:bad_request)
+      json = JSON.parse(response.body)
+      expect(json.dig('errors', 0, 'title')).to eq 'Catkey not found in Symphony'
     end
   end
 end

--- a/spec/requests/get_marcxml_spec.rb
+++ b/spec/requests/get_marcxml_spec.rb
@@ -80,11 +80,12 @@ RSpec.describe "Looking up an item's marcxml" do
     context 'when catkey not found' do
       let(:bogus_value) { 'bogus' }
 
-      it 'returns a 500 error when fetching marcxml' do
+      it 'returns a 400 error when fetching marcxml' do
         stub_request(:get, format(marc_url, catkey: bogus_value)).to_return(status: 404)
         get "/v1/catalog/marcxml?catkey=#{bogus_value}", headers: { 'Authorization' => "Bearer #{jwt}" }
-        expect(response.status).to eq(500)
-        expect(response.body).to eq("Record not found in Symphony. API call: https://sirsi.example.com/symws/catalog/bib/key/#{bogus_value}?includeFields=bib")
+        expect(response).to have_http_status(:bad_request)
+        json = JSON.parse(response.body)
+        expect(json.dig('errors', 0, 'title')).to eq 'Catkey not found in Symphony'
       end
     end
 

--- a/spec/requests/metadata_refresh_spec.rb
+++ b/spec/requests/metadata_refresh_spec.rb
@@ -86,11 +86,12 @@ RSpec.describe 'Refresh metadata' do
         stub_request(:get, format(marc_url, catkey: '666')).to_return(status: 404)
       end
 
-      it 'returns a 500 error' do
+      it 'returns a mk420bs7601 error' do
         post '/v1/objects/druid:mk420bs7601/refresh_metadata',
              headers: { 'Authorization' => "Bearer #{jwt}" }
-        expect(response.status).to eq(500)
-        expect(response.body).to eq('Record not found in Symphony. API call: https://sirsi.example.com/symws/catalog/bib/key/666?includeFields=bib')
+        expect(response).to have_http_status(:bad_request)
+        json = JSON.parse(response.body)
+        expect(json.dig('errors', 0, 'title')).to eq 'Catkey not found in Symphony'
       end
     end
 


### PR DESCRIPTION


## Why was this change made?

When you send a catkey that symphony doesn't know about, it should be a you problem, not a me problem.

## How was this change tested?



## Which documentation and/or configurations were updated?



