### PR TITLE
Sets provenanceMetadata to false with test change

### DIFF
--- a/app/services/datastream_extractor.rb
+++ b/app/services/datastream_extractor.rb
@@ -44,7 +44,7 @@ class DatastreamExtractor
       events: false,
       embargoMetadata: false,
       identityMetadata: true,
-      provenanceMetadata: true,
+      provenanceMetadata: false,
       relationshipMetadata: true,
       rightsMetadata: false,
       roleMetadata: false,

--- a/spec/services/datastream_extractor_spec.rb
+++ b/spec/services/datastream_extractor_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe DatastreamExtractor do
       expect(instance).to have_received(:datastream_content).with(:geoMetadata, false)
       expect(instance).to have_received(:datastream_content).with(:embargoMetadata, false)
       expect(instance).to have_received(:datastream_content).with(:identityMetadata, true)
-      expect(instance).to have_received(:datastream_content).with(:provenanceMetadata, true)
+      expect(instance).to have_received(:datastream_content).with(:provenanceMetadata, false)
       expect(instance).to have_received(:datastream_content).with(:relationshipMetadata, true)
       expect(instance).to have_received(:datastream_content).with(:roleMetadata, false)
       expect(instance).to have_received(:datastream_content).with(:sourceMetadata, false)


### PR DESCRIPTION
## Why was this change made?
Fixes downstream error in Preservation Catalog that causes the following error when running integration tests:
![Screen Shot 2021-11-09 at 3 23 37 PM](https://user-images.githubusercontent.com/71847/141015059-f9ce9ae6-5590-4d43-a1b4-cdc18b8778a5.png)




## How was this change tested?
Unit and integration tests


## Which documentation and/or configurations were updated?
n/a


