### PR TITLE
Removes id attr from contentMetadata in normalization

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -33,6 +33,7 @@ module Cocina
         remove_location
         remove_format
         remove_geodata
+        remove_id
         normalize_object_id(druid)
         normalize_reading_order(druid)
         normalize_label_attr
@@ -94,6 +95,12 @@ module Cocina
 
       def remove_geodata
         ng_xml.root.xpath('//geoData').each(&:remove)
+      end
+
+      def remove_id
+        return if ng_xml.root['id'].blank?
+
+        ng_xml.root.delete('id')
       end
 
       def normalize_reading_order(druid)

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -421,4 +421,36 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       )
     end
   end
+
+  context 'when normalizing contentMetadata node' do
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata type="webarchive-seed" id="druid:bb035tg0974">
+          <resource type="image" sequence="1" id="bb035tg0974_1">
+            <file preserve="no" publish="yes" shelve="yes" mimetype="image/jp2" id="thumbnail.jp2" size="20199">
+              <checksum type="md5">7a2e7d50f03917674f8014cacd77cc26</checksum>
+              <checksum type="sha1">9db56401e6c2c2515c9d7a75b8316ca1d5425709</checksum>
+              <imageData width="400" height="267"/>
+            </file>
+          </resource>
+        </contentMetadata>
+      XML
+    end
+
+    it 'removes id in root element' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <contentMetadata type="webarchive-seed" objectId="druid:bb035tg0974">
+            <resource type="image">
+              <file preserve="no" publish="yes" shelve="yes" mimetype="image/jp2" id="thumbnail.jp2" size="20199">
+                <checksum type="md5">7a2e7d50f03917674f8014cacd77cc26</checksum>
+                <checksum type="sha1">9db56401e6c2c2515c9d7a75b8316ca1d5425709</checksum>
+                <imageData width="400" height="267"/>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?
Resolves #3247.

## How was this change tested?
Added test and unit tests pass. When running `bin/validate-cocina-roundtrip -s 100000 -i druids.testbed.txt` success goes up.

Before 
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   96007 (96.086%)
  Different: 3911 (3.914%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

After
```Success:   96076 (96.155%)
  Different: 3842 (3.845%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)

```


## Which documentation and/or configurations were updated?



