### PR TITLE
Use a conflict error when accessioning can't be started

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -88,8 +88,8 @@ class ObjectsController < ApplicationController
 
     # if this object is currently already in accessioning, we cannot start it again
     if VersionService.in_accessioning?(@item)
-      head :not_acceptable
-      return
+      return json_api_error(status: :conflict,
+                            message: 'This object is already in accessioning, it can not be accessioned again until the workflow is complete')
     end
 
     # if this is an existing versionable object, open and close it without starting accessionWF

--- a/openapi.yml
+++ b/openapi.yml
@@ -194,6 +194,8 @@ paths:
       responses:
         '201':
           description: Accessioning/re-accessioning started
+        '409':
+          description: Unable to start accessioning because accessioning has already been started.
       parameters:
         - name: id
           in: path

--- a/spec/requests/start_accession_spec.rb
+++ b/spec/requests/start_accession_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
       expect(workflow_client).not_to have_received(:create_workflow_by_name)
       expect(VersionService).not_to have_received(:open)
       expect(VersionService).not_to have_received(:close)
-      expect(response).to have_http_status(:not_acceptable)
+      expect(response).to have_http_status(:conflict)
     end
   end
 end


### PR DESCRIPTION

## Why was this change made?

Previously we were using 406, which should only be used for content negotiation.  This was an improper use and the client was not handling it, so sdr-client would re-queue the request and get into a loop.


## How was this change tested?



## Which documentation and/or configurations were updated?



