### PR TITLE
Normalizes missing objectCreator in identityMetadata.

### DIFF
--- a/app/services/cocina/normalizers/identity_normalizer.rb
+++ b/app/services/cocina/normalizers/identity_normalizer.rb
@@ -33,6 +33,7 @@ module Cocina
         normalize_out_catkeys
         normalize_source_id_whitespace
         normalize_release_tags
+        normalize_object_creator
 
         regenerate_ng_xml(ng_xml.to_xml)
       end
@@ -128,6 +129,14 @@ module Cocina
           release_node.delete('displayType')
           release_node.delete('release')
         end
+      end
+
+      def normalize_object_creator
+        return if ng_xml.root.xpath('//objectCreator').present?
+
+        object_creator_node = Nokogiri::XML::Node.new('objectCreator', ng_xml)
+        object_creator_node.content = 'DOR'
+        ng_xml.root << object_creator_node
       end
     end
   end

--- a/spec/services/cocina/normalizers/identity_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/identity_normalizer_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
         <<~XML
           <identityMetadata>
              <sourceId source="sul">M0443_S2_D-K_B9_F33_011</sourceId>
+             <objectCreator>DOR</objectCreator>
           </identityMetadata>
         XML
       )
@@ -42,6 +43,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
             <identityMetadata>
               <sourceId source="foo">bar</sourceId>
               <otherId name="dissertationid">0000000666</otherId>
+              <objectCreator>DOR</objectCreator>
             </identityMetadata>
           XML
         )
@@ -62,6 +64,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
           <<~XML
             <identityMetadata>
               <sourceId source="dissertationid">0000000666</sourceId>
+              <objectCreator>DOR</objectCreator>
             </identityMetadata>
           XML
         )
@@ -116,6 +119,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
           <<~XML
             <identityMetadata>
               <otherId name="catkey">666</otherId>
+              <objectCreator>DOR</objectCreator>
             </identityMetadata>
           XML
         )
@@ -141,6 +145,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
             <identityMetadata>
               <objectId>foo</objectId>
               <otherId name="catkey">666</otherId>
+              <objectCreator>DOR</objectCreator>
             </identityMetadata>
           XML
         )
@@ -166,6 +171,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
             <identityMetadata>
               <objectId>foo</objectId>
               <otherId name="catkey">666</otherId>
+              <objectCreator>DOR</objectCreator>
             </identityMetadata>
           XML
         )
@@ -191,6 +197,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
             <identityMetadata>
               <objectId>foo</objectId>
               <otherId name="catkey">666</otherId>
+              <objectCreator>DOR</objectCreator>
             </identityMetadata>
           XML
         )
@@ -215,6 +222,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
             <identityMetadata>
               <objectId>foo</objectId>
               <otherId name="catkey">666</otherId>
+              <objectCreator>DOR</objectCreator>
             </identityMetadata>
           XML
         )
@@ -485,6 +493,28 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
         <<~XML
           <identityMetadata>
             <otherId name="catkey">90125</otherId>
+            <objectCreator>DOR</objectCreator>
+          </identityMetadata>
+        XML
+      )
+    end
+  end
+
+  context 'when there is no objectCreator' do
+    let(:original_xml) do
+      <<~XML
+        <identityMetadata>
+          <objectLabel>foo</objectLabel>
+        </identityMetadata>
+      XML
+    end
+
+    it 'adds it' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <identityMetadata>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>foo</objectLabel>
           </identityMetadata>
         XML
       )


### PR DESCRIPTION
## Why was this change made?
Resolves #3213. Normalizes to always add objectCreator to identityMetadata (some records do not have it originally). 

## How was this change tested?
Added test and unit tests passing. 

Results of ` bin/validate-cocina-roundtrip -s 100000 -i druids.testbed.txt`:

Before:
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   94916 (94.994%)
  Different: 5002 (5.006%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

After:
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   94919 (94.997%)
  Different: 4999 (5.003%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```


## Which documentation and/or configurations were updated?



