### PR TITLE
Tooling tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ Usage: bin/validate-cocina-roundtrip [options]
     -s, --sample SAMPLE              Sample size, otherwise all druids.
     -u, --update                     Run object update instead of object create.
     -r, --random                     Select random druids.
-    -f, --fast                       Without content metadata.
+    -f, --no_content                 Without content metadata (fast).
+    -n, --no_descriptive             Without descriptive metadata.
     -d, --druids DRUIDS              List of druids (instead of druids.txt).
     -i, --input FILENAME             File containing list of druids (instead of druids.txt).
     -h, --help                       Displays help.

--- a/README.md
+++ b/README.md
@@ -365,6 +365,15 @@ $ bin/generate-druid-list 'is_governed_by_ssim:"info:fedora/druid:rp029yq2361"'
 
 The results are written to `druids.txt`.
 
+### Removing deleted items from a list of druids
+$ bin/clean-druid-list -h
+Usage: bin/clean-druid-list [options]
+    -i, --input FILENAME             File containing list of druids (instead of druids.txt).
+    -o, --output FILENAME            File to write list of druids (instead of druids.clean.txt).
+    -h, --help                       Displays help.
+
+Solr is used to determine if an item still exists.
+
 ### Refreshing descriptive metadata
 ```
 $ bin/refresh-metadata

--- a/bin/clean-druid-list
+++ b/bin/clean-druid-list
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../config/environment'
+require 'optparse'
+
+options = { input: 'druids.txt', output: 'druids.clean.txt' }
+parser = OptionParser.new do |option_parser|
+  option_parser.banner = 'Usage: bin/clean-druid-list [options]'
+
+  option_parser.on('-iFILENAME', '--input FILENAME', String, 'File containing list of druids (instead of druids.txt).')
+  option_parser.on('-oFILENAME', '--output FILENAME', String, 'File to write list of druids (instead of druids.clean.txt).')
+  option_parser.on('-h', '--help', 'Displays help.') do
+    puts option_parser
+    exit
+  end
+end
+parser.parse!(into: options)
+
+druids = File.read(options[:input]).split
+
+count = 0
+File.open(options[:output], 'w') do |file|
+  druids.each_with_index do |druid, index|
+    puts "Finding #{druid} (#{index + 1})"
+    next if ActiveFedora::SolrService.query('*:*', fl: 'id', rows: 1, fq: "id:\"#{druid}\"").empty?
+
+    file.write("#{druid}\n")
+    count += 1
+  end
+end
+
+puts "Original: #{druids.size} druids"
+puts "Cleaned: #{count} druids"

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -11,14 +11,15 @@ require 'diffy'
 require 'dor/services/client'
 require 'equivalent-xml'
 
-options = { random: false, druids: [], fast: false, update: false, input: 'druids.txt' }
+options = { random: false, druids: [], no_content: false, update: false, input: 'druids.txt', no_descriptive: false }
 parser = OptionParser.new do |option_parser|
   option_parser.banner = 'Usage: bin/validate-cocina-roundtrip [options]'
 
   option_parser.on('-sSAMPLE', '--sample SAMPLE', Integer, 'Sample size, otherwise all druids.')
   option_parser.on('-u', '--update', 'Run object update instead of object create.')
   option_parser.on('-r', '--random', 'Select random druids.')
-  option_parser.on('-f', '--fast', 'Without content metadata.')
+  option_parser.on('-f', '--no_content', 'Without content metadata (fast).')
+  option_parser.on('-n', '--no_descriptive', 'Without descriptive metadata.')
   option_parser.on('-dDRUIDS', '--druids DRUIDS', Array, 'List of druids (instead of druids.txt).')
   option_parser.on('-iFILENAME', '--input FILENAME', String, 'File containing list of druids (instead of druids.txt).')
   option_parser.on('-h', '--help', 'Displays help.') do
@@ -139,18 +140,30 @@ def diff_datatreams_for(druid, label, orig_datastreams, fedora_obj, apo)
   diff_datastreams
 end
 
-def fast_content_metadata(fedora_obj, druid, create)
+def empty_content_metadata(fedora_obj, druid, create)
   content_type = fedora_obj.contentMetadata.contentType.first
   object_id = create ? "objectId='#{druid}'" : ''
   book_data = content_type&.include?('book') || content_type&.include?('manuscript') ? '<bookData readingOrder="ltr"/>' : ''
   "<contentMetadata type='#{content_type}' #{object_id}>#{book_data}</contentMetadata>"
 end
 
+def empty_desc_metadata
+  <<~XML
+    <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3"
+      version="3.7"
+      xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
+      <titleInfo>
+        <title>Descriptive metadata has been removed.</title>
+      </titleInfo>
+    </mods>
+  XML
+end
+
 # rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/CyclomaticComplexity
 # rubocop:disable Metrics/MethodLength
 # rubocop:disable Metrics/PerceivedComplexity
-def validate_druid(druid, loader, fast: false, create: false)
+def validate_druid(druid, loader, no_content: false, no_desc: false, create: false)
   return [druid, :missing] unless loader.cached?(druid)
 
   begin
@@ -164,7 +177,9 @@ def validate_druid(druid, loader, fast: false, create: false)
     return [druid, :unmapped]
   end
 
-  fedora_obj.contentMetadata.content = fast_content_metadata(fedora_obj, druid, create) if fast && fedora_obj.datastreams.include?('contentMetadata')
+  fedora_obj.contentMetadata.content = empty_content_metadata(fedora_obj, druid, create) if no_content && fedora_obj.datastreams.include?('contentMetadata')
+
+  fedora_obj.descMetadata.content = empty_desc_metadata if no_desc && fedora_obj.datastreams.include?('descMetadata')
 
   # defaultObjectRights has to be normalized before mapping
   if fedora_obj.datastreams.include?('defaultObjectRights')
@@ -250,7 +265,7 @@ else
 end
 
 results = Parallel.map(druids, progress: 'Testing') do |druid|
-  validate_druid(druid, loader, fast: options[:fast], create: !options[:update])
+  validate_druid(druid, loader, no_content: options[:no_content], no_desc: options[:no_descriptive], create: !options[:update])
 end
 counts = { different: 0, success: 0, mapping_error: 0, update_error: 0, create_error: 0, normalization_error: 0, missing: 0, unmapped: 0, expected_unmapped: 0, bad_cache: 0 }
 File.open('results/results.txt', 'w') do |file|


### PR DESCRIPTION
## Why was this change made?
More effective testing. In particular, provide the ability to clean up our druid lists and items are purged and to omit descriptive md differences when evaluating roundtrip differences.


## How was this change tested?
sdr-deploy, local


## Which documentation and/or configurations were updated?



