### PR TITLE
Rename doi_prefix to datacite.prefix

### DIFF
--- a/app/services/doi.rb
+++ b/app/services/doi.rb
@@ -9,6 +9,6 @@ class Doi
   end
 
   def self.prefix
-    Settings.doi_prefix
+    Settings.datacite.prefix
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -102,4 +102,5 @@ from_fedora_data_errors:
   notify_warn: true
   notify_error: true
 
-doi_prefix: '10.80343'
+datacite:
+  prefix: '10.80343'

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe 'Create object' do
           allow(Dor::Item).to receive(:new).and_return(item)
           allow(item).to receive(:collections).and_return([])
           allow(item).to receive(:save!)
-          allow(Settings).to receive(:doi_prefix).and_return('10.25740')
+          allow(Settings.datacite).to receive(:prefix).and_return('10.25740')
         end
 
         it 'registers the object with a DOI' do

--- a/spec/services/cocina/object_creator_spec.rb
+++ b/spec/services/cocina/object_creator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Cocina::ObjectCreator do
       args[:fedora_object].descMetadata.mods_title = 'foo'
     end
     allow(SynchronousIndexer).to receive(:reindex_remotely)
-    allow(Settings).to receive(:doi_prefix).and_return('10.25740')
+    allow(Settings.datacite).to receive(:prefix).and_return('10.25740')
   end
 
   context 'when Cocina::Models::RequestDRO is received' do


### PR DESCRIPTION


## Why was this change made?

This prefix belongs to a set of credentials that include a username and password

## How was this change tested?



## Which documentation and/or configurations were updated?



