### PR TITLE
Remove the license if the user has said so

### DIFF
--- a/app/services/cocina/to_fedora/license.rb
+++ b/app/services/cocina/to_fedora/license.rb
@@ -16,9 +16,10 @@ module Cocina
       def update
         initialize_use_node!
         clear_licenses
-        if uri # don't build a license node if there is no license
-          license_node = use_node.xpath('license').first || use_node.add_child('<license/>').first
+        if uri
           license_node.content = uri
+        else
+          license_node.remove
         end
 
         datastream.ng_xml_will_change!
@@ -27,6 +28,10 @@ module Cocina
       private
 
       attr_reader :uri, :datastream
+
+      def license_node
+        use_node.xpath('license').first || use_node.add_child('<license/>').first
+      end
 
       # Remove the legacy nodes
       def clear_licenses

--- a/spec/services/cocina/to_fedora/license_spec.rb
+++ b/spec/services/cocina/to_fedora/license_spec.rb
@@ -88,4 +88,39 @@ RSpec.describe Cocina::ToFedora::License do
       XML
     end
   end
+
+  context 'when license is nil' do
+    let(:uri) { nil }
+
+    let(:datastream_xml) do
+      <<~XML
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <world/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <world rule="no-download"/>
+            </machine>
+          </access>
+          <use>
+           <license>https://creativecommons.org/share-your-work/public-domain/cc0/</license>
+          </use>
+          <copyright>
+            <human/>
+          </copyright>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'writes the XML with the license removed' do
+      apply
+      expect(datastream.ng_xml.xpath('//use')).to be_equivalent_to <<~XML
+        <use>
+        </use>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
Fixes sul-dlss/argo#3018

## Why was this change made?

Without this change, the APO edit page in Argo (e.g., https://argo-stage.stanford.edu/view/druid:sc012gz0974) fails to do what the user expects when they set the default use license for an APO to none.

## How was this change tested?

CI + @andrewjbtw tested successfully IN QA

## Which documentation and/or configurations were updated?

None

