### PR TITLE
[Hold] h2 event mapping tweaks to and from MODS for h2

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -26,6 +26,7 @@ module Cocina
           'copyright',
           'creation',
           'degree conferral',
+          'deposit',
           'development',
           'distribution',
           'generation',
@@ -366,8 +367,19 @@ module Cocina
           return if publisher_nodes.empty?
 
           event[:contributor] ||= []
+          # rubocop:disable Metrics/BlockLength
           publisher_nodes.each do |publisher_node|
             next if publisher_node.text.blank?
+
+            contrib_type = nil
+            roles = [role_for(event)]
+            if origin_info_node['eventType'] == 'deposit' || origin_info_node['eventType'] == 'release'
+              roles << {
+                value: 'Publisher',
+                type: 'DataCite role'
+              }
+              contrib_type = 'organization'
+            end
 
             event[:contributor] << {
               name: [
@@ -385,9 +397,11 @@ module Cocina
                   end
                 end.compact
               ],
-              role: [role_for(event)]
+              role: roles,
+              type: contrib_type
             }.compact
           end
+          # rubocop:enable Metrics/BlockLength
 
           event.delete(:contributor) if event[:contributor].empty?
         end

--- a/spec/services/cocina/mapping/descriptive/h2/event_h2_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/event_h2_spec.rb
@@ -953,6 +953,11 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
         }
       end
 
+      # how do I know when (an event) publisher is uncited from the MODS?
+      #   if the publisher also appears in name with marcrelator role publisher, it is cited. if it does not, it is uncited.
+      #   in h2, the user has entered an author or contributor with the publisher role,
+      #     so there is a user-supplied publisher for an additional publication event,
+      #     in addition to the "Stanford Digital Repository" publisher entry that is automatically generated.
       let(:mods) do
         <<~XML
           <originInfo eventType="creation">
@@ -1068,6 +1073,11 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
         }
       end
 
+      # how do I know when (an event) publisher is uncited from the MODS?
+      #   if the publisher also appears in name with marcrelator role publisher, it is cited. if it does not, it is uncited.
+      #   in h2, the user has entered an author or contributor with the publisher role,
+      #     so there is a user-supplied publisher for an additional publication event,
+      #     in addition to the "Stanford Digital Repository" publisher entry that is automatically generated.
       let(:mods) do
         <<~XML
           <originInfo eventType="publication">
@@ -1082,4 +1092,6 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
       end
     end
   end
+
+  # FIXME: Arcadia to add spec for a cited publisher
 end

--- a/spec/services/cocina/mapping/descriptive/h2/event_h2_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/event_h2_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   describe 'Publication date: 2021-01-01, Embargo: none, Deposited: 2022-01-01' do
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           event: [
@@ -74,7 +74,7 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'Publication date entered as: 2020-01-01, Embargo: until 2022-01-01, Deposited: 2021-01-01' do
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           event: [
@@ -161,7 +161,7 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'No publication date provided, Embargo: until 2022-01-01, Deposited: 2021-01-01' do
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           event: [
@@ -233,7 +233,7 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'No publication date provided, Embargo: none, Deposited: 2021-01-01' do
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           event: [
@@ -290,7 +290,7 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'Creation date: 2021-01-01, Deposited: 2022-01-01' do
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           event: [
@@ -362,7 +362,7 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'Creation date range: 2020-01-01 to 2021-01-01, Deposited: 2022-01-01' do
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           event: [
@@ -444,7 +444,7 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'Approximate single creation date, Deposited: 2022-01-01' do
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           event: [
@@ -517,7 +517,7 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'Approximate creation start date: approx. 1900, Deposited: 2022-01-01' do
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           event: [
@@ -600,7 +600,7 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'Approximate creation end date: approx. 1900, Deposited: 2022-01-01' do
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           event: [
@@ -683,7 +683,7 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'Approximate creation date range: approx. 1900, Deposited: 2022-01-01' do
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           event: [
@@ -766,7 +766,7 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'Creation date: 2021-01-01, Embargo: until 2023-01-01, Deposited: 2022-01-01' do
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           event: [
@@ -853,7 +853,7 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'Creation date: 2021-01-01, Deposited: 2022-01-01, Uncited publisher: Stanford University Press' do
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           event: [
@@ -971,7 +971,7 @@ RSpec.describe 'Cocina --> MODS mappings for event (h2 specific)' do
   end
 
   describe 'Publication date: 2021-01-01, Deposited: 2022-01-01, Uncited publisher: Stanford University Press' do
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           event: [


### PR DESCRIPTION
[HOLD - need clarification from Arcadia on what to do for MODS -> Cocina for uncited publisher]

## Why was this change made?

a) We need to map cocina generated by h2 to datacite format so we can update DOI data;  
b) we need cocina generated by h2 to be stored as MODS with the correct info so we can reconstitute cocina from MODS and send the right stuff to DataCite

This PR implements specs Arcadia asked for in PRs #2925 and #2954, and is also related to her PRs #2920 and #2927 ... all this for H2 which requires DSA to be able to update DOI information  ...

## How was this change tested?

Arcadia's specs.

## Which documentation and/or configurations were updated?



