### PR TITLE
datacite mappings: cocina identifier and purl -> datacite identifiers

### DIFF
--- a/app/services/cocina/to_datacite/attributes.rb
+++ b/app/services/cocina/to_datacite/attributes.rb
@@ -5,21 +5,21 @@ module Cocina
     # Transform the Cocina::Models::DRO schema to DataCite attributes
     #  see https://support.datacite.org/reference/dois-2#put_dois-id
     class Attributes
-      # @param [Cocina::Models::DRO] cocina_dro
+      # @param [Cocina::Models::DRO] cocina_item
       # @return [Hash] Hash of DataCite attributes, conforming to the expectations of HTTP PUT request to DataCite
-      def self.mapped_from_cocina(cocina_dro)
-        return unless cocina_dro&.dro?
+      def self.mapped_from_cocina(cocina_item)
+        return unless cocina_item&.dro?
 
-        new(cocina_dro).mapped_from_cocina
+        new(cocina_item).mapped_from_cocina
       end
 
-      def initialize(cocina_dro)
-        @cocina_dro = cocina_dro
+      def initialize(cocina_item)
+        @cocina_item = cocina_item
       end
 
       # @return [Hash] Hash of DataCite attributes, conforming to the expectations of HTTP PUT request to DataCite
       def mapped_from_cocina
-        return if !cocina_dro&.dro? || doi.nil?
+        return if !cocina_item&.dro? || doi.nil?
 
         {
           doi: doi,
@@ -41,12 +41,12 @@ module Cocina
 
       private
 
-      attr :cocina_dro
+      attr :cocina_item
 
       #  example: '10.25740/bc123df4567'
       # @return [String] DOI of object or nil
       def doi
-        cocina_dro.identification.doi
+        cocina_item.identification.doi
       end
 
       # @return [String] DOI prefix, e.g. '10.25740' for '10.25740/bc123df4567'
@@ -57,32 +57,32 @@ module Cocina
       end
 
       def alternate_identifier
-        @alternate_identifier ||= Identifier.alternate_identifier_attributes(cocina_dro.description)
+        @alternate_identifier ||= Identifier.alternate_identifier_attributes(cocina_item.description)
         @alternate_identifier.presence
       end
 
       def description
-        @description ||= Note.descriptions_attributes(cocina_dro.description)
+        @description ||= Note.descriptions_attributes(cocina_item.description)
         @description.presence
       end
 
       def identifier
-        @identifier ||= Identifier.identifier_attributes(cocina_dro.description)
+        @identifier ||= Identifier.identifier_attributes(cocina_item.description)
         @identifier.presence
       end
 
       def related_item
-        @related_item ||= RelatedResource.related_item_attributes(cocina_dro.description)
+        @related_item ||= RelatedResource.related_item_attributes(cocina_item.description)
         @related_item.presence
       end
 
       def title
-        @title ||= Title.title_attributes(cocina_dro.description)
+        @title ||= Title.title_attributes(cocina_item.description)
         @title.presence
       end
 
       def types_attributes
-        @types_attributes ||= Form.type_attributes(cocina_dro.description)
+        @types_attributes ||= Form.type_attributes(cocina_item.description)
         @types_attributes.presence
       end
     end

--- a/app/services/cocina/to_datacite/attributes.rb
+++ b/app/services/cocina/to_datacite/attributes.rb
@@ -25,10 +25,11 @@ module Cocina
           doi: doi,
           prefix: doi_prefix
         }.tap do |attribs|
+          attribs[:alternateIdentifiers] = [alternate_identifier] if alternate_identifier
           attribs[:creators] = [] # to be implemented from contributors_h2 mapping
           attribs[:dates] = [] # to be implemented from event_h2 mapping
           attribs[:descriptions] = [description] if description
-          attribs[:identifiers] = [] # needs mapping
+          attribs[:identifiers] = [identifier] if identifier
           attribs[:publicationYear] = 1964 # to be implemented from event_h2 mapping,
           attribs[:publisher] = 'to be implemented' # to be implemented from event_h2 mapping
           attribs[:relatedItems] = [related_item] if related_item
@@ -55,9 +56,19 @@ module Cocina
         doi.split('/').first
       end
 
+      def alternate_identifier
+        @alternate_identifier ||= Identifier.alternate_identifier_attributes(cocina_dro.description)
+        @alternate_identifier.presence
+      end
+
       def description
         @description ||= Note.descriptions_attributes(cocina_dro.description)
         @description.presence
+      end
+
+      def identifier
+        @identifier ||= Identifier.identifier_attributes(cocina_dro.description)
+        @identifier.presence
       end
 
       def related_item

--- a/app/services/cocina/to_datacite/identifier.rb
+++ b/app/services/cocina/to_datacite/identifier.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Cocina
+  module ToDatacite
+    # Transform the Cocina::Models::Description identifier and purl attributes to the DataCite identifer and alternateIdentifier attributes
+    #  see https://support.datacite.org/reference/dois-2#put_dois-id
+    class Identifier
+      # @param [Cocina::Models::Description] cocina_desc
+      # @return [Hash] Hash of DataCite identifier attributes, conforming to the expectations of HTTP PUT request to DataCite
+      def self.identifier_attributes(cocina_desc)
+        new(cocina_desc).identifier_attributes
+      end
+
+      # @param [Cocina::Models::Description] cocina_desc
+      # @return [Hash] Hash of DataCite alternateIdentifier attributes, conforming to the expectations of HTTP PUT request to DataCite
+      def self.alternate_identifier_attributes(cocina_desc)
+        new(cocina_desc).alternate_identifier_attributes
+      end
+
+      def initialize(cocina_desc)
+        @cocina_desc = cocina_desc
+      end
+
+      # @return [Hash] Hash of DataCite identifier attributes, conforming to the expectations of HTTP PUT request to DataCite
+      def identifier_attributes
+        return if doi.blank?
+
+        {
+          identifier: doi,
+          identifierType: 'DOI'
+        }
+      end
+
+      # @return [Hash] Hash of DataCite alternateIdentifier attributes, conforming to the expectations of HTTP PUT request to DataCite
+      def alternate_identifier_attributes
+        return if purl.blank?
+
+        {
+          alternateIdentifier: purl,
+          alternateIdentifierType: 'PURL'
+        }
+      end
+
+      private
+
+      attr :cocina_desc
+
+      def purl
+        @purl ||= cocina_desc.purl
+      end
+
+      def doi
+        @doi ||= cocina_desc.identifier&.find { |cocina_identifier| cocina_identifier.type == 'DOI' }&.value
+      end
+    end
+  end
+end

--- a/spec/services/cocina/mapping/descriptive/h2_datacite/identifiers_h2_datacite_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2_datacite/identifiers_h2_datacite_spec.rb
@@ -3,56 +3,114 @@
 require 'rails_helper'
 
 RSpec.describe 'Cocina --> DataCite mappings for identifier and alternateIdentifier (H2 specific)' do
+  # NOTE: Because we haven't set a title in this Cocina::Models::Description, it will not validate against the openapi.
+  let(:cocina_description) { Cocina::Models::Description.new(cocina, false, false) }
+  let(:identifier_attributes) { Cocina::ToDatacite::Identifier.identifier_attributes(cocina_description) }
+  let(:alternate_identifier_attributes) { Cocina::ToDatacite::Identifier.alternate_identifier_attributes(cocina_description) }
+
   describe 'DOI' do
     # DOI: 10.5072/example
-    xit 'not implemented' do
-      let(:cocina) do
-        {
-          identifier: [
-            {
-              value: '10.5072/example',
-              type: 'DOI'
-            }
-          ]
-        }
-      end
-
-      let(:datacite) do
-        {
-          data: {
-            attributes: {
-              identifier: '10.5072/example',
-              identifierType: 'DOI'
-            }
+    let(:cocina) do
+      {
+        identifier: [
+          {
+            value: '10.5072/example',
+            type: 'DOI'
           }
+        ]
+      }
+    end
+
+    it 'populates identifier_attributes correctly' do
+      expect(identifier_attributes).to eq(
+        {
+          identifier: '10.5072/example',
+          identifierType: 'DOI'
         }
-      end
+      )
     end
   end
 
   describe 'purl' do
     # purl: http://purl.stanford.edu/gz708sf9862
-    xit 'not implemented' do
-      let(:cocina) do
-        {
-          purl: 'http://purl.stanford.edu/gz708sf9862'
-        }
-      end
+    let(:cocina) do
+      {
+        purl: 'http://purl.stanford.edu/gz708sf9862'
+      }
+    end
 
-      let(:datacite) do
+    it 'populates alternate_identifier_attributes correctly' do
+      expect(alternate_identifier_attributes).to eq(
         {
-          data: {
-            attributes: {
-              alternateIdentifiers: [
-                {
-                  alternateIdentifier: 'http://purl.stanford.edu/gz708sf9862',
-                  alternateIdentifierType: 'PURL'
-                }
-              ]
-            }
-          }
+          alternateIdentifier: 'http://purl.stanford.edu/gz708sf9862',
+          alternateIdentifierType: 'PURL'
         }
-      end
+      )
+    end
+  end
+
+  ### --------------- specs below added by developers ---------------
+
+  context 'when cocina identifier array has empty hash' do
+    let(:cocina) do
+      {
+        identifier: [
+          {
+          }
+        ]
+      }
+    end
+
+    it 'identifier_attributes is nil' do
+      expect(identifier_attributes).to eq nil
+    end
+  end
+
+  context 'when cocina identifier is empty array' do
+    let(:cocina) do
+      {
+        identifier: []
+      }
+    end
+
+    it 'identifier_attributes is nil' do
+      expect(identifier_attributes).to eq nil
+    end
+  end
+
+  context 'when cocina has no identifier' do
+    let(:cocina) do
+      {
+      }
+    end
+
+    it 'identifier_attributes is nil' do
+      expect(identifier_attributes).to eq nil
+    end
+  end
+
+  # NOTE: purl in cocina-model openapi is a String of format uri, so it cannot be nil
+
+  context 'when cocina purl is empty string' do
+    let(:cocina) do
+      {
+        purl: ''
+      }
+    end
+
+    it 'alternate_identifier_attributes is nil' do
+      expect(alternate_identifier_attributes).to eq nil
+    end
+  end
+
+  context 'when cocina has no purl' do
+    let(:cocina) do
+      {
+      }
+    end
+
+    it 'alternate_identifier_attributes is nil' do
+      expect(alternate_identifier_attributes).to eq nil
     end
   end
 end

--- a/spec/services/cocina/to_datacite/attributes_spec.rb
+++ b/spec/services/cocina/to_datacite/attributes_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Cocina::ToDatacite::Attributes do
 
   let(:druid) { 'druid:bb666bb1234' }
   let(:doi) { "10.25740/#{druid.split(':').last}" }
+  let(:purl) { "http://purl.stanford.edu/#{druid.split(':').last}" }
   let(:label) { 'label' }
   let(:title) { 'title' }
   let(:apo_druid) { 'druid:pp000pp0000' }
@@ -37,7 +38,6 @@ RSpec.describe Cocina::ToDatacite::Attributes do
           prefix: '10.25740',
           creators: [],
           dates: [],
-          identifiers: [],
           publicationYear: 1964,
           publisher: 'to be implemented',
           subjects: [],
@@ -47,14 +47,13 @@ RSpec.describe Cocina::ToDatacite::Attributes do
     end
   end
 
-  context 'with cocina description form, note and relatedResource values' do
+  context 'with cocina description form, identifier, note, purl, relatedResource values' do
     let(:cocina_dro) do
       Cocina::Models::DRO.new(externalIdentifier: druid,
                               type: Cocina::Models::Vocab.object,
                               label: label,
                               version: 1,
                               description: {
-                                title: [{ value: title }],
                                 form: [
                                   {
                                     structuredValue: [
@@ -99,12 +98,19 @@ RSpec.describe Cocina::ToDatacite::Attributes do
                                     }
                                   }
                                 ],
+                                identifier: [
+                                  {
+                                    value: doi,
+                                    type: 'DOI'
+                                  }
+                                ],
                                 note: [
                                   {
                                     type: 'abstract',
                                     value: 'My paper is about dolphins.'
                                   }
                                 ],
+                                purl: purl,
                                 relatedResource: [
                                   {
                                     note: [
@@ -114,7 +120,8 @@ RSpec.describe Cocina::ToDatacite::Attributes do
                                       }
                                     ]
                                   }
-                                ]
+                                ],
+                                title: [{ value: title }]
                               },
                               identification: {
                                 sourceId: 'sul:8.559351',
@@ -131,6 +138,12 @@ RSpec.describe Cocina::ToDatacite::Attributes do
         {
           doi: doi,
           prefix: '10.25740',
+          alternateIdentifiers: [
+            {
+              alternateIdentifier: purl,
+              alternateIdentifierType: 'PURL'
+            }
+          ],
           creators: [],
           dates: [],
           descriptions: [
@@ -139,7 +152,12 @@ RSpec.describe Cocina::ToDatacite::Attributes do
               descriptionType: 'Abstract'
             }
           ],
-          identifiers: [],
+          identifiers: [
+            {
+              identifier: doi,
+              identifierType: 'DOI'
+            }
+          ],
           publicationYear: 1964,
           publisher: 'to be implemented',
           relatedItems: [

--- a/spec/services/cocina/to_datacite/attributes_spec.rb
+++ b/spec/services/cocina/to_datacite/attributes_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::ToDatacite::Attributes do
-  let(:attributes) { described_class.mapped_from_cocina(cocina_dro) }
+  let(:attributes) { described_class.mapped_from_cocina(cocina_item) }
 
   let(:druid) { 'druid:bb666bb1234' }
   let(:doi) { "10.25740/#{druid.split(':').last}" }
@@ -13,7 +13,7 @@ RSpec.describe Cocina::ToDatacite::Attributes do
   let(:apo_druid) { 'druid:pp000pp0000' }
 
   context 'with a minimal description' do
-    let(:cocina_dro) do
+    let(:cocina_item) do
       Cocina::Models::DRO.new(externalIdentifier: druid,
                               type: Cocina::Models::Vocab.object,
                               label: label,
@@ -48,7 +48,7 @@ RSpec.describe Cocina::ToDatacite::Attributes do
   end
 
   context 'with cocina description form, identifier, note, purl, relatedResource values' do
-    let(:cocina_dro) do
+    let(:cocina_item) do
       Cocina::Models::DRO.new(externalIdentifier: druid,
                               type: Cocina::Models::Vocab.object,
                               label: label,
@@ -182,8 +182,8 @@ RSpec.describe Cocina::ToDatacite::Attributes do
     end
   end
 
-  context 'when cocina_dro is nil' do
-    let(:cocina_dro) { nil }
+  context 'when cocina_item is nil' do
+    let(:cocina_item) { nil }
 
     it 'attributes retuns nil' do
       expect(attributes).to be_nil
@@ -191,7 +191,7 @@ RSpec.describe Cocina::ToDatacite::Attributes do
   end
 
   context 'when cocina type is collection' do
-    let(:cocina_dro) do
+    let(:cocina_item) do
       Cocina::Models::Collection.new(externalIdentifier: druid,
                                      type: Cocina::Models::Vocab.collection,
                                      label: label,
@@ -212,7 +212,7 @@ RSpec.describe Cocina::ToDatacite::Attributes do
   end
 
   context 'when cocina type is APO' do
-    let(:cocina_dro) do
+    let(:cocina_item) do
       Cocina::Models::AdminPolicy.new(externalIdentifier: druid,
                                       type: Cocina::Models::Vocab.admin_policy,
                                       label: label,


### PR DESCRIPTION
## Why was this change made?

We need to map cocina generated by h2 to datacite format so we can update DOI data.

## How was this change tested?

Arcadia's specs and my additions to them.

## Which documentation and/or configurations were updated?



