### PR TITLE
Normalize APO rights

### DIFF
--- a/app/services/cocina/from_fedora/access/license.rb
+++ b/app/services/cocina/from_fedora/access/license.rb
@@ -31,7 +31,7 @@ module Cocina
         end
 
         def self.find_legacy_license(datastream)
-          return NONE_LICENSE_URI if datastream.use_license.first == 'none'
+          return NONE_LICENSE_URI if datastream.use_license&.first == 'none'
 
           uris = datastream.ng_xml.xpath('/rightsMetadata/use/machine[@uri]').map { |node| node['uri'] }.reject(&:blank?)
           return uris.first if uris.present?

--- a/app/services/deep_equal.rb
+++ b/app/services/deep_equal.rb
@@ -3,6 +3,8 @@
 # Deeply compares two objects, ignoring array order.
 # Based on https://github.com/amogil/rspec-deep-ignore-order-matcher/blob/master/lib/rspec_deep_ignore_order_matcher.rb
 class DeepEqual
+  XML_KEYS = [:defaultObjectRights].freeze
+
   def self.match?(actual, expected)
     new(actual, expected).match?
   end
@@ -20,9 +22,10 @@ class DeepEqual
 
   attr_reader :actual, :expected
 
-  def objects_match?(actual_obj, expected_obj)
+  def objects_match?(actual_obj, expected_obj, xml: false)
     return arrays_match?(actual_obj, expected_obj) if expected_obj.is_a?(Array) && actual_obj.is_a?(Array)
     return hashes_match?(actual_obj, expected_obj) if expected_obj.is_a?(Hash) && actual_obj.is_a?(Hash)
+    return EquivalentXml.equivalent?(actual_obj, expected_obj) if xml
 
     expected_obj == actual_obj
   end
@@ -41,7 +44,10 @@ class DeepEqual
   def hashes_match?(actual_hash, expected_hash)
     return false unless actual_hash.keys.sort == expected_hash.keys.sort
 
-    actual_hash.each { |key, value| return false unless objects_match? value, expected_hash[key] }
+    actual_hash.each do |key, value|
+      return false unless objects_match?(value, expected_hash[key], xml: XML_KEYS.include?(key))
+    end
+
     true
   end
 end

--- a/app/services/deep_equal.rb
+++ b/app/services/deep_equal.rb
@@ -3,6 +3,8 @@
 # Deeply compares two objects, ignoring array order.
 # Based on https://github.com/amogil/rspec-deep-ignore-order-matcher/blob/master/lib/rspec_deep_ignore_order_matcher.rb
 class DeepEqual
+  # TODO: Remove the XML-related bits of the class once we've moved away from defaultObjectRights:
+  #       https://github.com/sul-dlss/dor-services-app/issues/3241
   XML_KEYS = [:defaultObjectRights].freeze
 
   def self.match?(actual, expected)

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -166,6 +166,11 @@ def validate_druid(druid, loader, fast: false, create: false)
 
   fedora_obj.contentMetadata.content = fast_content_metadata(fedora_obj, druid, create) if fast && fedora_obj.datastreams.include?('contentMetadata')
 
+  # defaultObjectRights has to be normalized before mapping
+  if fedora_obj.datastreams.include?('defaultObjectRights')
+    fedora_obj.defaultObjectRights.content = Cocina::Normalizers::RightsNormalizer.normalize(datastream: fedora_obj.defaultObjectRights).to_xml
+  end
+
   orig_datastreams = {}
   FedoraCache::DATASTREAMS.each { |dsid| orig_datastreams[dsid] = fedora_obj.datastreams[dsid]&.content }
   label = fedora_obj.label

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -90,8 +90,8 @@ def norm_orig_datastream_ng_xml_for(dsid, orig_datastream_ng_xml, druid, label, 
     Cocina::Normalizers::AdminNormalizer.normalize(admin_ng_xml: orig_datastream_ng_xml)
   when 'descMetadata'
     Cocina::Normalizers::ModsNormalizer.normalize(mods_ng_xml: orig_datastream_ng_xml, druid: druid, label: label)
-  when 'rightsMetadata'
-    Cocina::Normalizers::RightsNormalizer.normalize(datastream: fedora_obj.datastreams['rightsMetadata'])
+  when 'rightsMetadata', 'defaultObjectRights'
+    Cocina::Normalizers::RightsNormalizer.normalize(datastream: fedora_obj.datastreams[dsid])
   when 'contentMetadata'
     Cocina::Normalizers::ContentMetadataNormalizer.normalize(druid: druid, content_ng_xml: orig_datastream_ng_xml)
   when 'identityMetadata'

--- a/spec/services/cocina/mapping/access/dro_access_spec.rb
+++ b/spec/services/cocina/mapping/access/dro_access_spec.rb
@@ -118,15 +118,11 @@ RSpec.shared_examples 'DRO Access Fedora Cocina mapping' do
     end
 
     it 'rightsMetadata roundtrips thru cocina model to provided expected rightsMetadata.xml' do
-      # for some reason, fedora_item.rightsMetadata.ng_xml.to_xml fails here, but fedora_item.rightsMetadata.to_xml passes.
-      #   ? Maybe some encoding assumptions baked in to active fedora.  Likewise, the opposite is true for the test below.
-      expect(fedora_item.rightsMetadata.to_xml).to be_equivalent_to(roundtrip_rights_metadata_xml)
+      expect(fedora_item.rightsMetadata.ng_xml).to be_equivalent_to(roundtrip_rights_metadata_xml)
     end
 
     it 'rightsMetadata roundtrips thru cocina model to normalized original rightsMetadata.xml' do
-      # for some reason, fedora_item.rightsMetadata.to_xml fails here, but fedora_item.rightsMetadata.ng_xml.to_xml passes.
-      #    ? Maybe some encoding assumptions baked in to active fedora.  Likewise, the opposite is true for the test above.
-      expect(fedora_item.rightsMetadata.ng_xml.to_xml).to be_equivalent_to(normalized_orig_rights_xml)
+      expect(fedora_item.rightsMetadata.ng_xml).to be_equivalent_to(normalized_orig_rights_xml)
     end
 
     it 'contentMetadata roundtrips thru cocina model to original contentMetadata.xml' do

--- a/spec/services/cocina/mapping/administrative/apo_administrative_spec.rb
+++ b/spec/services/cocina/mapping/administrative/apo_administrative_spec.rb
@@ -50,7 +50,7 @@ RSpec.shared_examples 'valid APO mappings' do
     }
   end
 
-  context 'when mapping Fedora to Cocina' do
+  context 'when mapping from Fedora to Cocina' do
     it 'produces valid AdminPolicyAdministrative' do
       expect { Cocina::Models::AdminPolicyAdministrative.new(cocina) }.not_to raise_error
     end
@@ -60,7 +60,7 @@ RSpec.shared_examples 'valid APO mappings' do
     end
   end
 
-  context 'when mapping Cocina to Fedora' do
+  context 'when mapping from Cocina to Fedora' do
     let(:actual_cocina_apo_admin) { Cocina::Models::AdminPolicyAdministrative.new(cocina) }
     let(:roundtrip_fedora_apo) do
       Dor::AdminPolicyObject.new(pid: actual_cocina_props[:externalIdentifier],
@@ -69,7 +69,7 @@ RSpec.shared_examples 'valid APO mappings' do
                                  label: actual_cocina_props[:label])
     end
 
-    describe 'AdministrativeMetadata' do
+    describe 'Cocina::ToFedora::AdministrativeMetadata' do
       let(:actual_admin_metadata_xml) do
         Cocina::ToFedora::AdministrativeMetadata.write(roundtrip_fedora_apo.administrativeMetadata, actual_cocina_apo_admin)
         roundtrip_fedora_apo.administrativeMetadata.to_xml
@@ -79,12 +79,12 @@ RSpec.shared_examples 'valid APO mappings' do
         expect(actual_admin_metadata_xml).to be_equivalent_to(admin_metadata_xml)
       end
 
-      it 'AdministrativeMetadata roundtrips thru cocina maps to normalized original administrativeMetadata.xml' do
+      it 'roundtrips to normalized original administrativeMetadata.xml' do
         expect(actual_admin_metadata_xml).to be_equivalent_to normalized_orig_admin_xml
       end
     end
 
-    describe 'DefaultRights' do
+    describe 'Cocina::ToFedora::DefaultRights' do
       let(:roundtrip_rights_metadata_xml) { defined?(roundtrip_default_object_rights_xml) ? roundtrip_default_object_rights_xml : default_object_rights_xml }
 
       let(:normalized_orig_rights_xml) do
@@ -95,16 +95,16 @@ RSpec.shared_examples 'valid APO mappings' do
         Cocina::ToFedora::DefaultRights.write(orig_fedora_apo_mock.defaultObjectRights, actual_cocina_apo_admin.defaultAccess)
       end
 
-      it 'roundtrips to expected defaultObjectRights xml' do
+      it 'roundtrips to expected defaultObjectRights.xml' do
         expect(orig_fedora_apo_mock.defaultObjectRights.ng_xml).to be_equivalent_to(roundtrip_rights_metadata_xml)
       end
 
-      it 'roundtrips to normalized original defaultObjectRights xml' do
+      it 'roundtrips to normalized original defaultObjectRights.xml' do
         expect(orig_fedora_apo_mock.defaultObjectRights.ng_xml).to be_equivalent_to(normalized_orig_rights_xml)
       end
     end
 
-    describe 'Roles' do
+    describe 'Cocina::ToFedora::Roles' do
       let(:actual_role_xml) do
         Cocina::ToFedora::Roles.write(roundtrip_fedora_apo, actual_cocina_apo_admin.roles)
         roundtrip_fedora_apo.roleMetadata.to_xml
@@ -114,12 +114,12 @@ RSpec.shared_examples 'valid APO mappings' do
         defined?(roundtrip_role_metadata_xml) ? roundtrip_role_metadata_xml : role_metadata_xml
       end
 
-      it 'AdminPolicyAdministrative cocina model roundtrips to expected roundtrip roleMetadata.xml' do
+      it 'roundtrips to expected roleMetadata.xml' do
         expect(actual_role_xml).to be_equivalent_to(expected_role_metadata_xml)
       end
     end
 
-    describe 'object relations' do
+    describe 'object relationships (RELS-EXT)' do
       let(:rels_ext_ng_xml) do
         ng = Nokogiri::XML(roundtrip_fedora_apo.datastreams['RELS-EXT'].to_rels_ext)
         ng.remove_namespaces!
@@ -135,7 +135,7 @@ RSpec.shared_examples 'valid APO mappings' do
     end
   end
 
-  context 'when mapping roundtripped Fedora to Cocina' do
+  context 'when mapping from roundtripped Fedora to Cocina' do
     let(:my_roundtrip_admin_metadata_xml) do
       defined?(roundtrip_admin_metadata_xml) ? roundtrip_admin_metadata_xml : admin_metadata_xml
     end
@@ -427,7 +427,7 @@ RSpec.describe 'APO administrative mappings' do
 
   describe 'no collections, has license, roles with type person' do
     # based on kt538yv1733 combined with default_obj_rights and roles from qv549bf9093
-    it_behaves_like 'APO Fedora Cocina mapping' do
+    it_behaves_like 'valid APO mappings' do
       let(:admin_metadata_xml) do
         <<~XML
           <administrativeMetadata>
@@ -598,8 +598,8 @@ RSpec.describe 'APO administrative mappings' do
               </machine>
             </access>
             <use>
-              <human type="useAndReproduction">Use at will.</human>
               <license>https://creativecommons.org/licenses/by-nc/3.0/legalcode</license>
+              <human type="useAndReproduction">Use at will.</human>
             </use>
           </rightsMetadata>
         XML

--- a/spec/services/cocina/mapping/administrative/apo_administrative_spec.rb
+++ b/spec/services/cocina/mapping/administrative/apo_administrative_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.shared_examples 'APO Fedora Cocina mapping' do
+RSpec.shared_examples 'valid APO mappings' do
   # Required: admin_metadata_xml, default_object_rights_xml, role_metadata_xml, agreement_druid, cocina
   # Optional: roundtrip_admin_metadata_xml, roundtrip_default_object_rights_xml, roundtrip_role_metadata_xml
 
@@ -20,8 +20,7 @@ RSpec.shared_examples 'APO Fedora Cocina mapping' do
       agreement_object_id: agreement_druid,
       administrativeMetadata: Dor::AdministrativeMetadataDS.from_xml(admin_metadata_xml),
       descMetadata: Dor::DescMetadataDS.from_xml('<mods/>'),
-      # NOTE: DefaultObjectRights doesn't work with :from_xml
-      defaultObjectRights: instance_double(Dor::DefaultObjectRightsDS, content: default_object_rights_xml),
+      defaultObjectRights: default_object_rights_ds,
       roleMetadata: Dor::RoleMetadataDS.from_xml(role_metadata_xml)
     )
   end
@@ -51,17 +50,17 @@ RSpec.shared_examples 'APO Fedora Cocina mapping' do
     }
   end
 
-  context 'when mapping from Fedora to Cocina' do
-    it 'cocina hash produces valid Cocina AdminPolicyAdministrative' do
+  context 'when mapping Fedora to Cocina' do
+    it 'produces valid AdminPolicyAdministrative' do
       expect { Cocina::Models::AdminPolicyAdministrative.new(cocina) }.not_to raise_error
     end
 
-    it 'Fedora maps to expected Cocina object props' do
+    it 'maps to expected object props' do
       expect(actual_cocina_props).to be_deep_equal(expected_cocina_props)
     end
   end
 
-  context 'when mapping from Cocina to Fedora' do
+  context 'when mapping Cocina to Fedora' do
     let(:actual_cocina_apo_admin) { Cocina::Models::AdminPolicyAdministrative.new(cocina) }
     let(:roundtrip_fedora_apo) do
       Dor::AdminPolicyObject.new(pid: actual_cocina_props[:externalIdentifier],
@@ -70,13 +69,13 @@ RSpec.shared_examples 'APO Fedora Cocina mapping' do
                                  label: actual_cocina_props[:label])
     end
 
-    describe 'Cocina::ToFedora::AdministrativeMetadata' do
+    describe 'AdministrativeMetadata' do
       let(:actual_admin_metadata_xml) do
         Cocina::ToFedora::AdministrativeMetadata.write(roundtrip_fedora_apo.administrativeMetadata, actual_cocina_apo_admin)
         roundtrip_fedora_apo.administrativeMetadata.to_xml
       end
 
-      it 'AdminPolicyAdministrative cocina model roundtrips to original administrativeMetadata.xml' do
+      it 'roundtrips to original administrativeMetadata.xml' do
         expect(actual_admin_metadata_xml).to be_equivalent_to(admin_metadata_xml)
       end
 
@@ -85,22 +84,21 @@ RSpec.shared_examples 'APO Fedora Cocina mapping' do
       end
     end
 
-    describe 'Cocina::ToFedora::DefaultRights' do
+    describe 'DefaultRights' do
+      let(:normalized_default_rights_xml) do
+        Cocina::Normalizers::RightsNormalizer.normalize(datastream: default_object_rights_ds).to_xml
+      end
       let(:actual_default_rights_xml) do
         Cocina::ToFedora::DefaultRights.write(roundtrip_fedora_apo.defaultObjectRights, actual_cocina_apo_admin.defaultAccess) if actual_cocina_props[:administrative][:defaultAccess]
         roundtrip_fedora_apo.defaultObjectRights.to_xml
       end
 
-      let(:expected_default_object_rights_xml) do
-        defined?(roundtrip_default_object_rights_xml) ? roundtrip_default_object_rights_xml : default_object_rights_xml
-      end
-
-      it 'AdminPolicyAdministrative cocina model roundtrips to original defaultObjectRights.xml' do
-        expect(actual_default_rights_xml).to be_equivalent_to(expected_default_object_rights_xml)
+      it 'roundtrips to normalized defaultObjectRights.xml' do
+        expect(actual_default_rights_xml).to be_equivalent_to(normalized_default_rights_xml)
       end
     end
 
-    describe 'Cocina::ToFedora::Roles' do
+    describe 'Roles' do
       let(:actual_role_xml) do
         Cocina::ToFedora::Roles.write(roundtrip_fedora_apo, actual_cocina_apo_admin.roles)
         roundtrip_fedora_apo.roleMetadata.to_xml
@@ -115,23 +113,23 @@ RSpec.shared_examples 'APO Fedora Cocina mapping' do
       end
     end
 
-    describe 'object relations (RELS-EXT)' do
+    describe 'object relations' do
       let(:rels_ext_ng_xml) do
         ng = Nokogiri::XML(roundtrip_fedora_apo.datastreams['RELS-EXT'].to_rels_ext)
         ng.remove_namespaces!
       end
 
-      it 'admin_policy_object_id roundtrips to original' do
+      it 'roundtrips to original APO ID' do
         expect(rels_ext_ng_xml.xpath('//RDF/Description/isGovernedBy/@resource').text).to eq "info:fedora/#{cocina[:hasAdminPolicy]}"
       end
 
-      it 'agreement_object_id roundtrips to original' do
+      it 'roundtrips to original agreement ID' do
         expect(rels_ext_ng_xml.xpath('//RDF/Description/referencesAgreement/@resource').text).to eq "info:fedora/#{agreement_druid}"
       end
     end
   end
 
-  context 'when mapping from roundtrip Fedora to Cocina' do
+  context 'when mapping roundtripped Fedora to Cocina' do
     let(:my_roundtrip_admin_metadata_xml) do
       defined?(roundtrip_admin_metadata_xml) ? roundtrip_admin_metadata_xml : admin_metadata_xml
     end
@@ -149,24 +147,24 @@ RSpec.shared_examples 'APO Fedora Cocina mapping' do
         agreement_object_id: agreement_druid,
         administrativeMetadata: Dor::AdministrativeMetadataDS.from_xml(my_roundtrip_admin_metadata_xml),
         descMetadata: Dor::DescMetadataDS.from_xml('<mods/>'),
-        # NOTE: DefaultObjectRights doesn't work with :from_xml
-        defaultObjectRights: instance_double(Dor::DefaultObjectRightsDS, content: default_object_rights_xml),
+        defaultObjectRights: default_object_rights_ds,
         roleMetadata: Dor::RoleMetadataDS.from_xml(my_roundtrip_role_metadata_xml)
       )
     end
+
     let(:roundtrip_cocina_props) { Cocina::FromFedora::APO.props(roundtrip_fedora_apo_mock) }
 
-    it 'roundtrip Fedora maps to expected Cocina object props' do
+    it 'maps to expected object props' do
       expect(roundtrip_cocina_props).to be_deep_equal(expected_cocina_props)
     end
   end
 end
 
-RSpec.describe 'Fedora APO objects <--> cocina administrative mappings' do
+RSpec.describe 'APO administrative mappings' do
   # NOTE:  some APO have descMetadata, contact, accessioning (WF) in the administrativeMetadata.  Ignoring for now
-  describe 'world access, registration workflows, collection, single role' do
+  context 'with world access, registration workflows, a collection, & a single role' do
     # from bz845pv2292
-    it_behaves_like 'APO Fedora Cocina mapping' do
+    it_behaves_like 'valid APO mappings' do
       let(:admin_metadata_xml) do
         <<~XML
           <administrativeMetadata>
@@ -242,9 +240,9 @@ RSpec.describe 'Fedora APO objects <--> cocina administrative mappings' do
     end
   end
 
-  describe 'with disseminationWF, single registrationWF' do
+  context 'with disseminationWF, & single registrationWF' do
     # based on wr005wn5739 - web archiving crawl APO
-    it_behaves_like 'APO Fedora Cocina mapping' do
+    it_behaves_like 'valid APO mappings' do
       let(:admin_metadata_xml) do
         <<~XML
           <administrativeMetadata>
@@ -334,9 +332,9 @@ RSpec.describe 'Fedora APO objects <--> cocina administrative mappings' do
     end
   end
 
-  describe 'defaultObjectRights no-download, copyright, use' do
+  context 'with defaultObjectRights, no-download, copyright, & use statement' do
     # based on zd878cf9993
-    it_behaves_like 'APO Fedora Cocina mapping' do
+    it_behaves_like 'valid APO mappings' do
       let(:admin_metadata_xml) do
         <<~XML
           <administrativeMetadata>
@@ -549,7 +547,7 @@ RSpec.describe 'Fedora APO objects <--> cocina administrative mappings' do
 
   describe 'no collections, has license, roles with type sunetid' do
     # based on kt538yv1733 combined with default_obj_rights and roles from qv549bf9093
-    it_behaves_like 'APO Fedora Cocina mapping' do
+    it_behaves_like 'valid APO mappings' do
       let(:admin_metadata_xml) do
         <<~XML
           <administrativeMetadata>

--- a/spec/services/cocina/mapping/identification/dro_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/dro_identity_spec.rb
@@ -92,15 +92,11 @@ RSpec.shared_examples 'DRO Identification Fedora Cocina mapping' do
     end
 
     it 'identityMetadata roundtrips thru cocina model to expected roundtrip identityMetadata.xml' do
-      # for some reason, fedora_item.identityMetadata.ng_xml.to_xml fails here, but fedora_item.identityMetadata.to_xml passes.
-      #   ? Maybe some encoding assumptions baked in to active fedora.  Likewise, the opposite is true for the test below.
-      expect(roundtrip_fedora_item.identityMetadata.to_xml).to be_equivalent_to(roundtrip_identity_md_xml)
+      expect(roundtrip_fedora_item.identityMetadata.ng_xml).to be_equivalent_to(roundtrip_identity_md_xml)
     end
 
     it 'identityMetadata roundtrips thru cocina maps to normalized original identityMetadata.xml' do
-      # for some reason, fedora_item.identityMetadata.to_xml fails here, but fedora_item.identityMetadata.ng_xml.to_xml passes.
-      #    ? Maybe some encoding assumptions baked in to active fedora.  Likewise, the opposite is true for the test above.
-      expect(roundtrip_fedora_item.identityMetadata.ng_xml.to_xml).to be_equivalent_to normalized_orig_identity_xml
+      expect(roundtrip_fedora_item.identityMetadata.ng_xml).to be_equivalent_to normalized_orig_identity_xml
     end
   end
 

--- a/spec/services/deep_equal_spec.rb
+++ b/spec/services/deep_equal_spec.rb
@@ -24,4 +24,8 @@ RSpec.describe DeepEqual do
     expect(described_class.match?({ a: 'foo', b: ['foo', 'bar'] }, { a: 'foo', b: ['bar', 'foo'] })).to be true
     expect(described_class.match?({ a: 'foo', b: ['foo', 'bar'] }, { a: 'foo', b: ['bar'] })).to be false
   end
+
+  it 'compares xml strings' do
+    expect(described_class.match?({ defaultObjectRights: '<xml>foo!</xml>' }, { defaultObjectRights: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n<xml>foo!</xml>" })).to be true
+  end
 end

--- a/spec/support/matchers/deep_ignore_order_matcher.rb
+++ b/spec/support/matchers/deep_ignore_order_matcher.rb
@@ -4,7 +4,7 @@
 RSpec::Matchers.define :be_deep_equal do |expected|
   match { |actual| DeepEqual.match?(actual, expected) }
 
-  # Added diffable because it is helpful for troubleshooting, even if it mistakingly adds spurious diffs.
+  # Added diffable because it is helpful for troubleshooting, even if it mistakenly adds spurious diffs.
   diffable
 
   failure_message do |actual|


### PR DESCRIPTION
## Why was this change made?

Fixes #3129

Includes:
* Add normalization of APO default rights to cocina roundtrip validator
* Make checking of `#use_license` safer in the APO context as DefaultObjectRightsDS does not define this method allowing us to use our existing rights normalizer on APO rights
* Allow DeepEqual service to smartly compare XML blobs in Cocina (currently used only in the APO context)
* Improve how APO admin feature specs read in RSpec using more idiomatic, less repetitive `it`/`describe`/etc. labels

## How was this change tested?

### Before

```
$ bin/validate-cocina-roundtrip -f -r -s 10000
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9643 (96.546%)
  Different: 344 (3.444%)
  Mapping error:     1 (0.01%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     12 (0.12%)
  Bad cache:     0 (0.0%)

```

### After

```
$ bin/validate-cocina-roundtrip -f -r -s 10000                                                    
Status (n=10000; not using Missing for success/different/error stats):                                                          
  Success:   9647 (96.596%)                                                                                                     
  Different: 340 (3.404%)                                       
  Mapping error:     0 (0.0%)                                   
  Create error:     0 (0.0%)                                    
  Normalization error:     0 (0.0%)                                                                                             
  Missing from cache:     0 (0.0%)                                                                                              
  Unmapped:     0 (0.0%)                                        
  Expected unmapped:     13 (0.13%)                                                                                             
  Bad cache:     0 (0.0%)               
```

## Which documentation and/or configurations were updated?

None
