### PR TITLE
datacite form mappings hardcoded as a stopgap

### DIFF
--- a/app/services/cocina/to_datacite/form.rb
+++ b/app/services/cocina/to_datacite/form.rb
@@ -21,6 +21,9 @@ module Cocina
 
         {}.tap do |attribs|
           # FIXME: the following were coded without Arcadia's mappings as a stopgap to be able to debug update_doi_metadata
+          warning_msg = 'DataCite mappings result in empty resourceTypeGeneral and/or empty resourceType; using hardcoded default values'
+          Honeybadger.notify(warning_msg) if resource_type_general.blank? || resource_type.blank?
+
           attribs[:resourceTypeGeneral] = resource_type_general || 'Text'
           attribs[:resourceType] = resource_type || 'Testing'
         end

--- a/app/services/cocina/to_datacite/form.rb
+++ b/app/services/cocina/to_datacite/form.rb
@@ -20,8 +20,9 @@ module Cocina
         return {} if cocina_desc&.form.blank?
 
         {}.tap do |attribs|
-          attribs[:resourceTypeGeneral] = resource_type_general if resource_type_general
-          attribs[:resourceType] = resource_type if resource_type
+          # FIXME: the following were coded without Arcadia's mappings as a stopgap to be able to debug update_doi_metadata
+          attribs[:resourceTypeGeneral] = resource_type_general || 'Text'
+          attribs[:resourceType] = resource_type || 'Testing'
         end
       end
 

--- a/spec/services/cocina/mapping/descriptive/h2_datacite/form_h2_datacite_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2_datacite/form_h2_datacite_spec.rb
@@ -257,6 +257,12 @@ RSpec.describe 'Cocina --> DataCite mappings for form (H2 specific)' do
 
   # FIXME: the following were coded without Arcadia's mappings as a stopgap to be able to debug update_doi_metadata
   context 'without DataCite term' do
+    let(:honeybadger_msg) { 'DataCite mappings result in empty resourceTypeGeneral and/or empty resourceType; using hardcoded default values' }
+
+    before do
+      allow(Honeybadger).to receive(:notify).with(honeybadger_msg)
+    end
+
     context 'with type only (no subtype)' do
       let(:cocina) do
         {
@@ -277,13 +283,14 @@ RSpec.describe 'Cocina --> DataCite mappings for form (H2 specific)' do
         }
       end
 
-      it 'populates type_attributes correctly' do
+      it 'populates type_attributes correctly and notifies Honeybadger' do
         expect(type_attributes).to eq(
           {
             resourceTypeGeneral: 'Text',
             resourceType: 'whatever'
           }
         )
+        expect(Honeybadger).to have_received(:notify).with(honeybadger_msg)
       end
     end
 
@@ -318,13 +325,14 @@ RSpec.describe 'Cocina --> DataCite mappings for form (H2 specific)' do
         }
       end
 
-      it 'populates type_attributes correctly' do
+      it 'populates type_attributes correctly and notifies Honeybadger' do
         expect(type_attributes).to eq(
           {
             resourceTypeGeneral: 'Text',
             resourceType: 'whatever'
           }
         )
+        expect(Honeybadger).to have_received(:notify).with(honeybadger_msg)
       end
     end
   end

--- a/spec/services/cocina/mapping/descriptive/h2_datacite/form_h2_datacite_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2_datacite/form_h2_datacite_spec.rb
@@ -255,6 +255,80 @@ RSpec.describe 'Cocina --> DataCite mappings for form (H2 specific)' do
 
   ### --------------- specs below added by developers ---------------
 
+  # FIXME: the following were coded without Arcadia's mappings as a stopgap to be able to debug update_doi_metadata
+  context 'without DataCite term' do
+    context 'with type only (no subtype)' do
+      let(:cocina) do
+        {
+          form: [
+            {
+              structuredValue: [
+                {
+                  value: 'whatever',
+                  type: 'type'
+                }
+              ],
+              source: {
+                value: 'Stanford self-deposit resource types'
+              },
+              type: 'resource type'
+            }
+          ]
+        }
+      end
+
+      it 'populates type_attributes correctly' do
+        expect(type_attributes).to eq(
+          {
+            resourceTypeGeneral: 'Text',
+            resourceType: 'whatever'
+          }
+        )
+      end
+    end
+
+    context 'with subtype' do
+      let(:cocina) do
+        {
+          form: [
+            {
+              structuredValue: [
+                {
+                  value: 'Mixed Materials',
+                  type: 'type'
+                },
+                {
+                  value: 'whatever',
+                  type: 'subtype'
+                }
+              ],
+              source: {
+                value: 'Stanford self-deposit resource types'
+              },
+              type: 'resource type'
+            },
+            {
+              value: 'text',
+              type: 'resource type',
+              source: {
+                value: 'MODS resource types'
+              }
+            }
+          ]
+        }
+      end
+
+      it 'populates type_attributes correctly' do
+        expect(type_attributes).to eq(
+          {
+            resourceTypeGeneral: 'Text',
+            resourceType: 'whatever'
+          }
+        )
+      end
+    end
+  end
+
   context 'when cocina form array has empty hash' do
     let(:cocina) do
       {
@@ -265,7 +339,7 @@ RSpec.describe 'Cocina --> DataCite mappings for form (H2 specific)' do
       }
     end
 
-    it 'type_attributes is empty hash' do
+    xit 'to be mapped/implemented: type_attributes cannot be empty hash' do
       expect(type_attributes).to eq({})
     end
   end
@@ -277,7 +351,7 @@ RSpec.describe 'Cocina --> DataCite mappings for form (H2 specific)' do
       }
     end
 
-    it 'type_attributes is empty hash' do
+    xit 'to be mapped/implemented: type_attributes cannot be empty hash' do
       expect(type_attributes).to eq({})
     end
   end
@@ -288,7 +362,7 @@ RSpec.describe 'Cocina --> DataCite mappings for form (H2 specific)' do
       }
     end
 
-    it 'type_attributes is empty hash' do
+    xit 'to be mapped/implemented: type_attributes cannot be empty hash' do
       expect(type_attributes).to eq({})
     end
   end


### PR DESCRIPTION
NOTE:  **It may be advantageous NOT to merge this and wait for correct, roundtrippable mappings from @arcadiafalcone.**

## Why was this change made?

To be able to debug `update_doi_metadata` endpoint and `UpdateDoiMetadataJob`   

If this is merged, issue #2979 is about removing the hardcodings.

## How was this change tested?

created some H2 objects in stage.

## Which documentation and/or configurations were updated?



