### PR TITLE
Remove dlss-capistrano provided bundler2 config

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -46,8 +46,6 @@ set :rails_env, 'production'
 set :sidekiq_systemd_role, :worker
 set :sidekiq_systemd_use_hooks, true
 
-set :bundler2_config_use_hook, true
-
 # Run db migrations on app servers, not db server
 set :migration_role, :app
 


### PR DESCRIPTION



## Why was this change made?

This functionality is now handled by capistrano-bundler 2.0

## How was this change tested?



## Which documentation and/or configurations were updated?



