### PR TITLE
Map multiple record modification notes

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
+++ b/app/services/cocina/from_fedora/descriptive/admin_metadata.rb
@@ -39,8 +39,9 @@ module Cocina
         def build_events
           events = []
           events << build_event_for(creation_event, 'creation') if creation_event
-          events << build_event_for(modification_event, 'modification') if modification_event
-
+          modification_events.each do |event|
+            events << build_event_for(event, 'modification')
+          end
           return nil if events.empty?
 
           events
@@ -199,8 +200,8 @@ module Cocina
           @creation_event ||= record_info.xpath('mods:recordCreationDate', mods: DESC_METADATA_NS).first
         end
 
-        def modification_event
-          @modification_event ||= record_info.xpath('mods:recordChangeDate', mods: DESC_METADATA_NS).first
+        def modification_events
+          @modification_events ||= record_info.xpath('mods:recordChangeDate', mods: DESC_METADATA_NS)
         end
 
         def record_identifiers

--- a/spec/services/cocina/mapping/descriptive/mods/record_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/record_info_spec.rb
@@ -514,7 +514,7 @@ RSpec.describe 'MODS recordInfo <--> cocina mappings' do
   end
 
   describe 'Multiple modification dates' do
-    xit 'not implemented' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <recordInfo>


### PR DESCRIPTION
## Why was this change made?
Resolves #2740.

## How was this change tested?

Unit tests and running `bin/validate-desc-cocina-roundtrip`.

As always, I'd appreciate attention to the ruby methods I'm using, especially in this case `modification_events&.each`.

Before:
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   99992 (99.993%)
  Different: 7 (0.007%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     1 (0.001%)
```

After:
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   99992 (99.993%)
  Different: 7 (0.007%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     1 (0.001%)

```

## Which documentation and/or configurations were updated?



