### PR TITLE
Remove DataCite roles from specs.

### DIFF
--- a/spec/services/cocina/mapping/descriptive/h2_datacite/creators_h2_datacite_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2_datacite/creators_h2_datacite_spec.rb
@@ -48,10 +48,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           }
@@ -122,10 +118,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           },
@@ -160,10 +152,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           }
@@ -248,10 +236,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           },
@@ -277,10 +261,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           }
@@ -351,10 +331,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           }
@@ -415,10 +391,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           },
@@ -444,10 +416,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           }
@@ -526,10 +494,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           },
@@ -563,13 +527,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                 source: {
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
-                }
-              },
-              {
-                value: 'Other',
-                type: 'DataCite role',
-                source: {
-                  value: 'DataCite contributor types'
                 }
               }
             ],
@@ -639,10 +596,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           },
@@ -667,13 +620,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                 source: {
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
-                }
-              },
-              {
-                value: 'Sponsor',
-                type: 'DataCite role',
-                source: {
-                  value: 'DataCite contributor types'
                 }
               }
             ],
@@ -740,10 +686,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                 source: {
                   value: 'H2 contributor role terms'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           }
@@ -814,10 +756,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           },
@@ -833,13 +771,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                 value: 'Event',
                 source: {
                   value: 'H2 contributor role terms'
-                }
-              },
-              {
-                value: 'Other',
-                type: 'DataCite role',
-                source: {
-                  value: 'DataCite contributor types'
                 }
               }
             ],
@@ -906,10 +837,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                 source: {
                   value: 'H2 contributor role terms'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           }
@@ -980,10 +907,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           },
@@ -999,13 +922,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                 value: 'Conference',
                 source: {
                   value: 'H2 contributor role terms'
-                }
-              },
-              {
-                value: 'Other',
-                type: 'DataCite role',
-                source: {
-                  value: 'DataCite contributor types'
                 }
               }
             ],
@@ -1081,14 +997,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
-              },
-              {
-                value: 'Funder',
-                type: 'DataCite role'
               }
             ]
           }
@@ -1164,10 +1072,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           },
@@ -1193,10 +1097,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Funder',
-                type: 'DataCite role'
               }
             ],
             note: [
@@ -1273,10 +1173,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           }
@@ -1300,13 +1196,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                     source: {
                       code: 'marcrelator',
                       uri: 'http://id.loc.gov/vocabulary/relators/'
-                    }
-                  },
-                  {
-                    value: 'Distributor',
-                    type: 'DataCite role',
-                    source: {
-                      value: 'DataCite contributor types'
                     }
                   }
                 ]
@@ -1382,10 +1271,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ]
           }
@@ -1415,13 +1300,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                     source: {
                       code: 'marcrelator',
                       uri: 'http://id.loc.gov/vocabulary/relators/'
-                    }
-                  },
-                  {
-                    value: 'Distributor',
-                    type: 'DataCite role',
-                    source: {
-                      value: 'DataCite contributor types'
                     }
                   }
                 ],
@@ -1509,10 +1387,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
                 }
-              },
-              {
-                value: 'Creator',
-                type: 'DataCite role'
               }
             ],
             identifier: [
@@ -1601,13 +1475,6 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
                 source: {
                   code: 'marcrelator',
                   uri: 'http://id.loc.gov/vocabulary/relators/'
-                }
-              },
-              {
-                value: 'Other',
-                type: 'DataCite role',
-                source: {
-                  value: 'DataCite contributor types'
                 }
               }
             ],

--- a/spec/services/cocina/to_datacite/event_dates_spec.rb
+++ b/spec/services/cocina/to_datacite/event_dates_spec.rb
@@ -72,10 +72,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -153,10 +149,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -253,10 +245,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -344,10 +332,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -416,10 +400,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -506,10 +486,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -588,10 +564,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -680,10 +652,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -772,10 +740,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -864,10 +828,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -946,10 +906,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -1058,10 +1014,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -1097,13 +1049,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                       source: {
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
-                      }
-                    },
-                    {
-                      value: 'Distributor',
-                      type: 'DataCite role',
-                      source: {
-                        value: 'DataCite contributor types'
                       }
                     }
                   ],
@@ -1182,13 +1127,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Distributor',
-                      type: 'DataCite role',
-                      source: {
-                        value: 'DataCite contributor types'
-                      }
                     }
                   ],
                   type: 'organization'
@@ -1222,10 +1160,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'

--- a/spec/services/cocina/to_datacite/event_pub_year_spec.rb
+++ b/spec/services/cocina/to_datacite/event_pub_year_spec.rb
@@ -68,10 +68,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -131,10 +127,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -204,10 +196,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -277,10 +265,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -340,10 +324,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -412,10 +392,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -476,10 +452,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -549,10 +521,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -622,10 +590,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -695,10 +659,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -758,10 +718,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -843,10 +799,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'
@@ -882,13 +834,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                       source: {
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
-                      }
-                    },
-                    {
-                      value: 'Distributor',
-                      type: 'DataCite role',
-                      source: {
-                        value: 'DataCite contributor types'
                       }
                     }
                   ],
@@ -949,13 +894,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Distributor',
-                      type: 'DataCite role',
-                      source: {
-                        value: 'DataCite contributor types'
-                      }
                     }
                   ],
                   type: 'organization'
@@ -989,10 +927,6 @@ RSpec.describe Cocina::ToDatacite::Event do
                         code: 'marcrelator',
                         uri: 'http://id.loc.gov/vocabulary/relators/'
                       }
-                    },
-                    {
-                      value: 'Publisher',
-                      type: 'DataCite role'
                     }
                   ],
                   type: 'organization'


### PR DESCRIPTION
closes #3020

## Why was this change made?
H2 is no longer sending DataCite roles.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



