### PR TITLE
Update cocina-models to 0.61.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.60.0'
+gem 'cocina-models', '~> 0.61.0'
 gem 'dor-rights-auth', '>= 1.5.0' # required for new CDL rights
 gem 'dor-services', '~> 9.6'
 gem 'dor-workflow-client', '~> 3.17'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.60.0)
+    cocina-models (0.61.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -148,9 +148,9 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (6.36.0)
+    dor-services-client (4.20.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.60.0)
+      cocina-models (~> 0.29)
       deprecation
       faraday (>= 0.15, < 2)
       moab-versioning (~> 4.0)
@@ -380,7 +380,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
-    rake (13.0.3)
+    rake (13.0.4)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -437,7 +437,7 @@ GEM
     rspec-support (3.10.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.18.2)
+    rubocop (1.18.3)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -470,7 +470,7 @@ GEM
       mime-types
       nokogiri
       rest-client
-    rubyzip (2.3.1)
+    rubyzip (2.3.2)
     scrub_rb (1.0.1)
     set (1.0.1)
     sidekiq (6.2.1)
@@ -557,7 +557,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.60.0)
+  cocina-models (~> 0.61.0)
   committee
   config
   deprecation

--- a/openapi.yml
+++ b/openapi.yml
@@ -1694,9 +1694,7 @@ components:
           items:
             $ref: "#/components/schemas/DescriptiveValue"
         purl:
-          description: Stanford persistent URL associated with the resource.
-          type: string
-          format: uri
+          $ref: "#/components/schemas/Purl"
         access:
           $ref: "#/components/schemas/DescriptiveAccessMetadata"
         relatedResource:
@@ -1954,6 +1952,11 @@ components:
               $ref: '#/components/schemas/Standard'
               # description: An alphabet or other notation used to represent a
               #   language or other symbolic system of the descriptive element value.
+    DOI:
+      type: string
+      description: Digital Object Identifier (https://www.doi.org)
+      pattern: '^10\.25740\/druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
+      example: '10.25740/druid:bc123df4567'
     DRO:
       description: Domain-defined abstraction of a 'work'. Digital Repository Objects' abstraction is describable for our domain’s purposes, i.e. for management needs within our system.
       type: object
@@ -2291,14 +2294,16 @@ components:
       type: object
       additionalProperties: false
       properties:
-        sourceId:
-          $ref: '#/components/schemas/SourceId'
+        barcode:
+          $ref: '#/components/schemas/Barcode'
         catalogLinks:
           type: array
           items:
             $ref: '#/components/schemas/CatalogLink'
-        barcode:
-          $ref: '#/components/schemas/Barcode'
+        doi:
+          $ref: '#/components/schemas/DOI'
+        sourceId:
+          $ref: '#/components/schemas/SourceId'
     Language:
       description: Languages, scripts, symbolic systems, and notations used in all
         or part of a resource or its descriptive metadata.
@@ -2462,6 +2467,12 @@ components:
         width:
           description: Width in pixels
           type: integer
+    Purl:
+      description: Stanford persistent URL associated with the related resource. Note this is http, not https.
+      type: string
+      format: uri
+      # Canonical URI is http, even though this redirects to https.
+      pattern: '^http:\/\/'
     RelatedResource:
       description: Other resource associated with the described resource.
       type: object
@@ -2523,9 +2534,7 @@ components:
           items:
             $ref: "#/components/schemas/DescriptiveValue"
         purl:
-          description: Stanford persistent URL associated with the related resource.
-          type: string
-          format: uri
+          $ref: "#/components/schemas/Purl"
         access:
           $ref: "#/components/schemas/DescriptiveAccessMetadata"
         relatedResource:
@@ -2775,14 +2784,16 @@ components:
       type: object
       additionalProperties: false
       properties:
-        sourceId:
-          $ref: '#/components/schemas/SourceId'
+        barcode:
+          $ref: '#/components/schemas/Barcode'
         catalogLinks:
           type: array
           items:
             $ref: '#/components/schemas/CatalogLink'
-        barcode:
-          $ref: '#/components/schemas/Barcode'
+        doi:
+          $ref: '#/components/schemas/DOI'
+        sourceId:
+          $ref: '#/components/schemas/SourceId'
       required:
         - sourceId
     Sequence:


### PR DESCRIPTION
Hold because this must be released in conjunction with the dor-services-client release.

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



