### PR TITLE
Map and normalize contentMetadata file deliver attribute

### DIFF
--- a/app/services/cocina/from_fedora/file_sets.rb
+++ b/app/services/cocina/from_fedora/file_sets.rb
@@ -83,7 +83,7 @@ module Cocina
             hasMessageDigests: digests(node),
             access: access(node['id']),
             administrative: {
-              publish: node['publish'] == 'yes',
+              publish: node['publish'] == 'yes' || node['deliver'] == 'yes',
               sdrPreserve: node['preserve'] == 'yes',
               shelve: node['shelve'] == 'yes'
             }

--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -35,6 +35,7 @@ module Cocina
         normalize_reading_order(druid)
         normalize_label_attr
         normalize_attr
+        normalize_publish
 
         regenerate_ng_xml(ng_xml.to_s)
       end
@@ -104,6 +105,13 @@ module Cocina
 
       def normalize_attr
         ng_xml.root.xpath('//attr[@name="mergedFromResource" or @name="mergedFromPid" or @name="representation"]').each(&:remove)
+      end
+
+      def normalize_publish
+        ng_xml.root.xpath('//file').each do |file|
+          file['publish'] ||= file['deliver']
+          file.delete('deliver')
+        end
       end
     end
   end

--- a/spec/services/cocina/mapping/structural/dro_structural_spec.rb
+++ b/spec/services/cocina/mapping/structural/dro_structural_spec.rb
@@ -344,4 +344,55 @@ RSpec.describe 'Fedora item content metadata <--> Cocina DRO structural mappings
       end
     end
   end
+
+  context 'when no publish but there is deliver' do
+    it_behaves_like 'DRO Structural Fedora Cocina mapping' do
+      let(:content_xml) do
+        <<~XML
+          <contentMetadata type="book" objectId="#{druid}">
+            <resource sequence="1" type="file" id="folder1PuSu">
+            <label>Folder 1</label>
+              <file mimetype="text/plain" shelve="yes" size="7888" preserve="no" id="folder1PuSu/story1u.txt" deliver="yes">
+                <checksum type="md5">e2837b9f02e0b0b76f526eeb81c7aa7b</checksum>
+                <checksum type="sha1">61dfac472b7904e1413e0cbf4de432bda2a97627</checksum>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      end
+
+      let(:roundtrip_content_xml) do
+        <<~XML
+          <contentMetadata type="book" objectId="#{druid}">
+            <resource sequence="1" type="file" id="folder1PuSu">
+              <label>Folder 1</label>
+              <file mimetype="text/plain" shelve="yes" publish="yes" size="7888" preserve="no" id="folder1PuSu/story1u.txt">
+                <checksum type="md5">e2837b9f02e0b0b76f526eeb81c7aa7b</checksum>
+                <checksum type="sha1">61dfac472b7904e1413e0cbf4de432bda2a97627</checksum>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      end
+
+      let(:cocina_structural_props) do
+        { contains: [{ externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/8d17c28b-5b3e-477e-912c-f168a1f4213f',
+                       type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+                       version: 1,
+                       structural: { contains: [{ externalIdentifier: 'http://cocina.sul.stanford.edu/file/be451fd9-7908-4559-9e81-8d6f496a3181',
+                                                  type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                                                  label: 'folder1PuSu/story1u.txt',
+                                                  filename: 'folder1PuSu/story1u.txt',
+                                                  size: 7888,
+                                                  version: 1,
+                                                  hasMessageDigests: [{ type: 'sha1',
+                                                                        digest: '61dfac472b7904e1413e0cbf4de432bda2a97627' },
+                                                                      { type: 'md5', digest: 'e2837b9f02e0b0b76f526eeb81c7aa7b' }],
+                                                  access: { access: 'world', download: 'world' },
+                                                  administrative: { publish: true, sdrPreserve: false, shelve: true },
+                                                  hasMimeType: 'text/plain' }] },
+                       label: 'Folder 1' }] }
+      end
+    end
+  end
 end

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -172,12 +172,12 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
           <<~XML
             <contentMetadata objectId="druid:bk689jd2364" type="file">
               <resource type="page">
-                <file preserve="yes" mimetype="image/jp2" size="92631" shelve="no" id="00000268.jp2" deliver="no">
+                <file preserve="yes" mimetype="image/jp2" size="92631" shelve="no" id="00000268.jp2" publish="no">
                   <imageData width="1310" height="2071"/>
                   <checksum type="SHA-1">50d77a392ba30dcbbf4ada379e09ded02f9658f2</checksum>
                   <checksum type="MD5">dcea2fd8ed01b2ef978093cf45ea3ce9</checksum>
                 </file>
-                <file preserve="yes" mimetype="text/html" size="19144" dataType="hocr" shelve="yes" id="00000268.html" deliver="no">
+                <file preserve="yes" mimetype="text/html" size="19144" dataType="hocr" shelve="yes" id="00000268.html" publish="no">
                   <checksum type="SHA-1">335c75c2e2a13f024f73b0dd7dc5fc35fc47e7ce</checksum>
                   <checksum type="MD5">42d8261046c449230a7c3809a246b353</checksum>
                 </file>
@@ -210,7 +210,7 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
               <contentMetadata type="file" objectId="druid:tt395zz8686">
               <resource type="file">
                 <label>Using xSearch for Accelerating Research-Review of Deep Web Technologies Federated Search Service</label>
-                <file preserve="yes" deliver="yes" size="4333001" mimetype="application/pdf" id="xSearch_Review_Charleston_Advisor.pdf" shelve="yes" publish="yes">
+                <file preserve="yes" size="4333001" mimetype="application/pdf" id="xSearch_Review_Charleston_Advisor.pdf" shelve="yes" publish="yes">
                   <checksum type="md5">c22b3d0fd5569fc1039901bf22dad4f0</checksum>
                   <checksum type="sha1">50b90a7ef7937b048db6f6d4b41637f59a2a57cf</checksum>
                 </file>


### PR DESCRIPTION
## Why was this change made?
Resolves #3070. Maps deliver attribute to publish attribute on contentMetadata files and removes deprecated deliver attribute. 

## How was this change tested?

Added tests and unit tests pass. 
Before:
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   94916 (94.994%)
  Different: 5002 (5.006%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

After:
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   94916 (94.994%)
  Different: 5002 (5.006%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```
## Which documentation and/or configurations were updated?



