### PR TITLE
MODS recordInfoNote mapping

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
+++ b/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
@@ -76,10 +76,15 @@ module Cocina
               value: record_origin.text
             }
           end
-          if record_info_note
-            notes << {
-              valueAt: record_info_note['xlink:href']
-            }
+          record_info_notes.each do |info_note|
+            notes << if info_note['xlink:href']
+                       { valueAt: info_note['xlink:href'] }
+                     else
+                       {
+                         type: 'record information',
+                         value: info_note.text
+                       }
+                     end
           end
           notes.presence
         end
@@ -186,8 +191,8 @@ module Cocina
           @record_origins ||= record_info.xpath('mods:recordOrigin', mods: DESC_METADATA_NS)
         end
 
-        def record_info_note
-          @record_info_note ||= record_info.xpath('mods:recordInfoNote[@xlink:href]', mods: DESC_METADATA_NS, xlink: XLINK_NS).first
+        def record_info_notes
+          @record_info_notes ||= record_info.xpath('mods:recordInfoNote', mods: DESC_METADATA_NS)
         end
 
         def creation_event

--- a/app/services/cocina/to_fedora/descriptive/admin_metadata.rb
+++ b/app/services/cocina/to_fedora/descriptive/admin_metadata.rb
@@ -24,7 +24,7 @@ module Cocina
             build_content_source
             build_description_standard
             build_record_origin
-            build_record_info_note
+            build_record_info_notes
             build_event
             build_identifier
           end
@@ -40,11 +40,18 @@ module Cocina
           end
         end
 
-        def build_record_info_note
-          record_info_note = Array(admin_metadata.note).find(&:valueAt)
-          return unless record_info_note
+        def build_record_info_notes
+          record_info_notes = Array(admin_metadata.note)
+          # return unless record_info_notes
+          return if record_info_notes.empty?
 
-          xml.recordInfoNote nil, { 'xlink:href' => record_info_note.valueAt }
+          record_info_notes.each do |info_note|
+            if info_note.valueAt.present?
+              xml.recordInfoNote nil, { 'xlink:href' => info_note.valueAt }
+            elsif info_note.type == 'record information'
+              xml.recordInfoNote info_note.value
+            end
+          end
         end
 
         def build_content_source

--- a/spec/services/cocina/mapping/descriptive/mods/record_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/record_info_spec.rb
@@ -489,7 +489,7 @@ RSpec.describe 'MODS recordInfo <--> cocina mappings' do
   end
 
   describe 'With recordInfoNote' do
-    xit 'not implemented' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <recordInfo>


### PR DESCRIPTION
## Why was this change made?

Resolves #2689 to map recordInfoNote from MODS. 

## How was this change tested?

Unit tests. Validating on sdr-deploy with `bin/validate-desc-cocina-roundtrip`:

Before
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   99984 (99.984%)
  Different: 16 (0.016%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     0 (0.0%)
```

After
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   99984 (99.984%)
  Different: 16 (0.016%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     0 (0.0%)
```


## Which documentation and/or configurations were updated?



