### PR TITLE
Normalizes resource objectId

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -27,6 +27,7 @@ module Cocina
 
       def normalize(druid:)
         remove_resource_id
+        remove_resource_objectid
         remove_sequence
         remove_location
         remove_format
@@ -51,6 +52,10 @@ module Cocina
 
       def remove_resource_id
         ng_xml.root.xpath('//resource[@id]').each { |resource_node| resource_node.delete('id') }
+      end
+
+      def remove_resource_objectid
+        ng_xml.root.xpath('//resource[@objectId]').each { |resource_node| resource_node.delete('objectId') }
       end
 
       def remove_sequence

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -42,6 +42,28 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
     end
   end
 
+  context 'when normalizing resource objectids' do
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata objectId="druid:bb035tg0974" type="file">
+          <resource objectId="druid:bb035tg0974" id="content" type="file" />
+        </contentMetadata>
+      XML
+    end
+
+    let(:expected_xml) do
+      <<~XML
+        <contentMetadata objectId="druid:bb035tg0974" type="file">
+          <resource type="file" />
+        </contentMetadata>
+      XML
+    end
+
+    it 'removes resource objectids' do
+      expect(normalized_ng_xml).to be_equivalent_to(expected_xml)
+    end
+  end
+
   context 'when normalizing objectId' do
     let(:original_xml) do
       <<~XML
@@ -186,7 +208,7 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
         expect(normalized_ng_xml).to be_equivalent_to(
           <<~XML
               <contentMetadata type="file" objectId="druid:tt395zz8686">
-              <resource objectId="druid:tt395zz8686" type="file">
+              <resource type="file">
                 <label>Using xSearch for Accelerating Research-Review of Deep Web Technologies Federated Search Service</label>
                 <file preserve="yes" deliver="yes" size="4333001" mimetype="application/pdf" id="xSearch_Review_Charleston_Advisor.pdf" shelve="yes" publish="yes">
                   <checksum type="md5">c22b3d0fd5569fc1039901bf22dad4f0</checksum>


### PR DESCRIPTION
## Why was this change made?
Closes #3118. Removes objectId attributes from resource nodes in contentMetadata in normalization

## How was this change tested?
Before:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   94533 (94.611%)
  Different: 5385 (5.389%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```
After:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   94587 (94.665%)
  Different: 5331 (5.335%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```



## Which documentation and/or configurations were updated?



