### PR TITLE
[refactor] Extract FileInventoryBuilder from SdrIngestService

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -97,6 +97,7 @@ RSpec/AnyInstance:
     - 'spec/requests/notify_goobi_spec.rb'
     - 'spec/services/publish/metadata_transfer_service_spec.rb'
     - 'spec/services/publish/public_xml_service_spec.rb'
+    - 'spec/services/sdr_ingest_service_spec.rb'
 
 # Offense count: 20
 RSpec/Be:
@@ -136,7 +137,7 @@ RSpec/InstanceVariable:
   Exclude:
     - 'spec/services/digital_stacks_service_spec.rb'
 
-# Offense count: 61
+# Offense count: 56
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: have_received, receive
 RSpec/MessageSpies:
@@ -173,7 +174,7 @@ RSpec/ScatteredSetup:
     - 'spec/services/publish/metadata_transfer_service_spec.rb'
     - 'spec/services/publish/public_desc_metadata_service_spec.rb'
 
-# Offense count: 25
+# Offense count: 21
 RSpec/StubbedMock:
   Exclude:
     - 'spec/dor/update_marc_record_service_spec.rb'

--- a/app/services/preserve/file_inventory_builder.rb
+++ b/app/services/preserve/file_inventory_builder.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Preserve
+  # This creates a Moab::FileInventory from the contentMetadata.xml
+  class FileInventoryBuilder
+    # @param [Pathname] metadata_dir The location of the the object's metadata files
+    # @param [String] druid The object identifier
+    # @param [Integer] version_id The version number
+    # @return [Moab::FileInventory] Generate and return a version inventory for the object
+    def self.build(metadata_dir:, druid:, version_id:)
+      new(metadata_dir: metadata_dir,
+          druid: druid,
+          version_id: version_id).build
+    end
+
+    def initialize(metadata_dir:, druid:, version_id:)
+      @metadata_dir = metadata_dir
+      @druid = druid
+      @version_id = version_id
+    end
+
+    def build
+      content_inventory.tap do |version_inventory|
+        version_inventory.groups << metadata_file_group
+      end
+    end
+
+    attr_reader :metadata_dir, :druid, :version_id
+
+    # @return [Moab::FileInventory] Parse the contentMetadata
+    #   and generate a new version inventory object containing a content group
+    def content_inventory
+      if content_metadata
+        Stanford::ContentInventory.new.inventory_from_cm(content_metadata, druid, 'preserve', version_id)
+      else
+        Moab::FileInventory.new(type: 'version', digital_object_id: druid, version_id: version_id)
+      end
+    end
+
+    # @return [String] Return the contents of the contentMetadata.xml file from the content directory
+    def content_metadata
+      @content_metadata ||= (content_metadata_pathname.read if content_metadata_pathname.exist?)
+    end
+
+    def content_metadata_pathname
+      @content_metadata_pathname ||= metadata_dir.join('contentMetadata.xml')
+    end
+
+    # @return [Moab::FileGroup] Traverse the metadata directory and generate a metadata group
+    def metadata_file_group
+      Moab::FileGroup.new(group_id: 'metadata').group_from_directory(metadata_dir)
+    end
+  end
+end

--- a/spec/services/preserve/file_inventory_builder_spec.rb
+++ b/spec/services/preserve/file_inventory_builder_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'fileutils'
+
+RSpec.describe Preserve::FileInventoryBuilder do
+  let(:fixtures) { Pathname(File.dirname(__FILE__)).join('../../fixtures') }
+  let(:export_dir) { Pathname(Settings.sdr.local_export_home) }
+  let(:fixture_sig_cat_obj) do
+    Moab::SignatureCatalog.parse(
+      File.read(fixtures.join('sdr_repo/dd116zh0343/v0001/manifests/signatureCatalog.xml'))
+    )
+  end
+
+  before do
+    allow(Settings.sdr).to receive_messages(local_workspace_root: fixtures.join('workspace').to_s,
+                                            local_export_home: fixtures.join('export').to_s)
+
+    export_dir.rmtree if export_dir.exist? && export_dir.basename.to_s == 'export'
+    export_dir.mkdir
+  end
+
+  after do
+    export_dir.rmtree if export_dir.exist? && export_dir.basename.to_s == 'export'
+  end
+
+  describe '.build' do
+    subject(:result) do
+      described_class.build(metadata_dir: metadata_dir, druid: druid, version_id: version_id)
+    end
+
+    let(:metadata_dir) { fixtures.join('workspace/ab/123/cd/4567/ab123cd4567/metadata') }
+    let(:druid) { 'druid:ab123cd4567' }
+    let(:version_id) { 2 }
+
+    it 'creates a file inventory' do
+      expect(result).to be_instance_of Moab::FileInventory
+      expect(result.groups.size).to eq 2
+    end
+  end
+
+  describe '#content_inventory' do
+    subject(:version_inventory) { instance.content_inventory }
+
+    let(:druid) { 'druid:ab123cd4567' }
+    let(:version_id) { 2 }
+
+    let(:instance) do
+      described_class.new(metadata_dir: metadata_dir, druid: druid, version_id: version_id)
+    end
+
+    context 'when contentMetadata.xml exists' do
+      let(:metadata_dir) { fixtures.join('workspace/ab/123/cd/4567/ab123cd4567/metadata') }
+
+      it 'builds the inventory from contentMetadata' do
+        expect(version_inventory).to be_instance_of Moab::FileInventory
+        expect(version_inventory.version_id).to eq 2
+        content_group = version_inventory.groups[0]
+        expect(content_group.group_id).to eq 'content'
+        expect(content_group.files.size).to eq 2
+        # files in the 2nd resource are copied from the first resource
+        expect(content_group.files[0].instances.size).to eq 2
+      end
+    end
+
+    context "when contentMetadata.xml doesn't exist" do
+      let(:metadata_dir) { fixtures.join('workspace/ab/123/cd/4567/ab123cd4567') }
+
+      it 'has no groups' do
+        expect(version_inventory.groups.size).to eq 0
+      end
+    end
+  end
+
+  describe '#content_metadata' do
+    subject(:content_metadata) { instance.content_metadata }
+
+    let(:druid) { 'druid:ab123cd4567' }
+    let(:version_id) { 2 }
+
+    let(:instance) do
+      described_class.new(metadata_dir: metadata_dir, druid: druid, version_id: version_id)
+    end
+
+    context 'when contentMetadata.xml exists' do
+      let(:metadata_dir) { fixtures.join('workspace/ab/123/cd/4567/ab123cd4567/metadata') }
+
+      it { is_expected.to match(/<contentMetadata /) }
+    end
+
+    context "when contentMetadata.xml doesn't exist" do
+      let(:metadata_dir) { fixtures.join('workspace/ab/123/cd/4567/ab123cd4567') }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#metadata_file_group' do
+    let(:druid) { 'druid:ab123cd4567' }
+    let(:version_id) { 2 }
+    let(:metadata_dir) { fixtures.join('workspace/ab/123/cd/4567/ab123cd4567/metadata') }
+
+    let(:instance) do
+      described_class.new(metadata_dir: metadata_dir, druid: druid, version_id: version_id)
+    end
+
+    let(:file_group) { instance_double(Moab::FileGroup, group_from_directory: nil) }
+
+    before do
+      allow(Moab::FileGroup).to receive(:new).and_return(file_group)
+    end
+
+    it 'initializes the file group' do
+      instance.metadata_file_group
+      expect(Moab::FileGroup).to have_received(:new).with(group_id: 'metadata')
+      expect(file_group).to have_received(:group_from_directory).with(metadata_dir)
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Each class should have a single responsibility, this refactoring creates a new class with the exclusive responsibility of building a Moab::FileInventory. 



## How was this change tested?
Unit tests.



## Which documentation and/or configurations were updated?



