### PR TITLE
[PROOF OF CONCEPT] Support round-tripping italics for some fields

### DIFF
--- a/spec/services/cocina/mapping/descriptive/mods/abstract_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/abstract_spec.rb
@@ -24,6 +24,33 @@ RSpec.describe 'MODS abstract <--> cocina mappings' do
     end
   end
 
+  describe 'Single abstract with CDATA' do
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <abstract>This is an <![CDATA[<i>]]>abstract<![CDATA[</i>]]>.</abstract>
+        XML
+      end
+
+      let(:roundtrip_mods) do
+        <<~XML
+          <abstract>This is an <![CDATA[<i>]]>abstract<![CDATA[</i>]]>.</abstract>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          note: [
+            {
+              value: 'This is an <i>abstract</i>.',
+              type: 'abstract'
+            }
+          ]
+        }
+      end
+    end
+  end
+
   describe 'Multilingual abstract' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do


### PR DESCRIPTION
Connects to sul-dlss/exhibits#1981

This is a proof of concept to support shipping italicized data to public XML, so that fields render as expected. This is being done to support the Martin Wong collection work. It has several limitations at this point:

* Only applies italics to abstracts, and only "basic values" (not structured or parallel values, etc.)
* Has not been tested in different systems to see what affect it has (e.g., Argo, PURL)
