### PR TITLE
[refactor] Extract Preserve::BagVerifier from SdrIngestService

### DIFF
--- a/app/services/preserve/bag_verifier.rb
+++ b/app/services/preserve/bag_verifier.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Preserve
+  # This checks to ensure the bag is well formed
+  class BagVerifier
+    REQUIRED_FILES = %w[
+      data
+      bagit.txt
+      bag-info.txt
+      manifest-sha256.txt
+      tagmanifest-sha256.txt
+      versionAdditions.xml
+      versionInventory.xml
+      data/metadata/versionMetadata.xml
+    ].freeze
+
+    # @param [Pathname] bag_dir the location of the bag to be verified
+    # @return [Boolean] true if all required files exist
+    # @raises [StandardError] a required file is missing
+    def self.verify(directory:)
+      new(directory: directory).verify
+    end
+
+    def initialize(directory:)
+      @directory = directory
+    end
+
+    attr_reader :directory
+
+    def verify
+      verify_pathname(directory)
+      REQUIRED_FILES.each do |path|
+        verify_pathname(directory.join(path))
+      end
+      true
+    end
+
+    # @param [Pathname] pathname The file whose existence should be verified
+    # @return [Boolean] true if file exists, raises exception if not
+    def verify_pathname(pathname)
+      raise "#{pathname.basename} not found at #{pathname}" unless pathname.exist?
+
+      true
+    end
+  end
+end

--- a/app/services/sdr_ingest_service.rb
+++ b/app/services/sdr_ingest_service.rb
@@ -38,7 +38,7 @@ class SdrIngestService
     bagger.deposit_group('content', content_dir)
     bagger.deposit_group('metadata', metadata_dir)
     bagger.create_tagfiles
-    verify_bag_structure(bag_dir)
+    Preserve::BagVerifier.verify(directory: bag_dir)
   end
 
   # NOTE: the following methods should probably all be private
@@ -73,33 +73,11 @@ class SdrIngestService
   # @param [Pathname] pathname the location of the versionMetadata file
   # @return [Integer] the versionId found in the last version element, or nil if missing
   def self.vmfile_version_id(pathname)
-    verify_pathname(pathname)
+    raise "#{pathname.basename} not found at #{pathname}" unless pathname.exist?
+
     doc = Nokogiri::XML(File.read(pathname.to_s))
     nodeset = doc.xpath('/versionMetadata/version')
     version_id = nodeset.last['versionId']
     version_id.nil? ? nil : version_id.to_i
-  end
-
-  # @param [Pathname] bag_dir the location of the bag to be verified
-  # @return [Boolean] true if all required files exist, raises exception if not
-  def self.verify_bag_structure(bag_dir)
-    verify_pathname(bag_dir)
-    verify_pathname(bag_dir.join('data'))
-    verify_pathname(bag_dir.join('bagit.txt'))
-    verify_pathname(bag_dir.join('bag-info.txt'))
-    verify_pathname(bag_dir.join('manifest-sha256.txt'))
-    verify_pathname(bag_dir.join('tagmanifest-sha256.txt'))
-    verify_pathname(bag_dir.join('versionAdditions.xml'))
-    verify_pathname(bag_dir.join('versionInventory.xml'))
-    verify_pathname(bag_dir.join('data', 'metadata', 'versionMetadata.xml'))
-    true
-  end
-
-  # @param [Pathname] pathname The file whose existence should be verified
-  # @return [Boolean] true if file exists, raises exception if not
-  def self.verify_pathname(pathname)
-    raise "#{pathname.basename} not found at #{pathname}" unless pathname.exist?
-
-    true
   end
 end

--- a/spec/services/preserve/bag_verifier_spec.rb
+++ b/spec/services/preserve/bag_verifier_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Preserve::BagVerifier do
+  let(:fixtures) { Pathname(File.dirname(__FILE__)).join('../../fixtures') }
+
+  describe '#verify_pathname' do
+    subject(:verify_pathname) { instance.verify_pathname(path) }
+
+    let(:instance) { described_class.new(directory: instance_double(Pathname)) }
+
+    context 'with an existing directory' do
+      let(:path) { fixtures.join('workspace/dd/116/zh/0343/dd116zh0343/metadata') }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with an existing file' do
+      let(:path) { fixtures.join('workspace/dd/116/zh/0343/dd116zh0343/metadata/versionMetadata.xml') }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with a non-existent file' do
+      let(:path) { fixtures.join('workspace/dd/116/zh/0343/dd116zh0343/metadata/badfile.xml') }
+
+      it 'raises an exception' do
+        expect { verify_pathname }.to raise_exception(/badfile.xml not found/)
+      end
+    end
+  end
+end

--- a/spec/services/sdr_ingest_service_spec.rb
+++ b/spec/services/sdr_ingest_service_spec.rb
@@ -150,13 +150,4 @@ RSpec.describe SdrIngestService do
     vmfile = metadata_dir.join('versionMetadata.xml')
     expect(described_class.vmfile_version_id(vmfile)).to eq 2
   end
-
-  specify '.verify_pathname' do
-    metadata_dir = fixtures.join('workspace/dd/116/zh/0343/dd116zh0343/metadata')
-    expect(described_class.verify_pathname(metadata_dir)).to be_truthy
-    vmfile = metadata_dir.join('versionMetadata.xml')
-    expect(described_class.verify_pathname(vmfile)).to be_truthy
-    badfile = metadata_dir.join('badfile.xml')
-    expect { described_class.verify_pathname(badfile) }.to raise_exception(/badfile.xml not found/)
-  end
 end


### PR DESCRIPTION
## Why was this change made?

Each class should only have one responsibility.  This new class verifies the bag is as expected.


## How was this change tested?



## Which documentation and/or configurations were updated?



