### PR TITLE
remove attr representation

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -103,7 +103,7 @@ module Cocina
       end
 
       def normalize_attr
-        ng_xml.root.xpath('//attr[@name="mergedFromResource" or @name="mergedFromPid"]').each(&:remove)
+        ng_xml.root.xpath('//attr[@name="mergedFromResource" or @name="mergedFromPid" or @name="representation"]').each(&:remove)
       end
     end
   end

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -229,6 +229,7 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
             <resource type="image" sequence="2">
               <attr name="mergedFromResource">rh008rn6156_1</attr>
               <attr name="mergedFromPid">druid:rh008rn6156</attr>
+              <attr name="representation">uncropped</attr>
               <label>Image 2</label>
               <file preserve="yes" shelve="no" publish="no" id="IMG_08673_2.JPG" mimetype="image/jpeg" size="141335">
                 <checksum type="md5">53b3d300e4f03dd122c4eba604bf6750</checksum>


### PR DESCRIPTION
Remove <attr name="representation"> from the mapping. Fixes #3180

## Why was this change made?

`<attr name="representation">` was an artifact of some old prototyping work and is no longer needed.

## How was this change tested?

Unit tests

## Which documentation and/or configurations were updated?

