### PR TITLE
Removes released embargoes.

### DIFF
--- a/app/services/cocina/normalizers/embargo_normalizer.rb
+++ b/app/services/cocina/normalizers/embargo_normalizer.rb
@@ -18,6 +18,8 @@ module Cocina
       end
 
       def normalize
+        return regenerate_ng_xml(ng_xml.to_xml) if normalize_released
+
         normalize_empty
 
         regenerate_ng_xml(ng_xml.to_xml)
@@ -30,6 +32,13 @@ module Cocina
       def normalize_empty
         ng_xml.root.xpath('*[count(*) = 0]').each(&:remove)
         ng_xml.root.remove if ng_xml.root.xpath('*').empty?
+      end
+
+      def normalize_released
+        return false if ng_xml.root.xpath('//status[text() = "released"]').blank?
+
+        ng_xml.root.remove
+        true
       end
     end
   end

--- a/spec/services/cocina/normalizers/embargo_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/embargo_normalizer_spec.rb
@@ -5,6 +5,33 @@ require 'rails_helper'
 RSpec.describe Cocina::Normalizers::EmbargoNormalizer do
   let(:normalized_ng_xml) { described_class.normalize(embargo_ng_xml: Nokogiri::XML(original_xml)) }
 
+  context 'when released embargo' do
+    let(:original_xml) do
+      <<~XML
+        <embargoMetadata>
+          <status>released</status>
+          <releaseDate>2018-06-02T07:00:00Z</releaseDate>
+          <twentyPctVisibilityStatus/>
+          <twentyPctVisibilityReleaseDate/>
+          <releaseAccess>
+            <access type="read">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+          </releaseAccess>
+        </embargoMetadata>
+      XML
+    end
+
+    it 'removes embargo' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+        XML
+      )
+    end
+  end
+
   context 'when #normalize_empty' do
     let(:original_xml) do
       <<~XML


### PR DESCRIPTION
closes #3123

## Why was this change made?
Roundtripping.


## How was this change tested?
Unit

Before:
```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9536 (95.436%)
  Different: 456 (4.564%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     8 (0.08%)
  Bad cache:     0 (0.0%)
```

After:
```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9538 (95.456%)
  Different: 454 (4.544%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     8 (0.08%)
  Bad cache:     0 (0.0%)
```


## Which documentation and/or configurations were updated?



