### PR TITLE
FileSets: if HB alerting on an invalid type, tag alert as data error

### DIFF
--- a/app/services/cocina/from_fedora/dro.rb
+++ b/app/services/cocina/from_fedora/dro.rb
@@ -61,7 +61,7 @@ module Cocina
           version: fedora_item.current_version.to_i,
           administrative: FromFedora::Administrative.props(fedora_item),
           access: DROAccess.props(fedora_item.rightsMetadata, fedora_item.embargoMetadata),
-          structural: DroStructural.props(fedora_item, type: type)
+          structural: DroStructural.props(fedora_item, type: type, notifier: notifier)
         }.tap do |props|
           title_builder = FromFedora::Descriptive::TitleBuilderStrategy.find(label: fedora_item.label)
           description = FromFedora::Descriptive.props(title_builder: title_builder,

--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -23,7 +23,8 @@ module Cocina
           # access/rights.
           contains = FileSets.build(fedora_item.contentMetadata,
                                     rights_metadata: fedora_item.rightsMetadata,
-                                    version: fedora_item.current_version.to_i)
+                                    version: fedora_item.current_version.to_i,
+                                    druid: fedora_item.pid)
           structural[:contains] = contains if contains.present?
 
           begin

--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -4,13 +4,14 @@ module Cocina
   module FromFedora
     # builds the Structural subschema for Cocina::Models::DRO from a Dor::Item
     class DroStructural
-      def self.props(fedora_item, type:)
-        new(fedora_item, type: type).props
+      def self.props(fedora_item, type:, notifier:)
+        new(fedora_item, type: type, notifier: notifier).props
       end
 
-      def initialize(fedora_item, type:)
+      def initialize(fedora_item, type:, notifier:)
         @fedora_item = fedora_item
         @type = type
+        @notifier = notifier
       end
 
       def props
@@ -24,7 +25,7 @@ module Cocina
           contains = FileSets.build(fedora_item.contentMetadata,
                                     rights_metadata: fedora_item.rightsMetadata,
                                     version: fedora_item.current_version.to_i,
-                                    druid: fedora_item.pid)
+                                    notifier: notifier)
           structural[:contains] = contains if contains.present?
 
           begin
@@ -40,7 +41,7 @@ module Cocina
 
       private
 
-      attr_reader :fedora_item, :type
+      attr_reader :fedora_item, :type, :notifier
 
       def build_has_member_orders
         member_orders = create_member_order if type == Cocina::Models::Vocab.book

--- a/app/services/cocina/from_fedora/file_sets.rb
+++ b/app/services/cocina/from_fedora/file_sets.rb
@@ -4,22 +4,22 @@ module Cocina
   module FromFedora
     # builds the FileSet instance from a Dor::Item
     class FileSets
-      def self.build(content_metadata_ds, rights_metadata:, version:, druid:, ignore_resource_type_errors: false)
+      def self.build(content_metadata_ds, rights_metadata:, version:, notifier:, ignore_resource_type_errors: false)
         new(
           content_metadata_ds,
           rights_metadata: rights_metadata,
           version: version,
-          druid: druid,
+          notifier: notifier,
           ignore_resource_type_errors: ignore_resource_type_errors
         ).build
       end
 
-      def initialize(content_metadata_ds, rights_metadata:, version:, druid:, ignore_resource_type_errors:)
+      def initialize(content_metadata_ds, rights_metadata:, version:, notifier:, ignore_resource_type_errors:)
         @content_metadata_ds = content_metadata_ds
         @rights_metadata = rights_metadata
         @version = version
         @ignore_resource_type_errors = ignore_resource_type_errors
-        @data_err_notifier = DataErrorNotifier.new(druid: druid)
+        @notifier = notifier
       end
 
       def build
@@ -40,7 +40,7 @@ module Cocina
 
       private
 
-      attr_reader :content_metadata_ds, :rights_metadata, :version, :data_err_notifier, :ignore_resource_type_errors
+      attr_reader :content_metadata_ds, :rights_metadata, :version, :notifier, :ignore_resource_type_errors
 
       def rights_object
         rights_metadata.dra_object
@@ -53,7 +53,7 @@ module Cocina
           Cocina::Models::Vocab::Resources.public_send(val)
         else
           # skip sending alerts for Project Phoenix (old Google books) which are known to have bad resource types
-          data_err_notifier.error("Invalid resource type: '#{val}'") unless ignore_resource_type_errors
+          notifier.error("Invalid resource type: '#{val}'") unless ignore_resource_type_errors
           Cocina::Models::Vocab::Resources.file
         end
       end

--- a/bin/validate-rights-cocina-roundtrip
+++ b/bin/validate-rights-cocina-roundtrip
@@ -87,7 +87,7 @@ def validate_druid(druid, loader)
     cocina_access_props = Cocina::FromFedora::DROAccess.props(fedora_obj.rightsMetadata, fedora_obj.embargoMetadata)
     cocina_access = Cocina::Models::DROAccess.new(cocina_access_props)
 
-    cocina_structural_props = Cocina::FromFedora::DroStructural.props(fedora_obj, type: Cocina::FromFedora::DRO.dro_type(fedora_obj))
+    cocina_structural_props = Cocina::FromFedora::DroStructural.props(fedora_obj, type: Cocina::FromFedora::DRO.dro_type(fedora_obj), notifier: DataErrorNotifier.new)
     cocina_structural = Cocina::Models::DROStructural.new(cocina_structural_props)
   rescue StandardError => e
     write_error(druid, original_ng_xml, cocina_access_props, e)

--- a/spec/services/cocina/from_fedora/dro_structural_spec.rb
+++ b/spec/services/cocina/from_fedora/dro_structural_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::FromFedora::DroStructural do
-  subject(:structural) { described_class.props(item, type: type) }
+  subject(:structural) { described_class.props(item, type: type, notifier: notifier) }
+
+  let(:notifier) { instance_double(Cocina::FromFedora::DataErrorNotifier) }
 
   let(:type) { Cocina::Models::Vocab.book }
 
@@ -74,6 +76,7 @@ RSpec.describe Cocina::FromFedora::DroStructural do
     before do
       # This gives every file and file set the same UUID. In reality, they would be unique.
       allow(SecureRandom).to receive(:uuid).and_return('123-456-789')
+      allow(notifier).to receive(:error)
     end
 
     let(:xml) do
@@ -129,6 +132,7 @@ RSpec.describe Cocina::FromFedora::DroStructural do
 
       resource2 = structural[:contains].second
       expect(resource2[:label]).to eq ''
+      expect(notifier).to have_received(:error).twice.with("Invalid resource type: ''")
     end
   end
 

--- a/spec/services/cocina/from_fedora/file_sets_spec.rb
+++ b/spec/services/cocina/from_fedora/file_sets_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Cocina::FromFedora::FileSets do
     described_class.new(content_metadata_ds,
                         rights_metadata: rights_metadata_ds,
                         version: 1,
+                        druid: 'druid:gs491bt1345',
                         ignore_resource_type_errors: ignore_resource_type_errors)
   end
   let(:content_metadata_ds) do
@@ -80,7 +81,9 @@ RSpec.describe Cocina::FromFedora::FileSets do
       context 'when ignore_resource_type_errors is not set' do
         it 'notifies Honeybadger' do
           instance.send(:resource_type, node)
-          expect(Honeybadger).to have_received(:notify)
+          expect(Honeybadger).to have_received(:notify).with(
+            "[DATA ERROR] Invalid resource type: 'bogus'", context: { druid: 'druid:gs491bt1345' }, tags: 'data_error'
+          )
         end
       end
 

--- a/spec/services/cocina/from_fedora/file_sets_spec.rb
+++ b/spec/services/cocina/from_fedora/file_sets_spec.rb
@@ -32,11 +32,12 @@ RSpec.describe Cocina::FromFedora::FileSets do
     XML
   end
   let(:ignore_resource_type_errors) { false }
+  let(:notifier) { Cocina::FromFedora::DataErrorNotifier.new(druid: 'druid:gs491bt1345') }
   let(:instance) do
     described_class.new(content_metadata_ds,
                         rights_metadata: rights_metadata_ds,
                         version: 1,
-                        druid: 'druid:gs491bt1345',
+                        notifier: notifier,
                         ignore_resource_type_errors: ignore_resource_type_errors)
   end
   let(:content_metadata_ds) do

--- a/spec/services/cocina/mapping/access/dro_access_spec.rb
+++ b/spec/services/cocina/mapping/access/dro_access_spec.rb
@@ -8,7 +8,8 @@ RSpec.shared_examples 'DRO Access Fedora Cocina mapping' do
 
   let(:fedora_item) { Dor::Item.new }
   let(:mapped_access_props) { Cocina::FromFedora::DROAccess.props(fedora_item.rightsMetadata, fedora_item.embargoMetadata) }
-  let(:mapped_structural_props) { Cocina::FromFedora::DroStructural.props(fedora_item, type: Cocina::Models::Vocab.book) }
+  let(:notifier) { Cocina::FromFedora::DataErrorNotifier.new(druid: 'druid:db708qz9486') }
+  let(:mapped_structural_props) { Cocina::FromFedora::DroStructural.props(fedora_item, type: Cocina::Models::Vocab.book, notifier: notifier) }
   let(:cocina_file_access_props) { cocina_access_props }
   let(:roundtrip_rights_metadata_xml) { defined?(roundtrip_rights_xml) ? roundtrip_rights_xml : rights_xml }
   let(:normalized_orig_rights_xml) do
@@ -133,7 +134,7 @@ RSpec.shared_examples 'DRO Access Fedora Cocina mapping' do
   context 'when mapping from roundtrip Fedora to (roundtrip) Cocina' do
     let(:roundtrip_fedora_item) { Dor::Item.new }
     let(:roundtrip_access_props) { Cocina::FromFedora::DROAccess.props(roundtrip_fedora_item.rightsMetadata, roundtrip_fedora_item.embargoMetadata) }
-    let(:roundtrip_structural_props) { Cocina::FromFedora::DroStructural.props(roundtrip_fedora_item, type: Cocina::Models::Vocab.book) }
+    let(:roundtrip_structural_props) { Cocina::FromFedora::DroStructural.props(roundtrip_fedora_item, type: Cocina::Models::Vocab.book, notifier: notifier) }
 
     before do
       roundtrip_rights_metadata_ds = Dor::RightsMetadataDS.from_xml(roundtrip_rights_metadata_xml)
@@ -155,7 +156,7 @@ RSpec.shared_examples 'DRO Access Fedora Cocina mapping' do
   context 'when mapping from normalized orig Fedora rights_xml to (roundtrip) Cocina' do
     let(:roundtrip_fedora_item) { Dor::Item.new }
     let(:roundtrip_access_props) { Cocina::FromFedora::DROAccess.props(roundtrip_fedora_item.rightsMetadata, roundtrip_fedora_item.embargoMetadata) }
-    let(:roundtrip_structural_props) { Cocina::FromFedora::DroStructural.props(roundtrip_fedora_item, type: Cocina::Models::Vocab.book) }
+    let(:roundtrip_structural_props) { Cocina::FromFedora::DroStructural.props(roundtrip_fedora_item, type: Cocina::Models::Vocab.book, notifier: notifier) }
 
     before do
       roundtrip_rights_metadata_ds = Dor::RightsMetadataDS.from_xml(normalized_orig_rights_xml)

--- a/spec/services/cocina/mapping/structural/dro_structural_spec.rb
+++ b/spec/services/cocina/mapping/structural/dro_structural_spec.rb
@@ -8,8 +8,9 @@ RSpec.shared_examples 'DRO Structural Fedora Cocina mapping' do
 
   let(:fedora_item) { Dor::Item.new }
   let(:druid) { 'druid:hv992ry2431' }
+  let(:notifier) { Cocina::FromFedora::DataErrorNotifier.new(druid: druid) }
   let(:object_type) { Cocina::Models::Vocab.book }
-  let(:mapped_structural_props) { Cocina::FromFedora::DroStructural.props(fedora_item, type: object_type) }
+  let(:mapped_structural_props) { Cocina::FromFedora::DroStructural.props(fedora_item, type: object_type, notifier: notifier) }
   let(:roundtrip_content_metadata_xml) { defined?(roundtrip_content_xml) ? roundtrip_content_xml : content_xml }
   let(:normalized_roundtrip_content_metadata_xml) { Cocina::Normalizers::ContentMetadataNormalizer.normalize_roundtrip(content_ng_xml: Nokogiri::XML(roundtrip_content_metadata_xml)).to_xml }
   let(:normalized_orig_content_xml) do
@@ -70,7 +71,7 @@ RSpec.shared_examples 'DRO Structural Fedora Cocina mapping' do
 
   context 'when mapping from roundtrip Fedora to (roundtrip) Cocina' do
     let(:roundtrip_fedora_item) { Dor::Item.new }
-    let(:actual_roundtrip_structural_props) { Cocina::FromFedora::DroStructural.props(roundtrip_fedora_item, type: object_type) }
+    let(:actual_roundtrip_structural_props) { Cocina::FromFedora::DroStructural.props(roundtrip_fedora_item, type: object_type, notifier: notifier) }
 
     before do
       roundtrip_rights_metadata_ds = Dor::RightsMetadataDS.from_xml(rights_xml)
@@ -86,7 +87,7 @@ RSpec.shared_examples 'DRO Structural Fedora Cocina mapping' do
 
   context 'when mapping from normalized orig Fedora content_xml to (roundtrip) Cocina' do
     let(:roundtrip_fedora_item) { Dor::Item.new }
-    let(:actual_roundtrip_structural_props) { Cocina::FromFedora::DroStructural.props(roundtrip_fedora_item, type: object_type) }
+    let(:actual_roundtrip_structural_props) { Cocina::FromFedora::DroStructural.props(roundtrip_fedora_item, type: object_type, notifier: notifier) }
 
     before do
       roundtrip_rights_metadata_ds = Dor::RightsMetadataDS.from_xml(rights_xml)


### PR DESCRIPTION
## Why was this change made?

closes #3232

after grepping around to double-check that i was using the right alert format, i realized i'd missed some applicable centralized code for this sort of alert, but also that the existing code wanted a druid, which wasn't immediately available from where the alert was being sent.  i threw on a second commit passing in the druid from the caller, and switching `FileSets` to use the centralized notifier code, but if it turns out that's bad for some reason, i can knock that commit off (or otherwise tweak as needed, of course).

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

n/a