### PR TITLE
refactor DublinCoreService to take MODS XML created by PublicDescMetadataService

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -5,7 +5,8 @@ class MetadataController < ApplicationController
   before_action :load_item
 
   def dublin_core
-    service = Publish::DublinCoreService.new(@item)
+    desc_md_xml = Publish::PublicDescMetadataService.new(@item).ng_xml(include_access_conditions: false)
+    service = Publish::DublinCoreService.new(desc_md_xml)
     render xml: service
   end
 

--- a/app/services/publish/dublin_core_service.rb
+++ b/app/services/publish/dublin_core_service.rb
@@ -6,9 +6,9 @@ module Publish
     XMLNS_OAI_DC = 'http://www.openarchives.org/OAI/2.0/oai_dc/'
     class CrosswalkError < Dor::DataError; end
 
-    # @param [Dor::Item] work the item to generate the DublinCore for.
-    def initialize(work)
-      @work = work
+    # @param [Nokogiri::XML::Document] the MODS XML to generate the DublinCore for.
+    def initialize(desc_md_xml)
+      @desc_md_xml = desc_md_xml
     end
 
     # Generates Dublin Core from the MODS in the descMetadata datastream using the LoC mods2dc stylesheet
@@ -16,7 +16,7 @@ module Publish
     # @raise [CrosswalkError] Raises an Exception if the generated DC is empty or has no children
     # @return [Nokogiri::XML::Document] the DublinCore XML document object
     def ng_xml
-      dc_doc = MODS_TO_DC_XSLT.transform(desc_md)
+      dc_doc = MODS_TO_DC_XSLT.transform(desc_md_xml)
       dc_doc.xpath('/oai_dc:dc/*[count(text()) = 0]', oai_dc: XMLNS_OAI_DC).remove # Remove empty nodes
       raise CrosswalkError, "DublinCoreService#ng_xml produced incorrect xml (no root):\n#{dc_doc.to_xml}" if dc_doc.root.nil?
       raise CrosswalkError, "DublinCoreService#ng_xml produced incorrect xml (no children):\n#{dc_doc.to_xml}" if dc_doc.root.children.empty?
@@ -29,10 +29,6 @@ module Publish
 
     private
 
-    def desc_md
-      PublicDescMetadataService.new(work).ng_xml(include_access_conditions: false)
-    end
-
-    attr_reader :work
+    attr_reader :desc_md_xml
   end
 end

--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -24,7 +24,8 @@ module Publish
       pub.add_child(public_content_metadata.root) if public_content_metadata.xpath('//resource').any?
       pub.add_child(public_rights_metadata.root)
       pub.add_child(public_relationships.root)
-      pub.add_child(DublinCoreService.new(object).ng_xml.root)
+      desc_md_xml = Publish::PublicDescMetadataService.new(object).ng_xml(include_access_conditions: false)
+      pub.add_child(DublinCoreService.new(desc_md_xml).ng_xml.root)
       pub.add_child(PublicDescMetadataService.new(object).ng_xml.root)
       pub.add_child(release_xml.root) unless release_xml.xpath('//release').children.empty? # If there are no release_tags, this prevents an empty <releaseData/> from being added
       # Note we cannot base this on if an individual object has release tags or not, because the collection may cause one to be generated for an item,

--- a/spec/services/publish/dublin_core_service_spec.rb
+++ b/spec/services/publish/dublin_core_service_spec.rb
@@ -3,9 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Publish::DublinCoreService do
-  subject(:service) { described_class.new(item) }
+  subject(:service) { described_class.new(desc_md_xml) }
 
   let(:item) { instantiate_fixture('druid:bc123df4567', Dor::Item) }
+  let(:desc_md_xml) { Publish::PublicDescMetadataService.new(item).ng_xml(include_access_conditions: false) }
 
   describe '#ng_xml' do
     subject(:xml) { service.ng_xml }


### PR DESCRIPTION
instead of a Fedora object

## Why was this change made?

closes #3099 

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

n/a