### PR TITLE
We currently use the objectId in ThumbnailService over resourceId

### DIFF
--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -61,7 +61,7 @@ module Cocina
       # @return [Array<String>] the identifiers of files in a sequence for a virtual object
       def build_sequence(content_metadata_ds)
         content_metadata_ds.ng_xml.xpath('//resource/externalFile').map do |resource_node|
-          "#{resource_node['resourceId']}/#{resource_node['fileId']}"
+          "#{resource_node['objectId']}/#{resource_node['fileId']}"
         end
       end
     end

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -257,17 +257,17 @@ RSpec.describe 'Get the object' do
                                     hasMemberOrders: [
                                       {
                                         members: [
-                                          'kq126jw7402_1/1592A.jp2',
-                                          'cv761kr7119_1/1592B.jp2',
-                                          'kn300wd1779_1/1592c.jp2',
-                                          'rz617vr4473_1/1592001.jp2',
-                                          'sd322dt2118_1/1592002.jp2',
-                                          'hp623ch4433_1/1592003.jp2',
-                                          'sq217qj5005_1/1592004.jp2',
-                                          'vd823mb5658_1/1592005.jp2',
-                                          'zp230ft8517_1/1592006.jp2',
-                                          'xx933wk5286_1/1592007.jp2',
-                                          'qf828rv2163_1/1592008.jp2'
+                                          'druid:kq126jw7402/1592A.jp2',
+                                          'druid:cv761kr7119/1592B.jp2',
+                                          'druid:kn300wd1779/1592c.jp2',
+                                          'druid:rz617vr4473/1592001.jp2',
+                                          'druid:sd322dt2118/1592002.jp2',
+                                          'druid:hp623ch4433/1592003.jp2',
+                                          'druid:sq217qj5005/1592004.jp2',
+                                          'druid:vd823mb5658/1592005.jp2',
+                                          'druid:zp230ft8517/1592006.jp2',
+                                          'druid:xx933wk5286/1592007.jp2',
+                                          'druid:qf828rv2163/1592008.jp2'
                                         ]
                                       }
                                     ]

--- a/spec/services/cocina/from_fedora/dro_structural_spec.rb
+++ b/spec/services/cocina/from_fedora/dro_structural_spec.rb
@@ -334,4 +334,28 @@ RSpec.describe Cocina::FromFedora::DroStructural do
 
     it { is_expected.to eq 'transcription' }
   end
+
+  context 'when there are externalFiles' do
+    let(:xml) do
+      <<~XML
+        <contentMetadata objectId="tf960jc7725" type="image">
+          <resource id="tf960jc7725_1" sequence="1" type="image">
+            <externalFile fileId="2576001.jp2" mimetype="image/jp2" objectId="druid:pj563wy4429" resourceId="pj563wy4429_1"/>
+            <relationship objectId="druid:pj563wy4429" type="alsoAvailableAs"/>
+          </resource>
+          <resource id="tf960jc7725_2" sequence="2" type="image">
+            <externalFile fileId="2576002.jp2" mimetype="image/jp2" objectId="druid:jv233bw7647" resourceId="jv233bw7647_1"/>
+            <relationship objectId="druid:jv233bw7647" type="alsoAvailableAs"/>
+          </resource>
+        </contentMetadata>
+      XML
+    end
+
+    it 'returns hasMemberOrders' do
+      expect(structural[:hasMemberOrders].size).to eq 1
+      expect(structural[:hasMemberOrders][0][:members].size).to eq 2
+      expect(structural[:hasMemberOrders][0][:members]).to include('druid:pj563wy4429/2576001.jp2')
+      expect(structural[:hasMemberOrders][0][:members]).to include('druid:jv233bw7647/2576002.jp2')
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

This should be reviewed by @andrewjbtw, @arcadiafalcone, @jcoyne, and @justinlittman to verify that this small change is ok.

When working in ThumbnailService, I noticed we expect the objectId (that includes a druid) to be used instead of resourceId which does not.

https://github.com/sul-dlss/dor-services-app/blob/main/app/services/thumbnail_service.rb#L50

For example, with content metadata of:

```
<contentMetadata objectId="tf960jc7725" type="image">
  <resource id="tf960jc7725_1" sequence="1" type="image">
    <externalFile fileId="2576001.jp2" mimetype="image/jp2" objectId="druid:pj563wy4429" resourceId="pj563wy4429_1"/>
    <relationship objectId="druid:pj563wy4429" type="alsoAvailableAs"/>
  </resource>
  <resource id="tf960jc7725_2" sequence="2" type="image">
    <externalFile fileId="2576002.jp2" mimetype="image/jp2" objectId="druid:jv233bw7647" resourceId="jv233bw7647_1"/>
    <relationship objectId="druid:jv233bw7647" type="alsoAvailableAs"/>
  </resource>
</contentMetadata>
```

we currently map as:
```
pj563wy4429_1/2576001.jp2
jv233bw7647_1/2576002.jp2
```

However, ThumbnailService expects:
```
druid:pj563wy4429/2576001.jp2
druid:jv233bw7647/2576002.jp2
```

If this was a design decision that I can ignore, please close. 

## How was this change tested?

Unit.


## Which documentation and/or configurations were updated?



