### PR TITLE
Adjust normalization of attr node (content metadata).

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -98,8 +98,7 @@ module Cocina
       end
 
       def normalize_attr
-        # Pending https://github.com/sul-dlss/dor-services-app/issues/2808
-        ng_xml.root.xpath('//attr').each(&:remove)
+        ng_xml.root.xpath('//attr[@name="mergedFromResource" or @name="mergedFromPid"]').each(&:remove)
       end
     end
   end

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -126,12 +126,11 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       end
     end
 
-    context 'when normalizing project phoenix' do
+    context 'when normalizing format' do
       let(:original_xml) do
         <<~XML
           <contentMetadata objectId="druid:bk689jd2364" type="file">
             <resource type="page" sequence="268" id="page268">
-              <attr name="pageLabel">256</attr>
               <file preserve="yes" mimetype="image/jp2" format="JPEG2000" size="92631" shelve="no" id="00000268.jp2" deliver="no">
                 <imageData width="1310" height="2071"/>
                 <checksum type="SHA-1">50d77a392ba30dcbbf4ada379e09ded02f9658f2</checksum>
@@ -146,7 +145,7 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
         XML
       end
 
-      it 'removes attrs and format' do
+      it 'removes format' do
         expect(normalized_ng_xml).to be_equivalent_to(
           <<~XML
             <contentMetadata objectId="druid:bk689jd2364" type="file">
@@ -198,6 +197,52 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
           XML
         )
       end
+    end
+  end
+
+  context 'when normalizing attr mergedFromResource and mergedFromPid' do
+    let(:original_xml) do
+      <<~XML
+          <contentMetadata type="image" objectId="druid:vv119cy9094">
+            <resource type="image" sequence="2">
+              <attr name="mergedFromResource">rh008rn6156_1</attr>
+              <attr name="mergedFromPid">druid:rh008rn6156</attr>
+              <label>Image 2</label>
+              <file preserve="yes" shelve="no" publish="no" id="IMG_08673_2.JPG" mimetype="image/jpeg" size="141335">
+                <checksum type="md5">53b3d300e4f03dd122c4eba604bf6750</checksum>
+                <checksum type="sha1">f8cfabf0d7b60040b7c881f69612715a565efcb3</checksum>
+                <imageData width="720" height="576"/>
+              </file>
+              <file id="IMG_08673_2.jp2" mimetype="image/jp2" size="78198" preserve="no" publish="yes" shelve="yes">
+                <checksum type="md5">6e1deb86a3560b5dff0dfc2e37a00f53</checksum>
+                <checksum type="sha1">bc8790cf29fd47e873ebf702f954d3ba8e242694</checksum>
+                <imageData width="720" height="576"/>
+              </file>
+            </resource>
+        </contentMetadata>
+      XML
+    end
+
+    it 'removes attr' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+              <contentMetadata type="image" objectId="druid:vv119cy9094">
+              <resource type="image">
+                <label>Image 2</label>
+                <file preserve="yes" shelve="no" publish="no" id="IMG_08673_2.JPG" mimetype="image/jpeg" size="141335">
+                  <checksum type="md5">53b3d300e4f03dd122c4eba604bf6750</checksum>
+                  <checksum type="sha1">f8cfabf0d7b60040b7c881f69612715a565efcb3</checksum>
+                  <imageData width="720" height="576"/>
+                </file>
+                <file id="IMG_08673_2.jp2" mimetype="image/jp2" size="78198" preserve="no" publish="yes" shelve="yes">
+                  <checksum type="md5">6e1deb86a3560b5dff0dfc2e37a00f53</checksum>
+                  <checksum type="sha1">bc8790cf29fd47e873ebf702f954d3ba8e242694</checksum>
+                  <imageData width="720" height="576"/>
+                </file>
+              </resource>
+          </contentMetadata>
+        XML
+      )
     end
   end
 end


### PR DESCRIPTION
closes #3172

## Why was this change made?
Be more specific when normalizing. This will allow us to verify that correctly handling all cases of <attr>.


## How was this change tested?
Before:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   94790 (94.868%)
  Different: 5128 (5.132%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

After:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   94533 (94.611%)
  Different: 5385 (5.389%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

This minor decrease is to be expected since reducing the normalization of attr. Newly discovered differences will be ticketed separately.

## Which documentation and/or configurations were updated?



