### PR TITLE
add normalizer for adminMetadata

### DIFF
--- a/app/services/cocina/normalizers/admin_normalizer.rb
+++ b/app/services/cocina/normalizers/admin_normalizer.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Cocina
+  module Normalizers
+    # Normalizes a Fedora object adminMetadata datastream, accounting for differences between Fedora and cocina that are valid but differ when round-tripping.
+    class AdminNormalizer
+      include Cocina::Normalizers::Base
+
+      # @param [Nokogiri::Document] admin_ng_xml admin metadata XML to be normalized
+      # @return [Nokogiri::Document] normalized admin metadata xml
+      def self.normalize(admin_ng_xml:)
+        new(admin_ng_xml: admin_ng_xml).normalize
+      end
+
+      def initialize(admin_ng_xml:)
+        @ng_xml = admin_ng_xml.dup
+        @ng_xml.encoding = 'UTF-8' if @ng_xml.respond_to?(:encoding=) # following pattern from other normalizers
+      end
+
+      def normalize
+        normalize_desc_metadata_nodes
+        normalize_empty_registration_and_dissemination
+        regenerate_ng_xml(ng_xml.to_xml)
+      end
+
+      private
+
+      attr_reader :ng_xml
+
+      def normalize_desc_metadata_nodes
+        # removes any nodes like this: <descMetadata><format>MODS</format><descMetadata>
+        ng_xml.root.xpath('//descMetadata/format[text()="MODS"]').each { |node| node.parent.remove }
+      end
+
+      def normalize_empty_registration_and_dissemination
+        # removes any empty nodes like this: <registration/> or <dissemation/>
+        ng_xml.root.xpath('//registration[not(node())]').each(&:remove)
+        ng_xml.root.xpath('//dissemination[not(node())]').each(&:remove)
+      end
+    end
+  end
+end

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -86,6 +86,8 @@ end
 def norm_orig_datastream_ng_xml_for(dsid, orig_datastream_ng_xml, druid, label, fedora_obj)
   case dsid
   # Additional normalizers to go here.
+  when 'administrativeMetadata'
+    Cocina::Normalizers::AdminNormalizer.normalize(admin_ng_xml: orig_datastream_ng_xml)
   when 'descMetadata'
     Cocina::Normalizers::ModsNormalizer.normalize(mods_ng_xml: orig_datastream_ng_xml, druid: druid, label: label)
   when 'rightsMetadata'

--- a/spec/services/cocina/mapping/administrative/apo_administrative_spec.rb
+++ b/spec/services/cocina/mapping/administrative/apo_administrative_spec.rb
@@ -25,6 +25,11 @@ RSpec.shared_examples 'APO Fedora Cocina mapping' do
       roleMetadata: Dor::RoleMetadataDS.from_xml(role_metadata_xml)
     )
   end
+  let(:normalized_orig_admin_xml) do
+    # the starting administrativeMetadata.xml is normalized to address discrepancies found against administrativeMetadata roundtripped
+    #  from data store (Fedora) and back
+    Cocina::Normalizers::AdminNormalizer.normalize(admin_ng_xml: Nokogiri::XML(admin_metadata_xml)).to_xml
+  end
   let(:actual_cocina_props) { Cocina::FromFedora::APO.props(orig_fedora_apo_mock) }
   let(:expected_cocina_props) do
     {
@@ -73,6 +78,10 @@ RSpec.shared_examples 'APO Fedora Cocina mapping' do
 
       it 'AdminPolicyAdministrative cocina model roundtrips to original administrativeMetadata.xml' do
         expect(actual_admin_metadata_xml).to be_equivalent_to(admin_metadata_xml)
+      end
+
+      it 'AdministrativeMetadata roundtrips thru cocina maps to normalized original administrativeMetadata.xml' do
+        expect(actual_admin_metadata_xml).to be_equivalent_to normalized_orig_admin_xml
       end
     end
 

--- a/spec/services/cocina/normalizers/admin_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/admin_normalizer_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::Normalizers::AdminNormalizer do
+  let(:normalized_ng_xml) { described_class.normalize(admin_ng_xml: Nokogiri::XML(original_xml)) }
+
+  context 'when #normalize_desc_metadata_nodes' do
+    let(:original_xml) do
+      <<~XML
+        <administrativeMetadata>
+          <registration>
+            <workflow id="goobiWF"/>
+            <collection id="druid:fm742nb7315"/>
+          </registration>
+          <dissemination>
+            <workflow id="someNotEmptyValue"/>
+          </dissemination>
+          <descMetadata>
+            <format>MODS</format>
+            <source>Symphony</source>
+           </descMetadata>
+        </administrativeMetadata>
+      XML
+    end
+
+    it 'removes unncessary descMetadata node' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <administrativeMetadata>
+            <registration>
+              <workflow id="goobiWF"/>
+              <collection id="druid:fm742nb7315"/>
+            </registration>
+            <dissemination>
+              <workflow id="someNotEmptyValue"/>
+            </dissemination>
+          </administrativeMetadata>
+        XML
+      )
+    end
+
+    context 'when #normalize_empty_registration_and_dissemination' do
+      let(:original_xml) do
+        <<~XML
+          <administrativeMetadata>
+            <registration>
+              <workflow id="goobiWF"/>
+              <collection id="druid:fm742nb7315"/>
+            </registration>
+            <dissemination>
+              <workflow id="someNotEmptyValue"/>
+            </dissemination>
+            <registration />
+            <dissemination />
+          </administrativeMetadata>
+        XML
+      end
+
+      it 'removes unncessary empty registration and dissemination nodes' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <administrativeMetadata>
+              <registration>
+                <workflow id="goobiWF"/>
+                <collection id="druid:fm742nb7315"/>
+              </registration>
+              <dissemination>
+                <workflow id="someNotEmptyValue"/>
+              </dissemination>
+            </administrativeMetadata>
+          XML
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Fixes #2707 - admin administrativeMetadata normalizer, add a spec for the new normalizer, run normalizer in validation script and in adminMetadata spec


## How was this change tested?

Test suite


## Which documentation and/or configurations were updated?



