### PR TITLE
update_doi_metadata endpoint added

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -140,6 +140,15 @@ class ObjectsController < ApplicationController
     head :created
   end
 
+  # Called by the robots.
+  def update_doi_metadata
+    # TODO:  this will call a background job to pull DOI and appropriate metadata from the repo and then
+    #   send an appropriate request to DataCite via its API
+    # The background job will not have a callback to update the workflow.
+    # The background job, if there is a failure, will log in HB, but then rely on the sidekiq mechanism to retry as necessary.
+    head :accepted
+  end
+
   def destroy
     DeleteService.destroy(@item.pid)
     head :no_content

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
         post 'publish'
         post 'preserve'
         post 'update_marc_record'
+        post 'update_doi_metadata'
         post 'unpublish'
         post 'notify_goobi'
         post 'accession'

--- a/openapi.yml
+++ b/openapi.yml
@@ -285,6 +285,23 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
+  '/v1/objects/{id}/update_doi_metadata':
+    post:
+      tags:
+        - integrations
+      summary: Update Datacite DOI metadata
+      description: 'Starts a background job to do this, from DOI and metadata in the repository'
+      operationId: 'objects#update_doi_metadata'
+      responses:
+        '202':
+          description: Accepted
+      parameters:
+        - name: id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
   '/v1/objects/{id}/unpublish':
     post:
       tags:

--- a/spec/requests/update_doi_metadata_spec.rb
+++ b/spec/requests/update_doi_metadata_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Update DOI metadata' do
+  let(:druid) { 'druid:mx123qw2323' }
+  let(:object) { Dor::Item.new(pid: druid) }
+
+  before do
+    allow(Dor).to receive(:find).and_return(object)
+  end
+
+  it 'responds to the request with 202 ("accepted")' do
+    post "/v1/objects/#{druid}/update_doi_metadata", headers: { 'Authorization' => "Bearer #{jwt}" }
+    expect(response.status).to eq(202)
+  end
+end


### PR DESCRIPTION
## Why was this change made?

We will need to be able to update DOI metadata at DataCite;  the mechanism chosen is for DSA to perform these requests.  

This PR is for a dummy endpoint so other tickets can be unblocked as we wait for definitive DataCite mappings from Arcadia.

part of #2912

## How was this change tested?

request spec added.

## Which documentation and/or configurations were updated?

openapi.yml


