### PR TITLE
Report to find APOs without agreementids

### DIFF
--- a/bin/reports/report-rels-apo_agreement_ids
+++ b/bin/reports/report-rels-apo_agreement_ids
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+RDF_NS = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+HYDRA_NS = 'http://projecthydra.org/ns/relations#'
+FEDORA_NS = 'info:fedora/fedora-system:def/model#'
+
+def check(ng_xml)
+  ng_xml.root.xpath('//fedora:hasModel/@rdf:resource="info:fedora/afmodel:Hydrus_AdminPolicyObject" and not(//hydra:referencesAgreement)', hydra: HYDRA_NS, fedora: FEDORA_NS, rdf: RDF_NS)
+end
+
+Report.new(name: 'rels_apo_without_agreement_ids', dsid: 'RELS-EXT', report_func: method(:check)).run


### PR DESCRIPTION
## Why was this change made?

To find APOs without agreement ids

## How was this change tested?

On sdr-deploy:

    bin/reports/report-rels-apo_agreement_ids

using: 

    /opt/app/deploy/dor-services-app/druids.txt

I've attached the report here:

[rels_apo_without_agreement_ids.csv](https://github.com/sul-dlss/dor-services-app/files/7901797/rels_apo_without_agreement_ids.csv)

Here is one of the items it found:

https://argo.stanford.edu/view/druid:cw247ty3859

Being new to the various data models I'm not confident this is finding what was needed, so please check [the logic](https://github.com/sul-dlss/dor-services-app/blob/apo-without-agreementids/bin/reports/report-rels-apo_agreement_ids#L12).

## Which documentation and/or configurations were updated?



