### PR TITLE
[Hold] H2 contrib mapping tweaks to and from MODS for h2

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/identifier_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/identifier_builder.rb
@@ -40,6 +40,7 @@ module Cocina
             else
               attrs[:type] = cocina_type
               attrs[:value] = identifier_element.text
+              attrs[:source] = { uri: identifier_element['typeURI'] } if identifier_element['typeURI']
             end
             attrs[:status] = 'invalid' if identifier_element['invalid'] == 'yes'
             attrs[:note] = build_note if mods_type && with_note

--- a/app/services/cocina/from_fedora/descriptive/name_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/name_builder.rb
@@ -228,10 +228,14 @@ module Cocina
           check_role_code(code, authority)
 
           {}.tap do |role|
-            source = {
-              code: Authority.normalize_code(authority, notifier),
-              uri: Authority.normalize_uri(authority_uri)
-            }.compact
+            source = if authority == ToFedora::Descriptive::ContributorWriter::H2_ROLE_AUTHORITY
+                       { value: authority }
+                     else
+                       {
+                         code: Authority.normalize_code(authority, notifier),
+                         uri: Authority.normalize_uri(authority_uri)
+                       }.compact
+                     end
             role[:source] = source if source.present?
 
             role[:uri] = ValueURI.sniff(authority_value, notifier)

--- a/app/services/cocina/from_fedora/descriptive/name_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/name_builder.rb
@@ -6,6 +6,8 @@ module Cocina
     class Descriptive
       # Maps a name
       class NameBuilder
+        UNCITED_DESCRIPTION = ToFedora::Descriptive::ContributorWriter::UNCITED_DESCRIPTION
+
         # @param [Array<Nokogiri::XML::Element>] name_elements (multiple if parallel)
         # @param [Cocina::FromFedora::DataErrorNotifier] notifier
         # @return [Hash] a hash that can be mapped to a cocina model
@@ -197,7 +199,13 @@ module Cocina
             end
 
             description = name_node.xpath('mods:description', mods: DESC_METADATA_NS).first
-            parts << { value: description.text, type: 'description' } if description
+            if description
+              parts << if description.text == UNCITED_DESCRIPTION
+                         { value: 'false', type: 'citation status' }
+                       else
+                         { value: description.text, type: 'description' }
+                       end
+            end
           end.presence
         end
 

--- a/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
@@ -196,6 +196,7 @@ module Cocina
           contributor.identifier.each do |identifier|
             id_attributes = {
               displayLabel: identifier.displayLabel,
+              typeURI: identifier.source&.uri,
               type: FromFedora::Descriptive::IdentifierType.mods_type_for_cocina_type(identifier.type)
             }.tap do |attrs|
               attrs[:invalid] = 'yes' if identifier.status == 'invalid'

--- a/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
@@ -9,6 +9,8 @@ module Cocina
         NAME_TYPE = Cocina::FromFedora::Descriptive::Contributor::ROLES.invert.merge('event' => 'corporate').freeze
         NAME_PART = FromFedora::Descriptive::Contributor::NAME_PART.invert.merge('activity dates' => 'date').freeze
 
+        UNCITED_DESCRIPTION = 'not included in citation'
+
         # @params [Nokogiri::XML::Builder] xml
         # @params [Cocina::Models::Contributor] contributor
         # @params [IdGenerator] id_generator
@@ -163,6 +165,8 @@ module Cocina
               xml.affiliation note.value
             when 'description'
               xml.description note.value
+            when 'citation status'
+              xml.description UNCITED_DESCRIPTION if note.value == 'false'
             end
           end
         end

--- a/spec/services/cocina/mapping/descriptive/h2/contributor_h2_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/contributor_h2_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Authors to include in citation
     ## Jane Stanford. Author.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -77,7 +77,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     ## Jane Stanford. Author.
     ## Leland Stanford. Author.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -190,7 +190,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     ## Jane Stanford. Data collector.
     ## Stanford University. Sponsor.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -292,7 +292,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Authors to include in citation
     ## Stanford University. Host institution.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -349,7 +349,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     ## Stanford University. Host institution.
     ## Department of English. Department.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -443,7 +443,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## Leland Stanford. Contributing author.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -567,7 +567,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## Stanford University. Sponsor.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -681,7 +681,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Authors to include in citation
     ## San Francisco Symphony Concert. Event.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -729,7 +729,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## San Francisco Symphony Concert. Event.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -831,7 +831,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Authors to include in citation
     ## LDCX. Conference.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -879,7 +879,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## LDCX. Conference.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -981,7 +981,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Authors to include in citation
     ## Stanford University. Funder.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -1045,7 +1045,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## Stanford University. Funder.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -1157,7 +1157,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     ## Stanford University Press. Publisher.
     # Cited publisher goes into both contributor and event in cocina.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -1252,7 +1252,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     ## Stanford University Press. Publisher.
     # Uncited publisher goes into event only.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -1366,7 +1366,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Authors to include in citation
     ## Jane Stanford. Author.
     ## ORCID: 0000-0000-0000-0000
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -1442,7 +1442,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## Jane Stanford. Contributing author.
     ## ORCID: 0000-0000-0000-0000
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [


### PR DESCRIPTION
[HOLD - need clarification from Arcadia on what to do for MODS -> Cocina for DataCite and H2 roles ... and a bunch of other work]

## Why was this change made?

a) We need to map cocina generated by h2 to datacite format so we can update DOI data;  
b) we need cocina generated by h2 to be stored as MODS with the correct info so we can reconstitute cocina from MODS and send the right stuff to DataCite

This PR implements specs Arcadia asked for in PRs #2925 and #2954, and is also related to her PRs #2920 and #2927 ... all this for H2 which requires DSA to be able to update DOI information  ...

## How was this change tested?

Arcadia's specs - the newly changed and the existing.

## Which documentation and/or configurations were updated?



