### PR TITLE
Fix validate-to-desc-cocina to handle a missing Fedora item.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,12 @@ Using the druids from `druids.txt` and the cache, this will create a Fedora item
 ### Validate mapping to Cocina from MODS (descriptive metadata only)
 ```
 $ bin/validate-to-desc-cocina -h
-Usage: bin/validate-to-cocina [options]
+Usage: bin/validate-to-desc-cocina [options]
     -s, --sample SAMPLE              Sample size, otherwise all druids.
     -u, --unique-filename            Result file named for branch and runtime
+    -a, --apo                        Include APO in report (slower).
+    -i, --input FILENAME             File containing list of druids (instead of druids.txt).
+    -d, --druids DRUIDS              List of druids (instead of druids.txt).
     -h, --help                       Displays help.
 
 $ bin/validate-to-desc-cocina -s 10

--- a/bin/validate-to-desc-cocina
+++ b/bin/validate-to-desc-cocina
@@ -6,7 +6,7 @@ require_relative '../lib/fedora_cache'
 require_relative '../lib/data_error_notifier'
 require 'optparse'
 
-options = { unique_filename: false, input: 'druids.txt' }
+options = { unique_filename: false, input: 'druids.txt', druids: [] }
 parser = OptionParser.new do |option_parser|
   option_parser.banner = 'Usage: bin/validate-to-desc-cocina [options]'
 
@@ -14,6 +14,7 @@ parser = OptionParser.new do |option_parser|
   option_parser.on('-u', '--unique-filename', 'Result file named for branch and runtime') { options[:unique_filename] = true }
   option_parser.on('-a', '--apo', 'Include APO in report (slower).') { options[:apo] = true }
   option_parser.on('-iFILENAME', '--input FILENAME', String, 'File containing list of druids (instead of druids.txt).')
+  option_parser.on('-dDRUIDS', '--druids DRUIDS', Array, 'List of druids (instead of druids.txt).')
   option_parser.on('-h', '--help', 'Displays help.') do
     puts option_parser
     exit
@@ -48,6 +49,8 @@ end
 def apo_for(druid)
   puts "Fetching #{druid}"
   Dor.find(druid).admin_policy_object_id
+rescue ActiveFedora::ObjectNotFoundError
+  'Not found'
 end
 
 def write_results(file, aggregated_error_results, label, with_apo)
@@ -83,8 +86,13 @@ def results_file_name(use_unique_filename)
   "results_to-cocina_#{now_str}_#{branch_name}_#{short_commit_hash}.txt"
 end
 
-druids = File.read(options[:input]).split
-druids = druids.take(options[:sample]) if options[:sample]
+if options[:druids].empty?
+  druids = File.read(options[:input]).split
+  druids = druids.take(options[:sample]) if options[:sample]
+else
+  druids = options[:druids]
+end
+
 @sample_size = druids.size
 
 Result = Struct.new(:druid, :msg, :error_type)


### PR DESCRIPTION
closes #3216

## Why was this change made?
Handle the case where an item is deleted from Fedora, but not deleted from cache.


## How was this change tested?
sdr-deploy


## Which documentation and/or configurations were updated?



