### PR TITLE
Standardize on Ruby 2.7.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.3-alpine
+FROM ruby:2.7.5-alpine
 
 # Provide SSL defaults that work in dev/test environments where we do not require connections to secured services
 # These values are overrideable at both buildtime and runtime (hence the ARG/ENV combo).


### PR DESCRIPTION
This is the version we have in CI, so I naïvely reckon it's the same we should have in the image?
