### PR TITLE
Add MODS>Cocina mapping for roundtripping DataCite resourceTypeGeneral

### DIFF
--- a/spec/services/cocina/mapping/descriptive/mods/datacite_extension_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/datacite_extension_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'MODS physicalDescription <--> cocina mappings' do
+  describe 'DataCite resourceTypeGeneral' do
+    xit 'not implemented' do
+      let(:mods) do
+        <<~XML
+          <extension displayLabel="datacite">
+            <resourceType resourceTypeGeneral="Dataset"/>
+          </extension>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          form: [
+            {
+              value: 'Dataset',
+              type: 'resource type',
+              source: {
+                value: 'DataCite resource types'
+              }
+            }
+          ]
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?
To help with testing Cocina>MODS>Cocina roundtrip for DataCite extension.


## How was this change tested?
CircleCI


## Which documentation and/or configurations were updated?
n/a


