### PR TITLE
datacite mappings: cocina event -> DataCite publicationYear with unit tests

### DIFF
--- a/app/services/cocina/to_datacite/event.rb
+++ b/app/services/cocina/to_datacite/event.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Cocina
+  module ToDatacite
+    # Transform the Cocina::Models::DRO.description.event attributes to appropriate DataCite attributes
+    #  see https://support.datacite.org/reference/dois-2#put_dois-id
+    class Event
+      def initialize(cocina_item)
+        @cocina_item = cocina_item
+      end
+
+      # For DataCite publicationYear, use year embargo lifted if present,
+      #  otherwise use deposit year, regardless of publication date entered
+      #
+      # @return [String] publication year, conforming to the expectations of HTTP PUT request to DataCite
+      def pub_year
+        if embargo?
+          embargo_release_date = cocina_dro_access&.embargo&.releaseDate
+          embargo_release_date&.year&.to_s
+        elsif deposit_event_publication_date
+          DateTime.parse(deposit_event_publication_date).year&.to_s
+        end
+      end
+
+      # Add Stanford Digital Repository as publisher to cocina release event if present, otherwise deposit event
+      def publisher
+        # TODO: implement this
+      end
+
+      # For DataCite dates
+      # H2 publication date > cocina event/date type publication > DataCite date type Issued
+      # H2 deposit date > cocina event type deposit > DataCite date type Submitted
+      ## If no embargo, > cocina date type publication
+      ## If embargo, > cocina date type deposit
+      # H2 embargo end date > cocina event type release and date type publication > DataCite date type Available
+      def dates
+        # TODO: implement this
+      end
+
+      private
+
+      attr :cocina_item
+
+      def embargo?
+        cocina_dro_access&.embargo&.releaseDate.presence
+      end
+
+      def deposit_event_publication_date
+        deposit_event&.date&.find { |date| date&.type == 'publication' }&.value
+      end
+
+      def deposit_event
+        cocina_events&.find { |event| event&.type == 'deposit' }
+      end
+
+      def cocina_events
+        @cocina_events ||= cocina_item.description.event
+      end
+
+      # embargo is in Cocina::Models::DROAccess -- the top level access, not description.access
+      def cocina_dro_access
+        @cocina_dro_access ||= cocina_item.access
+      end
+    end
+  end
+end

--- a/spec/services/cocina/to_datacite/event_pub_year_spec.rb
+++ b/spec/services/cocina/to_datacite/event_pub_year_spec.rb
@@ -1,0 +1,1054 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Unit tests for Cocina::ToDatacite::Event.pub_year (which will become DataCite pub_year)
+RSpec.describe Cocina::ToDatacite::Event do
+  let(:cocina_description) do
+    cocina[:title] = [{ value: 'title' }]
+    Cocina::Models::Description.new(cocina)
+  end
+  let(:cocina_item) do
+    Cocina::Models::DRO.new(type: Cocina::Models::Vocab.object,
+                            label: 'This is my label',
+                            version: 1,
+                            administrative: { hasAdminPolicy: 'druid:dd999df4567' },
+                            description: cocina_description,
+                            identification: { sourceId: 'cats:dogs' },
+                            externalIdentifier: 'druid:cc123dd1234',
+                            structural: {},
+                            access: cocina_access)
+  end
+  let(:mapped_event_instance) { described_class.new(cocina_item) }
+  let(:pub_year) { mapped_event_instance.pub_year }
+
+  describe '#pub_year' do
+    # For DataCite publication year, use year embargo lifted if present,
+    #  otherwise use deposit year, regardless of publication date entered
+
+    describe 'Publication date: 2021-01-01, Embargo: none, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                value: '2022-01-01',
+                type: 'publication',
+                encoding: {
+                  code: 'w3cdtf'
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'populates pub_year correctly' do
+        expect(pub_year).to eq '2022'
+      end
+    end
+
+    describe 'Publication date entered as: 2020-01-01, Embargo: until 2022-01-01, Deposited: 2021-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              date: [
+                {
+                  value: '2020-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'release',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'deposit',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) do
+        {
+          embargo:
+            {
+              access: 'world',
+              download: 'world',
+              releaseDate: DateTime.parse('2022-01-01'),
+              useAndReproductionStatement: 'in public domain'
+            }
+        }
+      end
+
+      it 'populates pub_year correctly' do
+        expect(pub_year).to eq('2022')
+      end
+    end
+
+    describe 'No publication date provided, Embargo: until 2022-01-01, Deposited: 2021-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'release',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'deposit',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) do
+        {
+          embargo:
+            {
+              access: 'world',
+              download: 'world',
+              releaseDate: DateTime.parse('2022-01-01'),
+              useAndReproductionStatement: 'in public domain'
+            }
+        }
+      end
+
+      it 'populates pub_year correctly' do
+        expect(pub_year).to eq('2022')
+      end
+    end
+
+    describe 'No publication date provided, Embargo: none, Deposited: 2021-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'populates pub_year correctly' do
+        expect(pub_year).to eq('2021')
+      end
+    end
+
+    describe 'Creation date: 2021-01-01, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'creation',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'populates pub_year correctly' do
+        expect(pub_year).to eq('2022')
+      end
+    end
+
+    describe 'Creation date range: 2020-01-01 to 2021-01-01, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '2020-01-01',
+                      type: 'start'
+                    },
+                    {
+                      value: '2021-01-01',
+                      type: 'end'
+                    }
+                  ],
+                  type: 'creation',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'populates pub_year correctly' do
+        expect(pub_year).to eq('2022')
+      end
+    end
+
+    describe 'Approximate single creation date, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  value: '1900',
+                  type: 'creation',
+                  qualifier: 'approximate',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'populates pub_year correctly' do
+        expect(pub_year).to eq('2022')
+      end
+    end
+
+    describe 'Approximate creation start date: approx. 1900, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '1900',
+                      type: 'start',
+                      qualifier: 'approximate'
+                    },
+                    {
+                      value: '1910',
+                      type: 'end'
+                    }
+                  ],
+                  type: 'creation',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'populates pub_year correctly' do
+        expect(pub_year).to eq('2022')
+      end
+    end
+
+    describe 'Approximate creation end date: approx. 1900, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '1900',
+                      type: 'start'
+                    },
+                    {
+                      value: '1910',
+                      type: 'end',
+                      qualifier: 'approximate'
+                    }
+                  ],
+                  type: 'creation',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'populates pub_year correctly' do
+        expect(pub_year).to eq('2022')
+      end
+    end
+
+    describe 'Approximate creation date range: approx. 1900, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '1900',
+                      type: 'start'
+                    },
+                    {
+                      value: '1910',
+                      type: 'end'
+                    }
+                  ],
+                  type: 'creation',
+                  qualifier: 'approximate',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'populates pub_year correctly' do
+        expect(pub_year).to eq('2022')
+      end
+    end
+
+    describe 'Creation date: 2021-01-01, Embargo: until 2023-01-01, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'creation',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'release',
+              date: [
+                {
+                  value: '2023-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'deposit',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) do
+        {
+          embargo:
+            {
+              access: 'world',
+              download: 'world',
+              releaseDate: DateTime.parse('2023-01-01'),
+              useAndReproductionStatement: 'in public domain'
+            }
+        }
+      end
+
+      it 'populates pub_year correctly' do
+        expect(pub_year).to eq('2023')
+      end
+    end
+
+    describe 'Creation date: 2021-01-01, Deposited: 2022-01-01, Uncited publisher: Stanford University Press' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'creation',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            },
+            {
+              type: 'publication',
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford University Press'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'Publisher',
+                      source: {
+                        value: 'H2 contributor role terms'
+                      },
+                      note: [
+                        {
+                          type: 'citation status',
+                          value: 'false'
+                        }
+                      ]
+                    },
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Distributor',
+                      type: 'DataCite role',
+                      source: {
+                        value: 'DataCite contributor types'
+                      }
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'populates pub_year correctly' do
+        expect(pub_year).to eq('2022')
+      end
+    end
+
+    describe 'Publication date: 2021-01-01, Deposited: 2022-01-01, Uncited publisher: Stanford University Press' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford University Press'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'Publisher',
+                      source: {
+                        value: 'H2 contributor role terms'
+                      },
+                      note: [
+                        {
+                          type: 'citation status',
+                          value: 'false'
+                        }
+                      ]
+                    },
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Distributor',
+                      type: 'DataCite role',
+                      source: {
+                        value: 'DataCite contributor types'
+                      }
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'populates pub_year correctly' do
+        expect(pub_year).to eq('2022')
+      end
+    end
+
+    ### --------------- specs below added by developers ---------------
+
+    context 'when cocina event array has empty hash' do
+      let(:cocina) do
+        {
+          event: [
+            {
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} }
+
+      it 'pub_year is nil' do
+        expect(pub_year).to eq nil
+      end
+    end
+
+    context 'when cocina event is empty array' do
+      let(:cocina) do
+        {
+          event: []
+        }
+      end
+      let(:cocina_access) { {} }
+
+      it 'pub_year is nil' do
+        expect(pub_year).to eq nil
+      end
+    end
+
+    context 'when cocina has no event attribute' do
+      let(:cocina) do
+        {
+        }
+      end
+      let(:cocina_access) { {} }
+
+      it 'pub_year is nil' do
+        expect(pub_year).to eq nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

We need to map cocina generated by h2 to datacite format so we can update DOI data.

This PR implements extracting correct publication year for DataCite mapping from cocina events

## How was this change tested?

unit tests adapted from Arcadia's tests

## Which documentation and/or configurations were updated?



