### PR TITLE
Removes format attribute from file node (content metadata).

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -29,6 +29,7 @@ module Cocina
         remove_resource_id
         remove_sequence
         remove_location
+        remove_format
         normalize_object_id
         normalize_reading_order(druid)
         normalize_label_attr
@@ -67,6 +68,10 @@ module Cocina
         return if object_id.nil? || object_id.start_with?('druid:')
 
         ng_xml.root['objectId'] = "druid:#{object_id}"
+      end
+
+      def remove_format
+        ng_xml.root.xpath('//file[@format]').each { |file_node| file_node.delete('format') }
       end
 
       def normalize_reading_order(druid)

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -146,17 +146,17 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
         XML
       end
 
-      it 'removes attrs' do
+      it 'removes attrs and format' do
         expect(normalized_ng_xml).to be_equivalent_to(
           <<~XML
             <contentMetadata objectId="druid:bk689jd2364" type="file">
               <resource type="page">
-                <file preserve="yes" mimetype="image/jp2" format="JPEG2000" size="92631" shelve="no" id="00000268.jp2" deliver="no">
+                <file preserve="yes" mimetype="image/jp2" size="92631" shelve="no" id="00000268.jp2" deliver="no">
                   <imageData width="1310" height="2071"/>
                   <checksum type="SHA-1">50d77a392ba30dcbbf4ada379e09ded02f9658f2</checksum>
                   <checksum type="MD5">dcea2fd8ed01b2ef978093cf45ea3ce9</checksum>
                 </file>
-                <file preserve="yes" mimetype="text/html" format="HTML" size="19144" dataType="hocr" shelve="yes" id="00000268.html" deliver="no">
+                <file preserve="yes" mimetype="text/html" size="19144" dataType="hocr" shelve="yes" id="00000268.html" deliver="no">
                   <checksum type="SHA-1">335c75c2e2a13f024f73b0dd7dc5fc35fc47e7ce</checksum>
                   <checksum type="MD5">42d8261046c449230a7c3809a246b353</checksum>
                 </file>


### PR DESCRIPTION
closes #3119

## Why was this change made?
Mapping


## How was this change tested?
Before:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   94046 (94.123%)
  Different: 5477 (5.481%)
  Mapping error:     0 (0.0%)
  Create error:     395 (0.395%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

After:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   94291 (94.368%)
  Different: 5232 (5.236%)
  Mapping error:     0 (0.0%)
  Create error:     395 (0.395%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```


## Which documentation and/or configurations were updated?



