### PR TITLE
embargo_normalizer_spec: #normalize_empty test with values accounts for fact that released embargoes get normalized out

### DIFF
--- a/spec/services/cocina/normalizers/embargo_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/embargo_normalizer_spec.rb
@@ -57,8 +57,7 @@ RSpec.describe Cocina::Normalizers::EmbargoNormalizer do
     let(:original_xml) do
       <<~XML
         <embargoMetadata>
-          <status>released</status>
-          <releaseDate>2018-06-02T07:00:00Z</releaseDate>
+          <releaseDate>2021-06-02T07:00:00Z</releaseDate>
           <releaseAccess/>
           <twentyPctVisibilityStatus/>
           <twentyPctVisibilityReleaseDate/>
@@ -70,8 +69,7 @@ RSpec.describe Cocina::Normalizers::EmbargoNormalizer do
       expect(normalized_ng_xml).to be_equivalent_to(
         <<~XML
           <embargoMetadata>
-            <status>released</status>
-            <releaseDate>2018-06-02T07:00:00Z</releaseDate>
+            <releaseDate>2021-06-02T07:00:00Z</releaseDate>
           </embargoMetadata>
         XML
       )


### PR DESCRIPTION
## Why was this change made?

i merged #3207, then #3205, but the former made it so that the assumptions of the latter's test no longer held.

## How was this change tested?

unit

## Which documentation and/or configurations were updated?

n/a