### PR TITLE
Normalize location (content metadata).

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -28,6 +28,7 @@ module Cocina
       def normalize(druid:)
         remove_resource_id
         remove_sequence
+        remove_location
         normalize_object_id
         normalize_reading_order(druid)
         normalize_attr
@@ -54,6 +55,10 @@ module Cocina
         # Some original content metadata does not have sequence for all resource nodes.
         # However, sequence is assigned to all resource nodes when mapping to fedora.
         ng_xml.root.xpath('//resource[@sequence]').each { |resource_node| resource_node.delete('sequence') }
+      end
+
+      def remove_location
+        ng_xml.root.xpath('//location[@type="url"]').each(&:remove)
       end
 
       def normalize_object_id

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -166,5 +166,38 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
         )
       end
     end
+
+    context 'when normalizing location' do
+      let(:original_xml) do
+        <<~XML
+          <contentMetadata type="file" objectId="druid:tt395zz8686">
+            <resource objectId="druid:tt395zz8686" id="content" type="file">
+              <label>Using xSearch for Accelerating Research-Review of Deep Web Technologies Federated Search Service</label>
+              <file preserve="yes" deliver="yes" size="4333001" mimetype="application/pdf" id="xSearch_Review_Charleston_Advisor.pdf" shelve="yes" publish="yes">
+                <location type="url">https://stacks.stanford.edu/file/druid:tt395zz8686/xSearch_Review_Charleston_Advisor.pdf</location>
+                <checksum type="md5">c22b3d0fd5569fc1039901bf22dad4f0</checksum>
+                <checksum type="sha1">50b90a7ef7937b048db6f6d4b41637f59a2a57cf</checksum>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      end
+
+      it 'removes location' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+              <contentMetadata type="file" objectId="druid:tt395zz8686">
+              <resource objectId="druid:tt395zz8686" type="file">
+                <label>Using xSearch for Accelerating Research-Review of Deep Web Technologies Federated Search Service</label>
+                <file preserve="yes" deliver="yes" size="4333001" mimetype="application/pdf" id="xSearch_Review_Charleston_Advisor.pdf" shelve="yes" publish="yes">
+                  <checksum type="md5">c22b3d0fd5569fc1039901bf22dad4f0</checksum>
+                  <checksum type="sha1">50b90a7ef7937b048db6f6d4b41637f59a2a57cf</checksum>
+                </file>
+              </resource>
+            </contentMetadata>
+          XML
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
closes #3085

## Why was this change made?
Mapping


## How was this change tested?
Before:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   94046 (94.123%)
  Different: 5477 (5.481%)
  Mapping error:     0 (0.0%)
  Create error:     395 (0.395%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

After:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   94046 (94.123%)
  Different: 5477 (5.481%)
  Mapping error:     0 (0.0%)
  Create error:     395 (0.395%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

## Which documentation and/or configurations were updated?



