### PR TITLE
H2 contrib roundtrip mappings

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/identifier_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/identifier_builder.rb
@@ -40,6 +40,7 @@ module Cocina
             else
               attrs[:type] = cocina_type
               attrs[:value] = identifier_element.text
+              attrs[:source] = { uri: identifier_element['typeURI'] } if identifier_element['typeURI']
             end
             attrs[:status] = 'invalid' if identifier_element['invalid'] == 'yes'
             attrs[:note] = build_note if mods_type && with_note

--- a/app/services/cocina/from_fedora/descriptive/name_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/name_builder.rb
@@ -6,6 +6,8 @@ module Cocina
     class Descriptive
       # Maps a name
       class NameBuilder
+        UNCITED_DESCRIPTION = ToFedora::Descriptive::ContributorWriter::UNCITED_DESCRIPTION
+
         # @param [Array<Nokogiri::XML::Element>] name_elements (multiple if parallel)
         # @param [Cocina::FromFedora::DataErrorNotifier] notifier
         # @return [Hash] a hash that can be mapped to a cocina model
@@ -197,7 +199,13 @@ module Cocina
             end
 
             description = name_node.xpath('mods:description', mods: DESC_METADATA_NS).first
-            parts << { value: description.text, type: 'description' } if description
+            if description
+              parts << if description.text == UNCITED_DESCRIPTION
+                         { value: 'false', type: 'citation status' }
+                       else
+                         { value: description.text, type: 'description' }
+                       end
+            end
           end.presence
         end
 

--- a/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
@@ -174,6 +174,7 @@ module Cocina
           contributor.identifier.each do |identifier|
             id_attributes = {
               displayLabel: identifier.displayLabel,
+              typeURI: identifier.source&.uri,
               type: FromFedora::Descriptive::IdentifierType.mods_type_for_cocina_type(identifier.type)
             }.tap do |attrs|
               attrs[:invalid] = 'yes' if identifier.status == 'invalid'

--- a/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
@@ -8,6 +8,7 @@ module Cocina
         # one way mapping:  MODS 'corporate' already maps to Cocina 'organization'
         NAME_TYPE = Cocina::FromFedora::Descriptive::Contributor::ROLES.invert.merge('event' => 'corporate').freeze
         NAME_PART = FromFedora::Descriptive::Contributor::NAME_PART.invert.merge('activity dates' => 'date').freeze
+        UNCITED_DESCRIPTION = 'not included in citation'
 
         # @params [Nokogiri::XML::Builder] xml
         # @params [Cocina::Models::Contributor] contributor
@@ -163,6 +164,8 @@ module Cocina
               xml.affiliation note.value
             when 'description'
               xml.description note.value
+            when 'citation status'
+              xml.description UNCITED_DESCRIPTION if note.value == 'false'
             end
           end
         end

--- a/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
@@ -6,7 +6,7 @@ module Cocina
       # Maps contributor from cocina to MODS XML
       class ContributorWriter
         # one way mapping:  MODS 'corporate' already maps to Cocina 'organization'
-        NAME_TYPE = Cocina::FromFedora::Descriptive::Contributor::ROLES.invert.merge('event' => 'corporate').freeze
+        NAME_TYPE = Cocina::FromFedora::Descriptive::Contributor::ROLES.invert.freeze
         NAME_PART = FromFedora::Descriptive::Contributor::NAME_PART.invert.merge('activity dates' => 'date').freeze
         UNCITED_DESCRIPTION = 'not included in citation'
 

--- a/spec/services/cocina/mapping/descriptive/h2/contributor_h2_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/contributor_h2_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Authors to include in citation
     ## Jane Stanford. Author.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -67,7 +67,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     ## Jane Stanford. Author.
     ## Leland Stanford. Author.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -160,7 +160,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     ## Jane Stanford. Data collector.
     ## Stanford University. Sponsor.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -242,7 +242,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Authors to include in citation
     ## Stanford University. Host institution.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -289,7 +289,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     ## Stanford University. Host institution.
     ## Department of English. Department.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -356,7 +356,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## Leland Stanford. Contributing author.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -457,7 +457,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## Stanford University. Sponsor.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -546,7 +546,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Authors to include in citation
     ## San Francisco Symphony Concert. Event.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -588,7 +588,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## San Francisco Symphony Concert. Event.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -670,7 +670,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Authors to include in citation
     ## LDCX. Conference.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -711,7 +711,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## LDCX. Conference.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -793,7 +793,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Authors to include in citation
     ## Stanford University. Funder.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -843,7 +843,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## Stanford University. Funder.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -935,7 +935,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     ## Stanford University Press. Publisher.
     # Cited publisher goes into both contributor and event in cocina.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -1013,7 +1013,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     ## Stanford University Press. Publisher.
     # Uncited publisher goes into event only.
 
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -1098,7 +1098,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Authors to include in citation
     ## Jane Stanford. Author.
     ## ORCID: 0000-0000-0000-0000
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [
@@ -1164,7 +1164,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
     # Additional contributors
     ## Jane Stanford. Contributing author.
     ## ORCID: 0000-0000-0000-0000
-    xit 'not implemented' do
+    it_behaves_like 'cocina MODS mapping' do
       let(:cocina) do
         {
           contributor: [

--- a/spec/services/cocina/mapping/descriptive/h2/contributor_h2_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/contributor_h2_spec.rb
@@ -1189,7 +1189,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
                 {
                   value: 'contributor',
                   code: 'ctb',
-                  uri: 'http://id.loc.gov/vocabulary/relators/aut',
+                  uri: 'http://id.loc.gov/vocabulary/relators/ctb',
                   source: {
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
@@ -1222,10 +1222,10 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
             <namePart type="given">Jane</namePart>
             <namePart type="family">Stanford</namePart>
             <description>not included in citation</description>
-            <nameIdentifier type="ORCID" typeURI="https://orcid.org">0000-0000-0000-0000</nameIdentifier>
+            <nameIdentifier type="orcid" typeURI="https://orcid.org">0000-0000-0000-0000</nameIdentifier>
             <role>
-              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>
+              <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/ctb">contributor</roleTerm>
+              <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/ctb">ctb</roleTerm>
             </role>
           </name>
         XML

--- a/spec/services/cocina/mapping/descriptive/h2/contributor_h2_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/contributor_h2_spec.rb
@@ -1149,7 +1149,7 @@ RSpec.describe 'Cocina --> MODS contributor mappings (H2 specific)' do
           <name type="personal" usage="primary">
             <namePart type="given">Jane</namePart>
             <namePart type="family">Stanford</namePart>
-            <nameIdentifier type="ORCID" typeURI="https://orcid.org">0000-0000-0000-0000</nameIdentifier>
+            <nameIdentifier type="orcid" typeURI="https://orcid.org">0000-0000-0000-0000</nameIdentifier>
             <role>
               <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
               <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/aut">aut</roleTerm>

--- a/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
@@ -796,7 +796,7 @@ RSpec.describe 'MODS name <--> cocina mappings' do
 
       let(:warnings) do
         [
-          Notification.new(msg: 'Contributor role code is missing authority')
+          Notification.new(msg: 'Contributor role code is missing authority', times: 2)
         ]
       end
     end
@@ -2634,7 +2634,7 @@ RSpec.describe 'MODS name <--> cocina mappings' do
 
         let(:errors) do
           [
-            Notification.new(msg: 'Contributor role code has unexpected value', context: { role: 'isbx' })
+            Notification.new(msg: 'Contributor role code has unexpected value', context: { role: 'isbx' }, times: 2)
           ]
         end
       end

--- a/spec/services/cocina/mapping/descriptive/mods/origin_info_publisher_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/origin_info_publisher_spec.rb
@@ -645,7 +645,8 @@ RSpec.describe 'MODS originInfo publisher <--> cocina mappings' do
                       value: 'Publisher',
                       source: { value: 'Stanford self-deposit contributor types' }
                     }
-                  ]
+                  ],
+                  type: 'organization'
                 }
               ]
             }


### PR DESCRIPTION
## Why was this change made?

part of #2960

This implements roundtrippable contributor mappings in DSA to support h2 functionality.

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?



