### PR TITLE
Fix fast for validate-cocina-roundtrip.

### DIFF
--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -137,6 +137,13 @@ def diff_datatreams_for(druid, label, orig_datastreams, fedora_obj, apo)
   diff_datastreams
 end
 
+def fast_content_metadata(fedora_obj, druid, create)
+  content_type = fedora_obj.contentMetadata.contentType.first
+  object_id = create ? "objectId='#{druid}'" : ''
+  book_data = content_type&.include?('book') || content_type&.include?('manuscript') ? '<bookData readingOrder="ltr"/>' : ''
+  "<contentMetadata type='#{content_type}' #{object_id}>#{book_data}</contentMetadata>"
+end
+
 # rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/CyclomaticComplexity
 # rubocop:disable Metrics/MethodLength
@@ -155,13 +162,7 @@ def validate_druid(druid, loader, fast: false, create: false)
     return [druid, :unmapped]
   end
 
-  if fast && fedora_obj.datastreams.include?('contentMetadata')
-    fedora_obj.contentMetadata.content = if create
-                                           "<contentMetadata type='#{fedora_obj.contentMetadata.contentType.first}' objectId='#{druid}'/>"
-                                         else
-                                           "<contentMetadata type='#{fedora_obj.contentMetadata.contentType.first}' />"
-                                         end
-  end
+  fedora_obj.contentMetadata.content = fast_content_metadata(fedora_obj, druid, create) if fast && fedora_obj.datastreams.include?('contentMetadata')
 
   orig_datastreams = {}
   FedoraCache::DATASTREAMS.each { |dsid| orig_datastreams[dsid] = fedora_obj.datastreams[dsid]&.content }


### PR DESCRIPTION
## Why was this change made?
Fast flag was producing erroneous results.


## How was this change tested?
Without fast flag:
```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9536 (95.436%)
  Different: 456 (4.564%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     8 (0.08%)
  Bad cache:     0 (0.0%)
```

With fast flag:
```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9707 (97.148%)
  Different: 282 (2.822%)
  Mapping error:     3 (0.03%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     8 (0.08%)
  Bad cache:     0 (0.0%)
```

Greater success to be expected, since not testing content metadata.

## Which documentation and/or configurations were updated?



