### PR TITLE
Remove Datacite Role from contributor mapping specs.

### DIFF
--- a/spec/services/cocina/mapping/descriptive/h2_datacite/contributor_h2_datacite_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2_datacite/contributor_h2_datacite_spec.rb
@@ -59,10 +59,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             }
@@ -142,10 +138,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             },
@@ -180,10 +172,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             }
@@ -274,10 +262,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             },
@@ -303,10 +287,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             }
@@ -383,10 +363,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             }
@@ -453,10 +429,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             },
@@ -482,10 +454,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             }
@@ -570,10 +538,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             },
@@ -607,13 +571,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                   source: {
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
-                  }
-                },
-                {
-                  value: 'Other',
-                  type: 'DataCite role',
-                  source: {
-                    value: 'DataCite contributor types'
                   }
                 }
               ],
@@ -717,10 +674,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             },
@@ -745,13 +698,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                   source: {
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
-                  }
-                },
-                {
-                  value: 'Sponsor',
-                  type: 'DataCite role',
-                  source: {
-                    value: 'DataCite contributor types'
                   }
                 }
               ],
@@ -831,10 +777,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                   source: {
                     value: 'H2 contributor role terms'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             }
@@ -911,10 +853,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             },
@@ -930,13 +868,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                   value: 'Event',
                   source: {
                     value: 'H2 contributor role terms'
-                  }
-                },
-                {
-                  value: 'Other',
-                  type: 'DataCite role',
-                  source: {
-                    value: 'DataCite contributor types'
                   }
                 }
               ],
@@ -1016,10 +947,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                   source: {
                     value: 'H2 contributor role terms'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             }
@@ -1096,10 +1023,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             },
@@ -1115,13 +1038,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                   value: 'Conference',
                   source: {
                     value: 'H2 contributor role terms'
-                  }
-                },
-                {
-                  value: 'Other',
-                  type: 'DataCite role',
-                  source: {
-                    value: 'DataCite contributor types'
                   }
                 }
               ],
@@ -1210,14 +1126,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
-                },
-                {
-                  value: 'Funder',
-                  type: 'DataCite role'
                 }
               ]
             }
@@ -1304,10 +1212,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             },
@@ -1333,10 +1237,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Funder',
-                  type: 'DataCite role'
                 }
               ],
               note: [
@@ -1424,10 +1324,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             }
@@ -1451,13 +1347,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                       source: {
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
-                      }
-                    },
-                    {
-                      value: 'Distributor',
-                      type: 'DataCite role',
-                      source: {
-                        value: 'DataCite contributor types'
                       }
                     }
                   ]
@@ -1540,10 +1429,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ]
             }
@@ -1573,13 +1458,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                       source: {
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
-                      }
-                    },
-                    {
-                      value: 'Distributor',
-                      type: 'DataCite role',
-                      source: {
-                        value: 'DataCite contributor types'
                       }
                     }
                   ],
@@ -1681,10 +1559,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
                   }
-                },
-                {
-                  value: 'Creator',
-                  type: 'DataCite role'
                 }
               ],
               identifier: [
@@ -1779,13 +1653,6 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
                   source: {
                     code: 'marcrelator',
                     uri: 'http://id.loc.gov/vocabulary/relators/'
-                  }
-                },
-                {
-                  value: 'Other',
-                  type: 'DataCite role',
-                  source: {
-                    value: 'DataCite contributor types'
                   }
                 }
               ],


### PR DESCRIPTION
## Why was this change made?
Datacite Role no longer added to descriptive cocina.


## How was this change tested?



## Which documentation and/or configurations were updated?



