### PR TITLE
Cocina-ize the AdminPolicyDefaultsController

### DIFF
--- a/app/controllers/admin_policy_defaults_controller.rb
+++ b/app/controllers/admin_policy_defaults_controller.rb
@@ -32,7 +32,28 @@ class AdminPolicyDefaultsController < ApplicationController
   end
 
   def updated_cocina_object
-    @cocina_object.new(access: @cocina_object.access.new(**default_access_from_apo))
+    @cocina_object.new(
+      access: @cocina_object.access.new(**default_access_from_apo),
+      structural: @cocina_object.structural.new(
+        contains: @cocina_object.structural.contains.map do |file_set|
+          file_set.new(
+            structural: file_set.structural.new(
+              contains: file_set.structural.contains.map do |file|
+                file.new(
+                  access: file.access.new(
+                    default_access_from_apo.to_h.slice(*file_access_props)
+                  )
+                )
+              end
+            )
+          )
+        end
+      )
+    )
+  end
+
+  def file_access_props
+    %i[access controlledDigitalLending download readLocation]
   end
 
   def default_access_from_apo

--- a/app/controllers/admin_policy_defaults_controller.rb
+++ b/app/controllers/admin_policy_defaults_controller.rb
@@ -7,7 +7,8 @@ class AdminPolicyDefaultsController < ApplicationController
   before_action :load_cocina_object, only: :apply
 
   def apply
-    return error_response unless current_workflow_state.in?(ALLOWED_WORKFLOW_STATES)
+    return type_error_response unless @cocina_object.dro? || @cocina_object.collection?
+    return workflow_error_response unless current_workflow_state.in?(ALLOWED_WORKFLOW_STATES)
 
     CocinaObjectStore.save(updated_cocina_object)
     head :no_content
@@ -22,7 +23,15 @@ class AdminPolicyDefaultsController < ApplicationController
       .display_simplified
   end
 
-  def error_response
+  def type_error_response
+    json_api_error(
+      status: :bad_request,
+      message: "#{@cocina_object.externalIdentifier} is a #{@cocina_object.class} and this type cannot currently have APO access defaults applied",
+      title: 'Object cannot inherit APO access defaults'
+    )
+  end
+
+  def workflow_error_response
     json_api_error(
       status: :unprocessable_entity,
       message: "#{@cocina_object.externalIdentifier} is in a state in which it cannot be modified (#{current_workflow_state}): " \
@@ -32,17 +41,19 @@ class AdminPolicyDefaultsController < ApplicationController
   end
 
   def updated_cocina_object
-    @cocina_object.new(
-      access: @cocina_object.access.new(**default_access_from_apo),
+    access_updated = @cocina_object.new(
+      access: @cocina_object.access.new(default_access_from_apo)
+    )
+    return access_updated unless access_updated.dro? && access_updated.structural&.contains&.any?
+
+    access_updated.new(
       structural: @cocina_object.structural.new(
         contains: @cocina_object.structural.contains.map do |file_set|
           file_set.new(
             structural: file_set.structural.new(
               contains: file_set.structural.contains.map do |file|
                 file.new(
-                  access: file.access.new(
-                    default_access_from_apo.to_h.slice(*file_access_props)
-                  )
+                  access: file.access.new(default_access_from_apo(file_level: true))
                 )
               end
             )
@@ -56,10 +67,19 @@ class AdminPolicyDefaultsController < ApplicationController
     %i[access controlledDigitalLending download readLocation]
   end
 
-  def default_access_from_apo
-    CocinaObjectStore
-      .find(@cocina_object.administrative.hasAdminPolicy)
-      .administrative
-      .defaultAccess
+  def collection_access_props
+    %i[access copyright license useAndReproductionStatement]
+  end
+
+  def default_access_from_apo(file_level: false)
+    default_access = CocinaObjectStore.find(@cocina_object.administrative.hasAdminPolicy)
+                                      .administrative
+                                      .defaultAccess
+                                      .to_h
+
+    return default_access.slice(*file_access_props) if file_level
+    return default_access.slice(*collection_access_props) if @cocina_object.collection?
+
+    default_access
   end
 end

--- a/app/controllers/admin_policy_defaults_controller.rb
+++ b/app/controllers/admin_policy_defaults_controller.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
+# TODO: This controller is doing way too much now. Consider extracting most of what is below into a new service object.
 # Applies the AdminPolicy defaults to a repository object
 class AdminPolicyDefaultsController < ApplicationController
   ALLOWED_WORKFLOW_STATES = %w[Registered Opened].freeze
+  COLLECTION_ACCESS = {
+    'citation-only' => 'world',
+    'dark' => 'dark',
+    'location-based' => 'world',
+    'stanford' => 'world',
+    'world' => 'world'
+  }.freeze
 
   before_action :load_cocina_object, only: :apply
 
@@ -78,7 +86,11 @@ class AdminPolicyDefaultsController < ApplicationController
                                       .to_h
 
     return default_access.slice(*file_access_props) if file_level
-    return default_access.slice(*collection_access_props) if @cocina_object.collection?
+
+    if @cocina_object.collection?
+      return default_access.slice(*collection_access_props)
+                           .tap { |access| access[:access] = COLLECTION_ACCESS[access[:access]] }
+    end
 
     default_access
   end

--- a/app/controllers/admin_policy_defaults_controller.rb
+++ b/app/controllers/admin_policy_defaults_controller.rb
@@ -2,14 +2,34 @@
 
 # Applies the AdminPolicy defaults to a repository object
 class AdminPolicyDefaultsController < ApplicationController
+  ALLOWED_WORKFLOW_STATES = %w[Registered Opened].freeze
+
   before_action :load_cocina_object, only: :apply
 
   def apply
+    return error_response unless current_workflow_state.in?(ALLOWED_WORKFLOW_STATES)
+
     CocinaObjectStore.save(updated_cocina_object)
     head :no_content
   end
 
   private
+
+  def current_workflow_state
+    WorkflowClientFactory
+      .build
+      .status(druid: @cocina_object.externalIdentifier, version: @cocina_object.version)
+      .display_simplified
+  end
+
+  def error_response
+    json_api_error(
+      status: :unprocessable_entity,
+      message: "#{@cocina_object.externalIdentifier} is in a state in which it cannot be modified (#{current_workflow_state}): " \
+               'APO defaults can only be applied when an object is either registered or opened for versioning',
+      title: 'Object cannot be modified in current state'
+    )
+  end
 
   def updated_cocina_object
     @cocina_object.new(access: @cocina_object.access.new(**default_access_from_apo))

--- a/app/controllers/admin_policy_defaults_controller.rb
+++ b/app/controllers/admin_policy_defaults_controller.rb
@@ -2,11 +2,23 @@
 
 # Applies the AdminPolicy defaults to a repository object
 class AdminPolicyDefaultsController < ApplicationController
-  before_action :load_item, only: :apply
+  before_action :load_cocina_object, only: :apply
 
   def apply
-    @item.rightsMetadata.content = @item.admin_policy_object.defaultObjectRights.content
-    @item.save!
+    CocinaObjectStore.save(updated_cocina_object)
     head :no_content
+  end
+
+  private
+
+  def updated_cocina_object
+    @cocina_object.new(access: @cocina_object.access.new(**default_access_from_apo))
+  end
+
+  def default_access_from_apo
+    CocinaObjectStore
+      .find(@cocina_object.administrative.hasAdminPolicy)
+      .administrative
+      .defaultAccess
   end
 end

--- a/app/services/workflow_client_factory.rb
+++ b/app/services/workflow_client_factory.rb
@@ -6,7 +6,10 @@ class WorkflowClientFactory
     logger = if Settings.workflow.logfile == 'rails'
                Rails.logger
              else
-               Logger.new(Settings.workflow.logfile, Settings.workflow.shift_age)
+               Logger.new(
+                 Rails.root.join(Settings.workflow.logfile),
+                 Settings.workflow.shift_age
+               )
              end
     Dor::Workflow::Client.new(url: Settings.workflow_url, logger: logger, timeout: Settings.workflow.timeout)
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,13 +42,13 @@ module DorServices
       parse_response_by_content_type: false,
       query_hash_key: 'action_dispatch.request.query_parameters'
     )
-
     # Ensure we are passing back valid responses when running tests
     if Rails.env.test?
       config.middleware.use(
         Committee::Middleware::ResponseValidation,
         schema_path: 'openapi.yml',
         parse_response_by_content_type: true,
+        query_hash_key: 'rack.request.query_hash',
         raise: true
       )
     end

--- a/openapi.yml
+++ b/openapi.yml
@@ -597,6 +597,12 @@ paths:
       responses:
         '200':
           description: OK
+        '400':
+          description: 'The object is not supported for inheritance of APO access defaults because its type is not supported'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: Not found
         '422':

--- a/openapi.yml
+++ b/openapi.yml
@@ -599,6 +599,12 @@ paths:
           description: OK
         '404':
           description: Not found
+        '422':
+          description: 'The object is in a state in which it cannot be modified: it must be either registered or opened for versioning'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal server error
       parameters:

--- a/spec/requests/apply_admin_policy_defaults_spec.rb
+++ b/spec/requests/apply_admin_policy_defaults_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe 'Apply APO access defaults to a member item' do
     allow(CocinaObjectStore).to receive(:find).with(object_druid).and_return(cocina_object)
     allow(CocinaObjectStore).to receive(:find).with(apo_druid).and_return(cocina_admin_policy)
     allow(CocinaObjectStore).to receive(:save)
+    allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
   end
 
   let(:apo_druid) { 'druid:df123cd4567' }
   let(:object_druid) { 'druid:bc123df4567' }
-  let(:ur_apo_druid) { 'druid:hv992ry2431' }
   let(:cocina_admin_policy) do
     Cocina::Models::AdminPolicy.new(
       externalIdentifier: apo_druid,
@@ -19,7 +19,8 @@ RSpec.describe 'Apply APO access defaults to a member item' do
       type: Cocina::Models::Vocab.admin_policy,
       label: 'Dummy APO',
       administrative: {
-        hasAdminPolicy: ur_apo_druid,
+        hasAdminPolicy: 'druid:hv992ry2431',
+        hasAgreement: 'druid:bc753qt7345',
         defaultAccess: default_access
       }
     )
@@ -34,42 +35,67 @@ RSpec.describe 'Apply APO access defaults to a member item' do
       administrative: { hasAdminPolicy: apo_druid }
     )
   end
+  let(:default_access) do
+    {
+      access: 'world',
+      download: 'world'
+    }
+  end
+  let(:workflow_client) { instance_double(Dor::Workflow::Client, status: status_client) }
+  let(:status_client) { instance_double(Dor::Workflow::Client::Status, display_simplified: workflow_state) }
 
-  context 'when APO picks up default default object rights' do
-    let(:default_access) do
-      {
-        access: 'world',
-        download: 'world'
-      }
-    end
+  AdminPolicyDefaultsController::ALLOWED_WORKFLOW_STATES.each do |workflow_state|
+    context "when item is in '#{workflow_state}' state" do
+      let(:workflow_state) { workflow_state }
 
-    it 'copies APO defaultAccess to item access' do
-      post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
-           headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response).to be_successful
-      expect(CocinaObjectStore).to have_received(:save)
-        .once
-        .with(cocina_object_with_access(default_access))
+      context 'when APO picks up default default object rights' do
+        it 'copies APO defaultAccess to item access' do
+          post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+               headers: { 'Authorization' => "Bearer #{jwt}" }
+          expect(response).to be_successful
+          expect(CocinaObjectStore).to have_received(:save)
+            .once
+            .with(cocina_object_with_access(default_access))
+        end
+      end
+
+      context 'when APO specifies custom default object rights' do
+        let(:default_access) do
+          {
+            access: 'world',
+            download: 'none',
+            useAndReproductionStatement: 'Use at will.',
+            license: 'https://creativecommons.org/licenses/by-nc/3.0/legalcode'
+          }
+        end
+
+        it 'copies APO defaultAccess to item access' do
+          post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+               headers: { 'Authorization' => "Bearer #{jwt}" }
+          expect(response).to be_successful
+          expect(CocinaObjectStore).to have_received(:save)
+            .once
+            .with(cocina_object_with_access(default_access))
+        end
+      end
     end
   end
 
-  context 'when APO specifies custom default object rights' do
-    let(:default_access) do
-      {
-        access: 'world',
-        download: 'none',
-        useAndReproductionStatement: 'Use at will.',
-        license: 'https://creativecommons.org/licenses/by-nc/3.0/legalcode'
-      }
-    end
+  ['Unknown Status', 'In accessioning', 'Accessioned'].each do |workflow_state|
+    context "when item is in '#{workflow_state}' state" do
+      let(:workflow_state) { workflow_state }
 
-    it 'copies APO defaultAccess to item access' do
-      post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
-           headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response).to be_successful
-      expect(CocinaObjectStore).to have_received(:save)
-        .once
-        .with(cocina_object_with_access(default_access))
+      it 'returns an HTTP 422 response with an error message' do
+        post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(JSON.parse(response.body)['errors'].first['detail']).to include(
+          "is in a state in which it cannot be modified (#{workflow_state}): APO defaults " \
+          'can only be applied when an object is either registered or opened for versioning'
+        )
+        expect(response).not_to be_successful
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(CocinaObjectStore).not_to have_received(:save)
+      end
     end
   end
 end

--- a/spec/requests/apply_admin_policy_defaults_spec.rb
+++ b/spec/requests/apply_admin_policy_defaults_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe 'Apply APO access defaults to a member item' do
         context 'when APO specifies custom default object rights' do
           let(:default_access) do
             {
-              access: 'world',
+              access: 'dark',
               download: 'none',
               useAndReproductionStatement: 'Use at will.',
               license: 'https://creativecommons.org/licenses/by-nc/3.0/legalcode'
@@ -331,7 +331,7 @@ RSpec.describe 'Apply APO access defaults to a member item' do
                     administrative: {
                       publish: true,
                       sdrPreserve: true,
-                      shelve: true
+                      shelve: false
                     },
                     access: default_access.slice(:access, :download),
                     hasMessageDigests: []

--- a/spec/requests/apply_admin_policy_defaults_spec.rb
+++ b/spec/requests/apply_admin_policy_defaults_spec.rb
@@ -76,114 +76,191 @@ RSpec.describe 'Apply APO access defaults to a member item' do
   end
   let(:workflow_client) { instance_double(Dor::Workflow::Client, status: status_client) }
   let(:status_client) { instance_double(Dor::Workflow::Client::Status, display_simplified: workflow_state) }
+  let(:workflow_state) { 'Registered' }
 
-  AdminPolicyDefaultsController::ALLOWED_WORKFLOW_STATES.each do |workflow_state|
-    context "when item is in '#{workflow_state}' state" do
-      let(:workflow_state) { workflow_state }
-
-      context 'when APO picks up default default object rights' do
-        let(:file_set_with_default_access) do
-          {
-            externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/234-567-890',
-            version: 1,
-            type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
-            label: 'Page 1',
-            structural: {
-              contains: [
-                {
-                  externalIdentifier: 'http://cocina.sul.stanford.edu/file/223-456-789',
-                  version: 1,
-                  type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
-                  filename: '00001.jp2',
-                  label: '00001.jp2',
-                  hasMimeType: 'image/jp2',
-                  administrative: {
-                    publish: true,
-                    sdrPreserve: true,
-                    shelve: true
-                  },
-                  access: default_access,
-                  hasMessageDigests: []
-                }
-              ]
-            }
-          }
-        end
-
-        it 'copies APO defaultAccess to item access' do
-          post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
-               headers: { 'Authorization' => "Bearer #{jwt}" }
-          expect(response).to be_successful
-          expect(CocinaObjectStore).to have_received(:save)
-            .once
-            .with(cocina_object_with(access: default_access, structural: { contains: [file_set_with_default_access] }))
-        end
+  describe 'object types' do
+    # NOTE: We do not explicitly test DROs here as they are tested everywhere else in this spec.
+    context 'with a collection' do
+      let(:cocina_object) do
+        Cocina::Models::Collection.new(
+          externalIdentifier: object_druid,
+          version: 1,
+          type: Cocina::Models::Vocab.collection,
+          label: 'Dummy Collection',
+          access: {},
+          administrative: { hasAdminPolicy: apo_druid }
+        )
       end
 
-      context 'when APO specifies custom default object rights' do
-        let(:default_access) do
-          {
-            access: 'world',
-            download: 'none',
-            useAndReproductionStatement: 'Use at will.',
-            license: 'https://creativecommons.org/licenses/by-nc/3.0/legalcode'
-          }
-        end
+      it 'copies APO defaultAccess to collection access' do
+        post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response).to be_successful
+        expect(CocinaObjectStore).to have_received(:save)
+          .once
+          .with(cocina_object_with(access: default_access.slice(:access, :copyright, :license, :useAndReproductionStatement)))
+      end
+    end
 
-        let(:file_set_with_custom_access) do
-          {
-            externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/234-567-890',
-            version: 1,
-            type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
-            label: 'Page 1',
-            structural: {
-              contains: [
-                {
-                  externalIdentifier: 'http://cocina.sul.stanford.edu/file/223-456-789',
-                  version: 1,
-                  type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
-                  filename: '00001.jp2',
-                  label: '00001.jp2',
-                  hasMimeType: 'image/jp2',
-                  administrative: {
-                    publish: true,
-                    sdrPreserve: true,
-                    shelve: true
-                  },
-                  access: default_access.slice(:access, :download),
-                  hasMessageDigests: []
-                }
-              ]
-            }
+    context 'with an APO' do
+      let(:cocina_object) do
+        Cocina::Models::AdminPolicy.new(
+          externalIdentifier: object_druid,
+          version: 1,
+          type: Cocina::Models::Vocab.admin_policy,
+          label: 'Dummy APO',
+          administrative: {
+            hasAdminPolicy: 'druid:hv992ry2431',
+            hasAgreement: 'druid:bc753qt7345',
+            defaultAccess: default_access
           }
-        end
+        )
+      end
 
-        it 'copies APO defaultAccess to item access' do
-          post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
-               headers: { 'Authorization' => "Bearer #{jwt}" }
-          expect(response).to be_successful
-          expect(CocinaObjectStore).to have_received(:save)
-            .once
-            .with(cocina_object_with(access: default_access, structural: { contains: [file_set_with_custom_access] }))
-        end
+      it 'returns an HTTP 400 response with an error message' do
+        post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(JSON.parse(response.body)['errors'].first['detail']).to include(
+          "#{object_druid} is a Cocina::Models::AdminPolicy and this type cannot currently have APO access defaults applied"
+        )
+        expect(response).not_to be_successful
+        expect(response).to have_http_status(:bad_request)
+        expect(CocinaObjectStore).not_to have_received(:save)
       end
     end
   end
 
-  ['Unknown Status', 'In accessioning', 'Accessioned'].each do |workflow_state|
-    context "when item is in '#{workflow_state}' state" do
-      let(:workflow_state) { workflow_state }
+  context 'an object without structural' do
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(
+        externalIdentifier: object_druid,
+        version: 1,
+        type: Cocina::Models::Vocab.object,
+        label: 'Dummy Object',
+        access: {},
+        administrative: { hasAdminPolicy: apo_druid }
+      )
+    end
 
-      it 'returns an HTTP 422 response with an error message' do
-        post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
-             headers: { 'Authorization' => "Bearer #{jwt}" }
-        expect(JSON.parse(response.body)['errors'].first['detail']).to include(
-          "is in a state in which it cannot be modified (#{workflow_state}): APO defaults " \
-          'can only be applied when an object is either registered or opened for versioning'
-        )
-        expect(response).not_to be_successful
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(CocinaObjectStore).not_to have_received(:save)
+    it 'copies APO defaultAccess to item access' do
+      post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+           headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to be_successful
+      expect(CocinaObjectStore).to have_received(:save)
+        .once
+        .with(cocina_object_with(access: default_access))
+    end
+  end
+
+  describe 'workflow states' do
+    AdminPolicyDefaultsController::ALLOWED_WORKFLOW_STATES.each do |workflow_state|
+      context "when item is in '#{workflow_state}' state" do
+        let(:workflow_state) { workflow_state }
+
+        context 'when APO picks up default default object rights' do
+          let(:file_set_with_default_access) do
+            {
+              externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/234-567-890',
+              version: 1,
+              type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+              label: 'Page 1',
+              structural: {
+                contains: [
+                  {
+                    externalIdentifier: 'http://cocina.sul.stanford.edu/file/223-456-789',
+                    version: 1,
+                    type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                    filename: '00001.jp2',
+                    label: '00001.jp2',
+                    hasMimeType: 'image/jp2',
+                    administrative: {
+                      publish: true,
+                      sdrPreserve: true,
+                      shelve: true
+                    },
+                    access: default_access,
+                    hasMessageDigests: []
+                  }
+                ]
+              }
+            }
+          end
+
+          it 'copies APO defaultAccess to item access' do
+            post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+                 headers: { 'Authorization' => "Bearer #{jwt}" }
+            expect(response).to be_successful
+            expect(CocinaObjectStore).to have_received(:save)
+              .once
+              .with(cocina_object_with(access: default_access, structural: { contains: [file_set_with_default_access] }))
+          end
+        end
+
+        context 'when APO specifies custom default object rights' do
+          let(:default_access) do
+            {
+              access: 'world',
+              download: 'none',
+              useAndReproductionStatement: 'Use at will.',
+              license: 'https://creativecommons.org/licenses/by-nc/3.0/legalcode'
+            }
+          end
+
+          let(:file_set_with_custom_access) do
+            {
+              externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/234-567-890',
+              version: 1,
+              type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+              label: 'Page 1',
+              structural: {
+                contains: [
+                  {
+                    externalIdentifier: 'http://cocina.sul.stanford.edu/file/223-456-789',
+                    version: 1,
+                    type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                    filename: '00001.jp2',
+                    label: '00001.jp2',
+                    hasMimeType: 'image/jp2',
+                    administrative: {
+                      publish: true,
+                      sdrPreserve: true,
+                      shelve: true
+                    },
+                    access: default_access.slice(:access, :download),
+                    hasMessageDigests: []
+                  }
+                ]
+              }
+            }
+          end
+
+          it 'copies APO defaultAccess to item access' do
+            post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+                 headers: { 'Authorization' => "Bearer #{jwt}" }
+            expect(response).to be_successful
+            expect(CocinaObjectStore).to have_received(:save)
+              .once
+              .with(cocina_object_with(access: default_access, structural: { contains: [file_set_with_custom_access] }))
+          end
+        end
+      end
+    end
+
+    ['Unknown Status', 'In accessioning', 'Accessioned'].each do |workflow_state|
+      context "when item is in '#{workflow_state}' state" do
+        let(:workflow_state) { workflow_state }
+
+        it 'returns an HTTP 422 response with an error message' do
+          post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+               headers: { 'Authorization' => "Bearer #{jwt}" }
+          expect(JSON.parse(response.body)['errors'].first['detail']).to include(
+            "is in a state in which it cannot be modified (#{workflow_state}): APO defaults " \
+            'can only be applied when an object is either registered or opened for versioning'
+          )
+          expect(response).not_to be_successful
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(CocinaObjectStore).not_to have_received(:save)
+        end
       end
     end
   end

--- a/spec/requests/apply_admin_policy_defaults_spec.rb
+++ b/spec/requests/apply_admin_policy_defaults_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Apply APO access defaults to a member item' do
   let(:workflow_state) { 'Registered' }
 
   describe 'object types' do
-    # NOTE: We do not explicitly test DROs here as they are tested everywhere else in this spec.
+    # NOTE: We do not explicitly test DROs here as they are tested elsewhere in this spec.
     context 'with a collection' do
       let(:cocina_object) do
         Cocina::Models::Collection.new(
@@ -130,7 +130,114 @@ RSpec.describe 'Apply APO access defaults to a member item' do
     end
   end
 
-  context 'an object without structural' do
+  context 'with a collection (supports subset of access values)' do
+    let(:cocina_object) do
+      Cocina::Models::Collection.new(
+        externalIdentifier: object_druid,
+        version: 1,
+        type: Cocina::Models::Vocab.collection,
+        label: 'Dummy Collection',
+        access: {},
+        administrative: { hasAdminPolicy: apo_druid }
+      )
+    end
+
+    context 'when APO specifies citation-only defaultAccess' do
+      let(:default_access) do
+        {
+          access: 'citation-only',
+          download: 'none'
+        }
+      end
+      let(:expected_access) do
+        {
+          access: 'world'
+        }
+      end
+
+      it 'maps to world collection access' do
+        post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response).to be_successful
+        expect(CocinaObjectStore).to have_received(:save)
+          .once
+          .with(cocina_object_with(access: expected_access))
+      end
+    end
+
+    context 'when APO specifies location-based defaultAccess' do
+      let(:default_access) do
+        {
+          access: 'location-based',
+          download: 'none',
+          readLocation: 'music'
+        }
+      end
+      let(:expected_access) do
+        {
+          access: 'world'
+        }
+      end
+
+      it 'maps to world collection access' do
+        post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response).to be_successful
+        expect(CocinaObjectStore).to have_received(:save)
+          .once
+          .with(cocina_object_with(access: expected_access))
+      end
+    end
+
+    context 'when APO specifies Stanford (or CDL) defaultAccess' do
+      let(:default_access) do
+        {
+          access: 'stanford',
+          download: 'none',
+          controlledDigitalLending: true
+        }
+      end
+      let(:expected_access) do
+        {
+          access: 'world'
+        }
+      end
+
+      it 'maps to world collection access' do
+        post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response).to be_successful
+        expect(CocinaObjectStore).to have_received(:save)
+          .once
+          .with(cocina_object_with(access: expected_access))
+      end
+    end
+
+    context 'when APO specifies dark defaultAccess' do
+      let(:default_access) do
+        {
+          access: 'dark',
+          download: 'none'
+        }
+      end
+      let(:expected_access) do
+        {
+          access: 'dark'
+        }
+      end
+
+      it 'maps to dark collection access' do
+        post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response).to be_successful
+        expect(CocinaObjectStore).to have_received(:save)
+          .once
+          .with(cocina_object_with(access: expected_access))
+      end
+    end
+  end
+
+  context 'with a DRO lacking structural metadata' do
     let(:cocina_object) do
       Cocina::Models::DRO.new(
         externalIdentifier: object_druid,

--- a/spec/requests/apply_admin_policy_defaults_spec.rb
+++ b/spec/requests/apply_admin_policy_defaults_spec.rb
@@ -2,24 +2,74 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Get the object' do
+RSpec.describe 'Apply APO access defaults to a member item' do
   before do
-    allow(Dor).to receive(:find).and_return(object)
-    allow(object).to receive(:save!)
+    allow(CocinaObjectStore).to receive(:find).with(object_druid).and_return(cocina_object)
+    allow(CocinaObjectStore).to receive(:find).with(apo_druid).and_return(cocina_admin_policy)
+    allow(CocinaObjectStore).to receive(:save)
   end
 
-  let(:object) { Dor::Item.new(admin_policy_object: admin_policy) }
-  let(:admin_policy) do
-    Dor::AdminPolicyObject.new.tap do |coll|
-      coll.defaultObjectRights.content = '<foo/>'
+  let(:apo_druid) { 'druid:df123cd4567' }
+  let(:object_druid) { 'druid:bc123df4567' }
+  let(:ur_apo_druid) { 'druid:hv992ry2431' }
+  let(:cocina_admin_policy) do
+    Cocina::Models::AdminPolicy.new(
+      externalIdentifier: apo_druid,
+      version: 1,
+      type: Cocina::Models::Vocab.admin_policy,
+      label: 'Dummy APO',
+      administrative: {
+        hasAdminPolicy: ur_apo_druid,
+        defaultAccess: default_access
+      }
+    )
+  end
+  let(:cocina_object) do
+    Cocina::Models::DRO.new(
+      externalIdentifier: object_druid,
+      version: 1,
+      type: Cocina::Models::Vocab.object,
+      label: 'Dummy Object',
+      access: {},
+      administrative: { hasAdminPolicy: apo_druid }
+    )
+  end
+
+  context 'when APO picks up default default object rights' do
+    let(:default_access) do
+      {
+        access: 'world',
+        download: 'world'
+      }
+    end
+
+    it 'copies APO defaultAccess to item access' do
+      post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+           headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to be_successful
+      expect(CocinaObjectStore).to have_received(:save)
+        .once
+        .with(cocina_object_with_access(default_access))
     end
   end
 
-  it 'copies the rights metadata from the AdminPolicy to the object' do
-    post '/v1/objects/druid:mk420bs7601/apply_admin_policy_defaults',
-         headers: { 'Authorization' => "Bearer #{jwt}" }
-    expect(response).to be_successful
-    expect(object.rightsMetadata.content).to eq '<foo/>'
-    expect(object).to have_received(:save!)
+  context 'when APO specifies custom default object rights' do
+    let(:default_access) do
+      {
+        access: 'world',
+        download: 'none',
+        useAndReproductionStatement: 'Use at will.',
+        license: 'https://creativecommons.org/licenses/by-nc/3.0/legalcode'
+      }
+    end
+
+    it 'copies APO defaultAccess to item access' do
+      post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+           headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to be_successful
+      expect(CocinaObjectStore).to have_received(:save)
+        .once
+        .with(cocina_object_with_access(default_access))
+    end
   end
 end

--- a/spec/support/cocina_matchers.rb
+++ b/spec/support/cocina_matchers.rb
@@ -34,16 +34,18 @@ module CocinaMatchers
   end
 
   # NOTE: each k/v pair in the hash passed to this matcher will need to be present in actual
-  matcher :cocina_object_with_access do |expected|
-    match do |actual|
-      expected.all? do |expected_key, expected_value|
-        # NOTE: there's no better method on Hash that I could find for this.
-        #        #include? and #member? only check keys, not k/v pairs
-        actual.access.to_h.any? do |actual_key, actual_value|
-          if expected_value.is_a?(Hash) && actual_value.is_a?(Hash)
-            expected_value.all? { |pair| actual_value.to_a.include?(pair) }
-          else
-            actual_key == expected_key && actual_value == expected_value
+  matcher :cocina_object_with do |**kwargs|
+    kwargs.each do |cocina_section, expected|
+      match do |actual|
+        expected.all? do |expected_key, expected_value|
+          # NOTE: there's no better method on Hash that I could find for this.
+          #        #include? and #member? only check keys, not k/v pairs
+          actual.public_send(cocina_section).to_h.any? do |actual_key, actual_value|
+            if expected_value.is_a?(Hash) && actual_value.is_a?(Hash)
+              expected_value.all? { |pair| actual_value.to_a.include?(pair) }
+            else
+              actual_key == expected_key && actual_value == expected_value
+            end
           end
         end
       end

--- a/spec/support/cocina_matchers.rb
+++ b/spec/support/cocina_matchers.rb
@@ -32,6 +32,23 @@ module CocinaMatchers
       "ERROR in CocinaMatchers: #{e}"
     end
   end
+
+  # NOTE: each k/v pair in the hash passed to this matcher will need to be present in actual
+  matcher :cocina_object_with_access do |expected|
+    match do |actual|
+      expected.all? do |expected_key, expected_value|
+        # NOTE: there's no better method on Hash that I could find for this.
+        #        #include? and #member? only check keys, not k/v pairs
+        actual.access.to_h.any? do |actual_key, actual_value|
+          if expected_value.is_a?(Hash) && actual_value.is_a?(Hash)
+            expected_value.all? { |pair| actual_value.to_a.include?(pair) }
+          else
+            actual_key == expected_key && actual_value == expected_value
+          end
+        end
+      end
+    end
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
And apply APO defaults only to items that are in the registered or opened workflow states.

## Why was this change made?

Fixes #3168
Fixes sul-dlss/argo#3019

This commit changes the AdminPolicyDefaultsController so that it saves and loads Cocina objects instead of Fedora ones. It tests both cases of default defaultAccess and custom defaultAccess. It also copies over an RSpec matcher from Argo allowing comparison of Cocina substructures, in this case the access substructure.

## How was this change tested?

CI. Will also test in stage.

## Which documentation and/or configurations were updated?

None

