### PR TITLE
descriptiveMetadata mapping for extent unit

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/form.rb
+++ b/app/services/cocina/from_fedora/descriptive/form.rb
@@ -233,10 +233,15 @@ module Cocina
             forms.concat(form_values)
             forms << { note: notes } if notes.present?
           elsif form_values.size == 1
-            forms << form_values.first.merge({
-              note: notes.presence,
-              displayLabel: physical_description_node['displayLabel']
-            }.compact)
+            if form_values.first[:note]&.first&.fetch(:type) == 'unit'
+              forms << form_values.first.compact
+              forms << { note: notes } if notes.present?
+            else
+              forms << form_values.first.merge({
+                note: notes.presence,
+                displayLabel: physical_description_node['displayLabel']
+              }.compact)
+            end
           else
             forms << {
               groupedValue: form_values,

--- a/spec/services/cocina/mapping/descriptive/mods/physical_description_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/physical_description_spec.rb
@@ -637,6 +637,56 @@ RSpec.describe 'MODS physicalDescription <--> cocina mappings' do
     end
   end
 
+  describe 'Multiple extent with one sibling note' do
+    it_behaves_like 'MODS cocina mapping' do
+      # druid:bh920np8004
+      let(:mods) do
+        <<~XML
+          <physicalDescription>
+            <extent unit="Linear feet">4</extent>
+            <extent unit="boxes">5</extent>
+            <note type="arrangement">Arranged in the following 4 series: 1. Biographical Materials ; 2. Education and Research ; 3. Patents ; 4. Oversized Materials</note>
+          </physicalDescription>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          form: [
+            {
+              value: '4',
+              type: 'extent',
+              note: [
+                {
+                  value: 'Linear feet',
+                  type: 'unit'
+                }
+              ]
+            },
+            {
+              value: '5',
+              type: 'extent',
+              note: [
+                {
+                  value: 'boxes',
+                  type: 'unit'
+                }
+              ]
+            },
+            {
+              note: [
+                {
+                  value: 'Arranged in the following 4 series: 1. Biographical Materials ; 2. Education and Research ; 3. Patents ; 4. Oversized Materials',
+                  type: 'arrangement'
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
+  end
+
   describe 'Physical description with empty note' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do

--- a/spec/services/cocina/mapping/descriptive/mods/physical_description_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/physical_description_spec.rb
@@ -600,7 +600,7 @@ RSpec.describe 'MODS physicalDescription <--> cocina mappings' do
 
   describe 'Extent with unit and note sibling' do
     # druid:gx952gd8699
-    xit 'not implemented' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <physicalDescription>


### PR DESCRIPTION
## Why was this change made?
Resolves #2731. 


## How was this change tested?
Unit tests pass.

Result of running `bin/validate-desc-cocina-roundtrip` on a single druid with the extent and note (druid:gx952gd8699) is:
```Status (n=1; not using Missing for success/different/error stats):
  Success:   1 (100.0%)
  Different: 0 (0.0%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     0 (0.0%)
```

Results of running `bin/validate-desc-cocina-roundtrip -s 100000 -i druids.testbed.txt`

Before:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99983 (99.983%)
  Different: 17 (0.017%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     0 (0.0%)

```
After
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99984 (99.984%)
  Different: 16 (0.016%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     0 (0.0%)
```

## Which documentation and/or configurations were updated?



