### PR TITLE
Omit empty mimetypes from cocina.

### DIFF
--- a/app/services/cocina/from_fedora/file_sets.rb
+++ b/app/services/cocina/from_fedora/file_sets.rb
@@ -88,8 +88,8 @@ module Cocina
               shelve: node['shelve'] == 'yes'
             }
           }.tap do |attrs|
-            # Files from Goobi and Hydrus don't have mimetype until they hit exif-collect in the assemblyWF
-            attrs[:hasMimeType] = node['mimetype'] if node['mimetype']
+            # Files from Goobi don't have mimetype until they hit exif-collect in the assemblyWF
+            attrs[:hasMimeType] = node['mimetype'] if node['mimetype'].present?
             attrs[:presentation] = { height: height, width: width } if height && width
             attrs[:use] = use if use
           end

--- a/spec/services/cocina/mapping/structural/dro_structural_spec.rb
+++ b/spec/services/cocina/mapping/structural/dro_structural_spec.rb
@@ -308,4 +308,40 @@ RSpec.describe 'Fedora item content metadata <--> Cocina DRO structural mappings
       end
     end
   end
+
+  context 'when blank mimetype' do
+    it_behaves_like 'DRO Structural Fedora Cocina mapping' do
+      let(:content_xml) do
+        <<~XML
+          <contentMetadata type="book" objectId="#{druid}">
+            <resource sequence="1" type="file" id="folder1PuSu">
+              <label>Folder 1</label>
+              <file mimetype="" shelve="yes" publish="yes" size="7888" preserve="no" id="folder1PuSu/story1u.txt">
+                <checksum type="md5">e2837b9f02e0b0b76f526eeb81c7aa7b</checksum>
+                <checksum type="sha1">61dfac472b7904e1413e0cbf4de432bda2a97627</checksum>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      end
+
+      let(:cocina_structural_props) do
+        { contains: [{ externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/8d17c28b-5b3e-477e-912c-f168a1f4213f',
+                       type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+                       version: 1,
+                       structural: { contains: [{ externalIdentifier: 'http://cocina.sul.stanford.edu/file/be451fd9-7908-4559-9e81-8d6f496a3181',
+                                                  type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                                                  label: 'folder1PuSu/story1u.txt',
+                                                  filename: 'folder1PuSu/story1u.txt',
+                                                  size: 7888,
+                                                  version: 1,
+                                                  hasMessageDigests: [{ type: 'sha1',
+                                                                        digest: '61dfac472b7904e1413e0cbf4de432bda2a97627' },
+                                                                      { type: 'md5', digest: 'e2837b9f02e0b0b76f526eeb81c7aa7b' }],
+                                                  access: { access: 'world', download: 'world' },
+                                                  administrative: { publish: true, sdrPreserve: false, shelve: true } }] },
+                       label: 'Folder 1' }] }
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes #3155

## Why was this change made?
Mapping.


## How was this change tested?
Before:
```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9409 (94.184%)
  Different: 545 (5.455%)
  Mapping error:     0 (0.0%)
  Create error:     36 (0.36%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     10 (0.1%)
  Bad cache:     0 (0.0%)
```

After:
```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9409 (94.184%)
  Different: 545 (5.455%)
  Mapping error:     0 (0.0%)
  Create error:     36 (0.36%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     10 (0.1%)
  Bad cache:     0 (0.0%)
```

## Which documentation and/or configurations were updated?



