### PR TITLE
Cocina update should overwrite release tags

### DIFF
--- a/app/services/cocina/to_fedora/identity.rb
+++ b/app/services/cocina/to_fedora/identity.rb
@@ -40,11 +40,14 @@ module Cocina
       def apply_release_tags(release_tags)
         return if release_tags.blank?
 
+        identity_md = fedora_object.identityMetadata
+        identity_md.ng_xml_will_change!
+        identity_md.ng_xml.xpath('//release').each(&:remove)
         release_tags.each do |release_tag|
           attrs = release_tag.to_h.except(:date)
           release = attrs.delete(:release)
           attrs[:when] = release_tag.date ? release_tag.date.utc.iso8601 : Time.now.utc.iso8601 # add the timestamp if necessary
-          fedora_object.identityMetadata.add_value(:release, release.to_s, attrs)
+          identity_md.add_value(:release, release.to_s, attrs)
         end
       end
 

--- a/spec/services/cocina/to_fedora/identity_spec.rb
+++ b/spec/services/cocina/to_fedora/identity_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::ToFedora::Identity do
+  subject(:apply) { described_class.update(datastream, uri) }
+
+  let(:datastream) do
+    Dor::IdentityMetadataDS.new.tap { |ds| ds.content = datastream_xml }
+  end
+
+  let(:fedora_object) do
+    instance_double(Dor::Item, identityMetadata: datastream)
+  end
+
+  describe '#apply_release_tags' do
+    subject(:apply_release_tags) { described_class.apply_release_tags(fedora_object, release_tags: release_tags) }
+
+    let(:release_tags) do
+      [
+        Cocina::Models::ReleaseTag.new(
+          to: 'Searchworks',
+          who: 'bergeraj',
+          what: 'self',
+          release: true,
+          date: '2021-07-01T12:12:12Z'
+        )
+      ]
+    end
+
+    let(:datastream_xml) do
+      <<~XML
+        <identityMetadata>
+          <release what="self" to="Searchworks" who="jcoyne85" when="2021-06-28T19:11:26Z">true</release>
+        </identityMetadata>
+      XML
+    end
+
+    it 'overwrites the existing tags' do
+      apply_release_tags
+      expect(datastream.ng_xml).to be_equivalent_to <<~XML
+        <identityMetadata>
+          <release what="self" to="Searchworks" who="bergeraj" when="2021-07-01T12:12:12Z">true</release>
+        </identityMetadata>
+      XML
+    end
+  end
+end


### PR DESCRIPTION

## Why was this change made?

Currently a cocina update appends release tags, which causes an exponential proliferation of release tags.  The correct approach is to overwrite these tags.


## How was this change tested?



## Which documentation and/or configurations were updated?



