### PR TITLE
Log errors when the indexing service is unreachable

### DIFF
--- a/app/services/synchronous_indexer.rb
+++ b/app/services/synchronous_indexer.rb
@@ -4,7 +4,12 @@
 # When we can't have latency in the indexing, we can use this class to directly call dor-indexing-app
 class SynchronousIndexer
   def self.reindex_remotely(pid)
-    connection.post("reindex/#{pid}")
+    result = connection.post("reindex/#{pid}")
+    return if result.success?
+
+    error_message = "Response for reindexing was an error. #{result.status}: #{result.body}"
+    Honeybadger.notify(error_message, { druid: pid })
+    Rails.logger.error(error_message)
   end
 
   def self.connection

--- a/spec/services/synchronous_indexer_spec.rb
+++ b/spec/services/synchronous_indexer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SynchronousIndexer do
+  subject(:reindex) { described_class.reindex_remotely(pid) }
+
+  let(:pid) { 'druid:bc123dg4893' }
+
+  context 'with a successful request' do
+    before do
+      stub_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:bc123dg4893')
+        .to_return(status: 200, body: '', headers: {})
+    end
+
+    it { is_expected.to be_nil }
+  end
+
+  context 'with an unsuccessful request' do
+    before do
+      allow(Honeybadger).to receive(:notify)
+      stub_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:bc123dg4893')
+        .to_return(status: 500, body: 'broken', headers: {})
+    end
+
+    it 'logs an error' do
+      reindex
+      expect(Honeybadger).to have_received(:notify)
+        .with('Response for reindexing was an error. 500: broken', druid: 'druid:bc123dg4893')
+    end
+  end
+end


### PR DESCRIPTION

## Why was this change made?
Earlier today I had failures in the argo test suite when DSA was unable to write to the index.  There were no errors, making this difficult to track down.



## How was this change tested?



## Which documentation and/or configurations were updated?



