### PR TITLE
[refactor] Update method names to use idiomatic ruby

### DIFF
--- a/app/services/sdr_ingest_service.rb
+++ b/app/services/sdr_ingest_service.rb
@@ -17,7 +17,7 @@ class SdrIngestService
     new_version_id = signature_catalog.version_id + 1
     metadata_dir = DatastreamExtractor.extract_datastreams(item: dor_item, workspace: workspace)
     verify_version_metadata(metadata_dir, new_version_id)
-    version_inventory = get_version_inventory(metadata_dir, druid, new_version_id)
+    version_inventory = version_inventory(metadata_dir, druid, new_version_id)
     version_additions = signature_catalog.version_additions(version_inventory)
     content_additions = version_additions.group('content')
     if content_additions.nil? || content_additions.files.empty?
@@ -82,9 +82,9 @@ class SdrIngestService
   # @param [String] druid The object identifier
   # @param [Integer] version_id The version number
   # @return [Moab::FileInventory] Generate and return a version inventory for the object
-  def self.get_version_inventory(metadata_dir, druid, version_id)
-    version_inventory = get_content_inventory(metadata_dir, druid, version_id)
-    version_inventory.groups << get_metadata_file_group(metadata_dir)
+  def self.version_inventory(metadata_dir, druid, version_id)
+    version_inventory = content_inventory(metadata_dir, druid, version_id)
+    version_inventory.groups << metadata_file_group(metadata_dir)
     version_inventory
   end
 
@@ -93,8 +93,8 @@ class SdrIngestService
   # @param [Integer] version_id The version number
   # @return [Moab::FileInventory] Parse the contentMetadata
   #   and generate a new version inventory object containing a content group
-  def self.get_content_inventory(metadata_dir, druid, version_id)
-    content_metadata = get_content_metadata(metadata_dir)
+  def self.content_inventory(metadata_dir, druid, version_id)
+    content_metadata = content_metadata(metadata_dir)
     if content_metadata
       Stanford::ContentInventory.new.inventory_from_cm(content_metadata, druid, 'preserve', version_id)
     else
@@ -104,14 +104,14 @@ class SdrIngestService
 
   # @param [Pathname] metadata_dir The location of the the object's metadata files
   # @return [String] Return the contents of the contentMetadata.xml file from the content directory
-  def self.get_content_metadata(metadata_dir)
+  def self.content_metadata(metadata_dir)
     content_metadata_pathname = metadata_dir.join('contentMetadata.xml')
     content_metadata_pathname.read if content_metadata_pathname.exist?
   end
 
   # @param [Pathname] metadata_dir The location of the the object's metadata files
   # @return [Moab::FileGroup] Traverse the metadata directory and generate a metadata group
-  def self.get_metadata_file_group(metadata_dir)
+  def self.metadata_file_group(metadata_dir)
     Moab::FileGroup.new(group_id: 'metadata').group_from_directory(metadata_dir)
   end
 

--- a/spec/services/sdr_ingest_service_spec.rb
+++ b/spec/services/sdr_ingest_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe SdrIngestService do
 
     specify 'with no change in content' do
       v1_content_metadata = fixtures.join('sdr_repo/dd116zh0343/v0001/data/metadata/contentMetadata.xml')
-      expect(described_class).to receive(:get_content_metadata).with(metadata_dir).and_return(v1_content_metadata.read)
+      expect(described_class).to receive(:content_metadata).with(metadata_dir).and_return(v1_content_metadata.read)
       described_class.transfer(dor_item)
       files = []
       fixtures.join('export/dd116zh0343').find { |f| files << f.relative_path_from(fixtures).to_s }
@@ -140,26 +140,26 @@ RSpec.describe SdrIngestService do
     end
   end
 
-  specify '.get_version_inventory' do
+  specify '.version_inventory' do
     metadata_dir = instance_double(Pathname)
     druid = 'druid:ab123cd4567'
     version_id = 2
     version_inventory = Moab::FileInventory.new
     version_inventory.groups << Moab::FileGroup.new(group_id: 'content')
     metadata_group = Moab::FileGroup.new(group_id: 'metadata')
-    expect(described_class).to receive(:get_content_inventory).with(metadata_dir, druid, version_id).and_return(version_inventory)
-    expect(described_class).to receive(:get_metadata_file_group).with(metadata_dir).and_return(metadata_group)
-    result = described_class.get_version_inventory(metadata_dir, druid, version_id)
+    expect(described_class).to receive(:content_inventory).with(metadata_dir, druid, version_id).and_return(version_inventory)
+    expect(described_class).to receive(:metadata_file_group).with(metadata_dir).and_return(metadata_group)
+    result = described_class.version_inventory(metadata_dir, druid, version_id)
     expect(result).to be_instance_of Moab::FileInventory
     expect(result.groups.size).to eq 2
   end
 
-  specify '.get_content_inventory' do
+  specify '.content_inventory' do
     metadata_dir = fixtures.join('workspace/ab/123/cd/4567/ab123cd4567/metadata')
     druid = 'druid:ab123cd4567'
     version_id = 2
 
-    version_inventory = described_class.get_content_inventory(metadata_dir, druid, version_id)
+    version_inventory = described_class.content_inventory(metadata_dir, druid, version_id)
     expect(version_inventory).to be_instance_of Moab::FileInventory
     expect(version_inventory.version_id).to eq 2
     content_group = version_inventory.groups[0]
@@ -170,27 +170,27 @@ RSpec.describe SdrIngestService do
 
     # if no content metadata
     metadata_dir = fixtures.join('workspace/ab/123/cd/4567/ab123cd4567')
-    version_inventory = described_class.get_content_inventory(metadata_dir, druid, version_id)
+    version_inventory = described_class.content_inventory(metadata_dir, druid, version_id)
     expect(version_inventory.groups.size).to eq 0
   end
 
-  specify '.get_content_metadata' do
+  specify '.content_metadata' do
     metadata_dir = fixtures.join('workspace/ab/123/cd/4567/ab123cd4567/metadata')
-    content_metadata = described_class.get_content_metadata(metadata_dir)
+    content_metadata = described_class.content_metadata(metadata_dir)
     expect(content_metadata).to match(/<contentMetadata /)
 
     # if no content metadata
     metadata_dir = fixtures.join('workspace/ab/123/cd/4567/ab123cd4567')
-    content_metadata = described_class.get_content_metadata(metadata_dir)
+    content_metadata = described_class.content_metadata(metadata_dir)
     expect(content_metadata).to be_nil
   end
 
-  specify '.get_metadata_file_group' do
+  specify '.metadata_file_group' do
     metadata_dir = instance_double(Pathname)
     file_group = instance_double(Moab::FileGroup)
     expect(Moab::FileGroup).to receive(:new).with(group_id: 'metadata').and_return(file_group)
     expect(file_group).to receive(:group_from_directory).with(metadata_dir)
-    described_class.get_metadata_file_group(metadata_dir)
+    described_class.metadata_file_group(metadata_dir)
   end
 
   specify '.verify_version_id' do


### PR DESCRIPTION
## Why was this change made?

In ruby typically we don't use methods beginning with `get_`

## How was this change tested?



## Which documentation and/or configurations were updated?



