### PR TITLE
Report on resources with thumb attribute

### DIFF
--- a/bin/reports/report-content-thumb
+++ b/bin/reports/report-content-thumb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+def has_resource_thumb?(ng_xml)
+  ng_xml.root.xpath('//resource/@thumb').present?
+end
+
+Report.new(name: 'content-resource-thumb', dsid: 'contentMetadata', report_func: method(:has_resource_thumb?)).run


### PR DESCRIPTION
## Why was this change made?
Info for #3187 next steps. Report on resources with thumb attribute. 10 druids were found. 

## How was this change tested?

Run on sdr-deploy with full `druids.testbed.txt`


## Which documentation and/or configurations were updated?



