### PR TITLE
parse/normalize new resource label type

### DIFF
--- a/app/services/cocina/from_fedora/file_sets.rb
+++ b/app/services/cocina/from_fedora/file_sets.rb
@@ -31,7 +31,7 @@ module Cocina
             version: version,
             structural: structural
           }.tap do |attrs|
-            attrs[:label] = resource_node.xpath('label', 'attr[@type="label"]').text # some will be missing labels, they will just be blank
+            attrs[:label] = resource_node.xpath('label', 'attr[@type="label"]', 'attr[@name="label"]').text # some will be missing labels, they will just be blank
           end
         end
       end

--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -117,8 +117,7 @@ module Cocina
       end
 
       def normalize_label_attr
-        # Pending https://github.com/sul-dlss/dor-services-app/issues/2808
-        ng_xml.root.xpath('//attr[@type="label"]').each do |attr_node|
+        ng_xml.root.xpath('//attr[@type="label"] | //attr[@name="label"]').each do |attr_node|
           label_node = Nokogiri::XML::Node.new('label', ng_xml)
           label_node.content = attr_node.content
           attr_node.parent << label_node

--- a/spec/services/cocina/from_fedora/file_sets_spec.rb
+++ b/spec/services/cocina/from_fedora/file_sets_spec.rb
@@ -22,12 +22,19 @@ RSpec.describe Cocina::FromFedora::FileSets do
           </file>
         </resource>
         <resource id="gs491bt1345_2" sequence="2" type="file">
-          <label>Program PDF</label>
+          <attr type="label">Program PDF</attr>
           <file id="gs491bt1345_sample_md.pdf" mimetype="application/pdf" size="930089" publish="yes" shelve="yes" preserve="yes">
             <checksum type="sha1">3b342f7b87f126997088720c1220122d41c8c159</checksum>
             <checksum type="md5">6ed0004f39657ff81dff7b2b017fb9d9</checksum>
           </file>
         </resource>
+        <resource id="gs491bt1345_3" sequence="3" type="file">
+          <attr name="label">Program Text</attr>
+          <file id="gs491bt1345_sample_md.txt" mimetype="plain/text" size="100" publish="yes" shelve="yes" preserve="yes">
+            <checksum type="sha1">11342f7b87f126997088720c1220122d41c8c159</checksum>
+            <checksum type="md5">11d0004f39657ff81dff7b2b017fb9d9</checksum>
+          </file>
+         </resource>
       </contentMetadata>
     XML
   end
@@ -95,6 +102,28 @@ RSpec.describe Cocina::FromFedora::FileSets do
     end
   end
 
+  describe 'label generation for file sets' do
+    let(:structural) { instance.build }
+
+    context 'when <label> node on resource' do
+      it 'maps the label correctly' do
+        expect(structural[0][:label]).to eq('Audio file')
+      end
+    end
+
+    context 'when <attr type="label"> node on resource' do
+      it 'maps the label correctly' do
+        expect(structural[1][:label]).to eq('Program PDF')
+      end
+    end
+
+    context 'when <attr name="label"> node on resource' do
+      it 'maps the label correctly' do
+        expect(structural[2][:label]).to eq('Program Text')
+      end
+    end
+  end
+
   describe 'file-level access rights' do
     let(:rights_xml) do
       <<~XML
@@ -128,8 +157,8 @@ RSpec.describe Cocina::FromFedora::FileSets do
     end
     let(:type) { Cocina::Models::Vocab.media }
     let(:structural) { instance.build }
-    let(:audio_fileset) { structural.first[:structural][:contains] }
-    let(:text_fileset) { structural.last[:structural][:contains] }
+    let(:audio_fileset) { structural[0][:structural][:contains] }
+    let(:text_fileset) { structural[1][:structural][:contains] }
 
     context 'when controlled digital lending' do
       let(:file_specific_rights) do

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -220,6 +220,53 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       end
     end
 
+    context 'when normalizing type="label" or name="label" attributes' do
+      # adapted/modified from druid:bf016hc1150
+      let(:original_xml) do
+        <<~XML
+            <contentMetadata type="file" objectId="druid:bf016hc1150">
+            <resource id="bf016hc1150_1" type="main-original">
+              <attr name="label">Body of dissertation (as submitted)</attr>
+              <file id="Jiajing Wang_Dissertation_final.pdf" mimetype="application/pdf" size="10063288" shelve="yes" publish="no" preserve="yes">
+                <checksum type="md5">4730200a3f0e2e59a4b5222b24c56479</checksum>
+                <checksum type="sha1">1da942c37bf02c83a50840607e5d537981a685ca</checksum>
+              </file>
+            </resource>
+            <resource id="bf016hc1150_2" type="main-augmented" objectId="druid:hn674mz7318">
+              <attr type="label">Body of dissertation</attr>
+              <file id="Jiajing Wang_Dissertation_final-augmented.pdf" mimetype="application/pdf" size="8669074" shelve="yes" publish="yes" preserve="yes">
+                <checksum type="md5">59447a86931f3663f5c129ffb2326808</checksum>
+                <checksum type="sha1">ff3b3c6ff560927890fc6258d5f7cb5073358624</checksum>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      end
+
+      it 'converts to label nodes' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <contentMetadata type="file" objectId="druid:bf016hc1150">
+              <resource type="main-original">
+                <label>Body of dissertation (as submitted)</label>
+                <file id="Jiajing Wang_Dissertation_final.pdf" mimetype="application/pdf" size="10063288" shelve="yes" publish="no" preserve="yes">
+                  <checksum type="md5">4730200a3f0e2e59a4b5222b24c56479</checksum>
+                  <checksum type="sha1">1da942c37bf02c83a50840607e5d537981a685ca</checksum>
+                </file>
+              </resource>
+              <resource type="main-augmented">
+                <label>Body of dissertation</label>
+                <file id="Jiajing Wang_Dissertation_final-augmented.pdf" mimetype="application/pdf" size="8669074" shelve="yes" publish="yes" preserve="yes">
+                  <checksum type="md5">59447a86931f3663f5c129ffb2326808</checksum>
+                  <checksum type="sha1">ff3b3c6ff560927890fc6258d5f7cb5073358624</checksum>
+                </file>
+              </resource>
+            </contentMetadata>
+          XML
+        )
+      end
+    end
+
     context 'when normalizing location' do
       let(:original_xml) do
         <<~XML


### PR DESCRIPTION
## Why was this change made?

Fixes #3246 - map (and normalize to standard `<label>` form) resource labels that are of form `<attr name="label">` in the same way we do it for `<attr type="label">` 
 
## How was this change tested?

Added tests
See results of running `validate-cocina-roundtrip` on server below

## Which documentation and/or configurations were updated?



