### PR TITLE
Set the datacite publisher

### DIFF
--- a/app/services/cocina/to_datacite/attributes.rb
+++ b/app/services/cocina/to_datacite/attributes.rb
@@ -30,7 +30,7 @@ module Cocina
           rightsList: rights_list,
           types: types_attributes,
           # publicationYear: '1964' # to be implemented from event_h2 mapping,
-          # publisher: 'to be implemented' # to be implemented from event_h2 mapping
+          publisher: 'Stanford Digital Repository',
           # NOTE: Per email from DataCite support on 7/21/2021, relatedItem is not currently supported in the ReST API v2.
           # Support will be added for the entire DataCite MetadataKernel 4.4 schema in v3 of the ReST API.
           # relatedItems: related_item

--- a/spec/services/cocina/to_datacite/attributes_spec.rb
+++ b/spec/services/cocina/to_datacite/attributes_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Cocina::ToDatacite::Attributes do
           creators: [],
           dates: [],
           # publicationYear: '1964',
-          # publisher: 'to be implemented',
+          publisher: 'Stanford Digital Repository',
           titles: [{ title: title }]
         }
       )
@@ -213,7 +213,7 @@ RSpec.describe Cocina::ToDatacite::Attributes do
             }
           ],
           # publicationYear: '1964',
-          # publisher: 'to be implemented',
+          publisher: 'Stanford Digital Repository',
           # NOTE: Per email from DataCite support on 7/21/2021, relatedItem is not currently supported in the ReST API v2.
           # Support will be added for the entire DataCite MetadataKernel 4.4 schema in v3 of the ReST API.
           # relatedItems: [


### PR DESCRIPTION


## Why was this change made?
It is required in order to produce a findable DOI


## How was this change tested?



## Which documentation and/or configurations were updated?



