### PR TITLE
Administrative metadata mapping for registration node

### DIFF
--- a/app/services/cocina/to_fedora/administrative_metadata.rb
+++ b/app/services/cocina/to_fedora/administrative_metadata.rb
@@ -35,6 +35,8 @@ module Cocina
       end
 
       def add_registration_nodes
+        return if administrative.registrationWorkflow.blank?
+
         registration_node = admin_node.xpath('registration').first || admin_node.add_child('<registration/>').first
         Array(administrative.registrationWorkflow).each do |wf_id|
           registration_node.add_child "<workflow id=\"#{wf_id}\" />"

--- a/spec/services/cocina/to_fedora/administrative_metadata_spec.rb
+++ b/spec/services/cocina/to_fedora/administrative_metadata_spec.rb
@@ -89,4 +89,30 @@ RSpec.describe Cocina::ToFedora::AdministrativeMetadata do
       expect(datastream.content).to be_equivalent_to expected
     end
   end
+
+  context 'when the administrative xml is empty node' do
+    let(:administrative) do
+      Cocina::Models::AdminPolicyAdministrative.new(
+        hasAdminPolicy: 'druid:bc123df4567',
+        registrationWorkflow: [],
+        collectionsForRegistration: []
+      )
+    end
+    let(:existing) do
+      <<~XML
+        <administrativeMetadata/>
+      XML
+    end
+
+    let(:expected) do
+      <<~XML
+        <administrativeMetadata/>
+      XML
+    end
+
+    it 'writes the converted structure' do
+      write
+      expect(datastream.content).to be_equivalent_to expected
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?
Resolves #3248.

## How was this change tested?
Test added and unit test pass. Running `bin/validate-desc-cocina-roundtrip -s 100000 -i druids.testbed.txt` shows no change.

Before
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   99984 (99.984%)
  Different: 16 (0.016%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     0 (0.0%)
```

After
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   99984 (99.984%)
  Different: 16 (0.016%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     0 (0.0%)
```

## Which documentation and/or configurations were updated?



