### PR TITLE
Normalizing missing objectId in contentMetadata

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -31,7 +31,7 @@ module Cocina
         remove_sequence
         remove_location
         remove_format
-        normalize_object_id
+        normalize_object_id(druid)
         normalize_reading_order(druid)
         normalize_label_attr
         normalize_attr
@@ -69,11 +69,16 @@ module Cocina
         ng_xml.root.xpath('//location[@type="url"]').each(&:remove)
       end
 
-      def normalize_object_id
+      def normalize_object_id(druid)
         object_id = ng_xml.root['objectId']
-        return if object_id.nil? || object_id.start_with?('druid:')
 
-        ng_xml.root['objectId'] = "druid:#{object_id}"
+        if object_id
+          return if object_id.start_with?('druid:')
+
+          ng_xml.root['objectId'] = "druid:#{object_id}"
+        else
+          ng_xml.root['objectId'] = druid
+        end
       end
 
       def remove_format

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -80,6 +80,22 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
     end
   end
 
+  context 'when normalizing missing objectId' do
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata type="image" />
+      XML
+    end
+
+    it 'adds druid as objectId' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <contentMetadata objectId="druid:bb035tg0974" type="image" />
+        XML
+      )
+    end
+  end
+
   context 'when normalizing reading order' do
     context 'when not a book' do
       let(:original_xml) do

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -96,6 +96,22 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
     end
   end
 
+  context 'when normalizing objectId without druid prefix' do
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata objectId="bb035tg0974" type="image" />
+      XML
+    end
+
+    it 'adds druid prefix to objectId' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <contentMetadata objectId="druid:bb035tg0974" type="image" />
+        XML
+      )
+    end
+  end
+
   context 'when normalizing reading order' do
     context 'when not a book' do
       let(:original_xml) do


### PR DESCRIPTION
## Why was this change made?

Resolves #3127. Normalization to put content Id at root level.

## How was this change tested?

Before
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   94844 (94.922%)
  Different: 5074 (5.078%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```
After
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   95156 (95.234%)
  Different: 4762 (4.766%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
## Which documentation and/or configurations were updated?


```
