### PR TITLE
Normalize resource sequence for content metadata.

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -27,6 +27,7 @@ module Cocina
 
       def normalize(druid:)
         remove_resource_id
+        remove_sequence
         normalize_object_id
         normalize_reading_order(druid)
         normalize_attr
@@ -36,6 +37,7 @@ module Cocina
 
       def normalize_roundtrip
         remove_resource_id
+        remove_sequence
 
         regenerate_ng_xml(ng_xml.to_s)
       end
@@ -46,6 +48,12 @@ module Cocina
 
       def remove_resource_id
         ng_xml.root.xpath('//resource[@id]').each { |resource_node| resource_node.delete('id') }
+      end
+
+      def remove_sequence
+        # Some original content metadata does not have sequence for all resource nodes.
+        # However, sequence is assigned to all resource nodes when mapping to fedora.
+        ng_xml.root.xpath('//resource[@sequence]').each { |resource_node| resource_node.delete('sequence') }
       end
 
       def normalize_object_id

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
     let(:expected_xml) do
       <<~XML
         <contentMetadata objectId="druid:bk689jd2364" type="file">
-          <resource sequence="1" type="file">
+          <resource type="file">
             <file id="Decision.Record_6-30-03_signed.pdf" preserve="yes" publish="yes" shelve="yes" mimetype="application/pdf" size="102937">
               <checksum type="md5">50d5fc2730503a98bc2dda643064ae5b</checksum>
               <checksum type="sha1">df31b2f415d8e0806fa283db4e2c7fda690d1b02</checksum>
@@ -119,7 +119,7 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
           <<~XML
             <contentMetadata objectId="druid:bb035tg0974" type="book">
               <bookData readingOrder="ltr"/>
-              <resource sequence="1" type="page" />
+              <resource type="page" />
             </contentMetadata>
           XML
         )
@@ -150,7 +150,7 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
         expect(normalized_ng_xml).to be_equivalent_to(
           <<~XML
             <contentMetadata objectId="druid:bk689jd2364" type="file">
-              <resource type="page" sequence="268">
+              <resource type="page">
                 <file preserve="yes" mimetype="image/jp2" format="JPEG2000" size="92631" shelve="no" id="00000268.jp2" deliver="no">
                   <imageData width="1310" height="2071"/>
                   <checksum type="SHA-1">50d77a392ba30dcbbf4ada379e09ded02f9658f2</checksum>


### PR DESCRIPTION
closes #3114

## Why was this change made?
Roundtripping happiness.

Sequence is not always present for every resource node in content metadata, but is present when mapped from cocina.


## How was this change tested?
Before:
```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9038 (90.489%)
  Different: 918 (9.191%)
  Mapping error:     0 (0.0%)
  Create error:     32 (0.32%)
  Normalization error:     0 (0.0%)
  Missing:     4 (0.04%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     8 (0.08%)
  Bad cache:     0 (0.0%)
```

After:
```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9465 (94.764%)
  Different: 481 (4.816%)
  Mapping error:     10 (0.1%)
  Create error:     32 (0.32%)
  Normalization error:     0 (0.0%)
  Missing:     4 (0.04%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     8 (0.08%)
  Bad cache:     0 (0.0%)
```


## Which documentation and/or configurations were updated?



