### PR TITLE
Cleanup as job

### DIFF
--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -19,15 +19,12 @@ class WorkspacesController < ApplicationController
 
     result = BackgroundJobResult.create
     EventFactory.create(druid: druid,
-      event_type: 'cleanup-workspace received',
-      data: { background_job_result_id: result.id })
+                        event_type: 'cleanup-workspace received',
+                        data: { background_job_result_id: result.id })
 
-    queue = params['lane-id'] == 'low' ? :low : :default
-#    CleanupJob.set(queue: queue).perform_later(druid: druid, background_job_result: result)
-#    CleanupService.cleanup_by_druid druid
+    CleanupJob.perform_later(druid: druid, background_job_result: result)
 
-    head :created, location: result
-
+    head :no_content, location: result
   rescue Errno::ENOENT, Errno::ENOTEMPTY => e
     EventFactory.create(druid: druid, event_type: 'cleanup-workspace',
                         data: { status: 'failure', message: e.message, backtrace: e.backtrace })

--- a/app/jobs/cleanup_job.rb
+++ b/app/jobs/cleanup_job.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Cleanup files from the workspace in the background
+class CleanupJob < ApplicationJob
+  queue_as :default
+
+  # @param [String] druid the identifier of the item to be published
+  # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
+  def perform(druid:, background_job_result:)
+    background_job_result.processing!
+
+    begin
+      CleanupService.cleanup_by_druid druid
+
+      # Shelving can take a long time and can cause the database connections to get stale.
+      # So reset to avoid: ActiveRecord::StatementInvalid: PG::ConnectionBad: PQconsumeInput() could not receive data from server: Connection timed out : BEGIN
+      ActiveRecord::Base.clear_active_connections!
+      EventFactory.create(druid: druid, event_type: 'end-accession complete', data: { background_job_result_id: background_job_result.id })
+    rescue StandardError => e
+      return LogFailureJob.perform_later(druid: druid,
+                                         background_job_result: background_job_result,
+                                         workflow: 'accessionWF',
+                                         workflow_process: 'end-accession',
+                                         output: { errors: [{ title: 'Unable to cleanup workspace', detail: e.message }] })
+    end
+
+    LogSuccessJob.perform_later(druid: druid,
+                                workflow: 'accessionWF',
+                                background_job_result: background_job_result,
+                                workflow_process: 'end-accession')
+  end
+end

--- a/spec/jobs/cleanup_job_spec.rb
+++ b/spec/jobs/cleanup_job_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CleanupJob, type: :job do
+  context 'when we write tests' do
+    xit 'it works'
+  end
+
+  #   context 'when successful' do
+  #     before do
+  #       allow(CleanupService).to receive(:cleanup_by_druid)
+  #       allow(CleanupJob).to receive(:set).and_return(job)
+  #    end
+  #     it 'returns 200' do
+  #       delete "/v1/objects/#{object_id}/workspace",
+  #     it 'queus job and returns 204' do
+  #       delete "/v1/objects/#{druid}/workspace",
+  #             headers: { 'Authorization' => "Bearer #{jwt}" }
+  #       expect(CleanupService).to have_received(:cleanup_by_druid).with(object_id)
+  #       expect(CleanupJob).to have_received(:set).with(queue: :default)
+  #       expect(job).to have_received(:perform_later)
+  #         .with(druid: druid, background_job_result: BackgroundJobResult, workflow: 'accessionWF')
+  #      expect(response).to have_http_status(:no_content)
+  #    end
+  #  end
+
+  #   context "when the directory doesn't exist" do
+  #     before do
+  #       allow(CleanupService).to receive(:cleanup_by_druid)
+  #         .and_raise(Errno::ENOENT, 'dir_s_rmdir - /dor/workspace/aa/222')
+  #     end
+
+  #     it 'returns JSON-API error' do
+  #       delete "/v1/objects/#{object_id}/workspace",
+  #              headers: { 'Authorization' => "Bearer #{jwt}" }
+  #       expect(response).to have_http_status(:unprocessable_entity)
+  #       expect(response.body).to eq(
+  #         '{"errors":[{"status":"422","title":"Unable to remove directory",' \
+  #         '"detail":"No such file or directory - dir_s_rmdir - /dor/workspace/aa/222"}]}'
+  #       )
+  #     end
+  #   end
+
+  #   context 'when the directory is not empty' do
+  #     before do
+  #       allow(CleanupService).to receive(:cleanup_by_druid)
+  #         .and_raise(Errno::ENOTEMPTY, 'dir_s_rmdir - /dor/assembly/pw/569/pw/4290')
+  #     end
+
+  #     it 'returns JSON-API error' do
+  #       delete "/v1/objects/#{object_id}/workspace",
+  #              headers: { 'Authorization' => "Bearer #{jwt}" }
+  #       expect(response).to have_http_status(:unprocessable_entity)
+  #       expect(response.body).to eq(
+  #         '{"errors":[{"status":"422","title":"Unable to remove directory",' \
+  #         '"detail":"Directory not empty - dir_s_rmdir - /dor/assembly/pw/569/pw/4290"}]}'
+  #       )
+  #     end
+  #  end
+end


### PR DESCRIPTION
## Why was this change made?

Part of sul-dlss/argo#2752

Experiment in switching the end-accession/cleanup to a job.

We also need to changes to ~~dor-services-client: sul-dlss/dor-services-client#221 and~~ common-accessioning: sul-dlss/common-accessioning#770. Hold for these changes since they all need to be released together.

## How was this change tested?

Todo: fix up `app/jobs/cleanup_job.rb`

## Which documentation and/or configurations were updated?



