### PR TITLE
datacite mappings: cocina title -> datacite titles

### DIFF
--- a/app/services/cocina/to_datacite/attributes.rb
+++ b/app/services/cocina/to_datacite/attributes.rb
@@ -27,13 +27,13 @@ module Cocina
         }.tap do |attribs|
           attribs[:creators] = [] # to be implemented from contributors_h2 mapping
           attribs[:dates] = [] # to be implemented from event_h2 mapping
-          attribs[:descriptions] = [description].compact if description
+          attribs[:descriptions] = [description] if description
           attribs[:identifiers] = [] # needs mapping
           attribs[:publicationYear] = 1964 # to be implemented from event_h2 mapping,
           attribs[:publisher] = 'to be implemented' # to be implemented from event_h2 mapping
-          attribs[:relatedItems] = [related_item].compact if related_item
+          attribs[:relatedItems] = [related_item] if related_item
           attribs[:subjects] = [] # to be implemented from subject_h2 mapping
-          attribs[:titles] = [] # to be implemented
+          attribs[:titles] = [title] if title
           attribs[:types] = types_attributes if types_attributes
         end
       end
@@ -63,6 +63,11 @@ module Cocina
       def related_item
         @related_item ||= RelatedResource.related_item_attributes(cocina_dro.description)
         @related_item.presence
+      end
+
+      def title
+        @title ||= Title.title_attributes(cocina_dro.description)
+        @title.presence
       end
 
       def types_attributes

--- a/app/services/cocina/to_datacite/title.rb
+++ b/app/services/cocina/to_datacite/title.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Cocina
+  module ToDatacite
+    # Transform the Cocina::Models::Description title attributes to attributes for one DataCite title
+    #  see https://support.datacite.org/reference/dois-2#put_dois-id
+    class Title
+      # @param [Cocina::Models::Description] cocina_desc
+      # @return [Hash] Hash of attributes for one DataCite title, conforming to the expectations of HTTP PUT request to DataCite
+      def self.title_attributes(cocina_desc)
+        new(cocina_desc).title_attributes
+      end
+
+      def initialize(cocina_desc)
+        @cocina_desc = cocina_desc
+      end
+
+      # @return [Hash] Hash of attributes for one DataCite title, conforming to the expectations of HTTP PUT request to DataCite
+      def title_attributes
+        return {} if cocina_desc&.title.blank?
+
+        {}.tap do |attribs|
+          attribs[:title] = title if title
+        end
+      end
+
+      private
+
+      attr :cocina_desc
+
+      def title
+        @title ||= cocina_desc.title&.first&.value
+      end
+    end
+  end
+end

--- a/spec/services/cocina/mapping/descriptive/h2_datacite/title_h2_datacite_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2_datacite/title_h2_datacite_spec.rb
@@ -3,32 +3,73 @@
 require 'rails_helper'
 
 RSpec.describe 'Cocina --> DataCite mappings for title (H2 specific)' do
+  # Note that this instantiation of Cocina::Models::Description does NOT validate against OpenAPI due to missing title.
+  let(:cocina_description) { Cocina::Models::Description.new(cocina, false, false) }
+  let(:title_attributes) { Cocina::ToDatacite::Title.title_attributes(cocina_description) }
+
   describe 'Resource title' do
     # User enters title "Tales of a brooding sea star"
-    xit 'not implemented' do
-      let(:cocina) do
-        {
-          title: [
-            {
-              value: 'Tales of a brooding sea star'
-            }
-          ]
-        }
-      end
-
-      let(:datacite) do
-        {
-          data: {
-            attributes: {
-              titles: [
-                {
-                  title: 'Tales of a brooding sea star'
-                }
-              ]
-            }
+    let(:cocina) do
+      {
+        title: [
+          {
+            value: 'Tales of a brooding sea star'
           }
+        ]
+      }
+    end
+
+    it 'populates title_attributes correctly' do
+      # let(:datacite_xml) do
+      #   <<~XML
+      #     <resourceType resourceTypeGeneral="Dataset">Data</resourceType>
+      #   XML
+      # end
+      expect(title_attributes).to eq(
+        {
+          title: 'Tales of a brooding sea star'
         }
-      end
+      )
+    end
+  end
+
+  ### --------------- specs below added by developers ---------------
+
+  context 'when cocina title array has empty hash' do
+    let(:cocina) do
+      {
+        title: [
+          {
+          }
+        ]
+      }
+    end
+
+    it 'title_attributes is empty hash' do
+      expect(title_attributes).to eq({})
+    end
+  end
+
+  context 'when cocina title is empty array' do
+    let(:cocina) do
+      {
+        title: []
+      }
+    end
+
+    it 'title_attributes is empty hash' do
+      expect(title_attributes).to eq({})
+    end
+  end
+
+  context 'when cocina has no title' do
+    let(:cocina) do
+      {
+      }
+    end
+
+    it 'title_attributes is empty hash' do
+      expect(title_attributes).to eq({})
     end
   end
 end

--- a/spec/services/cocina/to_datacite/attributes_spec.rb
+++ b/spec/services/cocina/to_datacite/attributes_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Cocina::ToDatacite::Attributes do
           publicationYear: 1964,
           publisher: 'to be implemented',
           subjects: [],
-          titles: []
+          titles: [{ title: title }]
         }
       )
     end
@@ -154,7 +154,7 @@ RSpec.describe Cocina::ToDatacite::Attributes do
             }
           ],
           subjects: [],
-          titles: [],
+          titles: [{ title: title }],
           types: {
             resourceTypeGeneral: 'Dataset',
             resourceType: 'Data'


### PR DESCRIPTION
## Why was this change made?

We need to map cocina generated by h2 to datacite format so we can update DOI data.

## How was this change tested?

Arcadia's specs and my additions to them

## Which documentation and/or configurations were updated?



