### PR TITLE
Removes data attribute from resource node (content metadata).

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -28,6 +28,7 @@ module Cocina
       def normalize(druid:)
         remove_resource_id
         remove_resource_objectid
+        remove_resource_data
         remove_sequence
         remove_location
         remove_format
@@ -57,6 +58,10 @@ module Cocina
 
       def remove_resource_objectid
         ng_xml.root.xpath('//resource[@objectId]').each { |resource_node| resource_node.delete('objectId') }
+      end
+
+      def remove_resource_data
+        ng_xml.root.xpath('//resource[@data]').each { |resource_node| resource_node.delete('data') }
       end
 
       def remove_sequence

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -268,4 +268,37 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       )
     end
   end
+
+  context 'when normalizing resource nodes with data attributes' do
+    # Adapted from zn580kw6428
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata type="file" objectId="druid:zn580kw6428">
+          <resource data="content">
+            <label>Experimental Evidence on the Disposition Effect</label>
+            <file preserve="yes" shelve="yes" deliver="yes" size="919405" mimetype="application/pdf" id="v212299_pdf.pdf">
+              <checksum type="md5">174a44a8406b14949de14853612e4eb6</checksum>
+              <checksum type="sha1">258881e0f2293b90779cbc35e7f463882cc2bbf3</checksum>
+            </file>
+          </resource>
+        </contentMetadata>
+      XML
+    end
+
+    it 'removes data attributes' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <contentMetadata type="file" objectId="druid:zn580kw6428">
+            <resource>
+              <label>Experimental Evidence on the Disposition Effect</label>
+              <file preserve="yes" shelve="yes" publish="yes" size="919405" mimetype="application/pdf" id="v212299_pdf.pdf">
+                <checksum type="md5">174a44a8406b14949de14853612e4eb6</checksum>
+                <checksum type="sha1">258881e0f2293b90779cbc35e7f463882cc2bbf3</checksum>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      )
+    end
+  end
 end


### PR DESCRIPTION
closes #3084

## Why was this change made?
Normalization


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



