### PR TITLE
Normalizes PURLs to http.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/descriptive_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/descriptive_builder.rb
@@ -41,7 +41,7 @@ module Cocina
           title_result = @title_builder.build(resource_element: resource_element, require_title: require_title, notifier: notifier)
           cocina_description[:title] = title_result if title_result.present?
 
-          purl_value = purl || Descriptive::Purl.primary_purl_node(resource_element, purl)&.content&.presence
+          purl_value = purl || Descriptive::Purl.primary_purl_value(resource_element, purl)
           cocina_description[:purl] = purl_value if purl_value
 
           BUILDERS.each do |descriptive_property, builder|

--- a/app/services/cocina/from_fedora/descriptive/purl.rb
+++ b/app/services/cocina/from_fedora/descriptive/purl.rb
@@ -8,7 +8,7 @@ module Cocina
         def self.primary_purl_node(resource_element, purl)
           purl_nodes = resource_element.xpath('mods:location/mods:url', mods: DESC_METADATA_NS).select { |url_node| ::Purl.purl?(url_node.text) }
 
-          return purl_nodes.find { |purl_node| purl_node.content == purl } if purl
+          return purl_nodes.find { |purl_node| purl_value(purl_node) == purl } if purl
 
           # Prefer a primary PURL node
           primary_purl_node = purl_nodes.find { |purl_node| purl_node[:usage] == 'primary display' }
@@ -32,6 +32,15 @@ module Cocina
             }
           end
           notes
+        end
+
+        def self.primary_purl_value(resource_element, purl)
+          purl_value(primary_purl_node(resource_element, purl))
+        end
+
+        def self.purl_value(purl_node)
+          # Note that normalizing https to http
+          purl_node&.content&.sub(/^https/, 'http')&.presence
         end
       end
     end

--- a/app/services/cocina/from_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/from_fedora/descriptive/related_resource.rb
@@ -87,7 +87,7 @@ module Cocina
           purl_nodes = resource_element.xpath('mods:location/mods:url', mods: DESC_METADATA_NS).select { |url_node| ::Purl.purl?(url_node.text) && url_node != primary_purl_node }
           purl_nodes.map do |purl_node|
             {
-              purl: purl_node.content,
+              purl: Descriptive::Purl.purl_value(purl_node),
               access: {
                 note: Purl.purl_note(purl_node).presence,
                 digitalRepository: [{ value: 'Stanford Digital Repository' }]

--- a/app/services/cocina/normalizers/mods_normalizer.rb
+++ b/app/services/cocina/normalizers/mods_normalizer.rb
@@ -108,6 +108,11 @@ module Cocina
       end
 
       def normalize_purl_for(base_node, purl: nil)
+        # Normalize https to http
+        purl_nodes(base_node).each do |purl_node|
+          purl_node.content = purl_node.content.sub(/^https/, 'http')
+        end
+
         # If there is a purl, add a url node if there is not already one.
         if purl && purl_nodes(base_node).to_a.none? { |purl_node| purl_node.content == purl }
           new_location = Nokogiri::XML::Node.new('location', Nokogiri::XML(nil))

--- a/spec/services/cocina/mapping/descriptive/mods/location_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/location_spec.rb
@@ -210,6 +210,40 @@ RSpec.describe 'MODS location <--> cocina mappings' do
     end
   end
 
+  describe 'PURL with https' do
+    # if purl is only url in record or no other url has usage="primary display", assign to purl
+    it_behaves_like 'MODS cocina mapping' do
+      let(:druid) { 'ys701qw6956' }
+
+      let(:mods) do
+        <<~XML
+          <location>
+            <url usage="primary display">https://purl.stanford.edu/ys701qw6956</url>
+          </location>
+        XML
+      end
+
+      let(:roundtrip_mods) do
+        <<~XML
+          <location>
+            <url usage="primary display">http://purl.stanford.edu/ys701qw6956</url>
+          </location>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          purl: 'http://purl.stanford.edu/ys701qw6956',
+          access: {
+            digitalRepository: [
+              value: 'Stanford Digital Repository'
+            ]
+          }
+        }
+      end
+    end
+  end
+
   describe 'Web archive (with display label)' do
     it_behaves_like 'MODS cocina mapping' do
       let(:druid) { 'hf898mn6942' }

--- a/spec/services/cocina/normalizers/mods_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/mods_normalizer_spec.rb
@@ -110,6 +110,40 @@ RSpec.describe Cocina::Normalizers::ModsNormalizer do
     end
   end
 
+  context 'when normalizing PURL with https' do
+    let(:druid) { 'druid:bw502ns3302' }
+
+    let(:mods_ng_xml) do
+      Nokogiri::XML <<~XML
+        <mods #{MODS_ATTRIBUTES}>
+          <location>
+            <url usage="primary display">https://purl.stanford.edu/bw502ns3302</url>
+          </location>
+          <relatedItem>
+            <location>
+              <url usage="primary display">https://purl.stanford.edu/vt726fn1198</url>
+            </location>
+          </relatedItem>
+        </mods>
+      XML
+    end
+
+    it 'changes to https' do
+      expect(normalized_ng_xml.to_xml).to be_equivalent_to <<~XML
+        <mods #{MODS_ATTRIBUTES}>
+          <location>
+            <url usage="primary display">http://purl.stanford.edu/bw502ns3302</url>
+          </location>
+          <relatedItem>
+            <location>
+              <url usage="primary display">http://purl.stanford.edu/vt726fn1198</url>
+            </location>
+          </relatedItem>
+        </mods>
+      XML
+    end
+  end
+
   context 'when normalizing PURL but existing primary display in same <location> node' do
     let(:druid) { 'druid:bw502ns3302' }
 


### PR DESCRIPTION
closes #2903

## Why was this change made?
Existing PURLs in MODS with https were causing validation errors since PURLs are now validated as starting with https.


## How was this change tested?
Unit, stage


## Which documentation and/or configurations were updated?
NA


