### PR TITLE
Adds result summary file to validate roundtrip scripts.

### DIFF
--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -141,15 +141,15 @@ end
 # rubocop:disable Metrics/MethodLength
 # rubocop:disable Metrics/PerceivedComplexity
 def validate_druid(druid, loader, fast: false, create: false)
-  return :missing unless loader.cached?(druid)
+  return [druid, :missing] unless loader.cached?(druid)
 
   begin
     fedora_obj = loader.load(druid)
   rescue FedoraLoader::BadCache => e
     write_error(druid, e)
-    return :bad_cache
+    return [druid, :bad_cache]
   rescue FedoraLoader::Unmapped
-    return :unmapped
+    return [druid, :unmapped]
   end
 
   if fast && fedora_obj.datastreams.include?('contentMetadata')
@@ -168,7 +168,7 @@ def validate_druid(druid, loader, fast: false, create: false)
     orig_cocina_obj = Cocina::Mapper.build(fedora_obj, notifier: DataErrorNotifier.new)
   rescue StandardError => e
     write_error(druid, e)
-    return :mapping_error
+    return [druid, :mapping_error]
   end
 
   orig_cocina_hash = orig_cocina_obj.to_h
@@ -178,7 +178,7 @@ def validate_druid(druid, loader, fast: false, create: false)
       roundtrip_fedora_obj, roundtrip_cocina_obj = Cocina::ObjectCreator.trial_create(orig_cocina_obj, notifier: DataErrorNotifier.new)
     rescue StandardError => e
       write_error(druid, e)
-      return :create_error
+      return [druid, :create_error]
     end
     # RELS-EXT is not present in created Fedora object, so remove from orig_datastreams.
     orig_datastreams.delete('RELS-EXT')
@@ -188,7 +188,7 @@ def validate_druid(druid, loader, fast: false, create: false)
       roundtrip_fedora_obj = fedora_obj
     rescue StandardError => e
       write_error(druid, e)
-      return :update_error
+      return [druid, :update_error]
     end
   end
   roundtrip_cocina_hash = roundtrip_cocina_obj.to_h
@@ -197,13 +197,13 @@ def validate_druid(druid, loader, fast: false, create: false)
     diff_datastreams = diff_datatreams_for(druid, label, orig_datastreams, roundtrip_fedora_obj)
   rescue StandardError => e
     write_error(druid, e)
-    return :normalization_error
+    return [druid, :normalization_error]
   end
 
-  return :success if DeepEqual.match?(normalize_cocina(orig_cocina_hash), normalize_cocina(roundtrip_cocina_hash)) && diff_datastreams.empty?
+  return [druid, :success] if DeepEqual.match?(normalize_cocina(orig_cocina_hash), normalize_cocina(roundtrip_cocina_hash)) && diff_datastreams.empty?
 
   write_result(druid, orig_cocina_hash, roundtrip_cocina_hash, diff_datastreams)
-  :different
+  [druid, :different]
 end
 # rubocop:enable Metrics/AbcSize
 # rubocop:enable Metrics/CyclomaticComplexity
@@ -242,7 +242,12 @@ results = Parallel.map(druids, progress: 'Testing') do |druid|
   validate_druid(druid, loader, fast: options[:fast], create: options[:create])
 end
 counts = { different: 0, success: 0, mapping_error: 0, update_error: 0, create_error: 0, normalization_error: 0, missing: 0, unmapped: 0, bad_cache: 0 }
-results.each { |result| counts[result] += 1 }
+File.open('results/results.txt', 'w') do |file|
+  results.each do |druid, result|
+    counts[result] += 1
+    file.write("#{druid}=#{result}\n")
+  end
+end
 
 denom = druids.size - counts[:missing] - counts[:unmapped] - counts[:bad_cache]
 

--- a/bin/validate-desc-cocina-roundtrip
+++ b/bin/validate-desc-cocina-roundtrip
@@ -119,7 +119,7 @@ end
 # rubocop:disable Metrics/CyclomaticComplexity
 def validate_druid(druid, cache, fast: false)
   result = cache.label_and_desc_metadata(druid)
-  return :missing if result.failure?
+  return [druid, :missing] if result.failure?
 
   label, original_xml = result.value!
   original_ng_xml = Nokogiri::XML(original_xml)
@@ -130,7 +130,7 @@ def validate_druid(druid, cache, fast: false)
     cocina = Cocina::Models::Description.new(cocina_props)
   rescue StandardError => e
     write_error(druid, original_ng_xml, cocina_props, e) unless fast
-    return :to_cocina_error
+    return [druid, :to_cocina_error]
   end
 
   begin
@@ -138,23 +138,23 @@ def validate_druid(druid, cache, fast: false)
     norm_original_ng_xml = Cocina::Normalizers::ModsNormalizer.normalize(mods_ng_xml: original_ng_xml, druid: druid, label: label)
   rescue StandardError => e
     write_error(druid, original_ng_xml, cocina_props, e) unless fast
-    return :mods_normalizer_error
+    return [druid, :mods_normalizer_error]
   end
 
   begin
     roundtrip_ng_xml = round_tripped_ng_xml(cocina, druid)
   rescue StandardError => e
     write_error(druid, original_ng_xml, cocina_props, e) unless fast
-    return :to_fedora_error
+    return [druid, :to_fedora_error]
   end
 
   if fast
-    return ModsEquivalentService.equivalent?(norm_original_ng_xml, roundtrip_ng_xml) ? :success : :different
+    return [druid, ModsEquivalentService.equivalent?(norm_original_ng_xml, roundtrip_ng_xml) ? :success : :different]
   end
 
   equiv = ModsEquivalentService.equivalent_with_result?(norm_original_ng_xml, roundtrip_ng_xml)
 
-  return :success if equiv.success?
+  return [druid, :success] if equiv.success?
 
   # If not equivalent, but no diffs reported, then try in reverse.
   reverse_equiv = ModsEquivalentService.equivalent_with_result?(roundtrip_ng_xml, norm_original_ng_xml) if equiv.failure.empty?
@@ -167,7 +167,7 @@ def validate_druid(druid, cache, fast: false)
                Array(reverse_equiv&.failure),
                notifier.data_errors,
                validate_mods(original_ng_xml))
-  :different
+  [druid, :different]
 end
 # rubocop:enable Metrics/CyclomaticComplexity
 
@@ -201,7 +201,12 @@ results = Parallel.map(druids, progress: 'Testing') do |druid|
   validate_druid(druid, cache, fast: options[:fast])
 end
 counts = { different: 0, success: 0, to_cocina_error: 0, to_fedora_error: 0, missing: 0, mods_normalizer_error: 0 }
-results.each { |result| counts[result] += 1 }
+File.open('results/results.txt', 'w') do |file|
+  results.each do |druid, result|
+    counts[result] += 1
+    file.write("#{druid}=#{result}\n")
+  end
+end
 
 denom = druids.size - counts[:missing]
 

--- a/bin/validate-rights-cocina-roundtrip
+++ b/bin/validate-rights-cocina-roundtrip
@@ -68,16 +68,16 @@ def validate_druid(druid, loader)
   begin
     fedora_obj = loader.load(druid)
   rescue FedoraLoader::BadCache
-    return :bad_cache
+    return [druid, :bad_cache]
   rescue FedoraLoader::Unmapped
-    return :missing
+    return [druid, :missing]
   end
   # TODO: Also handle collections.
-  return :not_dro unless fedora_obj.is_a?(Dor::Item) || fedora_obj.is_a?(Hydrus::Item)
+  return [druid, :not_dro] unless fedora_obj.is_a?(Dor::Item) || fedora_obj.is_a?(Hydrus::Item)
 
   orig_datastreams = {}
   FedoraCache::DATASTREAMS.each { |dsid| orig_datastreams[dsid] = fedora_obj.datastreams[dsid]&.content }
-  return :missing unless orig_datastreams['rightsMetadata']
+  return [druid, :missing] unless orig_datastreams['rightsMetadata']
 
   original_ng_xml = Nokogiri::XML(orig_datastreams['rightsMetadata'])
 
@@ -89,31 +89,31 @@ def validate_druid(druid, loader)
     cocina_structural = Cocina::Models::DROStructural.new(cocina_structural_props)
   rescue StandardError => e
     write_error(druid, original_ng_xml, cocina_access_props, e)
-    return :to_cocina_error
+    return [druid, :to_cocina_error]
   end
 
   begin
     roundtrip_ng_xml = roundtripped_ng_xml(fedora_obj, cocina_access, cocina_structural)
   rescue StandardError => e
     write_error(druid, original_ng_xml, cocina_access_props, e)
-    return :to_fedora_error
+    return [druid, :to_fedora_error]
   end
 
   begin
     normalized_original_ng_xml = Cocina::Normalizers::RightsNormalizer.normalize(datastream: fedora_obj.datastreams['rightsMetadata'])
   rescue StandardError => e
     write_error(druid, original_ng_xml, cocina_access_props, e)
-    return :rights_normalizer_error
+    return [druid, :rights_normalizer_error]
   end
 
-  return :success if EquivalentXml.equivalent?(normalized_original_ng_xml, roundtrip_ng_xml)
+  return [druid, :success] if EquivalentXml.equivalent?(normalized_original_ng_xml, roundtrip_ng_xml)
 
   write_result(druid,
                original_ng_xml,
                normalized_original_ng_xml,
                roundtrip_ng_xml,
                cocina_access_props)
-  :different
+  [druid, :different]
 end
 
 def percentage(raw_num, denom)
@@ -144,7 +144,12 @@ results = Parallel.map(druids, progress: 'Testing') do |druid|
   validate_druid(druid, loader)
 end
 counts = { different: 0, success: 0, to_cocina_error: 0, to_fedora_error: 0, rights_normalizer_error: 0, missing: 0, not_dro: 0, bad_cache: 0 }
-results.each { |result| counts[result] += 1 }
+File.open('results/results.txt', 'w') do |file|
+  results.each do |druid, result|
+    counts[result] += 1
+    file.write("#{druid}=#{result}\n")
+  end
+end
 
 denom = druids.size - counts[:missing] - counts[:not_dro] - counts[:bad_cache]
 


### PR DESCRIPTION
## Why was this change made?
To make it easier to track down druids with odd states like "missing" and "bad cache".


## How was this change tested?
Local


## Which documentation and/or configurations were updated?



