### PR TITLE
Correctly sets namespace for mods identifier.

### DIFF
--- a/app/services/publish/public_desc_metadata_service.rb
+++ b/app/services/publish/public_desc_metadata_service.rb
@@ -50,7 +50,7 @@ module Publish
       value = object.identityMetadata.ng_xml.xpath('//doi').first
       return unless value
 
-      identifier = doc.create_element('mods:identifier')
+      identifier = doc.create_element('identifier', xmlns: MODS_NS)
       identifier.content = "https://doi.org/#{value.text}"
       identifier['type'] = 'doi'
       identifier['displayLabel'] = 'DOI'

--- a/spec/services/publish/public_desc_metadata_service_spec.rb
+++ b/spec/services/publish/public_desc_metadata_service_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Publish::PublicDescMetadataService do
       XML
     end
 
-    let(:mods) { read_fixture('ex2_related_mods.xml') }
+    let(:mods) { read_fixture('mods_default_ns.xml') }
     let(:obj) do
       b = Dor::Item.new
       b.descMetadata.content = mods
@@ -187,8 +187,8 @@ RSpec.describe Publish::PublicDescMetadataService do
     end
 
     it 'adds the doi in identityMetadata' do
-      expect(public_mods.xpath('//mods:identifier[@type="doi"]').to_xml).to eq(
-        '<mods:identifier type="doi" displayLabel="DOI">https://doi.org/10.80343/ty606df5808</mods:identifier>'
+      expect(public_mods.xpath('//mods:identifier[@type="doi"]', mods: Publish::PublicDescMetadataService::MODS_NS).to_xml).to eq(
+        '<identifier type="doi" displayLabel="DOI">https://doi.org/10.80343/ty606df5808</identifier>'
       )
     end
   end


### PR DESCRIPTION
closes #3021

## Why was this change made?
Prefer valid XML.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


