### PR TITLE
Remove cocina urls from published resource ids

### DIFF
--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -89,6 +89,10 @@ module Publish
         result = object.datastreams['contentMetadata'].ng_xml.clone
 
         # remove any resources or attributes that are not destined for the public XML
+        result.xpath('/contentMetadata/resource').each do |resource|
+          resource['id'] = resource['id'].sub('http://cocina.sul.stanford.edu/fileSet/', 'cocina-fileSet-')
+        end
+
         result.xpath('/contentMetadata/resource[not(file[(@deliver="yes" or @publish="yes")]|externalFile)]').each(&:remove)
         result.xpath('/contentMetadata/resource/file[not(@deliver="yes" or @publish="yes")]').each(&:remove)
         result.xpath('/contentMetadata/resource/file').xpath('@preserve|@shelve|@publish|@deliver').each(&:remove)
@@ -133,6 +137,7 @@ module Publish
       src_label.content = src_item.full_title
 
       # add the extracted label and imageData
+      external_file['resourceId'] = external_file['resourceId'].sub('http://cocina.sul.stanford.edu/fileSet/', 'cocina-fileSet-')
       external_file.add_previous_sibling(src_label)
       external_file << src_image_data unless src_image_data.nil?
     end

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -383,5 +383,22 @@ RSpec.describe Publish::PublicXmlService do
         end
       end
     end
+
+    context 'with a cocina-originating object' do
+      before do
+        item.contentMetadata.content = <<-XML
+          <?xml version="1.0"?>
+          <contentMetadata objectId="druid:bc123df4567" type="file">
+            <resource id="http://cocina.sul.stanford.edu/fileSet/7bf4cfb1-7e29-4f27-b865-79e10a77f29e" sequence="1" type="file">
+              <file id="some_file.pdf" mimetype="file/pdf" publish="yes"/>
+            </resource>
+          </contentMetadata>
+        XML
+      end
+
+      it 'cleans up the resource id to be XML-valid' do
+        expect(ng_xml.at_xpath('/publicObject/contentMetadata/resource[1]')['id']).to eq 'cocina-fileSet-7bf4cfb1-7e29-4f27-b865-79e10a77f29e'
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/purl/issues/528 and fixes https://github.com/sul-dlss/content_search/issues/350 by converting the internal resource identifiers to xml:id-valid identifiers.

