### PR TITLE
Remove an unnecessary compact call

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/event.rb
+++ b/app/services/cocina/from_fedora/descriptive/event.rb
@@ -83,8 +83,7 @@ module Cocina
                     origin_info.xpath('.//*[@valueURI]').empty? &&
                     origin_info.xpath('.//*[@xlink:href]', xlink: XLINK_NS).empty?
 
-            event = build_event_for_origin_info(origin_info)
-            event.compact
+            build_event_for_origin_info(origin_info)
           end
         end
 


### PR DESCRIPTION
## Why was this change made?

We don't need this code.

## How was this change tested?



## Which documentation and/or configurations were updated?



