### PR TITLE
normalize empty xml contentMetadata

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -38,6 +38,7 @@ module Cocina
         normalize_label_attr
         normalize_attr
         normalize_publish
+        normalize_empty_xml
 
         regenerate_ng_xml(ng_xml.to_s)
       end
@@ -127,6 +128,11 @@ module Cocina
           file['publish'] ||= file['deliver']
           file.delete('deliver')
         end
+      end
+
+      def normalize_empty_xml
+        # some objects have <xml> instead of <contentMetadata>, e.g. normalize <xml type="file"/> --> <contentMetadata type="file"/>
+        ng_xml.root.xpath('//xml[not(text())]').each { |node| node.name = 'contentMetadata' }
       end
     end
   end

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -404,4 +404,21 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       )
     end
   end
+
+  context 'when normalizing empty xml contentMetadata' do
+    # Adapted from bb423sd6663
+    let(:original_xml) do
+      <<~XML
+        <xml type="file"/>
+      XML
+    end
+
+    it 'replaces xml node with contentMetadata node' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <contentMetadata type="file" objectId="druid:bb035tg0974"/>
+        XML
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #3251 - normalize empty XML content metadata

See stats from running validate-cocina-roundtrip on sample druids below.

## How was this change tested?

Added a test, ran round-trip test on sdr-deploy



## Which documentation and/or configurations were updated?



