### PR TITLE
cocina to datacite mappings: DataCite relatedItem not yet supported

### DIFF
--- a/app/services/cocina/to_datacite/attributes.rb
+++ b/app/services/cocina/to_datacite/attributes.rb
@@ -27,7 +27,9 @@ module Cocina
           attribs[:identifiers] = [identifier] if identifier
           attribs[:publicationYear] = '1964' # to be implemented from event_h2 mapping,
           attribs[:publisher] = 'to be implemented' # to be implemented from event_h2 mapping
-          attribs[:relatedItems] = [related_item] if related_item
+          # NOTE: Per email from DataCite support on 7/21/2021, relatedItem is not currently supported in the ReST API v2.
+          # Support will be added for the entire DataCite MetadataKernel 4.4 schema in v3 of the ReST API.
+          # attribs[:relatedItems] = [related_item] if related_item
           attribs[:rightsList] = [rights] if rights
           attribs[:subjects] = [] # to be implemented from subject_h2 mapping
           attribs[:titles] = [title] if title
@@ -54,10 +56,12 @@ module Cocina
         @identifier.presence
       end
 
-      def related_item
-        @related_item ||= RelatedResource.related_item_attributes(cocina_item.description)
-        @related_item.presence
-      end
+      # NOTE: Per email from DataCite support on 7/21/2021, relatedItem is not currently supported in the ReST API v2.
+      # Support will be added for the entire DataCite MetadataKernel 4.4 schema in v3 of the ReST API.
+      # def related_item
+      #   @related_item ||= RelatedResource.related_item_attributes(cocina_item.description)
+      #   @related_item.presence
+      # end
 
       def rights
         @rights ||= DROAccess.rights_list_attributes(cocina_item.access)

--- a/app/services/cocina/to_datacite/related_resource.rb
+++ b/app/services/cocina/to_datacite/related_resource.rb
@@ -2,6 +2,9 @@
 
 module Cocina
   module ToDatacite
+    # NOTE: Per email from DataCite support on 7/21/2021, relatedItem is not currently supported in the ReST API v2.
+    # Support will be added for the entire DataCite MetadataKernel 4.4 schema in v3 of the ReST API.
+
     # Transform the Cocina::Models::Description relatedResource attributes to the DataCite relatedItem attributes
     #  see https://support.datacite.org/reference/dois-2#put_dois-id
     # relatedItem attribute new in DataCite schema v. 4.4 and not included in API docs as of 2021-07

--- a/spec/services/cocina/mapping/descriptive/h2_datacite/related_resource_h2_datacite_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2_datacite/related_resource_h2_datacite_spec.rb
@@ -1,184 +1,184 @@
 # frozen_string_literal: true
 
-# NOTE: Per email from DataCite support on 7/21/2021, relatedItem is not currently supported in the REST API v2. Support will be added for the entire
-#  DataCite 4.4 schema in v3 of the API.
+require 'rails_helper'
 
-# require 'rails_helper'
-#
-# # relatedItem attribute new in DataCite schema v. 4.4 and not included in API docs as of 2021-07
-# RSpec.describe 'Cocina --> DataCite mappings for relatedItem' do
-#   # NOTE: Because we haven't set a title in this Cocina::Models::Description, it will not validate against the openapi.
-#   let(:cocina_description) { Cocina::Models::Description.new(cocina, false, false) }
-#   let(:related_item_attributes) { Cocina::ToDatacite::RelatedResource.related_item_attributes(cocina_description) }
-#
-#   describe 'Related citation' do
-#     let(:cocina) do
-#       {
-#         relatedResource: [
-#           {
-#             note: [
-#               {
-#                 value: 'Stanford University (Stanford, CA.). (2020). May 2020 dataset. Atmospheric Pressure. Professor Maya Aguirre. Department of Earth Sciences, Stanford University.',
-#                 type: 'preferred citation'
-#               }
-#             ]
-#           }
-#         ]
-#       }
-#     end
-#
-#     it 'populates related_item_attributes correctly' do
-#       # let(:datacite_xml) do
-#       #   <<~XML
-#       #     <relatedItems>
-#       #       <relatedItem relatedItemType="Other" relationType="References">
-#       #         <titles>
-#       #           <title>Stanford University (Stanford, CA.). (2020). May 2020 dataset. yadda yadda</title>
-#       #         </titles>
-#       #       </relatedItem>
-#       #     </relatedItems>
-#       #   XML
-#       # end
-#       expect(related_item_attributes).to eq(
-#         {
-#           relatedItemType: 'Other',
-#           relationType: 'References',
-#           titles: [
-#             {
-#               title: 'Stanford University (Stanford, CA.). (2020). May 2020 dataset. Atmospheric Pressure. Professor Maya Aguirre. Department of Earth Sciences, Stanford University.'
-#             }
-#           ]
-#         }
-#       )
-#     end
-#   end
-#
-#   describe 'Related link with title' do
-#     let(:cocina) do
-#       {
-#         relatedResource: [
-#           {
-#             title: [
-#               {
-#                 value: 'A paper'
-#               }
-#             ],
-#             access: {
-#               url: [
-#                 {
-#                   value: 'https://www.example.com/paper.html'
-#                 }
-#               ]
-#             }
-#           }
-#         ]
-#       }
-#     end
-#
-#     it 'populates related_item_attributes correctly' do
-#       # let(:datacite_xml) do
-#       #   <<~XML
-#       #     <relatedItems>
-#       #       <relatedItem relatedItemType="Other" relationType="References">
-#       #         <titles>
-#       #           <title>A paper</title>
-#       #         </titles>
-#       #         <relatedItemIdentifier relatedItemIdentifierType="URL">https://www.example.com/paper.html</relatedItemIdentifier>
-#       #       </relatedItem>
-#       #     </relatedItems>
-#       #   XML
-#       # end
-#       expect(related_item_attributes).to eq(
-#         {
-#           relatedItemType: 'Other',
-#           relationType: 'References',
-#           relatedItemIdentifier: 'https://www.example.com/paper.html',
-#           relatedItemIdentifierType: 'URL',
-#           titles: [
-#             {
-#               title: 'A paper'
-#             }
-#           ]
-#         }
-#       )
-#     end
-#   end
-#
-#   describe 'Related link without title' do
-#     let(:cocina) do
-#       {
-#         relatedResource: [
-#           {
-#             access: {
-#               url: [
-#                 {
-#                   value: 'https://www.example.com/paper.html'
-#                 }
-#               ]
-#             }
-#           }
-#         ]
-#       }
-#     end
-#
-#     it 'populates related_item_attributes correctly' do
-#       # let(:datacite_xml) do
-#       #   <<~XML
-#       #     <relatedItems>
-#       #       <relatedItem relatedItemType="Other" relationType="References">
-#       #         <relatedItemIdentifier relatedItemIdentifierType="URL">https://www.example.com/paper.html</relatedItemIdentifier>
-#       #       </relatedItem>
-#       #     </relatedItems>
-#       #   XML
-#       # end
-#       expect(related_item_attributes).to eq(
-#         {
-#           relatedItemType: 'Other',
-#           relationType: 'References',
-#           relatedItemIdentifier: 'https://www.example.com/paper.html',
-#           relatedItemIdentifierType: 'URL'
-#         }
-#       )
-#     end
-#   end
-#
-#   ### --------------- specs below added by developers ---------------
-#
-#   context 'when cocina relatedResource array has empty hash' do
-#     let(:cocina) do
-#       {
-#         relatedResource: [
-#           {
-#           }
-#         ]
-#       }
-#     end
-#
-#     it 'related_item_attributes is empty hash' do
-#       expect(related_item_attributes).to eq({})
-#     end
-#   end
-#
-#   context 'when cocina relatedResource is empty array' do
-#     let(:cocina) do
-#       {
-#         relatedResource: []
-#       }
-#     end
-#
-#     it 'related_item_attributes is empty hash' do
-#       expect(related_item_attributes).to eq({})
-#     end
-#   end
-#
-#   context 'when cocina has no relatedResource' do
-#     let(:cocina) do
-#       {
-#       }
-#     end
-#
-#     it 'related_item_attributes is empty hash' do
-#       expect(related_item_attributes).to eq({})
-#     end
-#   end
-# end
+# NOTE: Per email from DataCite support on 7/21/2021, relatedItem is not currently supported in the DataCite ReST API v2.
+# Support will be added for the entire DataCite MetadataKernel 4.4 schema in v3 of the DataCite ReST API.
+
+# relatedItem attribute new in DataCite MetadataKerne schema v. 4.4 and not included in the DataCite ReST API docs as of 2021-07
+RSpec.describe 'Cocina --> DataCite mappings for relatedItem' do
+  # NOTE: Because we haven't set a title in this Cocina::Models::Description, it will not validate against the openapi.
+  let(:cocina_description) { Cocina::Models::Description.new(cocina, false, false) }
+  let(:related_item_attributes) { Cocina::ToDatacite::RelatedResource.related_item_attributes(cocina_description) }
+
+  describe 'Related citation' do
+    let(:cocina) do
+      {
+        relatedResource: [
+          {
+            note: [
+              {
+                value: 'Stanford University (Stanford, CA.). (2020). May 2020 dataset. Atmospheric Pressure. Professor Maya Aguirre. Department of Earth Sciences, Stanford University.',
+                type: 'preferred citation'
+              }
+            ]
+          }
+        ]
+      }
+    end
+
+    it 'populates related_item_attributes correctly' do
+      # let(:datacite_xml) do
+      #   <<~XML
+      #     <relatedItems>
+      #       <relatedItem relatedItemType="Other" relationType="References">
+      #         <titles>
+      #           <title>Stanford University (Stanford, CA.). (2020). May 2020 dataset. yadda yadda</title>
+      #         </titles>
+      #       </relatedItem>
+      #     </relatedItems>
+      #   XML
+      # end
+      expect(related_item_attributes).to eq(
+        {
+          relatedItemType: 'Other',
+          relationType: 'References',
+          titles: [
+            {
+              title: 'Stanford University (Stanford, CA.). (2020). May 2020 dataset. Atmospheric Pressure. Professor Maya Aguirre. Department of Earth Sciences, Stanford University.'
+            }
+          ]
+        }
+      )
+    end
+  end
+
+  describe 'Related link with title' do
+    let(:cocina) do
+      {
+        relatedResource: [
+          {
+            title: [
+              {
+                value: 'A paper'
+              }
+            ],
+            access: {
+              url: [
+                {
+                  value: 'https://www.example.com/paper.html'
+                }
+              ]
+            }
+          }
+        ]
+      }
+    end
+
+    it 'populates related_item_attributes correctly' do
+      # let(:datacite_xml) do
+      #   <<~XML
+      #     <relatedItems>
+      #       <relatedItem relatedItemType="Other" relationType="References">
+      #         <titles>
+      #           <title>A paper</title>
+      #         </titles>
+      #         <relatedItemIdentifier relatedItemIdentifierType="URL">https://www.example.com/paper.html</relatedItemIdentifier>
+      #       </relatedItem>
+      #     </relatedItems>
+      #   XML
+      # end
+      expect(related_item_attributes).to eq(
+        {
+          relatedItemType: 'Other',
+          relationType: 'References',
+          relatedItemIdentifier: 'https://www.example.com/paper.html',
+          relatedItemIdentifierType: 'URL',
+          titles: [
+            {
+              title: 'A paper'
+            }
+          ]
+        }
+      )
+    end
+  end
+
+  describe 'Related link without title' do
+    let(:cocina) do
+      {
+        relatedResource: [
+          {
+            access: {
+              url: [
+                {
+                  value: 'https://www.example.com/paper.html'
+                }
+              ]
+            }
+          }
+        ]
+      }
+    end
+
+    it 'populates related_item_attributes correctly' do
+      # let(:datacite_xml) do
+      #   <<~XML
+      #     <relatedItems>
+      #       <relatedItem relatedItemType="Other" relationType="References">
+      #         <relatedItemIdentifier relatedItemIdentifierType="URL">https://www.example.com/paper.html</relatedItemIdentifier>
+      #       </relatedItem>
+      #     </relatedItems>
+      #   XML
+      # end
+      expect(related_item_attributes).to eq(
+        {
+          relatedItemType: 'Other',
+          relationType: 'References',
+          relatedItemIdentifier: 'https://www.example.com/paper.html',
+          relatedItemIdentifierType: 'URL'
+        }
+      )
+    end
+  end
+
+  ### --------------- specs below added by developers ---------------
+
+  context 'when cocina relatedResource array has empty hash' do
+    let(:cocina) do
+      {
+        relatedResource: [
+          {
+          }
+        ]
+      }
+    end
+
+    it 'related_item_attributes is empty hash' do
+      expect(related_item_attributes).to eq({})
+    end
+  end
+
+  context 'when cocina relatedResource is empty array' do
+    let(:cocina) do
+      {
+        relatedResource: []
+      }
+    end
+
+    it 'related_item_attributes is empty hash' do
+      expect(related_item_attributes).to eq({})
+    end
+  end
+
+  context 'when cocina has no relatedResource' do
+    let(:cocina) do
+      {
+      }
+    end
+
+    it 'related_item_attributes is empty hash' do
+      expect(related_item_attributes).to eq({})
+    end
+  end
+end

--- a/spec/services/cocina/to_datacite/attributes_spec.rb
+++ b/spec/services/cocina/to_datacite/attributes_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Cocina::ToDatacite::Attributes do
                               })
     end
 
-    it 'populates types in the attributes hash' do
+    it 'populates the attributes hash correctly' do
       expect(attributes).to eq(
         {
           alternateIdentifiers: [
@@ -158,17 +158,19 @@ RSpec.describe Cocina::ToDatacite::Attributes do
           ],
           publicationYear: '1964',
           publisher: 'to be implemented',
-          relatedItems: [
-            {
-              relatedItemType: 'Other',
-              relationType: 'References',
-              titles: [
-                {
-                  title: 'Stanford University (Stanford, CA.). (2020). May 2020 dataset. yadda yadda.'
-                }
-              ]
-            }
-          ],
+          # NOTE: Per email from DataCite support on 7/21/2021, relatedItem is not currently supported in the ReST API v2.
+          # Support will be added for the entire DataCite MetadataKernel 4.4 schema in v3 of the ReST API.
+          # relatedItems: [
+          #   {
+          #     relatedItemType: 'Other',
+          #     relationType: 'References',
+          #     titles: [
+          #       {
+          #         title: 'Stanford University (Stanford, CA.). (2020). May 2020 dataset. yadda yadda.'
+          #       }
+          #     ]
+          #   }
+          # ],
           rightsList: [
             {
               rights: 'https://creativecommons.org/publicdomain/mark/1.0/'


### PR DESCRIPTION
## Why was this change made?

Deactivate relatedItem DataCite mapping that won't be used until version 3 of DataCite ReST API (current version is 2)

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?



