### PR TITLE
Multiple catkeys

### DIFF
--- a/app/services/cocina/normalizers/identity_normalizer.rb
+++ b/app/services/cocina/normalizers/identity_normalizer.rb
@@ -30,6 +30,7 @@ module Cocina
         normalize_out_citation_elements
         normalize_out_call_sequence_ids
         normalize_out_empty_other_ids
+        normalize_out_catkeys
         normalize_source_id_whitespace
         normalize_release_tags
 
@@ -111,6 +112,15 @@ module Cocina
       def normalize_out_call_sequence_ids
         ng_xml.root.xpath('//otherId[@name="callseq"]').each(&:remove)
         ng_xml.root.xpath('//otherId[@name="shelfseq"]').each(&:remove)
+      end
+
+      def normalize_out_catkeys
+        # remove duplicate catkeys
+        seen = Set[]
+        ng_xml.root.xpath('//otherId[@name="catkey"]').each do |id|
+          id.remove if seen.include? id.text
+          seen.add id.text
+        end
       end
 
       def normalize_release_tags

--- a/bin/reports/report-identity-multi_catkeys
+++ b/bin/reports/report-identity-multi_catkeys
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+def check(ng_xml)
+  ng_xml.root.xpath('//otherId[@name="catkey"]').map(&:text).uniq.length > 1
+end
+
+Report.new(name: 'identity-multi_catkeys', dsid: 'identityMetadata', report_func: method(:check)).run

--- a/spec/services/cocina/normalizers/identity_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/identity_normalizer_spec.rb
@@ -469,4 +469,25 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
       end
     end
   end
+
+  context 'when there are duplicate catkeys' do
+    let(:original_xml) do
+      <<~XML
+        <identityMetadata>
+          <otherId name="catkey">90125</otherId>
+          <otherId name="catkey">90125</otherId>
+        </identityMetadata>
+      XML
+    end
+
+    it 'collapses them' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <identityMetadata>
+            <otherId name="catkey">90125</otherId>
+          </identityMetadata>
+        XML
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

Remove duplicate catkeys from identity metadata

## How was this change tested?

Ran reports on sdr-deploy to identify items that have multiple catkeys. Ran unit tests.

## Which documentation and/or configurations were updated?

Closes #2833
