### PR TITLE
Remove rightsMetadata on round trip

### DIFF
--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -119,10 +119,11 @@ def equivalent?(dsid, orig_datastream_ng_xml, roundtrip_ng_xml)
   end
 end
 
-def diff_datatreams_for(druid, label, orig_datastreams, fedora_obj)
+def diff_datatreams_for(druid, label, orig_datastreams, fedora_obj, apo)
   diff_datastreams = {}
   orig_datastreams.each_pair do |dsid, orig_datastream|
     next if orig_datastream.nil?
+    next if apo && dsid == 'rightsMetadata' # ignoring rightsMetadata for APOs
 
     orig_datastream_ng_xml = ng_xml_for(orig_datastream)
     norm_orig_datastream_ng_xml = norm_orig_datastream_ng_xml_for(dsid, orig_datastream_ng_xml, druid, label, fedora_obj)
@@ -196,7 +197,7 @@ def validate_druid(druid, loader, fast: false, create: false)
   roundtrip_cocina_hash = roundtrip_cocina_obj.to_h
 
   begin
-    diff_datastreams = diff_datatreams_for(druid, label, orig_datastreams, roundtrip_fedora_obj)
+    diff_datastreams = diff_datatreams_for(druid, label, orig_datastreams, roundtrip_fedora_obj, orig_cocina_obj.is_a?(Cocina::Models::AdminPolicy))
   rescue StandardError => e
     write_error(druid, e)
     return [druid, :normalization_error]


### PR DESCRIPTION
## Why was this change made?

Fixes #3125 

Current (main):
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   93858 (94.447%)
  Different: 5518 (5.553%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     32 (0.032%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     592 (0.592%)
  Bad cache:     0 (0.0%)
```

After:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   93858 (94.447%)
  Different: 5518 (5.553%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     32 (0.032%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     592 (0.592%)
  Bad cache:     0 (0.0%)
```

## How was this change tested?

Round Trip results against large dataset

## Which documentation and/or configurations were updated?



