### PR TITLE
Enable new rubocops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -441,3 +441,11 @@ RSpec/SubjectDeclaration: # new in 2.5
   Enabled: true
 Rails/RedundantTravelBack: # new in 2.12
   Enabled: true
+Gemspec/RequireMFA: # new in 1.23
+  Enabled: true
+Lint/UselessRuby2Keywords: # new in 1.23
+  Enabled: true
+Style/OpenStructUse: # new in 1.23
+  Enabled: true
+Performance/ConcurrentMonotonicTime: # new in 1.12
+  Enabled: true


### PR DESCRIPTION
## Why was this change made?
Remove warnings when running rubocop


## How was this change tested?



## Which documentation and/or configurations were updated?



