### PR TITLE
Avoid retry loop when multiple project tags

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,6 +93,9 @@ RSpec/ExpectActual:
   Exclude:
     - 'spec/routing/**'
 
+RSpec/NestedGroups:
+  Max: 5
+
 Style/AsciiComments:
   Exclude:
     - 'spec/services/cocina/from_fedora/descriptive/contributor_spec.rb'

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -197,19 +197,21 @@ module Cocina
       return if trial
       raise "Must provide a #{prefix} tag for #{pid}" unless new_tag
 
-      existing_tag = tag_starting_with(pid, prefix)
-      if existing_tag.nil?
+      existing_tags = tags_starting_with(pid, prefix)
+      if existing_tags.empty?
         AdministrativeTags.create(pid: pid, tags: [new_tag])
-      elsif existing_tag != new_tag
-        AdministrativeTags.update(pid: pid, current: existing_tag, new: new_tag)
+      elsif existing_tags.size > 1
+        raise "Too many tags for prefix #{prefix}. Expected one."
+      elsif existing_tags.first != new_tag
+        AdministrativeTags.update(pid: pid, current: existing_tags.first, new: new_tag)
       end
     end
 
-    def tag_starting_with(pid, prefix)
-      AdministrativeTags.for(pid: pid).each do |tag|
-        return tag if tag.start_with?(prefix)
+    def tags_starting_with(pid, prefix)
+      prefix_count = prefix.count(':') + 1
+      AdministrativeTags.for(pid: pid).select do |tag|
+        tag.start_with?(prefix) && tag.count(':') == prefix_count
       end
-      nil
     end
 
     # TODO: duplicate from ObjectCreator

--- a/spec/services/cocina/object_updater_spec.rb
+++ b/spec/services/cocina/object_updater_spec.rb
@@ -387,10 +387,34 @@ RSpec.describe Cocina::ObjectUpdater do
           end
         end
 
-        it 'updates administrative' do
-          update
-          expect(item).to have_received(:admin_policy_object_id=).with('druid:ff000df4567')
-          expect(AdministrativeTags).to have_received(:create)
+        context 'when creating a new project tag' do
+          it 'updates administrative' do
+            update
+            expect(item).to have_received(:admin_policy_object_id=).with('druid:ff000df4567')
+            expect(AdministrativeTags).to have_received(:create)
+          end
+        end
+
+        context 'when multiple project tags already exists' do
+          before do
+            allow(AdministrativeTags).to receive(:for).and_return(['Project : Phoenix', 'Project : Google Books'])
+          end
+
+          it 'updates administrative' do
+            expect { update }.to raise_error(/Too many tags for prefix/)
+          end
+        end
+
+        context 'when creating a new project tag with an existing project subtag' do
+          before do
+            allow(AdministrativeTags).to receive(:for).and_return(['Project : Google Books : Special'])
+          end
+
+          it 'updates administrative' do
+            update
+            expect(item).to have_received(:admin_policy_object_id=).with('druid:ff000df4567')
+            expect(AdministrativeTags).to have_received(:create)
+          end
         end
       end
 


### PR DESCRIPTION
## Why was this change made?
Currently if an item has multiple project tags, it is causing a retry loop because the code is assuming that there will be only one project tag. This raises an error when more than one project tag is encountered.


## How was this change tested?
Unit, production


## Which documentation and/or configurations were updated?



