### PR TITLE
Map/normalize attr labels (content metadata).

### DIFF
--- a/app/services/cocina/from_fedora/file_sets.rb
+++ b/app/services/cocina/from_fedora/file_sets.rb
@@ -31,7 +31,7 @@ module Cocina
             version: version,
             structural: structural
           }.tap do |attrs|
-            attrs[:label] = resource_node.xpath('label').text # some will be missing labels, they will just be blank
+            attrs[:label] = resource_node.xpath('label', 'attr[@type="label"]').text # some will be missing labels, they will just be blank
           end
         end
       end

--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -30,6 +30,7 @@ module Cocina
         remove_sequence
         normalize_object_id
         normalize_reading_order(druid)
+        normalize_label_attr
         normalize_attr
 
         regenerate_ng_xml(ng_xml.to_s)
@@ -74,6 +75,16 @@ module Cocina
         book_data_node = Nokogiri::XML::Node.new('bookData', ng_xml)
         book_data_node['readingOrder'] = reading_direction == 'left-to-right' ? 'ltr' : 'rtl'
         ng_xml.root << book_data_node
+      end
+
+      def normalize_label_attr
+        # Pending https://github.com/sul-dlss/dor-services-app/issues/2808
+        ng_xml.root.xpath('//attr[@type="label"]').each do |attr_node|
+          label_node = Nokogiri::XML::Node.new('label', ng_xml)
+          label_node.content = attr_node.content
+          attr_node.parent << label_node
+          attr_node.remove
+        end
       end
 
       def normalize_attr

--- a/spec/services/cocina/mapping/structural/dro_structural_spec.rb
+++ b/spec/services/cocina/mapping/structural/dro_structural_spec.rb
@@ -256,4 +256,56 @@ RSpec.describe 'Fedora item content metadata <--> Cocina DRO structural mappings
       end
     end
   end
+
+  context 'when content metadata with label attr (e.g., legacy ETD)' do
+    it_behaves_like 'DRO Structural Fedora Cocina mapping' do
+      # See druid:bb164pj1759
+      let(:content_xml) do
+        <<~XML
+          <contentMetadata type="book" objectId="#{druid}">
+            <resource sequence="1" type="file" id="folder1PuSu">
+              <attr type="label">Folder 1</attr>
+              <file mimetype="text/plain" shelve="yes" publish="yes" size="7888" preserve="no" id="folder1PuSu/story1u.txt">
+                <checksum type="md5">e2837b9f02e0b0b76f526eeb81c7aa7b</checksum>
+                <checksum type="sha1">61dfac472b7904e1413e0cbf4de432bda2a97627</checksum>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      end
+
+      let(:roundtrip_content_xml) do
+        <<~XML
+          <contentMetadata type="book" objectId="#{druid}">
+            <resource sequence="1" type="file" id="folder1PuSu">
+              <label>Folder 1</label>
+              <file mimetype="text/plain" shelve="yes" publish="yes" size="7888" preserve="no" id="folder1PuSu/story1u.txt">
+                <checksum type="md5">e2837b9f02e0b0b76f526eeb81c7aa7b</checksum>
+                <checksum type="sha1">61dfac472b7904e1413e0cbf4de432bda2a97627</checksum>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      end
+
+      let(:cocina_structural_props) do
+        { contains: [{ externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/8d17c28b-5b3e-477e-912c-f168a1f4213f',
+                       type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+                       version: 1,
+                       structural: { contains: [{ externalIdentifier: 'http://cocina.sul.stanford.edu/file/be451fd9-7908-4559-9e81-8d6f496a3181',
+                                                  type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                                                  label: 'folder1PuSu/story1u.txt',
+                                                  filename: 'folder1PuSu/story1u.txt',
+                                                  size: 7888,
+                                                  version: 1,
+                                                  hasMessageDigests: [{ type: 'sha1',
+                                                                        digest: '61dfac472b7904e1413e0cbf4de432bda2a97627' },
+                                                                      { type: 'md5', digest: 'e2837b9f02e0b0b76f526eeb81c7aa7b' }],
+                                                  access: { access: 'world', download: 'world' },
+                                                  administrative: { publish: true, sdrPreserve: false, shelve: true },
+                                                  hasMimeType: 'text/plain' }] },
+                       label: 'Folder 1' }] }
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes #3151

## Why was this change made?
Mapping


## How was this change tested?
Before:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   94514 (94.589%)
  Different: 4980 (4.984%)
  Mapping error:     0 (0.0%)
  Create error:     427 (0.427%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     79 (0.079%)
  Bad cache:     0 (0.0%)
```

After:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   94514 (94.589%)
  Different: 4980 (4.984%)
  Mapping error:     0 (0.0%)
  Create error:     427 (0.427%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     79 (0.079%)
  Bad cache:     0 (0.0%)
```


## Which documentation and/or configurations were updated?



