### PR TITLE
quiet the logs to avoid filling them

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :error
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
## Why was this change made?

Temporarily lower the log level in production to avoid filling the logs on 8/5/2021 at 7:15pm.

see https://stanfordlib.slack.com/archives/C09M7P91R/p1628211638118000

Re-deploy main to get back to :debug level logging and then close the PR and delete the branch.


## How was this change tested?



## Which documentation and/or configurations were updated?



