### PR TITLE
datacite mappings: cocina event -> DataCite dates with unit tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,7 @@ Metrics/ClassLength:
     - 'app/services/cocina/normalizers/mods_normalizer.rb'
     - 'app/services/cocina/object_creator.rb'
     - 'app/services/cocina/object_updater.rb'
+    - 'app/services/cocina/to_datacite/event.rb'
     - 'app/services/cocina/to_fedora/descriptive/contributor_writer.rb'
     - 'app/services/cocina/to_fedora/descriptive/event.rb'
     - 'app/services/cocina/to_fedora/descriptive/form.rb'

--- a/app/services/cocina/to_datacite/event.rb
+++ b/app/services/cocina/to_datacite/event.rb
@@ -23,7 +23,12 @@ module Cocina
         end
       end
 
+      # H2 publisher role > same cocina event as publication date > see DataCite contributor mappings
       # Add Stanford Digital Repository as publisher to cocina release event if present, otherwise deposit event
+      #
+      # sdr is the publisher for the event where the content becomes public via purl -- deposit if no embargo, release if embargo present.
+      # if it's not public via purl, sdr should not be the publisher;
+      #   the user may enter someone with the publisher role in h2, referring to publication in another venue, regardless of the purl status.
       def publisher
         # TODO: implement this
       end

--- a/app/services/cocina/to_datacite/event.rb
+++ b/app/services/cocina/to_datacite/event.rb
@@ -18,8 +18,8 @@ module Cocina
         if embargo?
           embargo_release_date = cocina_dro_access&.embargo&.releaseDate
           embargo_release_date&.year&.to_s
-        elsif deposit_event_publication_date
-          DateTime.parse(deposit_event_publication_date).year&.to_s
+        elsif deposit_event_publication_date_value
+          DateTime.parse(deposit_event_publication_date_value).year&.to_s
         end
       end
 
@@ -33,14 +33,15 @@ module Cocina
         # TODO: implement this
       end
 
-      # For DataCite dates
-      # H2 publication date > cocina event/date type publication > DataCite date type Issued
-      # H2 deposit date > cocina event type deposit > DataCite date type Submitted
-      ## If no embargo, > cocina date type publication
-      ## If embargo, > cocina date type deposit
-      # H2 embargo end date > cocina event type release and date type publication > DataCite date type Available
+      # DataCite date (YYYY-MM-DD) is repeatable and each DataCite data has an associated type attribute
+      # @return [Array<Hash>] DataCite date hashs, conforming to the expectations of HTTP PUT request to DataCite
       def dates
-        # TODO: implement this
+        [].tap do |dates|
+          dates << submitted_date if submitted_date.present?
+          dates << available_date if available_date.present?
+          dates << issued_date if issued_date.present?
+          dates << created_date if created_date.present?
+        end
       end
 
       private
@@ -51,13 +52,126 @@ module Cocina
         cocina_dro_access&.embargo&.releaseDate.presence
       end
 
-      def deposit_event_publication_date
-        deposit_event&.date&.find { |date| date&.type == 'publication' }&.value
+      # If embargo,
+      #   Cocina event type deposit, date type deposit maps to DataCite date type Submitted
+      # If no embargo
+      #   Cocina event type deposit, date type publication maps to DataCite date type Submitted
+      # If no embargo and no deposit event with date type publication,
+      #   Cocina event type publication, date type publication maps to DataCite date type Submitted
+      def submitted_date
+        @submitted_date ||= {}.tap do |submitted_date|
+          if embargo? && deposit_event_deposit_date_value.present?
+            submitted_date[:date] = deposit_event_deposit_date_value
+          elsif deposit_event_publication_date_value.present? # no embargo
+            submitted_date[:date] = deposit_event_publication_date_value
+          elsif publication_event_publication_date_value.present? # no embargo
+            submitted_date[:date] = publication_event_publication_date_value
+          end
+          submitted_date[:dateType] = 'Submitted' if submitted_date.present?
+        end
+      end
+
+      # from Arcadia:
+      #   Cocina event type release, date type publication maps to DataCite date type Available
+      # In actuality:
+      #   embargo release date is in DROAccess, not in an event
+      def available_date
+        return unless embargo?
+
+        @available_date ||=
+          {
+            date: cocina_dro_access&.embargo&.releaseDate,
+            dateType: 'Available'
+          }
+      end
+
+      # Cocina event type publication, date type publication maps to DataCite date type Issued
+      def issued_date
+        return if publication_event_publication_date_value.blank?
+
+        @issued_date ||=
+          {
+            date: publication_event_publication_date_value,
+            dateType: 'Issued'
+          }
+      end
+
+      # Cocina event type creation, date type creation maps to DataCite date type Created
+      def created_date
+        return if creation_event_creation_date.blank?
+
+        @created_date ||= begin
+          created_date = {
+            dateType: 'Created'
+          }
+          if creation_event_creation_date.value
+            created_date[:date] = creation_event_creation_date.value
+            created_date[:dateInformation] = creation_event_creation_date.qualifier if creation_event_creation_date.qualifier.present?
+          else
+            created_date.merge!(structured_date_result(creation_event_creation_date))
+          end
+
+          created_date
+        end
+      end
+
+      def deposit_event_deposit_date_value
+        @deposit_event_deposit_date_value ||= deposit_event&.date&.find { |date| date&.type == 'deposit' }&.value
+      end
+
+      def deposit_event_publication_date_value
+        @deposit_event_publication_date_value ||= deposit_event&.date&.find { |date| date&.type == 'publication' }&.value
       end
 
       def deposit_event
-        cocina_events&.find { |event| event&.type == 'deposit' }
+        @deposit_event ||= cocina_events&.find { |event| event&.type == 'deposit' }
       end
+
+      def publication_event_publication_date_value
+        @publication_event_publication_date_value ||= publication_event&.date&.find { |date| date&.type == 'publication' }&.value
+      end
+
+      def publication_event
+        @publication_event ||= cocina_events&.find { |event| event&.type == 'publication' }
+      end
+
+      def creation_event_creation_date
+        @creation_event_creation_date ||= creation_event&.date&.find { |date| date&.type == 'creation' }
+      end
+
+      def creation_event
+        @creation_event ||= cocina_events&.find { |event| event&.type == 'creation' }
+      end
+
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/PerceivedComplexity
+      def structured_date_result(date)
+        return unless date.structuredValue
+
+        start_date, end_date, = ''
+        info = date.qualifier if date.qualifier.present?
+        date.structuredValue.each do |structured_val|
+          start_date = structured_val.value if structured_val.type == 'start'
+          end_date = structured_val.value if structured_val.type == 'end'
+          info = structured_val.qualifier if structured_val.qualifier
+        end
+
+        result_date = if start_date.present? && end_date.present?
+                        "#{start_date}/#{end_date}"
+                      elsif start_date.present?
+                        start_date
+                      elsif end_date.present?
+                        end_date
+                      end
+
+        {
+          date: result_date
+        }.tap do |attributes|
+          attributes[:dateInformation] = info if info.present? && result_date.present?
+        end.compact
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/PerceivedComplexity
 
       def cocina_events
         @cocina_events ||= cocina_item.description.event

--- a/spec/services/cocina/to_datacite/event_dates_spec.rb
+++ b/spec/services/cocina/to_datacite/event_dates_spec.rb
@@ -1,0 +1,1306 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Unit tests for Cocina::ToDatacite::Event.dates
+RSpec.describe Cocina::ToDatacite::Event do
+  let(:cocina_description) do
+    cocina[:title] = [{ value: 'title' }]
+    Cocina::Models::Description.new(cocina)
+  end
+  let(:cocina_item) do
+    Cocina::Models::DRO.new(type: Cocina::Models::Vocab.object,
+                            label: 'This is my label',
+                            version: 1,
+                            administrative: { hasAdminPolicy: 'druid:dd999df4567' },
+                            description: cocina_description,
+                            identification: { sourceId: 'cats:dogs' },
+                            externalIdentifier: 'druid:cc123dd1234',
+                            structural: {},
+                            access: cocina_access)
+  end
+  let(:mapped_event_instance) { described_class.new(cocina_item) }
+  let(:dates) { mapped_event_instance.dates }
+
+  describe '#dates' do
+    # For DataCite dates:
+    # H2 publication date > cocina event/date type publication > DataCite date type Issued
+    # H2 deposit date > cocina event type deposit > DataCite date type Submitted
+    ## If no embargo, > cocina date type publication
+    ## If embargo, > cocina date type deposit
+    # H2 embargo end date > cocina event type release and date type publication > DataCite date type Available
+    # H2 creation date > cocina event/date type creation > DataCite date type Creation
+
+    describe 'Publication date: 2021-01-01, Embargo: none, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                value: '2022-01-01',
+                type: 'publication',
+                encoding: {
+                  code: 'w3cdtf'
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'has 2 dates' do
+        expect(dates.size).to eq 2
+      end
+
+      it 'includes correct Submitted date' do
+        expect(dates).to include(
+          {
+            date: '2022-01-01',
+            dateType: 'Submitted'
+          }
+        )
+      end
+
+      it 'includes correct Issued date' do
+        expect(dates).to include(
+          {
+            date: '2021-01-01',
+            dateType: 'Issued'
+          }
+        )
+      end
+    end
+
+    describe 'Publication date entered as: 2020-01-01, Embargo: until 2022-01-01, Deposited: 2021-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              date: [
+                {
+                  value: '2020-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'release',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'deposit',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) do
+        {
+          embargo:
+            {
+              access: 'world',
+              download: 'world',
+              releaseDate: DateTime.parse('2022-01-01'),
+              useAndReproductionStatement: 'in public domain'
+            }
+        }
+      end
+
+      it 'has 3 dates' do
+        expect(dates.size).to eq 3
+      end
+
+      it 'includes correct Submitted date' do
+        expect(dates).to include(
+          {
+            date: '2021-01-01',
+            dateType: 'Submitted'
+          }
+        )
+      end
+
+      it 'includes correct Available date' do
+        expect(dates).to include(
+          {
+            date: '2022-01-01',
+            dateType: 'Available'
+          }
+        )
+      end
+
+      it 'includes correct Issued date' do
+        expect(dates).to include(
+          {
+            date: '2020-01-01',
+            dateType: 'Issued'
+          }
+        )
+      end
+    end
+
+    describe 'No publication date provided, Embargo: until 2022-01-01, Deposited: 2021-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'release',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'deposit',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) do
+        {
+          embargo:
+            {
+              access: 'world',
+              download: 'world',
+              releaseDate: DateTime.parse('2022-01-01'),
+              useAndReproductionStatement: 'in public domain'
+            }
+        }
+      end
+
+      it 'has 2 dates' do
+        expect(dates.size).to eq 2
+      end
+
+      it 'includes correct Submitted date' do
+        expect(dates).to include(
+          {
+            date: '2021-01-01',
+            dateType: 'Submitted'
+          }
+        )
+      end
+
+      it 'includes correct Available date' do
+        expect(dates).to include(
+          {
+            date: '2022-01-01',
+            dateType: 'Available'
+          }
+        )
+      end
+    end
+
+    describe 'No publication date provided, Embargo: none, Deposited: 2021-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'has 1 date' do
+        expect(dates.size).to eq 1
+      end
+
+      it 'includes correct Submitted date' do
+        expect(dates).to include(
+          {
+            date: '2021-01-01',
+            dateType: 'Submitted'
+          }
+        )
+      end
+    end
+
+    describe 'Creation date: 2021-01-01, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'creation',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'has 2 dates' do
+        expect(dates.size).to eq 2
+      end
+
+      it 'includes correct Submitted date' do
+        expect(dates).to include(
+          {
+            date: '2022-01-01',
+            dateType: 'Submitted'
+          }
+        )
+      end
+
+      it 'includes correct Created date' do
+        expect(dates).to include(
+          {
+            date: '2021-01-01',
+            dateType: 'Created'
+          }
+        )
+      end
+    end
+
+    describe 'Creation date range: 2020-01-01 to 2021-01-01, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '2020-01-01',
+                      type: 'start'
+                    },
+                    {
+                      value: '2021-01-01',
+                      type: 'end'
+                    }
+                  ],
+                  type: 'creation',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'has 2 dates' do
+        expect(dates.size).to eq 2
+      end
+
+      it 'includes correct Submitted date' do
+        expect(dates).to include(
+          {
+            date: '2022-01-01',
+            dateType: 'Submitted'
+          }
+        )
+      end
+
+      it 'includes correct Created date' do
+        expect(dates).to include(
+          {
+            date: '2020-01-01/2021-01-01',
+            dateType: 'Created'
+          }
+        )
+      end
+    end
+
+    describe 'Approximate single creation date: 1900, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  value: '1900',
+                  type: 'creation',
+                  qualifier: 'approximate',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'has 2 dates' do
+        expect(dates.size).to eq 2
+      end
+
+      it 'includes correct Submitted date' do
+        expect(dates).to include(
+          {
+            date: '2022-01-01',
+            dateType: 'Submitted'
+          }
+        )
+      end
+
+      it 'includes correct Created date' do
+        expect(dates).to include(
+          {
+            date: '1900',
+            dateType: 'Created',
+            dateInformation: 'approximate'
+          }
+        )
+      end
+    end
+
+    describe 'Approximate creation start date: approx. 1900-1910, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '1900',
+                      type: 'start',
+                      qualifier: 'approximate'
+                    },
+                    {
+                      value: '1910',
+                      type: 'end'
+                    }
+                  ],
+                  type: 'creation',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'has 2 dates' do
+        expect(dates.size).to eq 2
+      end
+
+      it 'includes correct Submitted date' do
+        expect(dates).to include(
+          {
+            date: '2022-01-01',
+            dateType: 'Submitted'
+          }
+        )
+      end
+
+      it 'includes correct Created date' do
+        expect(dates).to include(
+          {
+            date: '1900/1910',
+            dateType: 'Created',
+            dateInformation: 'approximate'
+          }
+        )
+      end
+    end
+
+    describe 'Approximate creation end date: 1900-approx. 1910, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '1900',
+                      type: 'start'
+                    },
+                    {
+                      value: '1910',
+                      type: 'end',
+                      qualifier: 'approximate'
+                    }
+                  ],
+                  type: 'creation',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'has 2 dates' do
+        expect(dates.size).to eq 2
+      end
+
+      it 'includes correct Submitted date' do
+        expect(dates).to include(
+          {
+            date: '2022-01-01',
+            dateType: 'Submitted'
+          }
+        )
+      end
+
+      it 'includes correct Created date' do
+        expect(dates).to include(
+          {
+            date: '1900/1910',
+            dateType: 'Created',
+            dateInformation: 'approximate'
+          }
+        )
+      end
+    end
+
+    describe 'Approximate creation date range: approx. 1900-approx. 1910, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  structuredValue: [
+                    {
+                      value: '1900',
+                      type: 'start'
+                    },
+                    {
+                      value: '1910',
+                      type: 'end'
+                    }
+                  ],
+                  type: 'creation',
+                  qualifier: 'approximate',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'has 2 dates' do
+        expect(dates.size).to eq 2
+      end
+
+      it 'includes correct Submitted date' do
+        expect(dates).to include(
+          {
+            date: '2022-01-01',
+            dateType: 'Submitted'
+          }
+        )
+      end
+
+      it 'includes correct Created date' do
+        expect(dates).to include(
+          {
+            date: '1900/1910',
+            dateType: 'Created',
+            dateInformation: 'approximate'
+          }
+        )
+      end
+    end
+
+    describe 'Creation date: 2021-01-01, Embargo: until 2023-01-01, Deposited: 2022-01-01' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'creation',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'release',
+              date: [
+                {
+                  value: '2023-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'deposit',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) do
+        {
+          embargo:
+            {
+              access: 'world',
+              download: 'world',
+              releaseDate: DateTime.parse('2023-01-01'),
+              useAndReproductionStatement: 'in public domain'
+            }
+        }
+      end
+
+      it 'has 3 dates' do
+        expect(dates.size).to eq 3
+      end
+
+      it 'includes correct Submitted date' do
+        expect(dates).to include(
+          {
+            date: '2022-01-01',
+            dateType: 'Submitted'
+          }
+        )
+      end
+
+      it 'includes correct Available date' do
+        expect(dates).to include(
+          {
+            date: '2023-01-01',
+            dateType: 'Available'
+          }
+        )
+      end
+
+      it 'includes correct Created date' do
+        expect(dates).to include(
+          {
+            date: '2021-01-01',
+            dateType: 'Created'
+          }
+        )
+      end
+    end
+
+    describe 'Creation date: 2021-01-01, Deposited: 2022-01-01, Uncited publisher: Stanford University Press' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'creation',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'creation',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            },
+            {
+              type: 'publication',
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford University Press'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'Publisher',
+                      source: {
+                        value: 'H2 contributor role terms'
+                      },
+                      note: [
+                        {
+                          type: 'citation status',
+                          value: 'false'
+                        }
+                      ]
+                    },
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Distributor',
+                      type: 'DataCite role',
+                      source: {
+                        value: 'DataCite contributor types'
+                      }
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'has 2 dates' do
+        expect(dates.size).to eq 2
+      end
+
+      it 'includes correct Submitted date' do
+        expect(dates).to include(
+          {
+            date: '2022-01-01',
+            dateType: 'Submitted'
+          }
+        )
+      end
+
+      it 'includes correct Created date' do
+        expect(dates).to include(
+          {
+            date: '2021-01-01',
+            dateType: 'Created'
+          }
+        )
+      end
+    end
+
+    describe 'Publication date: 2021-01-01, Deposited: 2022-01-01, Uncited publisher: Stanford University Press' do
+      let(:cocina) do
+        {
+          event: [
+            {
+              type: 'publication',
+              date: [
+                {
+                  value: '2021-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford University Press'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'Publisher',
+                      source: {
+                        value: 'H2 contributor role terms'
+                      },
+                      note: [
+                        {
+                          type: 'citation status',
+                          value: 'false'
+                        }
+                      ]
+                    },
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Distributor',
+                      type: 'DataCite role',
+                      source: {
+                        value: 'DataCite contributor types'
+                      }
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            },
+            {
+              type: 'deposit',
+              date: [
+                {
+                  value: '2022-01-01',
+                  type: 'publication',
+                  encoding: {
+                    code: 'w3cdtf'
+                  }
+                }
+              ],
+              contributor: [
+                {
+                  name: [
+                    {
+                      value: 'Stanford Digital Repository'
+                    }
+                  ],
+                  role: [
+                    {
+                      value: 'publisher',
+                      code: 'pbl',
+                      uri: 'http://id.loc.gov/vocabulary/relators/pbl',
+                      source: {
+                        code: 'marcrelator',
+                        uri: 'http://id.loc.gov/vocabulary/relators/'
+                      }
+                    },
+                    {
+                      value: 'Publisher',
+                      type: 'DataCite role'
+                    }
+                  ],
+                  type: 'organization'
+                }
+              ]
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} } # no embargo
+
+      it 'has 2 dates' do
+        expect(dates.size).to eq 2
+      end
+
+      it 'includes correct Submitted date' do
+        expect(dates).to include(
+          {
+            date: '2022-01-01',
+            dateType: 'Submitted'
+          }
+        )
+      end
+
+      it 'includes correct Issued date' do
+        expect(dates).to include(
+          {
+            date: '2021-01-01',
+            dateType: 'Issued'
+          }
+        )
+      end
+    end
+
+    ### --------------- specs below added by developers ---------------
+
+    context 'when cocina event array has empty hash' do
+      let(:cocina) do
+        {
+          event: [
+            {
+            }
+          ]
+        }
+      end
+      let(:cocina_access) { {} }
+
+      it 'dates returns []' do
+        expect(dates).to eq []
+      end
+    end
+
+    context 'when cocina event is empty array' do
+      let(:cocina) do
+        {
+          event: []
+        }
+      end
+      let(:cocina_access) { {} }
+
+      it 'dates returns []' do
+        expect(dates).to eq []
+      end
+    end
+
+    context 'when cocina has no event attribute' do
+      let(:cocina) do
+        {
+        }
+      end
+      let(:cocina_access) { {} }
+
+      it 'dates returns []' do
+        expect(dates).to eq []
+      end
+    end
+  end
+end


### PR DESCRIPTION
~~[Hold until Arcadia clarifies Submitted date algorithm and Created date algorithm and until PR #2949 is merged so this can be rebased.]~~

## Why was this change made?

We need to map cocina generated by h2 to datacite format so we can update DOI data.

This PR implements extracting correct date info for DataCite from cocina events

## How was this change tested?

unit tests adapted from Arcadia's tests

## Which documentation and/or configurations were updated?



