### PR TITLE
Report on file deliver attribute

### DIFF
--- a/bin/reports/report-content-file_deliver
+++ b/bin/reports/report-content-file_deliver
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+def has_file_deliver?(ng_xml)
+  ng_xml.root.xpath('//file/@deliver').present?
+end
+
+Report.new(name: 'content-file-deliver', dsid: 'contentMetadata', report_func: method(:has_file_deliver?)).run


### PR DESCRIPTION
## Why was this change made?
Report to find deliver attributes on file elements in contentMetadata. File attached to #3070.


## How was this change tested?
Run on full druids.testbed.txt file and spot-checked. 


## Which documentation and/or configurations were updated?



