### PR TITLE
Allow for multiple catkeys

### DIFF
--- a/app/services/cocina/from_fedora/dro.rb
+++ b/app/services/cocina/from_fedora/dro.rb
@@ -71,7 +71,6 @@ module Cocina
           props[:description] = description unless description.nil?
           props[:geographic] = { iso19139: fedora_item.geoMetadata.content } if type == Cocina::Models::Vocab.geo
           identification = FromFedora::Identification.props(fedora_item)
-          identification[:catalogLinks] = [{ catalog: 'symphony', catalogRecordId: fedora_item.catkey }] if fedora_item.catkey
           props[:identification] = identification unless identification.empty?
         end
       end

--- a/app/services/cocina/from_fedora/identification.rb
+++ b/app/services/cocina/from_fedora/identification.rb
@@ -19,7 +19,8 @@ module Cocina
         {
           barcode: fedora_object.identityMetadata.barcode,
           doi: doi,
-          sourceId: source_id
+          sourceId: source_id,
+          catalogLinks: catalog_links
         }.compact
       end
 
@@ -51,6 +52,13 @@ module Cocina
         return unless value
 
         value.text.delete_prefix('https://doi.org/')
+      end
+
+      def catalog_links
+        fedora_object
+          .identityMetadata.ng_xml.xpath('//otherId[@name="catkey"]')
+          .map { |link| { catalog: 'symphony', catalogRecordId: link.text } }
+          .presence
       end
     end
   end

--- a/app/services/cocina/from_fedora/identification.rb
+++ b/app/services/cocina/from_fedora/identification.rb
@@ -57,7 +57,8 @@ module Cocina
       def catalog_links
         fedora_object
           .identityMetadata.ng_xml.xpath('//otherId[@name="catkey"]')
-          .map { |link| { catalog: 'symphony', catalogRecordId: link.text } }
+          .map { |id| { catalog: 'symphony', catalogRecordId: id.text } }
+          .uniq { |clink| clink[:catalogRecordId] }
           .presence
       end
     end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -114,6 +114,7 @@ module Cocina
         identity.apply_label(cocina_item.label)
         identity.apply_release_tags(cocina_item.administrative&.releaseTags)
         identity.apply_doi(Doi.for(druid: pid)) if assign_doi
+        identity.apply_catalog_links(cocina_item.identification&.catalogLinks)
 
         fedora_item.identityMetadata.barcode = cocina_item.identification.barcode if cocina_item.identification.barcode
 
@@ -137,6 +138,7 @@ module Cocina
         apply_default_access(fedora_collection) unless trial
         Cocina::ToFedora::CollectionAccess.apply(fedora_collection, cocina_collection.access) if cocina_collection.access
         Cocina::ToFedora::Identity.initialize_identity(fedora_collection)
+        Cocina::ToFedora::Identity.apply_catalog_links(fedora_collection, catalog_links: cocina_collection.identification&.catalogLinks)
         Cocina::ToFedora::Identity.apply_label(fedora_collection, label: cocina_collection.label)
         Cocina::ToFedora::Identity.apply_release_tags(fedora_collection, release_tags: cocina_collection.administrative&.releaseTags)
       end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -90,6 +90,7 @@ module Cocina
     # @raises SymphonyReader::ResponseError if symphony connection failed
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     def create_dro(cocina_item, trial:, assign_doi:)
       pid = trial ? cocina_item.externalIdentifier : Dor::SuriService.mint_id
       klass = cocina_item.type == Cocina::Models::Vocab.agreement ? Dor::Agreement : Dor::Item
@@ -123,6 +124,7 @@ module Cocina
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
 
     # @param [Cocina::Models::RequestCollection,Cocina::Models::Collection] cocina_collection
     # @return [Dor::Collection] a persisted Collection model

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -98,12 +98,14 @@ module Cocina
         Cocina::ToFedora::Identity.apply_label(fedora_object, label: cocina_object.label)
       end
 
-      Cocina::ToFedora::Identity.apply_release_tags(fedora_object, release_tags: cocina_object.administrative&.releaseTags) if has_changed?(:administrative)
+      if has_changed?(:administrative)
+        Cocina::ToFedora::Identity.apply_release_tags(fedora_object, release_tags: cocina_object.administrative&.releaseTags)
+        fedora_object.admin_policy_object_id = cocina_object.administrative.hasAdminPolicy
+      end
+
       Cocina::ToFedora::Identity.apply_catalog_links(fedora_object, catalog_links: cocina_object.identification&.catalogLinks) if has_changed?(:identification)
 
       fedora_object.catkey = catkey_for(cocina_object)
-      fedora_object.admin_policy_object_id = cocina_object.administrative.hasAdminPolicy if has_changed?(:administrative)
-
       Cocina::ToFedora::CollectionAccess.apply(fedora_object, cocina_object.access) if has_changed?(:access)
     end
 

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -99,6 +99,7 @@ module Cocina
       end
 
       Cocina::ToFedora::Identity.apply_release_tags(fedora_object, release_tags: cocina_object.administrative&.releaseTags) if has_changed?(:administrative)
+      Cocina::ToFedora::Identity.apply_catalog_links(fedora_object, catalog_links: cocina_object.identification&.catalogLinks) if has_changed?(:identification)
 
       fedora_object.catkey = catkey_for(cocina_object)
       fedora_object.admin_policy_object_id = cocina_object.administrative.hasAdminPolicy if has_changed?(:administrative)
@@ -123,6 +124,7 @@ module Cocina
         identity_updater.apply_doi(cocina_object.identification.doi)
         fedora_object.source_id = cocina_object.identification.sourceId
         fedora_object.catkey = catkey_for(cocina_object)
+        identity_updater.apply_catalog_links(cocina_object.identification.catalogLinks)
         fedora_object.identityMetadata.barcode = cocina_object.identification.barcode
       end
 

--- a/app/services/cocina/to_fedora/identity.rb
+++ b/app/services/cocina/to_fedora/identity.rb
@@ -65,16 +65,16 @@ module Cocina
       end
 
       def apply_catalog_links(catalog_links)
-        return unless catalog_links
+        return if catalog_links.blank?
 
         identity_md.ng_xml_will_change!
         catalog_links
           # only symphony links are catkeys
-          .filter { |l| l.catalog == 'symphony' }
+          .filter { |clink| clink.catalog == 'symphony' }
           # filter out object.catkey to prevent duplicates
-          .filter { |l| l.catalogRecordId != identity_md.catkey }
-          .each do |l|
-            identity_md.add_value(:otherId, l.catalogRecordId, { name: 'catkey' })
+          .filter { |clink| clink.catalogRecordId != identity_md.catkey }
+          .each do |clink|
+            identity_md.add_value(:otherId, clink.catalogRecordId, { name: 'catkey' })
           end
       end
 

--- a/app/services/cocina/to_fedora/identity.rb
+++ b/app/services/cocina/to_fedora/identity.rb
@@ -21,6 +21,10 @@ module Cocina
         new(fedora_object).apply_release_tags(release_tags)
       end
 
+      def self.apply_catalog_links(fedora_object, catalog_links:)
+        new(fedora_object).apply_catalog_links(catalog_links)
+      end
+
       def initialize(fedora_object)
         @fedora_object = fedora_object
       end
@@ -56,6 +60,20 @@ module Cocina
         identity_md.ng_xml_will_change!
         identity_md.ng_xml.xpath('//doi').each(&:remove)
         identity_md.add_value(:doi, doi)
+      end
+
+      def apply_catalog_links(catalog_links)
+        return unless catalog_links
+
+        identity_md.ng_xml_will_change!
+        catalog_links
+          # only symphony links are catkeys
+          .filter { |l| l.catalog == 'symphony' }
+          # filter out object.catkey to prevent duplicates
+          .filter { |l| l.catalogRecordId != identity_md.catkey }
+          .each do |l|
+            identity_md.add_value(:otherId, l.catalogRecordId, { name: 'catkey' })
+          end
       end
 
       private

--- a/app/services/cocina/to_fedora/identity.rb
+++ b/app/services/cocina/to_fedora/identity.rb
@@ -21,6 +21,8 @@ module Cocina
         new(fedora_object).apply_release_tags(release_tags)
       end
 
+      # @param [Dor::Item,Dor::Collection,Dor::Etd,Dor::AdminPolicyObject] fedora_object
+      # @param [Array<Cocina::Model::CatalogLink>] catalog_links for collections and items.
       def self.apply_catalog_links(fedora_object, catalog_links:)
         new(fedora_object).apply_catalog_links(catalog_links)
       end

--- a/spec/services/cocina/mapping/identification/dro_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/dro_identity_spec.rb
@@ -141,7 +141,9 @@ RSpec.shared_examples 'DRO Identification Fedora Cocina mapping' do
                       contentMetadata: Dor::ContentMetadataDS.new,
                       rightsMetadata: Dor::RightsMetadataDS.new)
     end
-    let(:roundtrip_cocina_props) { Cocina::FromFedora::DRO.props(roundtrip_fedora_item_mock) }
+    let(:roundtrip_cocina_props) { 
+      Cocina::FromFedora::DRO.props(roundtrip_fedora_item_mock) 
+    }
 
     before do
       allow(roundtrip_fedora_item_mock).to receive(:is_a?).with(Dor::Agreement).and_return(false)

--- a/spec/services/cocina/mapping/identification/dro_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/dro_identity_spec.rb
@@ -141,9 +141,9 @@ RSpec.shared_examples 'DRO Identification Fedora Cocina mapping' do
                       contentMetadata: Dor::ContentMetadataDS.new,
                       rightsMetadata: Dor::RightsMetadataDS.new)
     end
-    let(:roundtrip_cocina_props) { 
-      Cocina::FromFedora::DRO.props(roundtrip_fedora_item_mock) 
-    }
+    let(:roundtrip_cocina_props) do
+      Cocina::FromFedora::DRO.props(roundtrip_fedora_item_mock)
+    end
 
     before do
       allow(roundtrip_fedora_item_mock).to receive(:is_a?).with(Dor::Agreement).and_return(false)

--- a/spec/services/cocina/mapping/identification/dro_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/dro_identity_spec.rb
@@ -70,6 +70,7 @@ RSpec.shared_examples 'DRO Identification Fedora Cocina mapping' do
     Cocina::ToFedora::Identity.initialize_identity(fedora_item)
     Cocina::ToFedora::Identity.apply_label(fedora_item, label: cocina_dro.label)
     Cocina::ToFedora::Identity.apply_release_tags(fedora_item, release_tags: cocina_dro.administrative.releaseTags)
+    Cocina::ToFedora::Identity.apply_catalog_links(fedora_item, catalog_links: cocina_dro.identification&.catalogLinks)
     fedora_item.identityMetadata.barcode = cocina_dro.identification.barcode
     identity_updater = Cocina::ToFedora::Identity.new(fedora_item)
     identity_updater.apply_doi(cocina_dro.identification.doi)
@@ -284,6 +285,59 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
               {
                 catalog: 'symphony',
                 catalogRecordId: catkey
+              }
+            ]
+          },
+          administrative: {
+            hasAdminPolicy: admin_policy_id
+          },
+          structural: {},
+          access: access_props,
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'with multiple catkeys' do
+    it_behaves_like 'DRO Identification Fedora Cocina mapping' do
+      let(:item_id) { 'druid:bb010dx6027' }
+      let(:label) { 'The rite of spring' }
+      let(:catkey1) { '8501137' }
+      let(:catkey2) { '8675309' }
+      let(:admin_policy_id) { 'druid:bz845pv2292' } # from RELS-EXT
+      let(:collection_ids) { [] } # not in RELS-EXT
+      let(:source_id_source) { 'sul' }
+      let(:source_id) { 'naxos_nac_8.557501' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="#{source_id_source}">#{source_id}</sourceId>
+            <otherId name="catkey">#{catkey1}</otherId>
+            <otherId name="catkey">#{catkey2}</otherId>
+            <objectLabel>#{label}</objectLabel>
+            <objectId>#{item_id}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectType>item</objectType>
+          </identityMetadata>
+        XML
+      end
+      let(:cocina_props) do
+        {
+          externalIdentifier: item_id,
+          type: Cocina::Models::Vocab.object,
+          label: label,
+          version: 1,
+          identification: {
+            sourceId: "#{source_id_source}:#{source_id}",
+            catalogLinks: [
+              {
+                catalog: 'symphony',
+                catalogRecordId: catkey1
+              },
+              {
+                catalog: 'symphony',
+                catalogRecordId: catkey2
               }
             ]
           },
@@ -617,104 +671,6 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
             ]
           },
           structural: {},
-          access: access_props,
-          description: description_props
-        }
-      end
-    end
-  end
-
-  context 'with ETD with 2 catkeys' do
-    # it_behaves_like 'DRO Identification Fedora Cocina mapping' do
-    xit 'to be implemented: what to do with 2 catkeys' do
-      let(:item_id) { 'druid:zw844wz5427' }
-      let(:label) { '' }
-      let(:catkey) { '8652337' }
-      let(:admin_policy_id) { 'druid:bx911tp9024' } # from RELS-EXT
-      let(:collection_ids) { [] } # not in RELS-EXT
-      let(:identity_metadata_xml) do
-        <<~XML
-          <identityMetadata>
-            <objectId>#{item_id}</objectId>
-            <objectType>item</objectType>
-            <objectLabel/>
-            <objectCreator>DOR</objectCreator>
-            <citationTitle>Multiphoton interactions with transparent tissues: applications to imaging and surgery</citationTitle>
-            <citationCreator>Toytman, Ilya</citationCreator>
-            <otherId name="dissertationid">0000000296</otherId>
-            <otherId name="catkey">#{catkey}</otherId>
-            <otherId name="uuid">bb8e629e-6328-11e1-9378-022c4a816c60</otherId>
-            <tag>ETD : Term 1106</tag>
-            <tag>ETD : Dissertation</tag>
-            <tag>Remediated By : 4.20.1</tag>
-            <release to="Searchworks" who="blalbrit" what="self" when="2017-02-07T11:07:41Z">true</release>
-            <release to="Searchworks" who="blalbrit" what="self" when="2017-02-07T15:15:41Z">true</release>
-            <otherId name="catkey">12303517</otherId>
-            <release to="Searchworks" who="cebraj" what="self" when="2018-05-14T23:26:59Z">true</release>
-          </identityMetadata>
-        XML
-      end
-      # NOTE: dissertationid becomes sourceId
-      let(:roundtrip_identity_metadata_xml) do
-        <<~XML
-          <identityMetadata>
-            <objectId>#{item_id}</objectId>
-            <objectType>item</objectType>
-            <objectLabel/>
-            <objectCreator>DOR</objectCreator>
-            <sourceId source="dissertationid">0000000296</sourceId>
-            <otherId name="catkey">#{catkey}</otherId>
-            <release to="Searchworks" who="blalbrit" what="self" when="2017-02-07T11:07:41Z">true</release>
-            <release to="Searchworks" who="blalbrit" what="self" when="2017-02-07T15:15:41Z">true</release>
-            <otherId name="catkey">12303517</otherId>
-            <release to="Searchworks" who="cebraj" what="self" when="2018-05-14T23:26:59Z">true</release>
-          </identityMetadata>
-        XML
-      end
-      let(:cocina_props) do
-        {
-          externalIdentifier: item_id,
-          type: Cocina::Models::Vocab.object,
-          label: '',
-          version: 1,
-          identification: {
-            sourceId: 'dissertationid:0000000296',
-            catalogLinks: [
-              {
-                catalog: 'symphony',
-                catalogRecordId: catkey
-              }
-            ]
-          },
-          administrative: {
-            hasAdminPolicy: admin_policy_id,
-            releaseTags: [
-              {
-                who: 'blalbrit',
-                what: 'self',
-                date: '2017-02-07T11:07:41Z',
-                to: 'Searchworks',
-                release: true
-              },
-              {
-                who: 'blalbrit',
-                what: 'self',
-                date: '2017-02-07T15:15:41Z',
-                to: 'Searchworks',
-                release: true
-              },
-              {
-                who: 'cebraj',
-                what: 'self',
-                date: '2018-05-14T23:26:59Z',
-                to: 'Searchworks',
-                release: true
-              }
-            ]
-          },
-          structural: {
-            hasAgreement: 'druid:ct692vv3660'
-          },
           access: access_props,
           description: description_props
         }

--- a/spec/services/cocina/object_updater_spec.rb
+++ b/spec/services/cocina/object_updater_spec.rb
@@ -435,6 +435,9 @@ RSpec.describe Cocina::ObjectUpdater do
         allow(item).to receive(:source_id=)
         allow(item).to receive(:catkey=)
         allow(identity_metadata).to receive(:barcode=)
+        allow(identity_metadata).to receive(:ng_xml_will_change!)
+        allow(identity_metadata).to receive(:add_value)
+        allow(identity_metadata).to receive(:catkey)
       end
 
       context 'when identication has changed' do
@@ -453,6 +456,7 @@ RSpec.describe Cocina::ObjectUpdater do
           expect(item).to have_received(:source_id=)
           expect(item).to have_received(:catkey=)
           expect(identity_metadata).to have_received(:barcode=)
+          expect(identity_metadata).to have_received(:ng_xml_will_change!)
         end
       end
 
@@ -714,6 +718,9 @@ RSpec.describe Cocina::ObjectUpdater do
       allow(book_data_node).to receive(:remove)
       allow(Cocina::ToFedora::DROAccess).to receive(:apply)
       allow(identity_metadata).to receive(:barcode=)
+      allow(identity_metadata).to receive(:ng_xml_will_change!)
+      allow(identity_metadata).to receive(:add_value)
+      allow(identity_metadata).to receive(:catkey)
     end
 
     it 'updates but does not save' do
@@ -736,6 +743,8 @@ RSpec.describe Cocina::ObjectUpdater do
       allow(content_metadata_ng_xml).to receive(:xpath).and_return([book_data_node])
       expect(Cocina::ToFedora::DROAccess).to have_received(:apply)
       expect(identity_metadata).to have_received(:barcode=)
+      expect(identity_metadata).to have_received(:ng_xml_will_change!)
+      expect(identity_metadata).to have_received(:add_value)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

To allow multiple catkeys to be expressed as Cocina identification.catalogLinks. Fixes #3221 

## How was this change tested?

Unit tests and roundtrip testing on sdr-deploy:

Before: 

```
Testing |Time: 00:20:10 | ============================================================================================== | Time: 00:20:10
Status (n=100000; not using Missing for success/different/error stats):
  Success:   96078 (96.157%)
  Different: 3840 (3.843%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

After:

```
Testing |Time: 00:20:12 | ============================================================================================== | Time: 00:20:12
Status (n=100000; not using Missing for success/different/error stats):
  Success:   96089 (96.168%)
  Different: 3829 (3.832%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%
```

## Which documentation and/or configurations were updated?
