### PR TITLE
Stop normalizing embargo nodes with text.

### DIFF
--- a/app/services/cocina/normalizers/embargo_normalizer.rb
+++ b/app/services/cocina/normalizers/embargo_normalizer.rb
@@ -28,7 +28,7 @@ module Cocina
       attr_reader :ng_xml
 
       def normalize_empty
-        ng_xml.root.xpath('*[count(*) = 0]').each(&:remove)
+        ng_xml.root.xpath('*[not(text())][not(@*)]').each(&:remove)
         ng_xml.root.remove if ng_xml.root.xpath('*').empty?
       end
     end

--- a/spec/services/cocina/normalizers/embargo_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/embargo_normalizer_spec.rb
@@ -25,4 +25,29 @@ RSpec.describe Cocina::Normalizers::EmbargoNormalizer do
       )
     end
   end
+
+  context 'when #normalize_empty with values' do
+    let(:original_xml) do
+      <<~XML
+        <embargoMetadata>
+          <status>released</status>
+          <releaseDate>2018-06-02T07:00:00Z</releaseDate>
+          <releaseAccess/>
+          <twentyPctVisibilityStatus/>
+          <twentyPctVisibilityReleaseDate/>
+        </embargoMetadata>
+      XML
+    end
+
+    it 'only removes empty elements' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <embargoMetadata>
+            <status>released</status>
+            <releaseDate>2018-06-02T07:00:00Z</releaseDate>
+          </embargoMetadata>
+        XML
+      )
+    end
+  end
 end


### PR DESCRIPTION
closes #3122

## Why was this change made?
Don't discard data that want to keep.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



