### PR TITLE
Handle a nil process content type tag

### DIFF
--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -189,7 +189,12 @@ module Cocina
     end
 
     def add_tags(pid, cocina_object)
-      add_tag(pid, ToFedora::ProcessTag.map(cocina_object.type, cocina_object.structural&.hasMemberOrders&.first&.viewingDirection), 'Process : Content Type') if has_changed?(:structural)
+      if has_changed?(:structural)
+        # This is necessary so that the content type tag for a book can get updated
+        # to reflect the new direction if the direction hash changed in the structural metadata.
+        tag = ToFedora::ProcessTag.map(cocina_object.type, cocina_object.structural&.hasMemberOrders&.first&.viewingDirection)
+        add_tag(pid, tag, 'Process : Content Type') if tag
+      end
       add_tag(pid, "Project : #{cocina_object.administrative.partOfProject}", 'Project') if cocina_object.administrative.partOfProject && has_changed?(:administrative)
     end
 

--- a/app/services/cocina/to_fedora/process_tag.rb
+++ b/app/services/cocina/to_fedora/process_tag.rb
@@ -5,30 +5,29 @@ module Cocina
     # This transforms the DRO.type attribute to the process tag value
     class ProcessTag
       # TODO: add Software
-      def self.map(type, direction)
-        tag = case type
-              when Cocina::Models::Vocab.image
-                'Image'
-              when Cocina::Models::Vocab.three_dimensional
-                '3D'
-              when Cocina::Models::Vocab.map
-                'Map'
-              when Cocina::Models::Vocab.media
-                'Media'
-              when Cocina::Models::Vocab.manuscript
-                'Manuscript'
-              when Cocina::Models::Vocab.book
-                short_dir = direction == 'right-to-left' ? 'rtl' : 'ltr'
-                "Book (#{short_dir})"
-              when Cocina::Models::Vocab.document
-                'Document'
-              when Cocina::Models::Vocab.object
-                'File'
-              when Cocina::Models::Vocab.webarchive_seed
-                'Webarchive Seed'
-              end
+      MAPPING = {
+        Cocina::Models::Vocab.image => 'Image',
+        Cocina::Models::Vocab.three_dimensional => '3D',
+        Cocina::Models::Vocab.map => 'Map',
+        Cocina::Models::Vocab.media => 'Media',
+        Cocina::Models::Vocab.manuscript => 'Manuscript',
+        Cocina::Models::Vocab.document => 'Document',
+        Cocina::Models::Vocab.book => 'Book',
+        Cocina::Models::Vocab.object => 'File',
+        Cocina::Models::Vocab.webarchive_seed => 'Webarchive Seed'
+      }.freeze
 
-        "Process : Content Type : #{tag}" if tag
+      def self.map(type, direction)
+        tag = MAPPING.fetch(type, nil)
+
+        return unless tag
+
+        if type == Cocina::Models::Vocab.book
+          short_dir = direction == 'right-to-left' ? 'rtl' : 'ltr'
+          tag += " (#{short_dir})"
+        end
+
+        "Process : Content Type : #{tag}"
       end
     end
   end

--- a/spec/services/cocina/to_fedora/process_tag_spec.rb
+++ b/spec/services/cocina/to_fedora/process_tag_spec.rb
@@ -18,4 +18,30 @@ RSpec.describe Cocina::ToFedora::ProcessTag do
 
     it { is_expected.to eq 'Process : Content Type : Webarchive Seed' }
   end
+
+  describe 'with book RTL' do
+    let(:type) { Cocina::Models::Vocab.book }
+    let(:direction) { 'right-to-left' }
+
+    it { is_expected.to eq 'Process : Content Type : Book (rtl)' }
+  end
+
+  describe 'with book LTR' do
+    let(:type) { Cocina::Models::Vocab.book }
+    let(:direction) { 'left-to-right' }
+
+    it { is_expected.to eq 'Process : Content Type : Book (ltr)' }
+  end
+
+  describe 'with agreement' do
+    let(:type) { Cocina::Models::Vocab.agreement }
+
+    it { is_expected.to be_nil }
+  end
+
+  describe 'with webarchive-binary' do
+    let(:type) { Cocina::Models::Vocab.webarchive_binary }
+
+    it { is_expected.to be_nil }
+  end
 end


### PR DESCRIPTION


## Why was this change made?

This was causing a problem in ObjectUpdater when it tries to add a tag with a nil value

## How was this change tested?



## Which documentation and/or configurations were updated?



