### PR TITLE
Updates cocina-models to 0.64.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.63.1'
+gem 'cocina-models', '~> 0.64.0'
 gem 'dor-rights-auth', '>= 1.5.0' # required for new CDL rights
 gem 'dor-services', '~> 9.6'
 gem 'dor-workflow-client', '~> 3.17'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,7 +257,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.4)
       domain_name (~> 0.5)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     iso-639 (0.2.10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.63.1)
+    cocina-models (0.64.0)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -154,9 +154,9 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (7.7.1)
+    dor-services-client (7.8.0)
       activesupport (>= 4.2, < 8)
-      cocina-models (~> 0.63.1)
+      cocina-models (~> 0.64.0)
       deprecation
       faraday (>= 0.15, < 2)
       zeitwerk (~> 2.1)
@@ -257,7 +257,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.4)
       domain_name (~> 0.5)
-    i18n (1.8.11)
+    i18n (1.9.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     iso-639 (0.2.10)
@@ -565,7 +565,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.63.1)
+  cocina-models (~> 0.64.0)
   committee
   config
   datacite (~> 0.2.0)

--- a/app/services/cocina/from_fedora/apo.rb
+++ b/app/services/cocina/from_fedora/apo.rb
@@ -46,7 +46,7 @@ module Cocina
           admin[:registrationWorkflow] = registration_workflows if registration_workflows.present?
           admin[:collectionsForRegistration] = registration_collections if registration_collections.present?
           admin[:hasAdminPolicy] = fedora_apo.admin_policy_object_id
-          admin[:referencesAgreement] = fedora_apo.agreement_object_id if fedora_apo.agreement_object_id.present?
+          admin[:hasAgreement] = fedora_apo.agreement_object_id if fedora_apo.agreement_object_id.present?
           admin[:roles] = build_roles
         end
       end

--- a/app/services/cocina/from_fedora/descriptive/access.rb
+++ b/app/services/cocina/from_fedora/descriptive/access.rb
@@ -33,8 +33,7 @@ module Cocina
             access[:accessContact] = access_contact.presence
             access[:url] = url.presence
             access[:note] = (note + purl_note).presence
-            access[:digitalRepository] = [{ value: 'Stanford Digital Repository' }] if purl
-          end.compact
+          end.compact.presence
         end
 
         private

--- a/app/services/cocina/from_fedora/descriptive/related_resource.rb
+++ b/app/services/cocina/from_fedora/descriptive/related_resource.rb
@@ -89,9 +89,8 @@ module Cocina
             {
               purl: Descriptive::Purl.purl_value(purl_node),
               access: {
-                note: Purl.purl_note(purl_node).presence,
-                digitalRepository: [{ value: 'Stanford Digital Repository' }]
-              }.compact
+                note: Purl.purl_note(purl_node).presence
+              }.compact.presence
             }.compact
           end
         end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -71,7 +71,7 @@ module Cocina
       pid = trial ? cocina_admin_policy.externalIdentifier : Dor::SuriService.mint_id
       Dor::AdminPolicyObject.new(pid: pid,
                                  admin_policy_object_id: cocina_admin_policy.administrative.hasAdminPolicy,
-                                 agreement_object_id: cocina_admin_policy.administrative.referencesAgreement,
+                                 agreement_object_id: cocina_admin_policy.administrative.hasAgreement,
                                  # source_id: cocina_admin_policy.identification.sourceId,
                                  label: cocina_admin_policy.label).tap do |fedora_apo|
         add_description(fedora_apo, cocina_admin_policy, trial: trial)

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -82,7 +82,7 @@ module Cocina
 
       if has_changed?(:administrative)
         fedora_object.admin_policy_object_id = cocina_object.administrative.hasAdminPolicy
-        fedora_object.agreement_object_id = cocina_object.administrative.referencesAgreement
+        fedora_object.agreement_object_id = cocina_object.administrative.hasAgreement
 
         Cocina::ToFedora::DefaultRights.write(fedora_object.defaultObjectRights, cocina_object.administrative.defaultAccess) if cocina_object.administrative.defaultAccess
         Cocina::ToFedora::AdministrativeMetadata.write(fedora_object.administrativeMetadata, cocina_object.administrative)

--- a/app/services/cocina/to_fedora/descriptive/access.rb
+++ b/app/services/cocina/to_fedora/descriptive/access.rb
@@ -102,7 +102,7 @@ module Cocina
         end
 
         def find_note_value(note_type)
-          Array(access.note).find do |note|
+          Array(access&.note).find do |note|
             note.type == note_type && purl_note?(note)
           end&.value
         end

--- a/app/services/cocina/to_fedora/descriptive/descriptive_writer.rb
+++ b/app/services/cocina/to_fedora/descriptive/descriptive_writer.rb
@@ -18,7 +18,7 @@ module Cocina
           Subject.write(xml: xml, subjects: descriptive.subject, forms: descriptive.form, id_generator: id_generator)
           Descriptive::Event.write(xml: xml, events: descriptive.event, id_generator: id_generator)
           Identifier.write(xml: xml, identifiers: descriptive.identifier, id_generator: id_generator)
-          Descriptive::Access.write(xml: xml, access: descriptive.access, purl: descriptive.purl)
+          Descriptive::Access.write(xml: xml, access: descriptive.access, purl: descriptive.respond_to?(:purl) ? descriptive.purl : nil)
           AdminMetadata.write(xml: xml, admin_metadata: descriptive.adminMetadata)
           RelatedResource.write(xml: xml, related_resources: descriptive.relatedResource, druid: druid, id_generator: id_generator)
           Geographic.write(xml: xml, geos: descriptive.geographic, druid: druid) if descriptive.respond_to?(:geographic)

--- a/openapi.yml
+++ b/openapi.yml
@@ -1311,6 +1311,8 @@ components:
       type: object
       additionalProperties: true
       properties:
+        cocinaVersion:
+          $ref: '#/components/schemas/CocinaVersion'
         type:
           type: string
           enum:
@@ -1326,6 +1328,7 @@ components:
         description:
           $ref: '#/components/schemas/Description'
       required:
+        - cocinaVersion
         - administrative
         - externalIdentifier
         - label
@@ -1359,6 +1362,8 @@ components:
             type: string
         hasAdminPolicy:
           $ref: '#/components/schemas/Druid'
+        hasAgreement:
+          $ref: '#/components/schemas/Druid'
         referencesAgreement:
           $ref: '#/components/schemas/Druid'
         roles:
@@ -1368,6 +1373,7 @@ components:
             $ref: '#/components/schemas/AccessRole'
       required:
         - hasAdminPolicy
+        - hasAgreement
     AdminPolicyDefaultAccess:
       description: 'Provides the default access settings for an AdminPolicy. This is almost the same as DROAccess, but it provides no defaults.'
       type: object
@@ -1499,11 +1505,18 @@ components:
       required:
         - access
         - download
+    CocinaVersion:
+      description: The version of Cocina with which this object conforms.
+      type: string
+      pattern: '^\d+\.\d+\.\d+$'
+      example: '1.2.3'
     Collection:
       description: A group of Digital Repository Objects that indicate some type of conceptual grouping within the domain that is worth reusing across the system.
       type: object
       additionalProperties: true
       properties:
+        cocinaVersion:
+            $ref: '#/components/schemas/CocinaVersion'
         type:
           description: The content type of the Collection. Selected from an established set of values.
           type: string
@@ -1530,6 +1543,7 @@ components:
         identification:
           $ref: '#/components/schemas/CollectionIdentification'
       required:
+        - cocinaVersion
         - externalIdentifier
         - label
         - type
@@ -1668,77 +1682,15 @@ components:
     Description:
       type: object
       additionalProperties: false
-      properties:
-        title:
-          description: Titles of the resource.
-          type: array
-          minItems: 1
-          items:
-            $ref: "#/components/schemas/Title"
-        contributor:
-          description: Agents contributing in some way to the creation and history of the
-            resource.
-          type: array
-          items:
-            $ref: "#/components/schemas/Contributor"
-        event:
-          description: Events in the history of the resource.
-          type: array
-          items:
-            $ref: "#/components/schemas/Event"
-        form:
-          description: Characteristics of the resource's physical, digital, and intellectual
-            form and genre, and of its process of creation.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
-        geographic:
-          description: Geographic description for items with coordinates or bounding boxes.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveGeographicMetadata"
-        language:
-          description: Languages, scripts, symbolic systems, and notations used in all or
-            part of a resource.
-          type: array
-          items:
-            $ref: "#/components/schemas/Language"
-        note:
-          description: Additional information relevant to a resource.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
-        identifier:
-          description: Identifiers and URIs associated with the resource.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
-        subject:
-          description: Terms associated with the intellectual content of the resource.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
-        purl:
-          $ref: "#/components/schemas/Purl"
-        access:
-          $ref: "#/components/schemas/DescriptiveAccessMetadata"
-        relatedResource:
-          description: Other resources associated with the described resource.
-          type: array
-          items:
-            $ref: "#/components/schemas/RelatedResource"
-        marcEncodedData:
-          description: Data about the resource represented in MARC fixed fields and codes.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
-        adminMetadata:
-          $ref: "#/components/schemas/DescriptiveAdminMetadata"
-        valueAt:
-          description: URL or other pointer to the location of the resource description.
-          type: string
-      required:
-        - title
+      allOf:
+        - $ref: "#/components/schemas/RequestDescription"
+        - type: object
+          additionalProperties: false
+          properties:
+            purl:
+              $ref: "#/components/schemas/Purl"
+          required:
+            - purl
     DescriptiveAccessMetadata:
       description: Information about how to access digital and physical versions of the object.
       type: object
@@ -2024,6 +1976,8 @@ components:
       type: object
       additionalProperties: true
       properties:
+        cocinaVersion:
+          $ref: '#/components/schemas/CocinaVersion'
         type:
           description: The content type of the DRO. Selected from an established set of values.
           type: string
@@ -2064,6 +2018,7 @@ components:
         geographic:
           $ref: '#/components/schemas/Geographic'
       required:
+        - cocinaVersion
         - access
         - administrative
         - externalIdentifier
@@ -2142,9 +2097,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Druid'
-        hasAgreement:
-          description: Agreement that covers the deposit of the DRO into SDR.
-          type: string
     Druid:
       type: string
       pattern: '^druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
@@ -2646,6 +2598,8 @@ components:
       type: object
       additionalProperties: false
       properties:
+        cocinaVersion:
+          $ref: '#/components/schemas/CocinaVersion'
         type:
           type: string
           enum:
@@ -2657,8 +2611,9 @@ components:
         administrative:
           $ref: '#/components/schemas/AdminPolicyAdministrative'
         description:
-          $ref: '#/components/schemas/Description'
+          $ref: '#/components/schemas/RequestDescription'
       required:
+        - cocinaVersion
         - administrative
         - label
         - type
@@ -2668,6 +2623,8 @@ components:
       type: object
       additionalProperties: false
       properties:
+        cocinaVersion:
+          $ref: '#/components/schemas/CocinaVersion'
         type:
           type: string
           enum:
@@ -2685,15 +2642,89 @@ components:
         administrative:
           $ref: '#/components/schemas/Administrative'
         description:
-          $ref: '#/components/schemas/Description'
+          $ref: '#/components/schemas/RequestDescription'
         identification:
           $ref: '#/components/schemas/CollectionIdentification'
       required:
+        - cocinaVersion
         - access
         - administrative
         - label
         - type
         - version
+    RequestDescription:
+      description: Description that is included in a request to create a DRO. This is the same as a Description, except excludes PURL.
+      type: object
+      additionalProperties: false
+      properties:
+        title:
+          description: Titles of the resource.
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/Title"
+        contributor:
+          description: Agents contributing in some way to the creation and history of the
+            resource.
+          type: array
+          items:
+            $ref: "#/components/schemas/Contributor"
+        event:
+          description: Events in the history of the resource.
+          type: array
+          items:
+            $ref: "#/components/schemas/Event"
+        form:
+          description: Characteristics of the resource's physical, digital, and intellectual
+            form and genre, and of its process of creation.
+          type: array
+          items:
+            $ref: "#/components/schemas/DescriptiveValue"
+        geographic:
+          description: Geographic description for items with coordinates or bounding boxes.
+          type: array
+          items:
+            $ref: "#/components/schemas/DescriptiveGeographicMetadata"
+        language:
+          description: Languages, scripts, symbolic systems, and notations used in all or
+            part of a resource.
+          type: array
+          items:
+            $ref: "#/components/schemas/Language"
+        note:
+          description: Additional information relevant to a resource.
+          type: array
+          items:
+            $ref: "#/components/schemas/DescriptiveValue"
+        identifier:
+          description: Identifiers and URIs associated with the resource.
+          type: array
+          items:
+            $ref: "#/components/schemas/DescriptiveValue"
+        subject:
+          description: Terms associated with the intellectual content of the resource.
+          type: array
+          items:
+            $ref: "#/components/schemas/DescriptiveValue"
+        access:
+          $ref: "#/components/schemas/DescriptiveAccessMetadata"
+        relatedResource:
+          description: Other resources associated with the described resource.
+          type: array
+          items:
+            $ref: "#/components/schemas/RelatedResource"
+        marcEncodedData:
+          description: Data about the resource represented in MARC fixed fields and codes.
+          type: array
+          items:
+            $ref: "#/components/schemas/DescriptiveValue"
+        adminMetadata:
+          $ref: "#/components/schemas/DescriptiveAdminMetadata"
+        valueAt:
+          description: URL or other pointer to the location of the resource description.
+          type: string
+      required:
+        - title
     RequestDRO:
       description: A request to create a DRO.  This has the same general structure as a DRO but doesn't have externalIdentifier and doesn't require the access subschema. If no access subschema is provided, these values will be inherited from the AdminPolicy.
       type: object
@@ -2702,6 +2733,8 @@ components:
       # Since POST /v1/objects has both, setting additionalProperties to true.
       additionalProperties: true
       properties:
+        cocinaVersion:
+          $ref: '#/components/schemas/CocinaVersion'
         type:
           type: string
           enum:
@@ -2729,7 +2762,7 @@ components:
         administrative:
           $ref: '#/components/schemas/Administrative'
         description:
-          $ref: '#/components/schemas/Description'
+          $ref: '#/components/schemas/RequestDescription'
         identification:
           $ref: '#/components/schemas/RequestIdentification'
         structural:
@@ -2737,6 +2770,7 @@ components:
         geographic:
           $ref: '#/components/schemas/Geographic'
       required:
+        - cocinaVersion
         - administrative
         - identification
         - label
@@ -2760,8 +2794,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Druid'
-        hasAgreement:
-          type: string
     RequestFile:
       type: object
       additionalProperties: false

--- a/spec/dor/goobi_spec.rb
+++ b/spec/dor/goobi_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe Dor::Goobi do
             {
               value: 'Constituent label & A Special character'
             }
-          ]
+          ],
+          purl: Purl.for(druid: druid)
         }
       end
 
@@ -265,7 +266,8 @@ RSpec.describe Dor::Goobi do
             {
               value: 'Constituent label & A Special character'
             }
-          ]
+          ],
+          purl: Purl.for(druid: druid)
         }
       end
 

--- a/spec/jobs/update_doi_metadata_job_spec.rb
+++ b/spec/jobs/update_doi_metadata_job_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe UpdateDoiMetadataJob, type: :job do
       },
       'description' => {
         'title' => [{ 'value' => 'Test obj' }],
+        'purl' => 'https://purl.stanford.edu/bc123df4567',
         'subject' => [{ 'type' => 'topic', 'value' => 'word' }]
       },
       'structural' => {

--- a/spec/requests/collections_for_object_spec.rb
+++ b/spec/requests/collections_for_object_spec.rb
@@ -34,12 +34,7 @@ RSpec.describe 'Get the object' do
                                            title: [
                                              { value: 'Hello' }
                                            ],
-                                           purl: 'https://purl.stanford.edu/bc123df4567',
-                                           access: {
-                                             digitalRepository: [
-                                               { value: 'Stanford Digital Repository' }
-                                             ]
-                                           }
+                                           purl: 'https://purl.stanford.edu/bc123df4567'
                                          }
                                        }).to_h
       ]

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -24,12 +24,7 @@ RSpec.describe 'Create object' do
                                      version: 1,
                                      description: {
                                        title: [{ value: title }],
-                                       purl: 'https://purl.stanford.edu/gg777gg7777',
-                                       access: {
-                                         digitalRepository: [
-                                           { value: 'Stanford Digital Repository' }
-                                         ]
-                                       }
+                                       purl: 'https://purl.stanford.edu/gg777gg7777'
                                      },
                                      identification: {
                                        sourceId: 'hydrus:collection-456'
@@ -43,11 +38,14 @@ RSpec.describe 'Create object' do
     end
     let(:data) do
       <<~JSON
-        {"type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
+        {
+          "cocinaVersion":"0.0.1",
+          "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
           "label":"#{label}","version":1,"access":{},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567","partOfProject":"Hydrus"},
           "identification":{"sourceId":"hydrus:collection-456"},
-          "description":{"title":[{"value":"#{title}"}],"purl":"https://purl.stanford.edu/gg777gg7777","access":{"digitalRepository":[{"value":"Stanford Digital Repository"}]}}}
+          "description":{"title":[{"value":"#{title}"}]}
+        }
       JSON
     end
 
@@ -55,7 +53,9 @@ RSpec.describe 'Create object' do
       let(:expected_label) { title } # label derived from catalog data
       let(:data) do
         <<~JSON
-          {"type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
+          {
+            "cocinaVersion":"0.0.1",
+            "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
             "label":"#{label}","version":1,"access":{},
             "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
             "description":{"title":[{"value":"#{title}"}]},
@@ -69,12 +69,7 @@ RSpec.describe 'Create object' do
                                        version: 1,
                                        description: {
                                          title: [{ value: title }],
-                                         purl: 'https://purl.stanford.edu/gg777gg7777',
-                                         access: {
-                                           digitalRepository: [
-                                             { value: 'Stanford Digital Repository' }
-                                           ]
-                                         }
+                                         purl: 'https://purl.stanford.edu/gg777gg7777'
                                        },
                                        administrative: {
                                          hasAdminPolicy: 'druid:dd999df4567'
@@ -125,7 +120,6 @@ RSpec.describe 'Create object' do
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
         expect(response.body).to equal_cocina_model(expected)
-
         expect(response.status).to eq(201)
         expect(response.location).to eq "/v1/objects/#{druid}"
       end
@@ -134,20 +128,16 @@ RSpec.describe 'Create object' do
     context 'when a description including summary note (abstract) is provided' do
       let(:data) do
         <<~JSON
-          {"type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
+          {
+            "cocinaVersion":"0.0.1",
+            "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
             "label":"#{label}",
             "version":1,
             "access":{},
             "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
             "description":{
               "title":[{"value":"#{title}"}],
-              "note":[{"value":"coll abstract","type":"abstract"}],
-                                       "purl": "https://purl.stanford.edu/gg777gg7777",
-                                       "access": {
-                                           "digitalRepository": [
-                                               { "value": "Stanford Digital Repository" }
-                                           ]
-                                       }
+              "note":[{"value":"coll abstract","type":"abstract"}]
               }
             }
         JSON
@@ -163,12 +153,7 @@ RSpec.describe 'Create object' do
                                        description: {
                                          title: [{ value: title }],
                                          note: [{ value: 'coll abstract', type: 'abstract' }],
-                                         purl: 'https://purl.stanford.edu/gg777gg7777',
-                                         access: {
-                                           digitalRepository: [
-                                             { value: 'Stanford Digital Repository' }
-                                           ]
-                                         }
+                                         purl: Purl.for(druid: druid)
                                        },
                                        externalIdentifier: druid)
       end
@@ -186,7 +171,9 @@ RSpec.describe 'Create object' do
     context 'when access is provided' do
       let(:data) do
         <<~JSON
-          {"type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
+          {
+            "cocinaVersion":"0.0.1",
+            "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
             "label":"#{label}",
             "version":1,
             "access":{ "access": "world" },
@@ -204,12 +191,7 @@ RSpec.describe 'Create object' do
                                        },
                                        description: {
                                          title: [{ value: expected_label }],
-                                         purl: 'https://purl.stanford.edu/gg777gg7777',
-                                         access: {
-                                           digitalRepository: [
-                                             { value: 'Stanford Digital Repository' }
-                                           ]
-                                         }
+                                         purl: 'https://purl.stanford.edu/gg777gg7777'
                                        },
                                        externalIdentifier: druid)
       end

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -34,12 +34,7 @@ RSpec.describe 'Create object' do
                               },
                               description: {
                                 title: [{ value: title }],
-                                purl: 'https://purl.stanford.edu/gg777gg7777',
-                                access: {
-                                  digitalRepository: [
-                                    { value: 'Stanford Digital Repository' }
-                                  ]
-                                }
+                                purl: 'https://purl.stanford.edu/gg777gg7777'
                               },
                               administrative: {
                                 hasAdminPolicy: 'druid:dd999df4567',
@@ -51,7 +46,9 @@ RSpec.describe 'Create object' do
     end
     let(:data) do
       <<~JSON
-        { "type":"http://cocina.sul.stanford.edu/models/image.jsonld",
+        {#{' '}
+          "cocinaVersion":"0.1.0",
+          "type":"http://cocina.sul.stanford.edu/models/image.jsonld",
           "label":"#{label}","version":1,
           "access":{
             "access":"#{access}",
@@ -60,7 +57,7 @@ RSpec.describe 'Create object' do
             "useAndReproductionStatement":"Property rights reside with the repository..."
           },
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567","partOfProject":"Google Books"},
-          "description":{"title":[{"value":"#{title}"}],"purl":"https://purl.stanford.edu/gg777gg7777","access":{"digitalRepository":[{"value":"Stanford Digital Repository"}]}},
+          "description":{"title":[{"value":"#{title}"}]},
           "identification":#{identification.to_json},
           "structural":#{structural.to_json}}
       JSON
@@ -255,9 +252,7 @@ RSpec.describe 'Create object' do
       context 'when descriptive roundtrip validation fails' do
         let(:changed_description) do
           {
-            title: [{ value: 'changed title' }],
-            purl: 'https://purl.stanford.edu/gg777gg7777',
-            access: { digitalRepository: [{ value: 'Stanford Digital Repository' }] }
+            title: [{ value: 'changed title' }]
           }
         end
 
@@ -599,12 +594,7 @@ RSpec.describe 'Create object' do
                               },
                               description: {
                                 title: [{ value: title }],
-                                purl: 'https://purl.stanford.edu/gg777gg7777',
-                                access: {
-                                  digitalRepository: [
-                                    { value: 'Stanford Digital Repository' }
-                                  ]
-                                }
+                                purl: 'https://purl.stanford.edu/gg777gg7777'
                               },
                               administrative: {
                                 hasAdminPolicy: 'druid:dd999df4567'
@@ -616,7 +606,9 @@ RSpec.describe 'Create object' do
 
     let(:data) do
       <<~JSON
-        { "type":"http://cocina.sul.stanford.edu/models/image.jsonld",
+        {#{' '}
+          "cocinaVersion":"0.1.0",
+          "type":"http://cocina.sul.stanford.edu/models/image.jsonld",
           "label":"#{label}","version":1,
           "access":{
             "access":"world",
@@ -625,7 +617,7 @@ RSpec.describe 'Create object' do
             "useAndReproductionStatement":"Property rights reside with the repository..."
           },
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
-          "description":{"title":[{"value":"#{title}"}],"purl":"https://purl.stanford.edu/gg777gg7777","access":{"digitalRepository":[{"value":"Stanford Digital Repository"}]}},
+          "description":{"title":[{"value":"#{title}"}]},
           "identification":{"sourceId":"googlebooks:999999"}}
       JSON
     end
@@ -740,12 +732,7 @@ RSpec.describe 'Create object' do
                               version: 1,
                               description: {
                                 title: [{ value: title }],
-                                purl: 'https://purl.stanford.edu/gg777gg7777',
-                                access: {
-                                  digitalRepository: [
-                                    { value: 'Stanford Digital Repository' }
-                                  ]
-                                }
+                                purl: 'https://purl.stanford.edu/gg777gg7777'
                               },
                               administrative: {
                                 hasAdminPolicy: 'druid:dd999df4567'
@@ -764,7 +751,9 @@ RSpec.describe 'Create object' do
     end
     let(:data) do
       <<~JSON
-        { "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
+        {#{' '}
+          "cocinaVersion":"0.1.0",
+          "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
           "label":"#{label}","version":1,"access":{"access":"world","download":"world"},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
           "description":{"title":[{"value":"#{title}"}]},
@@ -794,12 +783,7 @@ RSpec.describe 'Create object' do
                                       version: 1,
                                       description: {
                                         title: [{ value: 'This is my title' }],
-                                        purl: 'https://purl.stanford.edu/gg777gg7777',
-                                        access: {
-                                          digitalRepository: [
-                                            { value: 'Stanford Digital Repository' }
-                                          ]
-                                        }
+                                        purl: 'https://purl.stanford.edu/gg777gg7777'
                                       },
                                       administrative: {
                                         defaultObjectRights: expected_default_object_rights,
@@ -825,7 +809,8 @@ RSpec.describe 'Create object' do
                                               }
                                             ]
                                           }
-                                        ]
+                                        ],
+                                        hasAgreement: 'druid:bc753qt7345'
                                       },
                                       externalIdentifier: druid)
     end
@@ -885,7 +870,9 @@ RSpec.describe 'Create object' do
 
     let(:data) do
       <<~JSON
-        {"type":"http://cocina.sul.stanford.edu/models/admin_policy.jsonld",
+        {
+          "cocinaVersion":"0.1.0",
+          "type":"http://cocina.sul.stanford.edu/models/admin_policy.jsonld",
           "label":"This is my label","version":1,
           "administrative":{
             "defaultObjectRights":#{default_object_rights.to_json},
@@ -901,9 +888,10 @@ RSpec.describe 'Create object' do
             "registrationWorkflow":["goobiWF","registrationWF"],
             "collectionsForRegistration":["druid:gg888df4567","druid:bb888gg4444"],
             "hasAdminPolicy":"druid:dd999df4567",
+            "hasAgreement":"druid:bc753qt7345",
             "roles":[{"name":"dor-apo-manager","members":[{"type":"workgroup","identifier":"sdr:psm-staff"}]}]
           },
-          "description":{"title":[{"value":"This is my title"}],"purl":"https://purl.stanford.edu/gg777gg7777","access":{"digitalRepository":[{"value":"Stanford Digital Repository"}]}}}
+          "description":{"title":[{"value":"This is my title"}]}}
       JSON
     end
 
@@ -918,7 +906,6 @@ RSpec.describe 'Create object' do
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
         expect(response.body).to equal_cocina_model(expected)
-
         expect(response.status).to eq(201)
         expect(response.location).to eq "/v1/objects/#{druid}"
       end
@@ -954,12 +941,7 @@ RSpec.describe 'Create object' do
                                       version: 1,
                                       description: {
                                         title: [{ value: 'Hydrus' }],
-                                        purl: 'https://purl.stanford.edu/gg777gg7777',
-                                        access: {
-                                          digitalRepository: [
-                                            { value: 'Stanford Digital Repository' }
-                                          ]
-                                        }
+                                        purl: 'https://purl.stanford.edu/gg777gg7777'
                                       },
                                       administrative: {
                                         defaultObjectRights: default_object_rights,
@@ -968,7 +950,8 @@ RSpec.describe 'Create object' do
                                           download: 'world'
                                         },
                                         hasAdminPolicy: 'druid:dd999df4567',
-                                        roles: []
+                                        roles: [],
+                                        hasAgreement: 'druid:bc753qt7345'
                                       },
                                       externalIdentifier: druid)
     end
@@ -977,11 +960,14 @@ RSpec.describe 'Create object' do
 
     let(:data) do
       <<~JSON
-        {"type":"http://cocina.sul.stanford.edu/models/admin_policy.jsonld",
+        {
+          "cocinaVersion":"0.1.0",
+          "type":"http://cocina.sul.stanford.edu/models/admin_policy.jsonld",
           "label":"Hydrus","version":1,
           "administrative":{
             "defaultObjectRights":#{default_object_rights.to_json},
-            "hasAdminPolicy":"druid:dd999df4567"}
+            "hasAdminPolicy":"druid:dd999df4567",
+            "hasAgreement":"druid:bc753qt7345"}
           }
       JSON
     end
@@ -1011,12 +997,7 @@ RSpec.describe 'Create object' do
                               version: 1,
                               description: {
                                 title: [{ value: 'This is my title' }],
-                                purl: 'https://purl.stanford.edu/gg777gg7777',
-                                access: {
-                                  digitalRepository: [
-                                    { value: 'Stanford Digital Repository' }
-                                  ]
-                                }
+                                purl: 'https://purl.stanford.edu/gg777gg7777'
                               },
                               administrative: {
                                 hasAdminPolicy: 'druid:dd999df4567'
@@ -1037,11 +1018,13 @@ RSpec.describe 'Create object' do
     end
     let(:data) do
       <<~JSON
-        { "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
+        {#{' '}
+          "cocinaVersion":"0.1.0",
+          "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
           "label":"This is my label","version":1,"access":{"access":"stanford","download":"none","controlledDigitalLending":false,
           "embargo":{"access":"world","download":"world","releaseDate":"2020-02-29"}},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
-          "description":{"title":[{"value":"This is my title"}],"purl":"https://purl.stanford.edu/gg777gg7777","access":{"digitalRepository":[{"value":"Stanford Digital Repository"}]}},
+          "description":{"title":[{"value":"This is my title"}]},
           "identification":{"sourceId":"googlebooks:999999"},
           "structural":{"hasMemberOrders":[{"viewingDirection":"right-to-left"}]}}
       JSON
@@ -1068,12 +1051,7 @@ RSpec.describe 'Create object' do
                               version: 1,
                               description: {
                                 title: [{ value: 'This is my title' }],
-                                purl: 'https://purl.stanford.edu/gg777gg7777',
-                                access: {
-                                  digitalRepository: [
-                                    { value: 'Stanford Digital Repository' }
-                                  ]
-                                }
+                                purl: 'https://purl.stanford.edu/gg777gg7777'
                               },
                               administrative: {
                                 hasAdminPolicy: 'druid:dd999df4567'
@@ -1093,11 +1071,14 @@ RSpec.describe 'Create object' do
     end
     let(:data) do
       <<~JSON
-        { "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
+        {#{' '}
+          "cocinaVersion":"0.1.0",
+          "cocinaVersion":"0.1.0",
+          "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
           "label":"This is my label","version":1,
           "access":{"access":"location-based","download":"location-based","readLocation":"m&m"},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
-          "description":{"title":[{"value":"This is my title"}],"purl":"https://purl.stanford.edu/gg777gg7777","access":{"digitalRepository":[{"value":"Stanford Digital Repository"}]}},
+          "description":{"title":[{"value":"This is my title"}]},
           "identification":{"sourceId":"googlebooks:999999"},
           "structural":{"hasMemberOrders":[{"viewingDirection":"right-to-left"}]}}
       JSON
@@ -1124,12 +1105,7 @@ RSpec.describe 'Create object' do
                               version: 1,
                               description: {
                                 title: [{ value: 'This is my title' }],
-                                purl: 'https://purl.stanford.edu/gg777gg7777',
-                                access: {
-                                  digitalRepository: [
-                                    { value: 'Stanford Digital Repository' }
-                                  ]
-                                }
+                                purl: 'https://purl.stanford.edu/gg777gg7777'
                               },
                               administrative: {
                                 hasAdminPolicy: 'druid:dd999df4567'
@@ -1148,11 +1124,13 @@ RSpec.describe 'Create object' do
     end
     let(:data) do
       <<~JSON
-        { "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
+        {#{' '}
+          "cocinaVersion":"0.1.0",
+          "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
           "label":"This is my label","version":1,
           "access":{"access":"world","download":"none"},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
-          "description":{"title":[{"value":"This is my title"}],"purl":"https://purl.stanford.edu/gg777gg7777","access":{"digitalRepository":[{"value":"Stanford Digital Repository"}]}},
+          "description":{"title":[{"value":"This is my title"}]},
           "identification":{"sourceId":"googlebooks:999999"},
           "structural":{"hasMemberOrders":[{"viewingDirection":"right-to-left"}]}}
       JSON
@@ -1188,12 +1166,7 @@ RSpec.describe 'Create object' do
                                   title: [
                                     { value: 'This is my label' }
                                   ],
-                                  purl: 'https://purl.stanford.edu/gg777gg7777',
-                                  access: {
-                                    digitalRepository: [
-                                      { value: 'Stanford Digital Repository' }
-                                    ]
-                                  }
+                                  purl: 'https://purl.stanford.edu/gg777gg7777'
                                 },
                                 identification: { sourceId: 'googlebooks:999999' },
                                 externalIdentifier: 'druid:gg777gg7777',
@@ -1202,7 +1175,9 @@ RSpec.describe 'Create object' do
       end
       let(:data) do
         <<~JSON
-          { "type":"http://cocina.sul.stanford.edu/models/object.jsonld",
+          {#{' '}
+            "cocinaVersion":"0.1.0",
+            "type":"http://cocina.sul.stanford.edu/models/object.jsonld",
             "label":"This is my label","version":1,"access":{},
             "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
             "identification":{"sourceId":"googlebooks:999999"},
@@ -1230,12 +1205,7 @@ RSpec.describe 'Create object' do
                                   title: [
                                     { value: 'This is my label' }
                                   ],
-                                  purl: 'https://purl.stanford.edu/gg777gg7777',
-                                  access: {
-                                    digitalRepository: [
-                                      { value: 'Stanford Digital Repository' }
-                                    ]
-                                  }
+                                  purl: 'https://purl.stanford.edu/gg777gg7777'
                                 },
                                 identification: { sourceId: 'googlebooks:999999' },
                                 externalIdentifier: 'druid:gg777gg7777',
@@ -1244,7 +1214,9 @@ RSpec.describe 'Create object' do
       end
       let(:data) do
         <<~JSON
-          { "type":"http://cocina.sul.stanford.edu/models/object.jsonld",
+          {#{' '}
+            "cocinaVersion":"0.1.0",
+            "type":"http://cocina.sul.stanford.edu/models/object.jsonld",
             "label":"This is my label","version":1,"access":{},
             "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
             "identification":{"sourceId":"googlebooks:999999"}}
@@ -1280,18 +1252,15 @@ RSpec.describe 'Create object' do
                                   title: [
                                     { value: 'This is my label' }
                                   ],
-                                  purl: 'https://purl.stanford.edu/gg777gg7777',
-                                  access: {
-                                    digitalRepository: [
-                                      { value: 'Stanford Digital Repository' }
-                                    ]
-                                  }
+                                  purl: 'https://purl.stanford.edu/gg777gg7777'
                                 })
       end
 
       let(:data) do
         <<~JSON
-          { "type":"http://cocina.sul.stanford.edu/models/object.jsonld",
+          {#{' '}
+            "cocinaVersion":"0.1.0",
+            "type":"http://cocina.sul.stanford.edu/models/object.jsonld",
             "label":"This is my label","version":1,
             "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
             "identification":{"sourceId":"googlebooks:999999"},
@@ -1348,12 +1317,7 @@ RSpec.describe 'Create object' do
                                 title: [
                                   { value: 'This is my label' }
                                 ],
-                                purl: 'https://purl.stanford.edu/gg777gg7777',
-                                access: {
-                                  digitalRepository: [
-                                    { value: 'Stanford Digital Repository' }
-                                  ]
-                                }
+                                purl: 'https://purl.stanford.edu/gg777gg7777'
                               },
                               identification: { sourceId: 'warc:999999' },
                               externalIdentifier: 'druid:gg777gg7777',
@@ -1362,7 +1326,9 @@ RSpec.describe 'Create object' do
     end
     let(:data) do
       <<~JSON
-        { "type":"http://cocina.sul.stanford.edu/models/webarchive-binary.jsonld",
+        {#{' '}
+          "cocinaVersion":"0.1.0",
+          "type":"http://cocina.sul.stanford.edu/models/webarchive-binary.jsonld",
           "label":"This is my label","version":1,"access":{},
           "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
           "identification":{"sourceId":"warc:999999"},
@@ -1396,12 +1362,7 @@ RSpec.describe 'Create object' do
                                 title: [
                                   { value: 'This is my label' }
                                 ],
-                                purl: 'https://purl.stanford.edu/gg777gg7777',
-                                access: {
-                                  digitalRepository: [
-                                    { value: 'Stanford Digital Repository' }
-                                  ]
-                                }
+                                purl: 'https://purl.stanford.edu/gg777gg7777'
                               },
                               identification: { sourceId: 'warc:999999' },
                               externalIdentifier: 'druid:gg777gg7777',
@@ -1410,7 +1371,9 @@ RSpec.describe 'Create object' do
     end
     let(:data) do
       <<~JSON
-        { "type":"http://cocina.sul.stanford.edu/models/object.jsonld",
+        {#{' '}
+          "cocinaVersion":"0.1.0",
+          "type":"http://cocina.sul.stanford.edu/models/object.jsonld",
           "label":"This is my label","version":1,"access":{},
           "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
           "identification":{"sourceId":"warc:999999"},

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -43,12 +43,7 @@ RSpec.describe 'Get the object' do
               title: [
                 { value: 'Hello' }
               ],
-              purl: 'https://purl.stanford.edu/bc123df4567',
-              access: {
-                digitalRepository: [
-                  { value: 'Stanford Digital Repository' }
-                ]
-              }
+              purl: 'https://purl.stanford.edu/bc123df4567'
             },
             identification: {
               sourceId: 'src:99999'
@@ -117,12 +112,7 @@ RSpec.describe 'Get the object' do
               title: [
                 { value: 'Hello' }
               ],
-              purl: 'https://purl.stanford.edu/bc123df4567',
-              access: {
-                digitalRepository: [
-                  { value: 'Stanford Digital Repository' }
-                ]
-              }
+              purl: 'https://purl.stanford.edu/bc123df4567'
             },
             identification: {
               sourceId: 'src:99999'
@@ -168,12 +158,7 @@ RSpec.describe 'Get the object' do
                                     title: [
                                       { value: 'Hello' }
                                     ],
-                                    purl: 'https://purl.stanford.edu/bc123df4567',
-                                    access: {
-                                      digitalRepository: [
-                                        { value: 'Stanford Digital Repository' }
-                                      ]
-                                    }
+                                    purl: 'https://purl.stanford.edu/bc123df4567'
                                   },
                                   identification: {
                                     sourceId: 'src:99999'
@@ -263,12 +248,7 @@ RSpec.describe 'Get the object' do
                                     title: [
                                       { value: 'Hello' }
                                     ],
-                                    purl: 'https://purl.stanford.edu/bc123df4567',
-                                    access: {
-                                      digitalRepository: [
-                                        { value: 'Stanford Digital Repository' }
-                                      ]
-                                    }
+                                    purl: 'https://purl.stanford.edu/bc123df4567'
                                   },
                                   identification: {
                                     sourceId: 'src:99999'
@@ -424,12 +404,7 @@ RSpec.describe 'Get the object' do
           title: [
             { value: 'Hello' }
           ],
-          purl: 'https://purl.stanford.edu/bc123df4567',
-          access: {
-            digitalRepository: [
-              { value: 'Stanford Digital Repository' }
-            ]
-          }
+          purl: 'https://purl.stanford.edu/bc123df4567'
         }
       )
     end
@@ -449,6 +424,7 @@ RSpec.describe 'Get the object' do
       before do
         object.descMetadata.title_info.main_title = 'Hello'
         object.label = 'foo'
+        object.agreement_object_id = 'druid:bb008zm4587'
       end
 
       it 'returns the object' do
@@ -501,6 +477,7 @@ RSpec.describe 'Get the object' do
         XML
         object.descMetadata.title_info.main_title = 'Hello'
         object.label = 'foo'
+        object.agreement_object_id = 'druid:bb008zm4587'
       end
 
       it 'returns the object' do

--- a/spec/requests/update_doi_metadata_spec.rb
+++ b/spec/requests/update_doi_metadata_spec.rb
@@ -7,89 +7,90 @@ RSpec.describe 'Update DOI metadata' do
   let(:object) { Dor::Item.new(pid: druid) }
 
   let(:cocina_item) do
-    Cocina::Models.build(
-      'externalIdentifier' => 'druid:bc123df4567',
-      'type' => Cocina::Models::Vocab.image,
-      'version' => 1,
-      'label' => 'testing',
-      'access' => {},
-      'administrative' => {
-        'hasAdminPolicy' => 'druid:xx123xx4567'
-      },
-      'description' => {
-        'title' => [{ 'value' => 'Test obj' }],
-        'subject' => [{ 'type' => 'topic', 'value' => 'word' }],
-        contributor: [
-          {
-            name: [
-              {
-                structuredValue: [
-                  {
-                    value: 'Jane',
-                    type: 'forename'
-                  },
-                  {
-                    value: 'Stanford',
-                    type: 'surname'
-                  }
-                ]
-              }
-            ],
-            type: 'person'
-          }
-        ],
-        form: [
-          {
-            structuredValue: [
-              {
-                value: 'Data',
-                type: 'type'
-              }
-            ],
-            source: {
-              value: 'Stanford self-deposit resource types'
-            },
-            type: 'resource type'
-          },
-          {
-            value: 'Dataset',
-            type: 'resource type',
-            uri: 'http://id.loc.gov/vocabulary/resourceTypes/dat',
-            source: {
-              uri: 'http://id.loc.gov/vocabulary/resourceTypes/'
-            }
-          },
-          {
-            value: 'Data sets',
-            type: 'genre',
-            uri: 'https://id.loc.gov/authorities/genreForms/gf2018026119',
-            source: {
-              code: 'lcgft'
-            }
-          },
-          {
-            value: 'dataset',
-            type: 'genre',
-            source: {
-              code: 'local'
-            }
-          },
-          {
-            value: 'Dataset',
-            type: 'resource type',
-            source: {
-              value: 'DataCite resource types'
-            }
-          }
-        ]
-      },
-      'structural' => {
-        'contains' => []
-      },
-      'identification' => {
-        'doi' => '10.80343/bc123df4567'
-      }
-    )
+    Cocina::Models.build({
+                           externalIdentifier: 'druid:bc123df4567',
+                           'type' => Cocina::Models::Vocab.image,
+                           version: 1,
+                           label: 'testing',
+                           access: {},
+                           administrative: {
+                             hasAdminPolicy: 'druid:xx123xx4567'
+                           },
+                           description: {
+                             title: [{ value: 'Test obj' }],
+                             purl: 'https://purl.stanford.edu/bc123df4567',
+                             subject: [{ type: 'topic', value: 'word' }],
+                             contributor: [
+                               {
+                                 name: [
+                                   {
+                                     structuredValue: [
+                                       {
+                                         value: 'Jane',
+                                         type: 'forename'
+                                       },
+                                       {
+                                         value: 'Stanford',
+                                         type: 'surname'
+                                       }
+                                     ]
+                                   }
+                                 ],
+                                 type: 'person'
+                               }
+                             ],
+                             form: [
+                               {
+                                 structuredValue: [
+                                   {
+                                     value: 'Data',
+                                     type: 'type'
+                                   }
+                                 ],
+                                 source: {
+                                   value: 'Stanford self-deposit resource types'
+                                 },
+                                 type: 'resource type'
+                               },
+                               {
+                                 value: 'Dataset',
+                                 type: 'resource type',
+                                 uri: 'http://id.loc.gov/vocabulary/resourceTypes/dat',
+                                 source: {
+                                   uri: 'http://id.loc.gov/vocabulary/resourceTypes/'
+                                 }
+                               },
+                               {
+                                 value: 'Data sets',
+                                 type: 'genre',
+                                 uri: 'https://id.loc.gov/authorities/genreForms/gf2018026119',
+                                 source: {
+                                   code: 'lcgft'
+                                 }
+                               },
+                               {
+                                 value: 'dataset',
+                                 type: 'genre',
+                                 source: {
+                                   code: 'local'
+                                 }
+                               },
+                               {
+                                 value: 'Dataset',
+                                 type: 'resource type',
+                                 source: {
+                                   value: 'DataCite resource types'
+                                 }
+                               }
+                             ]
+                           },
+                           structural: {
+                             contains: []
+                           },
+                           identification: {
+                             doi: '10.80343/bc123df4567'
+                           }
+                         })
   end
 
   before do
@@ -124,6 +125,7 @@ RSpec.describe 'Update DOI metadata' do
           },
           'description' => {
             'title' => [{ 'value' => 'Test obj' }],
+            'purl' => 'https://purl.stanford.edu/bc123df4567',
             'subject' => [{ 'type' => 'topic', 'value' => 'word' }]
           },
           'structural' => {

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -68,15 +68,7 @@ RSpec.describe 'Update object' do
                               copyright: 'All rights reserved unless otherwise indicated.',
                               useAndReproductionStatement: 'Property rights reside with the repository...'
                             }.merge(cocina_access.to_h),
-                            description: {
-                              title: [{ value: title }],
-                              purl: 'https://purl.stanford.edu/gg777gg7777',
-                              access: {
-                                digitalRepository: [
-                                  { value: 'Stanford Digital Repository' }
-                                ]
-                              }
-                            },
+                            description: description,
                             administrative: {
                               hasAdminPolicy: apo_druid,
                               partOfProject: 'Google Books'
@@ -86,12 +78,16 @@ RSpec.describe 'Update object' do
   end
 
   let(:description) do
-    { title: [{ value: title }] }
+    {
+      title: [{ value: title }],
+      purl: 'https://purl.stanford.edu/gg777gg7777'
+    }
   end
 
   let(:data) do
     <<~JSON
       {
+        "cocinaVersion": "0.0.1",
         "externalIdentifier": "#{druid}",
         "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
         "label":"#{label}","version":1,
@@ -146,12 +142,7 @@ RSpec.describe 'Update object' do
           { type: 'preferred citation', value: 'test citation' },
           { displayLabel: 'Contact', type: 'email', value: 'io@io.io' }
         ],
-        purl: 'https://purl.stanford.edu/gg777gg7777',
-        access: {
-          digitalRepository: [
-            { value: 'Stanford Digital Repository' }
-          ]
-        }
+        purl: 'https://purl.stanford.edu/gg777gg7777'
       }
     end
 
@@ -227,7 +218,8 @@ RSpec.describe 'Update object' do
               { value: '4', type: 'nonsorting character count' }
             ]
           }
-        ]
+        ],
+        purl: 'https://purl.stanford.edu/gg777gg7777'
       }
     end
 
@@ -294,12 +286,7 @@ RSpec.describe 'Update object' do
                                     ]
                                   }
                                 ],
-                                purl: 'https://purl.stanford.edu/gg777gg7777',
-                                access: {
-                                  digitalRepository: [
-                                    { value: 'Stanford Digital Repository' }
-                                  ]
-                                }
+                                purl: 'https://purl.stanford.edu/gg777gg7777'
                               },
                               administrative: {
                                 hasAdminPolicy: apo_druid,
@@ -311,6 +298,7 @@ RSpec.describe 'Update object' do
     let(:data) do
       <<~JSON
         {
+          "cocinaVersion": "0.0.1",
           "externalIdentifier": "#{druid}",
           "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
           "label":"#{label}","version":1,
@@ -321,7 +309,10 @@ RSpec.describe 'Update object' do
             "useAndReproductionStatement":"Property rights reside with the repository..."
           },
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567","partOfProject":"Google Books"},
-          "description":{"title":[{"structuredValue":[{"value":"#{title}","type":"main title"},{"value":"(repeat)","type":"subtitle"}]}]},
+          "description":{
+            "title":[{"structuredValue":[{"value":"#{title}","type":"main title"},{"value":"(repeat)","type":"subtitle"}]}],
+            "purl":"https://purl.stanford.edu/gg777gg7777"
+          },
           "identification":#{identification.to_json},
           "structural":{
             "hasMemberOrders":[{"viewingDirection":"right-to-left"}],
@@ -505,12 +496,7 @@ RSpec.describe 'Update object' do
                               },
                               description: {
                                 title: [{ value: title }],
-                                purl: 'https://purl.stanford.edu/gg777gg7777',
-                                access: {
-                                  digitalRepository: [
-                                    { value: 'Stanford Digital Repository' }
-                                  ]
-                                }
+                                purl: 'https://purl.stanford.edu/gg777gg7777'
                               },
                               administrative: {
                                 hasAdminPolicy: 'druid:dd999df4567',
@@ -522,6 +508,7 @@ RSpec.describe 'Update object' do
     let(:data) do
       <<~JSON
         {
+          "cocinaVersion": "0.0.1",
           "externalIdentifier": "#{druid}",
           "type":"http://cocina.sul.stanford.edu/models/image.jsonld",
           "label":"#{expected_label}","version":1,
@@ -532,7 +519,10 @@ RSpec.describe 'Update object' do
             "useAndReproductionStatement":"Property rights reside with the repository..."
           },
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567","partOfProject":"Google Books"},
-          "description":{"title":[{"value":"#{title}"}]},
+          "description":{
+            "title":[{"value":"#{title}"}],
+            "purl":"https://purl.stanford.edu/gg777gg7777"
+          },
           "identification":#{identification.to_json},
           "structural":{
             "isMemberOf":["druid:xx888xx7777"]
@@ -705,6 +695,7 @@ RSpec.describe 'Update object' do
       let(:data) do
         <<~JSON
           {
+            "cocinaVersion": "0.0.1",
             "externalIdentifier": "#{druid}",
             "type":"http://cocina.sul.stanford.edu/models/image.jsonld",
             "label":"#{label}","version":1,
@@ -715,7 +706,10 @@ RSpec.describe 'Update object' do
               "useAndReproductionStatement":"Property rights reside with the repository..."
             },
             "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567","partOfProject":"Google Books"},
-            "description":{"title":[{"value":"#{title}"}]},
+            "description":{
+              "title":[{"value":"#{title}"}],
+              "purl":"https://purl.stanford.edu/gg777gg7777"
+            },
             "identification":#{identification.to_json},"structural":{"contains":#{filesets.to_json}}}
         JSON
       end
@@ -826,6 +820,7 @@ RSpec.describe 'Update object' do
       let(:data) do
         <<~JSON
           {
+            "cocinaVersion":"0.0.1",
             "externalIdentifier": "#{druid}",
             "type":"http://cocina.sul.stanford.edu/models/image.jsonld",
             "label":"#{label}","version":1,
@@ -836,7 +831,10 @@ RSpec.describe 'Update object' do
               "useAndReproductionStatement":"Property rights reside with the repository..."
             },
             "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567","partOfProject":"Google Books"},
-            "description":{"title":[{"value":"#{title}"}]},
+            "description":{
+              "title":[{"value":"#{title}"}],
+              "purl":"https://purl.stanford.edu/gg777gg7777"
+            },
             "identification":#{identification.to_json},
             "structural":{"isMemberOf":["druid:xx888xx7777"]}}
         JSON
@@ -861,12 +859,7 @@ RSpec.describe 'Update object' do
                               version: 1,
                               description: {
                                 title: [{ value: title }],
-                                purl: 'https://purl.stanford.edu/gg777gg7777',
-                                access: {
-                                  digitalRepository: [
-                                    { value: 'Stanford Digital Repository' }
-                                  ]
-                                }
+                                purl: 'https://purl.stanford.edu/gg777gg7777'
                               },
                               administrative: {
                                 hasAdminPolicy: 'druid:dd999df4567'
@@ -884,6 +877,7 @@ RSpec.describe 'Update object' do
     let(:data) do
       <<~JSON
         {
+          "cocinaVersion": "0.0.1",
           "externalIdentifier": "#{druid}",
           "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
           "label":"#{label}","version":1,
@@ -892,7 +886,10 @@ RSpec.describe 'Update object' do
             "download":"world"
           },
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
-          "description":{"title":[{"value":"#{title}"}]},
+          "description":{
+            "title":[{"value":"#{title}"}],
+            "purl":"https://purl.stanford.edu/gg777gg7777"
+          },
           "identification":{"sourceId":"googlebooks:999999"},
           "structural":{
             "hasMemberOrders":[{"viewingDirection":"right-to-left"}],
@@ -932,12 +929,7 @@ RSpec.describe 'Update object' do
                                      version: 1,
                                      description: {
                                        title: [{ value: title }],
-                                       purl: 'https://purl.stanford.edu/gg777gg7777',
-                                       access: {
-                                         digitalRepository: [
-                                           { value: 'Stanford Digital Repository' }
-                                         ]
-                                       }
+                                       purl: 'https://purl.stanford.edu/gg777gg7777'
                                      },
                                      identification: identification,
                                      administrative: {
@@ -957,13 +949,18 @@ RSpec.describe 'Update object' do
     let(:data) do
       <<~JSON
         {
+          "cocinaVersion": "0.0.1",
           "externalIdentifier": "#{druid}",
           "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
           "label":"#{label}","version":1,
           "access":{},
           "identification":#{identification.to_json},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
-          "description":{"title":[{"value":"#{title}"}]}}
+          "description":{
+            "title":[{"value":"#{title}"}],
+            "purl":"https://purl.stanford.edu/gg777gg7777"
+          }
+        }
       JSON
     end
 
@@ -1022,18 +1019,13 @@ RSpec.describe 'Update object' do
                                       version: 1,
                                       description: {
                                         title: [{ value: 'This is my title' }],
-                                        purl: 'https://purl.stanford.edu/gg777gg7777',
-                                        access: {
-                                          digitalRepository: [
-                                            { value: 'Stanford Digital Repository' }
-                                          ]
-                                        }
+                                        purl: 'https://purl.stanford.edu/gg777gg7777'
                                       },
                                       administrative: {
                                         defaultObjectRights: default_object_rights_expected,
                                         defaultAccess: default_access_expected,
                                         hasAdminPolicy: 'druid:dd999df4567',
-                                        referencesAgreement: 'druid:bc123df4567',
+                                        hasAgreement: 'druid:bc123df4567',
                                         disseminationWorkflow: 'assemblyWF',
                                         registrationWorkflow: %w[goobiWF registrationWF],
                                         collectionsForRegistration: ['druid:gg888df4567', 'druid:bb888gg4444'],
@@ -1068,6 +1060,7 @@ RSpec.describe 'Update object' do
     let(:data) do
       <<~JSON
         {
+          "cocinaVersion": "0.0.1",
           "externalIdentifier": "#{druid}",
           "type":"http://cocina.sul.stanford.edu/models/admin_policy.jsonld",
           "label":"This is my label","version":1,
@@ -1077,11 +1070,15 @@ RSpec.describe 'Update object' do
             "registrationWorkflow":["goobiWF","registrationWF"],
             "collectionsForRegistration":["druid:gg888df4567","druid:bb888gg4444"],
             "hasAdminPolicy":"druid:dd999df4567",
-            "referencesAgreement":"druid:bc123df4567",
+            "hasAgreement":"druid:bc123df4567",
             "defaultAccess":#{default_access.to_json},
             "roles":[{"name":"dor-apo-manager","members":[{"type":"workgroup","identifier":"sdr:psm-staff"}]}]
           },
-          "description":{"title":[{"value":"This is my title"}]}}
+          "description":{
+            "title":[{"value":"This is my title"}],
+            "purl":"https://purl.stanford.edu/gg777gg7777"
+          }
+        }
       JSON
     end
 
@@ -1089,6 +1086,7 @@ RSpec.describe 'Update object' do
       before do
         # This stubs out Solr:
         allow(item).to receive(:admin_policy_object_id).and_return('druid:dd999df4567')
+        allow(item).to receive(:agreement_object_id).and_return('druid:bc123df4567')
       end
 
       it 'registers the object with the registration service' do
@@ -1096,7 +1094,6 @@ RSpec.describe 'Update object' do
               params: data,
               headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
         expect(response.body).to equal_cocina_model(expected)
-
         expect(response.status).to eq(200)
       end
     end
@@ -1137,6 +1134,7 @@ RSpec.describe 'Update object' do
       before do
         # This stubs out Solr:
         allow(item).to receive(:admin_policy_object_id).and_return('druid:dd999df4567')
+        allow(item).to receive(:agreement_object_id).and_return('druid:bc123df4567')
       end
 
       it 'updates the metadata' do
@@ -1157,12 +1155,7 @@ RSpec.describe 'Update object' do
                               version: 1,
                               description: {
                                 title: [{ value: 'This is my title' }],
-                                purl: 'https://purl.stanford.edu/gg777gg7777',
-                                access: {
-                                  digitalRepository: [
-                                    { value: 'Stanford Digital Repository' }
-                                  ]
-                                }
+                                purl: 'https://purl.stanford.edu/gg777gg7777'
                               },
                               administrative: {
                                 hasAdminPolicy: 'druid:dd999df4567'
@@ -1188,6 +1181,7 @@ RSpec.describe 'Update object' do
     let(:data) do
       <<~JSON
         {
+          "cocinaVersion": "0.0.1",
           "externalIdentifier": "#{druid}",
           "type":"http://cocina.sul.stanford.edu/models/book.jsonld",
           "label":"This is my label","version":1,
@@ -1195,7 +1189,10 @@ RSpec.describe 'Update object' do
             "embargo":{"access":"world","download":"world","releaseDate":"2020-02-29"}
           },
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
-          "description":{"title":[{"value":"This is my title"}]},
+          "description":{
+            "title":[{"value":"This is my title"}],
+            "purl":"https://purl.stanford.edu/gg777gg7777"
+          },
           "identification":{"sourceId":"googlebooks:999999"},
           "structural":{"hasMemberOrders":[{"viewingDirection":"right-to-left"}]}}
       JSON

--- a/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
       end
 
       it 'parses' do
-        expect { Cocina::Models::Description.new(title: build) }.not_to raise_error
+        expect { Cocina::Models::Description.new(title: build, purl: 'https://purl.stanford.edu/aa666bb1234') }.not_to raise_error
       end
 
       it 'ignores and warns' do
@@ -121,7 +121,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
       end
 
       it 'parses' do
-        expect { Cocina::Models::Description.new(title: build) }.not_to raise_error
+        expect { Cocina::Models::Description.new(title: build, purl: 'https://purl.stanford.edu/aa666bb1234') }.not_to raise_error
       end
 
       it 'ignores and warns' do
@@ -146,7 +146,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
       end
 
       it 'parses' do
-        expect { Cocina::Models::Description.new(title: build) }.not_to raise_error
+        expect { Cocina::Models::Description.new(title: build, purl: 'https://purl.stanford.edu/aa666bb1234') }.not_to raise_error
       end
 
       it 'creates model' do
@@ -180,7 +180,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
       end
 
       it 'parses' do
-        expect { Cocina::Models::Description.new(title: build) }.not_to raise_error
+        expect { Cocina::Models::Description.new(title: build, purl: 'https://purl.stanford.edu/aa666bb1234') }.not_to raise_error
       end
 
       it 'creates model' do
@@ -219,7 +219,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
       end
 
       it 'parses' do
-        expect { Cocina::Models::Description.new(title: build) }.not_to raise_error
+        expect { Cocina::Models::Description.new(title: build, purl: 'https://purl.stanford.edu/aa666bb1234') }.not_to raise_error
       end
 
       it 'creates value from the authority record' do
@@ -296,7 +296,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
       end
 
       it 'parses' do
-        expect { Cocina::Models::Description.new(title: build) }.not_to raise_error
+        expect { Cocina::Models::Description.new(title: build, purl: 'https://purl.stanford.edu/aa666bb1234') }.not_to raise_error
       end
 
       it 'creates value from the authority record' do
@@ -345,7 +345,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
       end
 
       it 'parses' do
-        expect { Cocina::Models::Description.new(title: build) }.not_to raise_error
+        expect { Cocina::Models::Description.new(title: build, purl: 'https://purl.stanford.edu/aa666bb1234') }.not_to raise_error
       end
 
       it 'creates value from the authority record and warns' do
@@ -386,7 +386,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
       end
 
       it 'parses' do
-        expect { Cocina::Models::Description.new(title: build) }.not_to raise_error
+        expect { Cocina::Models::Description.new(title: build, purl: 'https://purl.stanford.edu/aa666bb1234') }.not_to raise_error
       end
 
       it 'creates simple values' do

--- a/spec/services/cocina/mapping/administrative/apo_administrative_spec.rb
+++ b/spec/services/cocina/mapping/administrative/apo_administrative_spec.rb
@@ -38,14 +38,7 @@ RSpec.shared_examples 'valid APO mappings' do
       label: apo_label,
       version: 1,
       description: {
-        purl: "#{Settings.release.purl_base_url}/apo_druid",
-        access: {
-          digitalRepository: [
-            {
-              value: 'Stanford Digital Repository'
-            }
-          ]
-        }
+        purl: "#{Settings.release.purl_base_url}/apo_druid"
       }
     }
   end
@@ -65,7 +58,7 @@ RSpec.shared_examples 'valid APO mappings' do
     let(:roundtrip_fedora_apo) do
       Dor::AdminPolicyObject.new(pid: actual_cocina_props[:externalIdentifier],
                                  admin_policy_object_id: actual_cocina_apo_admin.hasAdminPolicy,
-                                 agreement_object_id: actual_cocina_apo_admin.referencesAgreement,
+                                 agreement_object_id: actual_cocina_apo_admin.hasAgreement,
                                  label: actual_cocina_props[:label])
     end
 
@@ -237,7 +230,7 @@ RSpec.describe 'APO administrative mappings' do
             'druid:ny719df8518'
           ],
           hasAdminPolicy: ur_apo_druid,
-          referencesAgreement: agreement_druid,
+          hasAgreement: agreement_druid,
           roles: [
             {
               name: 'dor-apo-manager',
@@ -321,7 +314,7 @@ RSpec.describe 'APO administrative mappings' do
             'druid:bp350ns9783'
           ],
           hasAdminPolicy: ur_apo_druid,
-          referencesAgreement: 'druid:wn586st0695',
+          hasAgreement: 'druid:wn586st0695',
           roles: [
             {
               name: 'dor-apo-manager',
@@ -412,7 +405,7 @@ RSpec.describe 'APO administrative mappings' do
             'druid:ns135jb1096'
           ],
           hasAdminPolicy: ur_apo_druid,
-          referencesAgreement: 'druid:zh747vq3919',
+          hasAgreement: 'druid:zh747vq3919',
           roles: [
             {
               name: 'dor-apo-manager',
@@ -534,7 +527,7 @@ RSpec.describe 'APO administrative mappings' do
             'registrationWF'
           ],
           hasAdminPolicy: ur_apo_druid,
-          referencesAgreement: agreement_druid,
+          hasAgreement: agreement_druid,
           roles: [
             {
               name: 'dor-apo-manager',
@@ -683,7 +676,7 @@ RSpec.describe 'APO administrative mappings' do
             'registrationWF'
           ],
           hasAdminPolicy: ur_apo_druid,
-          referencesAgreement: agreement_druid,
+          hasAgreement: agreement_druid,
           roles: [
             {
               name: 'hydrus-collection-manager',

--- a/spec/services/cocina/mapping/descriptive/h2/related_item_h2_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2/related_item_h2_spec.rb
@@ -140,14 +140,7 @@ RSpec.describe 'Cocina --> MODS mappings for relatedItem' do
                   value: 'Software Carpentry Workshop recordings from August 14, 2014'
                 }
               ],
-              purl:	'https://purl.stanford.edu/tx853fp2857',
-              access: {
-                digitalRepository: [
-                  {
-                    value: 'Stanford Digital Repository'
-                  }
-                ]
-              }
+              purl:	'https://purl.stanford.edu/tx853fp2857'
             }
           ]
         }

--- a/spec/services/cocina/mapping/descriptive/h2_datacite/contributor_h2_datacite_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2_datacite/contributor_h2_datacite_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Cocina --> DataCite contributor mappings (H2 specific)' do
   ## Do not map to DataCite contributors.name
   ## Instead map to DataCite fundingReference.funderName
 
-  let(:cocina_description) { Cocina::Models::Description.new(cocina, false, false) }
+  let(:cocina_description) { Cocina::Models::Description.new(cocina.merge(purl: Purl.for(druid: 'druid:bb423sd6663')), false, false) }
   let(:attributes) { Cocina::ToDatacite::CreatorContributorFunder.attributes(cocina_description) }
   let(:creator_attributes) { attributes[:creators] }
   let(:contributor_attributes) { attributes[:contributors] }

--- a/spec/services/cocina/mapping/descriptive/h2_datacite/creators_h2_datacite_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2_datacite/creators_h2_datacite_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Cocina --> DataCite creator mappings (H2 specific)' do
   # Full role mapping: https://docs.google.com/spreadsheets/d/1CvEd_NODprNhM2D9VfvJBFs1jfAMEUr0kDxXHe2HkL4/edit?usp=sharing
   # H2 Authors to include in citation
 
-  let(:cocina_description) { Cocina::Models::Description.new(cocina, false, false) }
+  let(:cocina_description) { Cocina::Models::Description.new(cocina.merge(purl: Purl.for(druid: 'druid:bb423sd6663')), false, false) }
   let(:attributes) { Cocina::ToDatacite::CreatorContributorFunder.attributes(cocina_description)[:creators] }
 
   describe 'Cited contributor with author role' do

--- a/spec/services/cocina/mapping/descriptive/h2_datacite/form_h2_datacite_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2_datacite/form_h2_datacite_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Cocina --> DataCite mappings for form (H2 specific)' do
   # If no H2 subtype, map H2 type to resourceType
 
   # NOTE: Because we haven't set a title in this Cocina::Models::Description, it will not validate against the openapi.
-  let(:cocina_description) { Cocina::Models::Description.new(cocina, false, false) }
+  let(:cocina_description) { Cocina::Models::Description.new(cocina.merge(purl: Purl.for(druid: 'druid:bb423sd6663')), false, false) }
   let(:type_attributes) { Cocina::ToDatacite::Form.type_attributes(cocina_description) }
 
   describe 'type only (no subtype)' do

--- a/spec/services/cocina/mapping/descriptive/h2_datacite/identifiers_h2_datacite_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2_datacite/identifiers_h2_datacite_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Cocina --> DataCite mappings for identifier and alternateIdentifier (H2 specific)' do
   # NOTE: Because we haven't set a title in this Cocina::Models::Description, it will not validate against the openapi.
-  let(:cocina_description) { Cocina::Models::Description.new(cocina, false, false) }
+  let(:cocina_description) { Cocina::Models::Description.new(cocina.merge(purl: cocina.fetch(:purl, 'https://purl.stanford.edu/aa666bb1234')), false, false) }
   let(:identifier_attributes) { Cocina::ToDatacite::Identifier.identifier_attributes(cocina_description) }
   let(:alternate_identifier_attributes) { Cocina::ToDatacite::Identifier.alternate_identifier_attributes(cocina_description) }
 
@@ -86,31 +86,6 @@ RSpec.describe 'Cocina --> DataCite mappings for identifier and alternateIdentif
 
     it 'identifier_attributes is nil' do
       expect(identifier_attributes).to eq nil
-    end
-  end
-
-  # NOTE: purl in cocina-model openapi is a String of format uri, so it cannot be nil
-
-  context 'when cocina purl is empty string' do
-    let(:cocina) do
-      {
-        purl: ''
-      }
-    end
-
-    it 'alternate_identifier_attributes is nil' do
-      expect(alternate_identifier_attributes).to eq nil
-    end
-  end
-
-  context 'when cocina has no purl' do
-    let(:cocina) do
-      {
-      }
-    end
-
-    it 'alternate_identifier_attributes is nil' do
-      expect(alternate_identifier_attributes).to eq nil
     end
   end
 end

--- a/spec/services/cocina/mapping/descriptive/h2_datacite/note_h2_datacite_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2_datacite/note_h2_datacite_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Cocina --> DataCite mappings for note' do
   # NOTE: Because we haven't set a title in this Cocina::Models::Description, it will not validate against the openapi.
-  let(:cocina_description) { Cocina::Models::Description.new(cocina, false, false) }
+  let(:cocina_description) { Cocina::Models::Description.new(cocina.merge(purl: cocina.fetch(:purl, 'https://purl.stanford.edu/aa666bb1234')), false, false) }
   let(:descriptions_attributes) { Cocina::ToDatacite::Note.descriptions_attributes(cocina_description) }
 
   describe 'Abstract' do

--- a/spec/services/cocina/mapping/descriptive/h2_datacite/related_resource_h2_datacite_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2_datacite/related_resource_h2_datacite_spec.rb
@@ -8,7 +8,7 @@ require 'rails_helper'
 # relatedItem attribute new in DataCite MetadataKerne schema v. 4.4 and not included in the DataCite ReST API docs as of 2021-07
 RSpec.describe 'Cocina --> DataCite mappings for relatedItem' do
   # NOTE: Because we haven't set a title in this Cocina::Models::Description, it will not validate against the openapi.
-  let(:cocina_description) { Cocina::Models::Description.new(cocina, false, false) }
+  let(:cocina_description) { Cocina::Models::Description.new(cocina.merge(purl: cocina.fetch(:purl, 'https://purl.stanford.edu/aa666bb1234')), false, false) }
   let(:related_item_attributes) { Cocina::ToDatacite::RelatedResource.related_item_attributes(cocina_description) }
 
   describe 'Related citation' do

--- a/spec/services/cocina/mapping/descriptive/h2_datacite/subject_h2_datacite_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2_datacite/subject_h2_datacite_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Cocina --> DataCite mappings for FAST subjects' do
   # NOTE: Because we haven't set a title in this Cocina::Models::Description, it will not validate against the openapi.
-  let(:cocina_description) { Cocina::Models::Description.new(cocina, false, false) }
+  let(:cocina_description) { Cocina::Models::Description.new(cocina.merge(purl: cocina.fetch(:purl, 'https://purl.stanford.edu/aa666bb1234')), false, false) }
   let(:subjects_attributes) { Cocina::ToDatacite::Subject.subjects_attributes(cocina_description) }
 
   describe 'FAST topic' do

--- a/spec/services/cocina/mapping/descriptive/h2_datacite/title_h2_datacite_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/h2_datacite/title_h2_datacite_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Cocina --> DataCite mappings for title (H2 specific)' do
   # Note that this instantiation of Cocina::Models::Description does NOT validate against OpenAPI due to missing title.
-  let(:cocina_description) { Cocina::Models::Description.new(cocina, false, false) }
+  let(:cocina_description) { Cocina::Models::Description.new(cocina.merge(purl: Purl.for(druid: 'druid:bb423sd6663')), false, false) }
   let(:title_attributes) { Cocina::ToDatacite::Title.title_attributes(cocina_description) }
 
   describe 'Resource title' do

--- a/spec/services/cocina/mapping/descriptive/mods/geo_extension_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/geo_extension_spec.rb
@@ -87,14 +87,7 @@ RSpec.describe 'MODS geo extension <--> cocina mappings' do
               ]
             }
           ],
-          purl: 'https://purl.stanford.edu/kk138ps4721',
-          access: {
-            digitalRepository: [
-              {
-                value: 'Stanford Digital Repository'
-              }
-            ]
-          }
+          purl: 'https://purl.stanford.edu/kk138ps4721'
         }
       end
     end
@@ -174,14 +167,7 @@ RSpec.describe 'MODS geo extension <--> cocina mappings' do
               ]
             }
           ],
-          purl: 'https://purl.stanford.edu/cw222pt0426',
-          access: {
-            digitalRepository: [
-              {
-                value: 'Stanford Digital Repository'
-              }
-            ]
-          }
+          purl: 'https://purl.stanford.edu/cw222pt0426'
         }
       end
     end
@@ -274,14 +260,7 @@ RSpec.describe 'MODS geo extension <--> cocina mappings' do
               ]
             }
           ],
-          purl: 'https://purl.stanford.edu/xy581jd9710',
-          access: {
-            digitalRepository: [
-              {
-                value: 'Stanford Digital Repository'
-              }
-            ]
-          }
+          purl: 'https://purl.stanford.edu/xy581jd9710'
         }
       end
     end
@@ -365,14 +344,7 @@ RSpec.describe 'MODS geo extension <--> cocina mappings' do
               ]
             }
           ],
-          purl: 'https://purl.stanford.edu/gq515vq0921',
-          access: {
-            digitalRepository: [
-              {
-                value: 'Stanford Digital Repository'
-              }
-            ]
-          }
+          purl: 'https://purl.stanford.edu/gq515vq0921'
         }
       end
     end
@@ -456,14 +428,7 @@ RSpec.describe 'MODS geo extension <--> cocina mappings' do
               ]
             }
           ],
-          purl: 'https://purl.stanford.edu/nr717dp9096',
-          access: {
-            digitalRepository: [
-              {
-                value: 'Stanford Digital Repository'
-              }
-            ]
-          }
+          purl: 'https://purl.stanford.edu/nr717dp9096'
         }
       end
     end
@@ -547,14 +512,7 @@ RSpec.describe 'MODS geo extension <--> cocina mappings' do
               ]
             }
           ],
-          purl: 'https://purl.stanford.edu/zz581px0362',
-          access: {
-            digitalRepository: [
-              {
-                value: 'Stanford Digital Repository'
-              }
-            ]
-          }
+          purl: 'https://purl.stanford.edu/zz581px0362'
         }
       end
     end
@@ -686,14 +644,7 @@ RSpec.describe 'MODS geo extension <--> cocina mappings' do
               ]
             }
           ],
-          purl: 'https://purl.stanford.edu/zg154pd4168',
-          access: {
-            digitalRepository: [
-              {
-                value: 'Stanford Digital Repository'
-              }
-            ]
-          }
+          purl: 'https://purl.stanford.edu/zg154pd4168'
         }
       end
     end

--- a/spec/services/cocina/mapping/descriptive/mods/location_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/location_spec.rb
@@ -199,12 +199,7 @@ RSpec.describe 'MODS location <--> cocina mappings' do
 
       let(:cocina) do
         {
-          purl: 'https://purl.stanford.edu/ys701qw6956',
-          access: {
-            digitalRepository: [
-              value: 'Stanford Digital Repository'
-            ]
-          }
+          purl: 'https://purl.stanford.edu/ys701qw6956'
         }
       end
     end
@@ -233,12 +228,7 @@ RSpec.describe 'MODS location <--> cocina mappings' do
 
       let(:cocina) do
         {
-          purl: 'https://purl.stanford.edu/ys701qw6956',
-          access: {
-            digitalRepository: [
-              value: 'Stanford Digital Repository'
-            ]
-          }
+          purl: 'https://purl.stanford.edu/ys701qw6956'
         }
       end
     end
@@ -296,9 +286,6 @@ RSpec.describe 'MODS location <--> cocina mappings' do
                 value: 'https://swap.stanford.edu/20171107174354/https://www.le.ac.uk/english/em1060to1220/index.html',
                 displayLabel: 'Archived website'
               }
-            ],
-            digitalRepository: [
-              value: 'Stanford Digital Repository'
             ]
           }
         }
@@ -489,9 +476,6 @@ RSpec.describe 'MODS location <--> cocina mappings' do
                 value: 'VICTOR\PLUS_PHOTOS_DAN\PLUS_TARD_PHOTOS_DAN_20071017\IMG_0852.JPG',
                 type: 'discovery'
               }
-            ],
-            digitalRepository: [
-              value: 'Stanford Digital Repository'
             ]
           }
         }
@@ -626,9 +610,6 @@ RSpec.describe 'MODS location <--> cocina mappings' do
               {
                 value: 'Stanford University Libraries'
               }
-            ],
-            digitalRepository: [
-              value: 'Stanford Digital Repository'
             ]
           }
         }
@@ -732,9 +713,6 @@ RSpec.describe 'MODS location <--> cocina mappings' do
                   }
                 ]
               }
-            ],
-            digitalRepository: [
-              value: 'Stanford Digital Repository'
             ]
           }
         }
@@ -793,9 +771,6 @@ RSpec.describe 'MODS location <--> cocina mappings' do
                   }
                 ]
               }
-            ],
-            digitalRepository: [
-              value: 'Stanford Digital Repository'
             ]
           },
           relatedResource: [
@@ -820,9 +795,6 @@ RSpec.describe 'MODS location <--> cocina mappings' do
                       }
                     ]
                   }
-                ],
-                digitalRepository: [
-                  value: 'Stanford Digital Repository'
                 ]
               }
             }
@@ -876,11 +848,6 @@ RSpec.describe 'MODS location <--> cocina mappings' do
       let(:cocina) do
         {
           purl: 'https://purl.stanford.edu/bq367mn3764',
-          access: {
-            digitalRepository: [
-              value: 'Stanford Digital Repository'
-            ]
-          },
           relatedResource: [
             {
               purl: 'https://purl.stanford.edu/cj288sh2297',
@@ -895,9 +862,6 @@ RSpec.describe 'MODS location <--> cocina mappings' do
                       }
                     ]
                   }
-                ],
-                digitalRepository: [
-                  value: 'Stanford Digital Repository'
                 ]
               }
             },
@@ -914,9 +878,6 @@ RSpec.describe 'MODS location <--> cocina mappings' do
                       }
                     ]
                   }
-                ],
-                digitalRepository: [
-                  value: 'Stanford Digital Repository'
                 ]
               }
             },
@@ -933,9 +894,6 @@ RSpec.describe 'MODS location <--> cocina mappings' do
                       }
                     ]
                   }
-                ],
-                digitalRepository: [
-                  value: 'Stanford Digital Repository'
                 ]
               }
             }
@@ -989,11 +947,6 @@ RSpec.describe 'MODS location <--> cocina mappings' do
         {
           purl: 'https://purl.stanford.edu/gr134wb6457',
           access: {
-            digitalRepository: [
-              {
-                value: 'Stanford Digital Repository'
-              }
-            ],
             url: [
               {
                 value: 'http://clerk.assembly.ca.gov/archive-list',
@@ -1016,9 +969,6 @@ RSpec.describe 'MODS location <--> cocina mappings' do
                       }
                     ]
                   }
-                ],
-                digitalRepository: [
-                  value: 'Stanford Digital Repository'
                 ]
               }
             },
@@ -1035,9 +985,6 @@ RSpec.describe 'MODS location <--> cocina mappings' do
                       }
                     ]
                   }
-                ],
-                digitalRepository: [
-                  value: 'Stanford Digital Repository'
                 ]
               }
             }

--- a/spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb
@@ -146,15 +146,7 @@ RSpec.describe 'MODS relatedItem <--> cocina mappings' do
         {
           relatedResource: [
             {
-              purl: 'https://purl.stanford.edu/ng599nr9959',
-              access: {
-
-                digitalRepository: [
-                  {
-                    value: 'Stanford Digital Repository'
-                  }
-                ]
-              }
+              purl: 'https://purl.stanford.edu/ng599nr9959'
             }
           ]
         }

--- a/spec/services/cocina/mapping/identification/agreement_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/agreement_identity_spec.rb
@@ -188,14 +188,7 @@ RSpec.describe 'Fedora Agreement Object identityMetadata <--> Cocina Identificat
       title: [
         value: 'agreement title'
       ],
-      purl: "https://purl.stanford.edu/#{agreement_id.split(':').last}",
-      access: {
-        digitalRepository: [
-          {
-            value: 'Stanford Digital Repository'
-          }
-        ]
-      }
+      purl: "https://purl.stanford.edu/#{agreement_id.split(':').last}"
     }
   end
 

--- a/spec/services/cocina/mapping/identification/apo_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/apo_identity_spec.rb
@@ -71,7 +71,7 @@ RSpec.shared_examples 'APO Identification Fedora Cocina mapping' do
     let(:mapped_fedora_apo) do
       Dor::AdminPolicyObject.new(pid: mapped_cocina_props[:externalIdentifier],
                                  admin_policy_object_id: mapped_cocina_props[:administrative][:hasAdminPolicy],
-                                 agreement_object_id: mapped_cocina_props[:administrative][:referencesAgreement],
+                                 agreement_object_id: mapped_cocina_props[:administrative][:hasAgreement],
                                  # source_id: cocina_admin_policy.identification.sourceId,
                                  label: mapped_cocina_props[:label])
     end
@@ -97,7 +97,7 @@ RSpec.shared_examples 'APO Identification Fedora Cocina mapping' do
                       label: mapped_cocina_props[:label],
                       current_version: '1',
                       admin_policy_object_id: mapped_cocina_props[:administrative][:hasAdminPolicy],
-                      agreement_object_id: mapped_cocina_props[:administrative][:referencesAgreement],
+                      agreement_object_id: mapped_cocina_props[:administrative][:hasAgreement],
                       identityMetadata: Dor::IdentityMetadataDS.from_xml(identity_metadata_xml),
                       descMetadata: instance_double(Dor::DescMetadataDS, ng_xml: mods_ng_xml),
                       defaultObjectRights: instance_double(Dor::DefaultObjectRightsDS, content: default_object_rights_xml),
@@ -149,18 +149,11 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
       title: [
         value: 'APO title'
       ],
-      purl: "https://purl.stanford.edu/#{pid.split(':').last}",
-      access: {
-        digitalRepository: [
-          {
-            value: 'Stanford Digital Repository'
-          }
-        ]
-      }
+      purl: "https://purl.stanford.edu/#{pid.split(':').last}"
     }
   end
 
-  context 'without adminPolicy, without referencesAgreement in identityMetadata.xml (in RELS_EXT)' do
+  context 'without adminPolicy, without hasAgreement in identityMetadata.xml (in RELS_EXT)' do
     it_behaves_like 'APO Identification Fedora Cocina mapping' do
       let(:pid) { 'druid:zd878cf9993' }
       let(:label) { 'Fondo Lanciani' }
@@ -199,7 +192,7 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
           version: 1,
           administrative: {
             hasAdminPolicy: admin_policy_id,
-            referencesAgreement: agreement_object_id,
+            hasAgreement: agreement_object_id,
             defaultAccess: default_access_props,
             defaultObjectRights: default_object_rights_xml,
             roles: []
@@ -250,7 +243,7 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
           version: 1,
           administrative: {
             hasAdminPolicy: admin_policy_id,
-            referencesAgreement: agreement_object_id,
+            hasAgreement: agreement_object_id,
             defaultAccess: default_access_props,
             defaultObjectRights: default_object_rights_xml,
             roles: []
@@ -304,7 +297,7 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
           version: 1,
           administrative: {
             hasAdminPolicy: admin_policy_id,
-            referencesAgreement: agreement_object_id,
+            hasAgreement: agreement_object_id,
             defaultAccess: default_access_props,
             defaultObjectRights: default_object_rights_xml,
             roles: []

--- a/spec/services/cocina/mapping/identification/collection_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/collection_identity_spec.rb
@@ -163,14 +163,7 @@ RSpec.describe 'Fedora Collection identityMetadata <--> Cocina Collection Identi
       title: [
         value: 'collection title'
       ],
-      purl: "https://purl.stanford.edu/#{collection_id.split(':').last}",
-      access: {
-        digitalRepository: [
-          {
-            value: 'Stanford Digital Repository'
-          }
-        ]
-      }
+      purl: "https://purl.stanford.edu/#{collection_id.split(':').last}"
     }
   end
 

--- a/spec/services/cocina/mapping/identification/dro_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/dro_identity_spec.rb
@@ -206,14 +206,7 @@ RSpec.describe 'Fedora Item identityMetadata <--> Cocina DRO Identification mapp
       title: [
         value: 'item title'
       ],
-      purl: "https://purl.stanford.edu/#{item_id.split(':').last}",
-      access: {
-        digitalRepository: [
-          {
-            value: 'Stanford Digital Repository'
-          }
-        ]
-      }
+      purl: "https://purl.stanford.edu/#{item_id.split(':').last}"
     }
   end
 

--- a/spec/services/cocina/object_updater_spec.rb
+++ b/spec/services/cocina/object_updater_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe Cocina::ObjectUpdater do
         externalIdentifier: 'druid:bc123df4567',
         label: 'orig label',
         version: 1,
-        administrative: { hasAdminPolicy: 'druid:dd999df4567' },
-        description: { title: [{ value: 'orig title' }] }
+        administrative: { hasAdminPolicy: 'druid:dd999df4567', hasAgreement: 'druid:jt959wc5586' },
+        description: { title: [{ value: 'orig title' }], purl: 'https://purl.stanford.edu/bc123df4567' }
       }
     end
 
@@ -94,7 +94,7 @@ RSpec.describe Cocina::ObjectUpdater do
       context 'when description has changed' do
         let(:cocina_attrs) do
           orig_cocina_attrs.tap do |attrs|
-            attrs[:description] = { title: [{ value: 'new title' }] }
+            attrs[:description] = { title: [{ value: 'new title' }], purl: 'https://purl.stanford.edu/bc123df4567' }
           end
         end
 
@@ -134,7 +134,7 @@ RSpec.describe Cocina::ObjectUpdater do
         it 'updates administrative' do
           update
           expect(item).to have_received(:admin_policy_object_id=).with('druid:dd999df4567')
-          expect(item).to have_received(:agreement_object_id=).with(nil) # nil is legitimate
+          expect(item).to have_received(:agreement_object_id=).with('druid:jt959wc5586')
           expect(Cocina::ToFedora::AdministrativeMetadata).to have_received(:write)
           expect(Cocina::ToFedora::Roles).to have_received(:write)
         end
@@ -213,7 +213,7 @@ RSpec.describe Cocina::ObjectUpdater do
       context 'when description has changed' do
         let(:cocina_attrs) do
           orig_cocina_attrs.tap do |attrs|
-            attrs[:description] = { title: [{ value: 'new title' }] }
+            attrs[:description] = { title: [{ value: 'new title' }], purl: 'https://purl.stanford.edu/bc123df4567' }
           end
         end
 
@@ -352,7 +352,7 @@ RSpec.describe Cocina::ObjectUpdater do
       context 'when description has changed' do
         let(:cocina_attrs) do
           orig_cocina_attrs.tap do |attrs|
-            attrs[:description] = { title: [{ value: 'new title' }] }
+            attrs[:description] = { title: [{ value: 'new title' }], purl: 'https://purl.stanford.edu/bc123df4567' }
           end
         end
 

--- a/spec/services/cocina/serializer_spec.rb
+++ b/spec/services/cocina/serializer_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe Cocina::Serializer do
         'description' => {
           'title' => [
             { 'value' => 'SUL Logo for golden_wonder_millet' }
-          ]
+          ],
+          'purl' => 'https://purl.stanford.edu/ft609gr4031'
         },
         'structural' => {
           'contains' => [
@@ -65,11 +66,90 @@ RSpec.describe Cocina::Serializer do
     )
   end
 
-  # rubocop:disable Layout/LineLength
   let(:json) do
-    '{"type":"http://cocina.sul.stanford.edu/models/object.jsonld","externalIdentifier":"druid:ft609gr4031","label":"SUL Logo for golden_wonder_millet","version":1,"access":{"access":"citation-only","download":"none","embargo":{"access":"world","download":"world","releaseDate":"2022-02-25T00:00:00.000+00:00"},"useAndReproductionStatement":"User agrees that, where applicable, content will not be used.","license":"https://creativecommons.org/publicdomain/zero/1.0/legalcode"},"administrative":{"hasAdminPolicy":"druid:zw306xn5593","releaseTags":[],"partOfProject":"H2"},"description":{"title":[{"structuredValue":[],"parallelValue":[],"groupedValue":[],"value":"SUL Logo for golden_wonder_millet","identifier":[],"note":[],"appliesTo":[]}],"contributor":[],"event":[],"form":[],"geographic":[],"language":[],"note":[],"identifier":[],"subject":[],"relatedResource":[],"marcEncodedData":[]},"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/resources/file.jsonld","externalIdentifier":"http://cocina.sul.stanford.edu/fileSet/e4c2b834-90ce-4be8-b9fa-445df89f5f10","label":"","version":1,"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld","externalIdentifier":"http://cocina.sul.stanford.edu/file/8ee2d21b-9183-4df6-9813-c0a104b329ce","label":"sul-logo.png","filename":"sul-logo.png","size":19823,"version":1,"hasMimeType":"image/png","hasMessageDigests":[{"type":"sha1","digest":"b5f3221455c8994afb85214576bc2905d6b15418"},{"type":"md5","digest":"7142ce948827c16120cc9e19b05acd49"}],"access":{"access":"world","download":"world"},"administrative":{"publish":true,"sdrPreserve":true,"shelve":true}}]}}],"hasMemberOrders":[],"isMemberOf":[]}}'
+    {
+      cocinaVersion: Cocina::Models::VERSION,
+      type: 'http://cocina.sul.stanford.edu/models/object.jsonld',
+      externalIdentifier: 'druid:ft609gr4031',
+      label: 'SUL Logo for golden_wonder_millet',
+      version: 1,
+      access: {
+        access: 'citation-only',
+        download: 'none',
+        embargo: {
+          access: 'world',
+          download: 'world',
+          releaseDate: '2022-02-25T00:00:00.000+00:00'
+        },
+        useAndReproductionStatement: 'User agrees that, where applicable, content will not be used.',
+        license: 'https://creativecommons.org/publicdomain/zero/1.0/legalcode'
+      },
+      administrative: {
+        hasAdminPolicy: 'druid:zw306xn5593',
+        releaseTags: [],
+        partOfProject: 'H2'
+      },
+      description: {
+        title: [{
+          structuredValue: [],
+          parallelValue: [],
+          groupedValue: [],
+          value: 'SUL Logo for golden_wonder_millet',
+          identifier: [],
+          note: [],
+          appliesTo: []
+        }],
+        contributor: [],
+        event: [],
+        form: [],
+        geographic: [],
+        language: [],
+        note: [],
+        identifier: [],
+        subject: [],
+        relatedResource: [],
+        marcEncodedData: [],
+        purl: 'https://purl.stanford.edu/ft609gr4031'
+      },
+      structural: {
+        contains: [{
+          type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+          externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/e4c2b834-90ce-4be8-b9fa-445df89f5f10',
+          label: '',
+          version: 1,
+          structural: {
+            contains: [{
+              type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+              externalIdentifier: 'http://cocina.sul.stanford.edu/file/8ee2d21b-9183-4df6-9813-c0a104b329ce',
+              label: 'sul-logo.png',
+              filename: 'sul-logo.png',
+              size: 19823,
+              version: 1,
+              hasMimeType: 'image/png',
+              hasMessageDigests: [{
+                type: 'sha1',
+                digest: 'b5f3221455c8994afb85214576bc2905d6b15418'
+              }, {
+                type: 'md5',
+                digest: '7142ce948827c16120cc9e19b05acd49'
+              }],
+              access: {
+                access: 'world',
+                download: 'world'
+              },
+              administrative: {
+                publish: true,
+                sdrPreserve: true,
+                shelve: true
+              }
+            }]
+          }
+        }],
+        hasMemberOrders: [],
+        isMemberOf: []
+      }
+    }.to_json
   end
-  # rubocop:enable Layout/LineLength
 
   describe '.serialize?' do
     it 'serializes DROs' do

--- a/spec/services/cocina/to_datacite/attributes_spec.rb
+++ b/spec/services/cocina/to_datacite/attributes_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Cocina::ToDatacite::Attributes do
                               label: label,
                               version: 1,
                               description: {
-                                title: [{ value: title }]
+                                title: [{ value: title }],
+                                purl: purl
                               },
                               identification: {
                                 sourceId: 'sul:8.559351',
@@ -46,7 +47,13 @@ RSpec.describe Cocina::ToDatacite::Attributes do
           dates: [],
           publicationYear: '2011',
           publisher: 'Stanford Digital Repository',
-          titles: [{ title: title }]
+          titles: [{ title: title }],
+          alternateIdentifiers: [
+            {
+              alternateIdentifier: purl,
+              alternateIdentifierType: 'PURL'
+            }
+          ]
         }
       )
     end
@@ -59,7 +66,8 @@ RSpec.describe Cocina::ToDatacite::Attributes do
                               label: label,
                               version: 1,
                               description: {
-                                title: [{ value: title }]
+                                title: [{ value: title }],
+                                purl: purl
                               },
                               identification: {
                                 sourceId: 'sul:8.559351',
@@ -86,7 +94,13 @@ RSpec.describe Cocina::ToDatacite::Attributes do
           dates: [],
           publicationYear: '2031',
           publisher: 'Stanford Digital Repository',
-          titles: [{ title: title }]
+          titles: [{ title: title }],
+          alternateIdentifiers: [
+            {
+              alternateIdentifier: purl,
+              alternateIdentifierType: 'PURL'
+            }
+          ]
         }
       )
     end
@@ -354,7 +368,8 @@ RSpec.describe Cocina::ToDatacite::Attributes do
                                      label: label,
                                      version: 1,
                                      description: {
-                                       title: [{ value: title }]
+                                       title: [{ value: title }],
+                                       purl: purl
                                      },
                                      identification: {},
                                      access: {},
@@ -375,10 +390,13 @@ RSpec.describe Cocina::ToDatacite::Attributes do
                                       label: label,
                                       version: 1,
                                       description: {
-                                        title: [{ value: title }]
+                                        title: [{ value: title }],
+                                        purl: purl
                                       },
                                       administrative: {
-                                        hasAdminPolicy: apo_druid
+                                        hasAdminPolicy: apo_druid,
+                                        hasAgreement: 'druid:bb423sd6663'
+
                                       })
     end
 

--- a/spec/services/cocina/to_datacite/event_dates_spec.rb
+++ b/spec/services/cocina/to_datacite/event_dates_spec.rb
@@ -6,6 +6,7 @@ require 'rails_helper'
 RSpec.describe Cocina::ToDatacite::Event do
   let(:cocina_description) do
     cocina[:title] = [{ value: 'title' }]
+    cocina[:purl] = 'https://purl.stanford.edu/zg154pd4168'
     Cocina::Models::Description.new(cocina)
   end
   let(:cocina_item) do

--- a/spec/services/cocina/to_datacite/event_pub_year_spec.rb
+++ b/spec/services/cocina/to_datacite/event_pub_year_spec.rb
@@ -6,6 +6,7 @@ require 'rails_helper'
 RSpec.describe Cocina::ToDatacite::Event do
   let(:cocina_description) do
     cocina[:title] = [{ value: 'title' }]
+    cocina[:purl] = 'https://purl.stanford.edu/zg154pd4168'
     Cocina::Models::Description.new(cocina)
   end
   let(:cocina_item) do

--- a/spec/services/cocina/to_fedora/administrative_metadata_spec.rb
+++ b/spec/services/cocina/to_fedora/administrative_metadata_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Cocina::ToFedora::AdministrativeMetadata do
       hasAdminPolicy: 'druid:bc123df4567',
       registrationWorkflow: ['registrationWF', 'assemblyWF'],
       disseminationWorkflow: 'wasWF',
-      collectionsForRegistration: ['druid:pp562fx0548', 'druid:qy781dy0220']
+      collectionsForRegistration: ['druid:pp562fx0548', 'druid:qy781dy0220'],
+      hasAgreement: 'druid:bb423sd6663'
     )
   end
 

--- a/spec/services/cocina/to_fedora/content_metadata_generator_spec.rb
+++ b/spec/services/cocina/to_fedora/content_metadata_generator_spec.rb
@@ -688,7 +688,10 @@ RSpec.describe Cocina::ToFedora::ContentMetadataGenerator do
           "type":"#{object_type}",
           "label":"The object label","version":1,"access":{},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
-          "description":{"title":[{"status":"primary","value":"the object title"}]},
+          "description":{
+            "title":[{"status":"primary","value":"the object title"}],
+            "purl":"https://purl.stanford.edu/bc123df5678"
+          },
           "identification":{"sourceId":"sul:9999999"},
           "structural":#{structural.to_json}}
       JSON

--- a/spec/services/cocina/to_fedora/descriptive_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Cocina::ToFedora::Descriptive do
       Cocina::Models::Description.new(
         title: [
           { value: 'Gaudy night' }
-        ]
+        ],
+        purl: 'https://purl.stanford.edu/aa666bb1234'
       )
     end
 
@@ -23,6 +24,9 @@ RSpec.describe Cocina::ToFedora::Descriptive do
           <titleInfo>
             <title>Gaudy night</title>
           </titleInfo>
+          <location>
+            <url usage="primary display">https://purl.stanford.edu/aa666bb1234</url>
+          </location>
         </mods>
       XML
     end
@@ -35,6 +39,7 @@ RSpec.describe Cocina::ToFedora::Descriptive do
         title: [
           { value: 'Gaudy night' }
         ],
+        purl: 'https://purl.stanford.edu/aa666bb1234',
         note: [
           {
             value: 'This is an abstract.',
@@ -92,6 +97,9 @@ RSpec.describe Cocina::ToFedora::Descriptive do
           <originInfo eventType="creation">
             <dateCreated>1980</dateCreated>
           </originInfo>
+          <location>
+            <url usage="primary display">https://purl.stanford.edu/aa666bb1234</url>
+          </location>
         </mods>
       XML
     end
@@ -104,6 +112,7 @@ RSpec.describe Cocina::ToFedora::Descriptive do
         title: [
           { value: 'Gaudy night' }
         ],
+        purl: 'https://purl.stanford.edu/aa666bb1234',
         adminMetadata: {
           note: [
             {
@@ -117,16 +126,19 @@ RSpec.describe Cocina::ToFedora::Descriptive do
 
     it 'builds the xml' do
       expect(xml).to be_equivalent_to <<~XML
-        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns="http://www.loc.gov/mods/v3" version="3.7"
-          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
-          <titleInfo>
-            <title>Gaudy night</title>
-          </titleInfo>
-          <recordInfo>
-           <recordOrigin>Converted from MARCXML to MODS version 3.7 using MARC21slim2MODS3-7_SDR_v1.xsl (SUL 3.7 version 1.1 20200917; LC Revision 1.140 20200717)</recordOrigin>
-         </recordInfo>
-        </mods>
+         <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://www.loc.gov/mods/v3" version="3.7"
+           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
+           <titleInfo>
+             <title>Gaudy night</title>
+           </titleInfo>
+           <recordInfo>
+            <recordOrigin>Converted from MARCXML to MODS version 3.7 using MARC21slim2MODS3-7_SDR_v1.xsl (SUL 3.7 version 1.1 20200917; LC Revision 1.140 20200717)</recordOrigin>
+          </recordInfo>
+          <location>
+          <url usage="primary display">https://purl.stanford.edu/aa666bb1234</url>
+        </location>
+         </mods>
       XML
     end
   end

--- a/spec/services/notifications/embargo_lifted_spec.rb
+++ b/spec/services/notifications/embargo_lifted_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe Notifications::EmbargoLifted do
     let(:model) do
       Cocina::Models::AdminPolicy.new(externalIdentifier: 'druid:bc123dg9393',
                                       administrative: {
-                                        hasAdminPolicy: 'druid:gg123vx9393'
+                                        hasAdminPolicy: 'druid:gg123vx9393',
+                                        hasAgreement: 'druid:bb008zm4587'
                                       },
                                       version: 1,
                                       label: 'just an apo',

--- a/spec/services/notifications/object_created_spec.rb
+++ b/spec/services/notifications/object_created_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe Notifications::ObjectCreated do
     let(:model) do
       Cocina::Models::AdminPolicy.new(externalIdentifier: 'druid:bc123dg9393',
                                       administrative: {
-                                        hasAdminPolicy: 'druid:gg123vx9393'
+                                        hasAdminPolicy: 'druid:gg123vx9393',
+                                        hasAgreement: 'druid:bb008zm4587'
                                       },
                                       version: 1,
                                       label: 'just an apo',

--- a/spec/services/notifications/object_updated_spec.rb
+++ b/spec/services/notifications/object_updated_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe Notifications::ObjectUpdated do
     let(:model) do
       Cocina::Models::AdminPolicy.new(externalIdentifier: 'druid:bc123dg9393',
                                       administrative: {
-                                        hasAdminPolicy: 'druid:gg123vx9393'
+                                        hasAdminPolicy: 'druid:gg123vx9393',
+                                        hasAgreement: 'druid:bb008zm4587'
                                       },
                                       version: 1,
                                       label: 'just an apo',

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Publish::MetadataTransferService do
 
       context 'with an item' do
         before do
-          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/{"type"/, 'cocina.json')
+          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/{"cocinaVersion"/, 'cocina.json')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<publicObject/, 'public')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<mods:mods/, 'mods')
           expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(no_args)
@@ -147,7 +147,7 @@ RSpec.describe Publish::MetadataTransferService do
         end
 
         before do
-          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/{"type"/, 'cocina.json')
+          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/{"cocinaVersion"/, 'cocina.json')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<publicObject/, 'public')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<mods:mods/, 'mods')
           expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(no_args)

--- a/spec/services/refresh_metadata_action_spec.rb
+++ b/spec/services/refresh_metadata_action_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RefreshMetadataAction do
 
   subject(:refresh) { described_class.run(identifiers: ['catkey:123'], fedora_object: item) }
 
-  let(:item) { Dor::Item.new }
+  let(:item) { Dor::Item.new(pid: 'druid:bc753qt7345') }
 
   let(:mods) do
     <<~XML

--- a/spec/validators/cocina/description_roundtrip_validator_spec.rb
+++ b/spec/validators/cocina/description_roundtrip_validator_spec.rb
@@ -17,12 +17,7 @@ RSpec.describe Cocina::DescriptionRoundtripValidator do
         },
         description: {
           title: [{ value: 'Born to Run' }],
-          purl: 'https://purl.stanford.edu/ff111df4567',
-          access: {
-            digitalRepository: [
-              { value: 'Stanford Digital Repository' }
-            ]
-          }
+          purl: 'https://purl.stanford.edu/ff111df4567'
         },
         administrative: {
           hasAdminPolicy: 'druid:dd999df4567'
@@ -54,7 +49,7 @@ RSpec.describe Cocina::DescriptionRoundtripValidator do
 
     context 'when invalid' do
       before do
-        changed_cocina_hash = cocina_hash[:description].except(:purl)
+        changed_cocina_hash = cocina_hash[:description].merge(contributor: [{ name: [{ value: 'Stanford University. Department of Geophysics' }] }])
         allow(Cocina::FromFedora::Descriptive).to receive(:props).and_return(changed_cocina_hash)
       end
 
@@ -64,7 +59,28 @@ RSpec.describe Cocina::DescriptionRoundtripValidator do
     end
 
     context 'with request' do
-      let(:cocina_object) { Cocina::Models::RequestDRO.new(cocina_hash.except(:externalIdentifier)) }
+      let(:request_cocina_hash) do
+        {
+          type: Cocina::Models::Vocab.book,
+          label: 'Born to Run',
+          version: 1,
+          access: {
+            access: 'world',
+            download: 'none'
+          },
+          description: {
+            title: [{ value: 'Born to Run' }]
+          },
+          administrative: {
+            hasAdminPolicy: 'druid:dd999df4567'
+          },
+          identification: { sourceId: 'googlebooks:999999' }
+        }
+      end
+
+      let(:cocina_object) do
+        Cocina::Models::RequestDRO.new(request_cocina_hash)
+      end
 
       it 'returns success' do
         expect(result.success?).to be true
@@ -80,14 +96,7 @@ RSpec.describe Cocina::DescriptionRoundtripValidator do
                 value: 'Software Carpentry Workshop recordings from August 14, 2014'
               }
             ],
-            purl: 'https://purl.stanford.edu/tx853fp2857',
-            access: {
-              digitalRepository: [
-                {
-                  value: 'Stanford Digital Repository'
-                }
-              ]
-            }
+            purl: 'https://purl.stanford.edu/tx853fp2857'
           }
         ]
       end


### PR DESCRIPTION
## Why was this change made?
Update cocina.

The substantive changes in this cocina release are:
* Add cocinaVersion attribute.
* Require purls for non-request descriptions.
* Require hasAgreements for APOs.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



