### PR TITLE
Cocina-ize ThumbnailService

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -2,7 +2,7 @@
 
 # A controller to display derived metadata about an object
 class MetadataController < ApplicationController
-  before_action :load_item
+  before_action :load_item, :load_cocina_object
 
   def dublin_core
     desc_md_xml = Publish::PublicDescMetadataService.new(@item).ng_xml(include_access_conditions: false)
@@ -21,7 +21,7 @@ class MetadataController < ApplicationController
 
   def public_xml
     release_tags = ReleaseTags.for(item: @item)
-    service = Publish::PublicXmlService.new(@item, released_for: release_tags)
+    service = Publish::PublicXmlService.new(@item, released_for: release_tags, thumbnail_service: ThumbnailService.new(@cocina_object))
     render xml: service
   end
 

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -143,7 +143,7 @@ class ObjectsController < ApplicationController
   end
 
   def update_marc_record
-    Dor::UpdateMarcRecordService.new(@item).update
+    Dor::UpdateMarcRecordService.new(@item, thumbnail_service: ThumbnailService.new(@cocina_object)).update
     head :created
   end
 

--- a/app/models/dor/update_marc_record_service.rb
+++ b/app/models/dor/update_marc_record_service.rb
@@ -9,10 +9,11 @@ module Dor
     # objects goverened by these APOs (ETD and EEMs) will get indicator 2 = 0, else 1
     BORN_DIGITAL_APOS = %w(druid:bx911tp9024 druid:jj305hm5259).freeze
 
-    def initialize(druid_obj)
+    def initialize(druid_obj, thumbnail_service:)
       @druid_obj = druid_obj
       @druid_id = Dor::PidUtils.remove_druid_prefix(druid_obj.id)
       @dra_object = druid_obj.rightsMetadata.dra_object
+      @thumbnail_service = thumbnail_service
     end
 
     def update
@@ -241,8 +242,7 @@ module Dor
     # the @id attribute of resource/file elements including extension
     # @return [String] thumbnail filename (nil if none found)
     def thumb
-      cocina_object = CocinaObjectStore.find(@druid_obj.pid)
-      @thumb ||= ERB::Util.url_encode(ThumbnailService.new(cocina_object).thumb).presence
+      @thumb ||= ERB::Util.url_encode(@thumbnail_service.thumb).presence
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/app/models/dor/update_marc_record_service.rb
+++ b/app/models/dor/update_marc_record_service.rb
@@ -241,7 +241,8 @@ module Dor
     # the @id attribute of resource/file elements including extension
     # @return [String] thumbnail filename (nil if none found)
     def thumb
-      @thumb ||= ERB::Util.url_encode(ThumbnailService.new(@druid_obj).thumb).presence
+      cocina_object = CocinaObjectStore.find(@druid_obj.pid)
+      @thumb ||= ERB::Util.url_encode(ThumbnailService.new(cocina_object).thumb).presence
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -31,7 +31,9 @@ module Publish
       # Note we cannot base this on if an individual object has release tags or not, because the collection may cause one to be generated for an item,
       # so we need to calculate it and then look at the final result.
 
-      thumb = ThumbnailService.new(object).thumb
+      cocina_object = CocinaObjectStore.find(object.pid)
+      thumb = ThumbnailService.new(cocina_object).thumb
+
       pub.add_child(Nokogiri("<thumb>#{thumb}</thumb>").root) unless thumb.nil?
 
       new_pub = Nokogiri::XML(pub.to_xml, &:noblanks)

--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -7,9 +7,10 @@ module Publish
 
     # @param [Dor::Item] object
     # @param [Hash{String => Boolean}] released_for keys are Project name strings, values are boolean
-    def initialize(object, released_for:)
+    def initialize(object, released_for:, thumbnail_service:)
       @object = object
       @released_for = released_for
+      @thumbnail_service = thumbnail_service
     end
 
     # @raise [Dor::DataError]
@@ -31,9 +32,7 @@ module Publish
       # Note we cannot base this on if an individual object has release tags or not, because the collection may cause one to be generated for an item,
       # so we need to calculate it and then look at the final result.
 
-      cocina_object = CocinaObjectStore.find(object.pid)
-      thumb = ThumbnailService.new(cocina_object).thumb
-
+      thumb = @thumbnail_service.thumb
       pub.add_child(Nokogiri("<thumb>#{thumb}</thumb>").root) unless thumb.nil?
 
       new_pub = Nokogiri::XML(pub.to_xml, &:noblanks)

--- a/app/services/thumbnail_service.rb
+++ b/app/services/thumbnail_service.rb
@@ -3,29 +3,9 @@
 # Responsible for finding a path to a thumbnail based on the contentMetadata of an object
 class ThumbnailService
   # allow the mimetype attribute to be lower or camelcase when searching to make it more robust
-  MIME_TYPE_FINDER = "@mimetype='image/jp2' or @mimeType='image/jp2'"
+  MIME_TYPE = 'image/jp2'
 
-  # these are the finders we will use to search for a thumb resource in contentMetadata, they will be searched in the order provided, stopping when one is reached
-  THUMB_XPATH_FINDERS = [
-    # first find a file of mimetype jp2 explicitly marked as a thumb in the resource type and with a thumb=yes attribute
-    { image_type: 'local', finder: "/contentMetadata/resource[@type='thumb' and @thumb='yes']/file[#{MIME_TYPE_FINDER}]" },
-    # same thing for external files
-    { image_type: 'external', finder: "/contentMetadata/resource[@type='thumb' and @thumb='yes']/externalFile[#{MIME_TYPE_FINDER}]" },
-    # next find any image or page resource types with the thumb=yes attribute of mimetype jp2
-    { image_type: 'local', finder: "/contentMetadata/resource[(@type='page' or @type='image') and @thumb='yes']/file[#{MIME_TYPE_FINDER}]" },
-    # same thing for external file
-    { image_type: 'external', finder: "/contentMetadata/resource[(@type='page' or @type='image') and @thumb='yes']/externalFile[#{MIME_TYPE_FINDER}]" },
-    # next find a file of mimetype jp2 and resource type=thumb but not marked with the thumb directive
-    { image_type: 'local', finder: "/contentMetadata/resource[@type='thumb']/file[#{MIME_TYPE_FINDER}]" },
-    # same thing for external file
-    { image_type: 'external', finder: "/contentMetadata/resource[@type='thumb']/externalFile[#{MIME_TYPE_FINDER}]" },
-    # finally find the first page or image resource of mimetype jp2
-    { image_type: 'local', finder: "/contentMetadata/resource[@type='page' or @type='image']/file[#{MIME_TYPE_FINDER}]" },
-    # same thing for external file
-    { image_type: 'external', finder: "/contentMetadata/resource[@type='page' or @type='image']/externalFile[#{MIME_TYPE_FINDER}]" }
-  ].freeze
-
-  # @param [Dor::Item] object
+  # @param [Cocina::Model::DRO] object
   def initialize(object)
     @object = object
   end
@@ -34,24 +14,18 @@ class ThumbnailService
 
   # @return [String] the computed thumb filename, with the druid prefix and a slash in front of it, e.g. oo000oo0001/filenamewith space.jp2
   def thumb
-    return unless object.respond_to?(:contentMetadata) && object.contentMetadata.present?
+    return unless object.respond_to?(:structural) && object.structural.present?
 
-    cm = object.contentMetadata.ng_xml
-    thumb_image = nil
+    object.structural.contains.each do |file_set|
+      file_set.structural.contains.each do |file|
+        next unless file.hasMimeType.include?(MIME_TYPE)
 
-    THUMB_XPATH_FINDERS.each do |search_path|
-      thumb_files = cm.xpath(search_path[:finder]) # look for a thumb
-      next if thumb_files.empty?
-
-      # if we find one, return the filename based on whether it is a local file or external file
-      thumb_image = if search_path[:image_type] == 'local'
-                      "#{Dor::PidUtils.remove_druid_prefix(object.pid)}/#{thumb_files[0]['id']}"
-                    else
-                      "#{Dor::PidUtils.remove_druid_prefix(thumb_files[0]['objectId'])}/#{thumb_files[0]['fileId']}"
-                    end
-      break # break out of the loop so we stop searching
+        return "#{Dor::PidUtils.remove_druid_prefix(object.externalIdentifier)}/#{file.filename}"
+      end
     end
 
-    thumb_image
+    return if object.structural.hasMemberOrders.empty?
+
+    object.structural.hasMemberOrders.first.members.first
   end
 end

--- a/app/services/thumbnail_service.rb
+++ b/app/services/thumbnail_service.rb
@@ -14,7 +14,7 @@ class ThumbnailService
 
   # @return [String] the computed thumb filename, with the druid prefix and a slash in front of it, e.g. oo000oo0001/filenamewith space.jp2
   def thumb
-    return unless object.respond_to?(:structural) && object.structural.present?
+    return unless object.respond_to?(:structural) && object.structural
 
     object.structural.contains.each do |file_set|
       file_set.structural.contains.each do |file|

--- a/spec/dor/update_marc_record_service_spec.rb
+++ b/spec/dor/update_marc_record_service_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Dor::UpdateMarcRecordService do
-  subject(:umrs) { described_class.new dor_item }
+  subject(:umrs) { described_class.new(dor_item, thumbnail_service: thumbnail_service) }
 
   let(:release_service) { instance_double(ReleaseTags::IdentityMetadata, released_for: release_data) }
   let(:release_data) { {} }
+  let(:thumbnail_service) { ThumbnailService.new(cocina_object) }
 
   before do
     allow(ReleaseTags::IdentityMetadata).to receive(:for).and_return(release_service)
@@ -271,7 +272,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
                                 administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
       end
 
-      let(:umrs) { described_class.new(collection) }
+      let(:umrs) { described_class.new(collection, thumbnail_service: thumbnail_service) }
 
       before do
         collection.rightsMetadata.content = build_rights_metadata_1

--- a/spec/dor/update_marc_record_service_spec.rb
+++ b/spec/dor/update_marc_record_service_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
   before do
     allow(ReleaseTags::IdentityMetadata).to receive(:for).and_return(release_service)
+    allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
     Settings.release.symphony_path = './spec/fixtures/sdr-purl'
   end
 
@@ -35,6 +36,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
     end
 
     let(:dor_item) { Dor::Item.new(pid: 'druid:aa222cc3333') }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
+    end
 
     it 'does nothing' do
       expect(umrs).not_to receive(:push_symphony_records)
@@ -45,6 +57,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
   context 'for a druid with a catkey' do
     let(:dor_item) { Dor::Item.new(pid: druid, catkey: '8832162') }
     let(:druid) { 'druid:bb333dd4444' }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
+    end
 
     it 'executes the UpdateMarcRecordService push_symphony_records method' do
       expect(umrs.generate_symphony_records).to eq(["8832162\t#{druid.gsub('druid:', '')}\t"])
@@ -56,6 +79,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
   describe '.push_symphony_records' do
     let(:dor_item) { Dor::Item.new(pid: druid) }
     let(:druid) { 'druid:aa111aa1111' }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
+    end
 
     it 'calls the relevant methods' do
       expect(umrs).to receive(:generate_symphony_records).once
@@ -73,6 +107,18 @@ RSpec.describe Dor::UpdateMarcRecordService do
     let(:release_data) { { 'Searchworks' => { 'release' => true } } }
 
     context "when the druid object doesn't have catkey or previous catkeys" do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                                structural: build_cocina_structural_metadata_1)
+      end
+
       before do
         dor_item.rightsMetadata.content = build_rights_metadata_1
         dor_item.identityMetadata.content = build_identity_metadata_4
@@ -86,6 +132,18 @@ RSpec.describe Dor::UpdateMarcRecordService do
     end
 
     context 'when an item object has a catkey' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                                structural: build_cocina_structural_metadata_1)
+      end
+
       before do
         dor_item.rightsMetadata.content = build_rights_metadata_1
         dor_item.identityMetadata.content = build_identity_metadata_1
@@ -101,12 +159,24 @@ RSpec.describe Dor::UpdateMarcRecordService do
       it 'generates a single symphony record' do
         # rubocop:disable Layout/LineLength
         expect(generate_symphony_records).to eq [
-          "8832162\taa111aa1111\t.856. 41|uhttps://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label & A Special character|xrights:world"
+          "8832162\taa111aa1111\t.856. 41|uhttps://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:bc123df4567%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label & A Special character|xrights:world"
         ]
       end
     end
 
     context 'when an object is stanford only and has a catkey' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                                structural: build_cocina_structural_metadata_1)
+      end
+
       before do
         dor_item.rightsMetadata.content = build_rights_metadata_2
         dor_item.identityMetadata.content = build_identity_metadata_1
@@ -120,12 +190,24 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
       it 'generates symphony record with a z subfield' do
         expect(generate_symphony_records).to match_array [
-          "8832162\taa111aa1111\t.856. 41|zAvailable to Stanford-affiliated users.|uhttps://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label & A Special character|xrights:group=stanford"
+          "8832162\taa111aa1111\t.856. 41|zAvailable to Stanford-affiliated users.|uhttps://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:bc123df4567%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label & A Special character|xrights:group=stanford"
         ]
       end
     end
 
     context 'when an object has both previous and current catkeys' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                                structural: build_cocina_structural_metadata_1)
+      end
+
       before do
         dor_item.rightsMetadata.content = build_rights_metadata_1
         dor_item.identityMetadata.content = build_identity_metadata_3
@@ -142,12 +224,24 @@ RSpec.describe Dor::UpdateMarcRecordService do
         expect(generate_symphony_records).to match_array [
           "123\taa111aa1111\t",
           "456\taa111aa1111\t",
-          "8832162\taa111aa1111\t.856. 41|uhttps://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xfile:aa111aa1111%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label & A Special character|xrights:world"
+          "8832162\taa111aa1111\t.856. 41|uhttps://purl.stanford.edu/aa111aa1111|xSDR-PURL|xitem|xfile:bc123df4567%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:dd111dd1111::Constituent label & A Special character|xrights:world"
         ]
       end
     end
 
     context 'when an object has only previous catkeys' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                                structural: build_cocina_structural_metadata_1)
+      end
+
       before do
         dor_item.rightsMetadata.content = build_rights_metadata_1
         dor_item.identityMetadata.content = build_identity_metadata_5
@@ -166,14 +260,25 @@ RSpec.describe Dor::UpdateMarcRecordService do
     end
 
     context 'when an collection object has a catkey' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+
+      let(:umrs) { described_class.new(collection) }
+
       before do
         collection.rightsMetadata.content = build_rights_metadata_1
         collection.identityMetadata.content = build_identity_metadata_2
 
         allow(collection).to receive_messages(collections: [])
       end
-
-      let(:umrs) { described_class.new(collection) }
 
       it 'generates a single symphony record' do
         expect(generate_symphony_records).to match_array ["8832162\tcc111cc1111\t.856. 41|uhttps://purl.stanford.edu/cc111cc1111|xSDR-PURL|xcollection|xrights:world"]
@@ -187,6 +292,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
     let(:dor_item) { Dor::Item.new(pid: druid) }
     let(:druid) { 'druid:aa111aa1111' }
     let(:fixtures) { './spec/fixtures' }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
+    end
 
     let(:output_file) do
       "#{fixtures}/sdr_purl/sdr-purl-856s"
@@ -262,6 +378,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
   describe '.get_z_field' do
     let(:dor_item) { Dor::Item.new(pid: 'druid:aa111aa1111') }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
+    end
 
     context 'with rights metadata 1' do
       before do
@@ -296,6 +423,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
   describe '.get_856_cons' do
     let(:dor_item) { Dor::Item.new(pid: 'druid:aa111aa1111') }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
+    end
 
     it 'returns a valid sdrpurl constant' do
       expect(umrs.get_856_cons).to eq('.856.')
@@ -304,6 +442,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
   describe '.get_1st_indicator' do
     let(:dor_item) { Dor::Item.new(pid: 'druid:aa111aa1111') }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
+    end
 
     it 'returns 4' do
       expect(umrs.get_1st_indicator).to eq('4')
@@ -312,6 +461,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
   describe '.get_2nd_indicator' do
     let(:dor_item) { Dor::Item.new(pid: 'druid:aa111aa1111') }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
+    end
 
     it 'returns 1 for a non born digital APO' do
       allow(dor_item).to receive(:admin_policy_object_id).and_return('info:fedora/druid:mb062dy1188')
@@ -331,6 +491,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
   describe '.get_u_field' do
     let(:dor_item) { Dor::Item.new(pid: 'druid:aa111aa1111') }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
+    end
 
     it 'returns valid purl url' do
       expect(umrs.get_u_field).to eq('|uhttps://purl.stanford.edu/aa111aa1111')
@@ -339,6 +510,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
   describe '.get_x1_sdrpurl_marker' do
     let(:dor_item) { Dor::Item.new(pid: 'druid:aa111aa1111') }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
+    end
 
     it 'returns a valid sdrpurl constant' do
       expect(umrs.get_x1_sdrpurl_marker).to eq('|xSDR-PURL')
@@ -347,6 +529,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
   describe '.get_x2_collection_info' do
     let(:dor_item) { Dor::Item.new(pid: 'druid:aa111aa1111') }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
+    end
 
     it 'returns an empty string for an object without collection' do
       expect(dor_item).to receive(:collections).and_return([])
@@ -373,6 +566,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
   describe '#get_x2_part_info' do
     let(:dor_item) { Dor::Item.new(pid: 'druid:aa111aa1111') }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
+    end
 
     before do
       dor_item.descMetadata.content = xml
@@ -521,6 +725,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
     subject(:rights_info) { umrs.get_x2_rights_info }
 
     let(:dor_item) { Dor::Item.new(pid: 'druid:aa111aa1111') }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
+    end
 
     before do
       dor_item.rightsMetadata.content = xml
@@ -656,6 +871,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
   describe 'Released to Searchworks' do
     let(:dor_item) { Dor::Item.new(pid: 'druid:aa111aa1111') }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
+    end
 
     context 'when release_data tag has release to=Searchworks and value is true' do
       let(:release_data) { { 'Searchworks' => { 'release' => true } } }
@@ -716,6 +942,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
   describe 'dor_items_for_constituents' do
     let(:dor_item) { Dor::Item.new(pid: 'druid:aa111aa1111') }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
+    end
 
     it 'returns empty array if no relationships' do
       allow(dor_item).to receive(:relationships).and_return(nil)
@@ -734,15 +971,53 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
     let(:dor_item) { Dor::Item.new(pid: druid) }
     let(:druid) { 'druid:bb111bb2222' }
-
-    it 'returns thumb from a valid contentMetadata' do
-      dor_item.contentMetadata.content = build_content_metadata_1
-      expect(thumb).to eq 'bb111bb2222%2Fwt183gy6220_00_0001.jp2'
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                              structural: build_cocina_structural_metadata_1)
     end
 
-    it 'returns nil for contentMetadata without thumb' do
-      dor_item.contentMetadata.content = build_content_metadata_2
-      expect(thumb).to be_nil
+    context 'with valid structural metadata' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                                structural: build_cocina_structural_metadata_1)
+      end
+
+      it 'returns a thumb' do
+        dor_item.contentMetadata.content = build_content_metadata_1
+        expect(thumb).to eq 'bc123df4567%2Fwt183gy6220_00_0001.jp2'
+      end
+    end
+
+    context 'with no structural metadata' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+
+      it 'returns nil' do
+        dor_item.contentMetadata.content = build_content_metadata_2
+        expect(thumb).to be_nil
+      end
     end
   end
 
@@ -751,6 +1026,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
     context 'when previous_catkeys exists' do
       let(:dor_item) { Dor::Item.new(pid: 'druid:aa111aa1111') }
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                                structural: build_cocina_structural_metadata_1)
+      end
 
       before do
         dor_item.identityMetadata.add_other_Id('previous_catkey', '123')
@@ -763,6 +1049,17 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
     context 'when previous_catkeys are empty' do
       let(:dor_item) { Dor::Item.new(pid: 'druid:aa111aa1111') }
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                                structural: build_cocina_structural_metadata_1)
+      end
 
       it 'returns an empty array for previous catkeys in identityMetadata without either' do
         expect(previous_ckeys).to eq([])

--- a/spec/requests/legacy_metadata_update_spec.rb
+++ b/spec/requests/legacy_metadata_update_spec.rb
@@ -98,9 +98,22 @@ RSpec.describe 'Update the legacy (datastream) metadata' do
     JSON
   end
 
+  let(:cocina_object) do
+    Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                            type: Cocina::Models::Vocab.object,
+                            label: 'A generic label',
+                            version: 1,
+                            description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                            identification: {},
+                            access: {},
+                            administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                            structural: build_cocina_structural_metadata_1)
+  end
+
   before do
     allow(Dor).to receive(:find).and_return(item)
     allow(LegacyMetadataService).to receive(:update_datastream_if_newer)
+    allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
   end
 
   context 'when update is successful' do

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -62,6 +62,16 @@ RSpec.describe 'Display metadata' do
         </rdf:RDF>
       XML
     end
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A generic label',
+                              version: 1,
+                              description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                              identification: {},
+                              access: {},
+                              administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+    end
 
     before do
       allow(ReleaseTags).to receive(:for).and_return(
@@ -70,6 +80,7 @@ RSpec.describe 'Display metadata' do
       )
       allow(Time).to receive(:now).and_return(now)
       allow_any_instance_of(PublishedRelationshipsFilter).to receive(:xml).and_return(Nokogiri::XML(relationships_xml))
+      allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
     end
 
     it 'returns the full public xml representation' do

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -4,10 +4,21 @@ require 'rails_helper'
 
 RSpec.describe 'Display metadata' do
   let(:object) { Dor::Item.new(pid: 'druid:mk420bs7601') }
+  let(:cocina_object) do
+    Cocina::Models::DRO.new(externalIdentifier: 'druid:mk420bs7601',
+                            type: Cocina::Models::Vocab.object,
+                            label: 'A generic label',
+                            version: 1,
+                            description: build_cocina_description_metadata_1('druid:mk420bs7601'),
+                            identification: {},
+                            access: {},
+                            administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+  end
 
   before do
     object.descMetadata.title_info.main_title = 'Hello'
     allow(Dor).to receive(:find).and_return(object)
+    allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
   end
 
   describe 'dublin core' do

--- a/spec/requests/update_marc_record_spec.rb
+++ b/spec/requests/update_marc_record_spec.rb
@@ -5,9 +5,20 @@ require 'rails_helper'
 RSpec.describe 'Update MARC record' do
   let(:druid) { 'druid:mx123qw2323' }
   let(:object) { Dor::Item.new(pid: druid) }
+  let(:cocina_object) do
+    Cocina::Models::DRO.new(externalIdentifier: druid,
+                            type: Cocina::Models::Vocab.object,
+                            label: 'A generic label',
+                            version: 1,
+                            description: build_cocina_description_metadata_1(druid),
+                            identification: {},
+                            access: {},
+                            administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+  end
 
   before do
     allow(Dor).to receive(:find).and_return(object)
+    allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
   end
 
   context 'when the request is successful' do

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -3,11 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Publish::PublicXmlService do
-  subject(:service) { described_class.new(item, released_for: release_tags) }
+  subject(:service) { described_class.new(item, released_for: release_tags, thumbnail_service: thumbnail_service) }
 
   let(:release_tags) { {} }
 
   let(:item) { instantiate_fixture('druid:bc123df4567', Dor::Item) }
+  let(:thumbnail_service) { ThumbnailService.new(cocina_object) }
 
   before do
     allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Publish::PublicXmlService do
 
   let(:item) { instantiate_fixture('druid:bc123df4567', Dor::Item) }
 
+  before do
+    allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
+  end
+
   describe '#to_xml' do
     subject(:xml) { service.to_xml }
 
@@ -67,6 +71,16 @@ RSpec.describe Publish::PublicXmlService do
 
     context 'when there are no release tags' do
       let(:release_tags) { {} }
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
 
       it 'does not include a releaseData element and any info in identityMetadata' do
         expect(ng_xml.at_xpath('/publicObject/releaseData')).to be_nil
@@ -75,6 +89,17 @@ RSpec.describe Publish::PublicXmlService do
     end
 
     context 'with an embargo' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+
       let(:embargo) do
         <<~XML
           <embargoMetadata>
@@ -112,6 +137,17 @@ RSpec.describe Publish::PublicXmlService do
     end
 
     context 'produces xml with' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                                structural: build_cocina_structural_metadata_1)
+      end
       let(:now) { Time.now.utc }
 
       before do
@@ -189,8 +225,21 @@ RSpec.describe Publish::PublicXmlService do
         expect(item.datastreams['RELS-EXT'].content).to be_equivalent_to rels
       end
 
-      it 'does not add a thumb node if no thumb is present' do
-        expect(ng_xml.at_xpath('/publicObject/thumb')).not_to be
+      context 'when no thumb is present' do
+        let(:cocina_object) do
+          Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                  type: Cocina::Models::Vocab.object,
+                                  label: 'A generic label',
+                                  version: 1,
+                                  description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                  identification: {},
+                                  access: {},
+                                  administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+        end
+
+        it 'does not add a thumb node' do
+          expect(ng_xml.at_xpath('/publicObject/thumb')).not_to be
+        end
       end
 
       it 'include a thumb node if a thumb is present' do
@@ -205,7 +254,7 @@ RSpec.describe Publish::PublicXmlService do
             </resource>
           </contentMetadata>
         XML
-        expect(ng_xml.at_xpath('/publicObject/thumb').to_xml).to be_equivalent_to('<thumb>bc123df4567/bc123df4567_05_0002.jp2</thumb>')
+        expect(ng_xml.at_xpath('/publicObject/thumb').to_xml).to be_equivalent_to('<thumb>bc123df4567/wt183gy6220_00_0001.jp2</thumb>')
       end
 
       context 'when there is content inside it' do
@@ -226,6 +275,18 @@ RSpec.describe Publish::PublicXmlService do
     end
 
     context 'with a collection' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                                structural: build_cocina_structural_metadata_1)
+      end
+
       it 'publishes the expected datastreams' do
         expect(ng_xml.at_xpath('/publicObject/identityMetadata')).to be
         expect(ng_xml.at_xpath('/publicObject/rightsMetadata')).to be
@@ -236,6 +297,18 @@ RSpec.describe Publish::PublicXmlService do
     end
 
     context 'with external references' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                                structural: build_cocina_structural_metadata_1)
+      end
+
       it 'handles externalFile references' do
         correct_content_md = Nokogiri::XML(read_fixture('hj097bm8879_publicObject.xml')).at_xpath('/publicObject/contentMetadata').to_xml
         item.contentMetadata.content = read_fixture('hj097bm8879_contentMetadata.xml')
@@ -247,7 +320,7 @@ RSpec.describe Publish::PublicXmlService do
 
         # generate publicObject XML and verify that the content metadata portion is correct and the correct thumb is present
         expect(ng_xml.at_xpath('/publicObject/contentMetadata').to_xml).to be_equivalent_to(correct_content_md)
-        expect(ng_xml.at_xpath('/publicObject/thumb').to_xml).to be_equivalent_to('<thumb>jw923xn5254/2542B.jp2</thumb>')
+        expect(ng_xml.at_xpath('/publicObject/thumb').to_xml).to be_equivalent_to('<thumb>bc123df4567/wt183gy6220_00_0001.jp2</thumb>')
       end
 
       context 'when the referenced object does not have the referenced resource' do
@@ -384,6 +457,18 @@ RSpec.describe Publish::PublicXmlService do
     end
 
     context 'with a cocina-originating object' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: build_cocina_description_metadata_1('druid:bc123df4567'),
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                                structural: build_cocina_structural_metadata_1)
+      end
+
       before do
         item.contentMetadata.content = <<-XML
           <?xml version="1.0"?>

--- a/spec/services/thumbnail_service_spec.rb
+++ b/spec/services/thumbnail_service_spec.rb
@@ -9,187 +9,93 @@ RSpec.describe ThumbnailService do
     subject { instance.thumb }
 
     context 'for a collection' do
-      let(:object) { instantiate_fixture('druid:bc123df4567', Dor::Collection) }
+      let(:object) do
+        Cocina::Models::Collection.new(externalIdentifier: 'druid:bc123df4567',
+                                       type: Cocina::Models::Vocab.collection,
+                                       label: 'Collection of new maps of Africa',
+                                       version: 1,
+                                       cocinaVersion: '0.0.1',
+                                       access: {})
+      end
 
-      it 'returns nil if there is no contentMetadata datastream' do
+      it 'returns nil if there is no structural metadata' do
         expect(subject).to be_nil
       end
     end
 
     context 'for an item' do
-      let(:object) { instantiate_fixture('druid:bc123df4567', Dor::Item) }
+      let(:druid) { 'druid:bc123df4567' }
+      let(:apo_druid) { 'druid:pp000pp0000' }
 
-      it 'returns nil if there is no contentMetadata' do
-        object.contentMetadata.content = '<contentMetadata/>'
-        expect(subject).to be_nil
+      context 'with no structural metadata' do
+        let(:object) do
+          Cocina::Models::DRO.new(externalIdentifier: druid,
+                                  type: Cocina::Models::Vocab.object,
+                                  label: 'A new map of Africa',
+                                  version: 1,
+                                  description: build_cocina_description_metadata_1(druid),
+                                  identification: {},
+                                  access: {},
+                                  administrative: { hasAdminPolicy: apo_druid })
+        end
+
+        it 'returns nil' do
+          expect(subject).to be_nil
+        end
       end
 
-      it 'finds the first image as the thumb when no specific thumbs are specified' do
-        object.contentMetadata.content = <<-XML
-          <?xml version="1.0"?>
-          <contentMetadata objectId="druid:bc123df4567" type="image">
-            <resource id="0001" sequence="1" type="image">
-              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
-            </resource>
-          </contentMetadata>
-        XML
-        expect(subject).to eq('bc123df4567/bc123df4567_05_0001.jp2')
+      context 'when no specific thumbs are specified' do
+        let(:object) do
+          Cocina::Models::DRO.new(externalIdentifier: druid,
+                                  type: Cocina::Models::Vocab.object,
+                                  label: 'A new map of Africa',
+                                  version: 1,
+                                  description: build_cocina_description_metadata_1(druid),
+                                  identification: {},
+                                  access: {},
+                                  administrative: { hasAdminPolicy: apo_druid },
+                                  structural: build_cocina_structural_metadata_1)
+        end
+
+        it 'finds the first image as the thumb' do
+          expect(subject).to eq('bc123df4567/wt183gy6220_00_0001.jp2')
+        end
       end
 
-      it 'finds a thumb resource marked as thumb with the thumb attribute first, even if it is listed second' do
-        object.contentMetadata.content = <<-XML
-          <?xml version="1.0"?>
-          <contentMetadata objectId="druid:bc123df4567" type="map">
-            <resource id="0001" sequence="1" type="image">
-              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
-            </resource>
-            <resource id="0002" sequence="2" thumb="yes" type="thumb">
-              <file id="bc123df4567_thumb.jp2" mimetype="image/jp2"/>
-            </resource>
-          </contentMetadata>
-        XML
-        expect(subject).to eq('bc123df4567/bc123df4567_thumb.jp2')
+      context 'when an externalFile image resource is the only image' do
+        let(:object) do
+          Cocina::Models::DRO.new(externalIdentifier: druid,
+                                  type: Cocina::Models::Vocab.object,
+                                  label: 'A new map of Africa',
+                                  version: 1,
+                                  description: build_cocina_description_metadata_1(druid),
+                                  identification: {},
+                                  access: {},
+                                  administrative: { hasAdminPolicy: apo_druid },
+                                  structural: build_cocina_structural_metadata_2)
+        end
+
+        it 'returns the image as the thumb' do
+          expect(subject).to eq('cg767mn6478_1/2542A.jp2')
+        end
       end
 
-      it 'finds a thumb resource marked as thumb without the thumb attribute first, even if it is listed second when there are no other thumbs specified' do
-        object.contentMetadata.content = <<-XML
-          <?xml version="1.0"?>
-          <contentMetadata objectId="druid:bc123df4567" type="map">
-            <resource id="0001" sequence="1" type="image">
-              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
-            </resource>
-            <resource id="0002" sequence="2" type="thumb">
-              <file id="bc123df4567_thumb.jp2" mimetype="image/jp2"/>
-            </resource>
-          </contentMetadata>
-        XML
-        expect(subject).to eq('bc123df4567/bc123df4567_thumb.jp2')
-      end
+      context 'when no thumb is identified' do
+        let(:object) do
+          Cocina::Models::DRO.new(externalIdentifier: druid,
+                                  type: Cocina::Models::Vocab.object,
+                                  label: 'A new map of Africa',
+                                  version: 1,
+                                  description: build_cocina_description_metadata_1(druid),
+                                  identification: {},
+                                  access: {},
+                                  administrative: { hasAdminPolicy: apo_druid },
+                                  structural: build_cocina_structural_metadata_3)
+        end
 
-      it 'finds a thumb resource marked as thumb with the thumb attribute first, even if it is listed second and there is another image marked as thumb first' do
-        object.contentMetadata.content = <<-XML
-          <?xml version="1.0"?>
-          <contentMetadata objectId="druid:bc123df4567" type="map">
-            <resource id="0001" sequence="1" thumb="yes" type="image">
-              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
-            </resource>
-            <resource id="0002" sequence="2" thumb="yes" type="thumb">
-              <file id="bc123df4567_thumb.jp2" mimetype="image/jp2"/>
-            </resource>
-          </contentMetadata>
-        XML
-        expect(subject).to eq('bc123df4567/bc123df4567_thumb.jp2')
-      end
-
-      it 'finds an image resource marked as thumb with the thumb attribute when there is no resource thumb specified' do
-        object.contentMetadata.content = <<-XML
-          <?xml version="1.0"?>
-          <contentMetadata objectId="druid:bc123df4567" type="map">
-            <resource id="0001" sequence="1" type="image">
-              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
-            </resource>
-            <resource id="0002" sequence="2" thumb="yes" type="image">
-              <file id="bc123df4567_05_0002.jp2" mimetype="image/jp2"/>
-            </resource>
-          </contentMetadata>
-        XML
-        expect(subject).to eq('bc123df4567/bc123df4567_05_0002.jp2')
-      end
-
-      it 'finds an image resource marked as thumb with the thumb attribute when there is a resource thumb specified but not the thumb attribute' do
-        object.contentMetadata.content = <<-XML
-          <?xml version="1.0"?>
-          <contentMetadata objectId="druid:bc123df4567" type="book">
-            <resource id="0001" sequence="1" type="thumb">
-              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
-            </resource>
-            <resource id="0002" sequence="2" thumb="yes" type="image">
-              <file id="bc123df4567_05_0002.jp2" mimetype="image/jp2"/>
-            </resource>
-          </contentMetadata>
-        XML
-        expect(subject).to eq('bc123df4567/bc123df4567_05_0002.jp2')
-      end
-
-      it 'finds a page resource marked as thumb with the thumb attribute when there is a resource thumb specified but not the thumb attribute' do
-        object.contentMetadata.content = <<-XML
-          <?xml version="1.0"?>
-          <contentMetadata objectId="druid:bc123df4567" type="file">
-            <resource id="0001" sequence="1" type="thumb">
-              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
-              <file id="extra_ignored_image" mimetype="image/jp2"/>
-            </resource>
-            <resource id="0002" sequence="2" thumb="yes" type="page">
-              <file id="bc123df4567_05_0002.jp2" mimetype="image/jp2"/>
-            </resource>
-            <resource id="0003" sequence="3" type="page">
-              <externalFile fileId="2542A.jp2" mimetype="image/jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1">
-            </resource>
-          </contentMetadata>
-        XML
-        expect(subject).to eq('bc123df4567/bc123df4567_05_0002.jp2')
-      end
-
-      it 'finds an externalFile image resource when there are no other images' do
-        object.contentMetadata.content = <<-XML
-          <?xml version="1.0"?>
-          <contentMetadata objectId="druid:bc123df4567" type="file">
-            <resource id="0001" sequence="1" type="file">
-              <file id="bc123df4567_05_0001.pdf" mimetype="file/pdf"/>
-            </resource>
-            <resource id="0002" sequence="2" type="image">
-              <externalFile fileId="2542A.jp2" mimetype="image/jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1">
-            </resource>
-          </contentMetadata>
-        XML
-        expect(subject).to eq('cg767mn6478/2542A.jp2')
-      end
-
-      it 'finds an externalFile page resource when there are no other images, even if objectId attribute is missing druid prefix' do
-        object.contentMetadata.content = <<-XML
-          <?xml version="1.0"?>
-          <contentMetadata objectId="druid:bc123df4567" type="file">
-            <resource id="0001" sequence="1" type="file">
-              <file id="bc123df4567_05_0001.pdf" mimetype="file/pdf"/>
-            </resource>
-            <resource id="0002" sequence="2" type="page">
-              <externalFile fileId="2542A.jp2" mimetype="image/jp2" objectId="cg767mn6478" resourceId="cg767mn6478_1">
-            </resource>
-          </contentMetadata>
-        XML
-        expect(subject).to eq('cg767mn6478/2542A.jp2')
-      end
-
-      it 'finds an explicit externalFile thumb resource before another image resource, and encode the space' do
-        object.contentMetadata.content = <<-XML
-          <?xml version="1.0"?>
-          <contentMetadata objectId="druid:bc123df4567" type="file">
-            <resource id="0001" sequence="1" type="image">
-              <file id="bc123df4567_05_0001.jp2" mimetype="image/jp2"/>
-            </resource>
-            <resource id="0002" sequence="2" thumb="yes" type="page">
-              <externalFile fileId="2542A withspace.jp2" mimetype="image/jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1">
-            </resource>
-          </contentMetadata>
-        XML
-        expect(subject).to eq('cg767mn6478/2542A withspace.jp2')
-      end
-
-      it 'returns nil if no thumb is identified' do
-        object.contentMetadata.content = <<-XML
-          <?xml version="1.0"?>
-          <contentMetadata objectId="druid:bc123df4567" type="file">
-            <resource id="0001" sequence="1" type="file">
-              <file id="some_file.pdf" mimetype="file/pdf"/>
-            </resource>
-          </contentMetadata>
-        XML
-        expect(subject).to be_nil
-      end
-
-      it 'returns nil if there is no contentMetadata datastream at all' do
-        object.datastreams['contentMetadata'] = nil
-        expect(subject).to be_nil
+        it 'returns nil' do
+          expect(subject).to be_nil
+        end
       end
     end
   end

--- a/spec/support/datastreams.rb
+++ b/spec/support/datastreams.rb
@@ -132,6 +132,72 @@ def build_content_metadata_1
   </contentMetadata>'
 end
 
+def build_cocina_structural_metadata_1
+  {
+    contains: [{
+      type: Cocina::Models::Vocab::Resources.image,
+      externalIdentifier: 'wt183gy6220',
+      label: 'Image 1',
+      version: 1,
+      structural: {
+        contains: [{
+          type: Cocina::Models::Vocab.file,
+          externalIdentifier: 'wt183gy6220_1',
+          label: 'Image 1',
+          filename: 'wt183gy6220_00_0001.jp2',
+          hasMimeType: 'image/jp2',
+          size: 3_182_927,
+          version: 1,
+          access: {},
+          administrative: {
+            publish: false,
+            sdrPreserve: false,
+            shelve: false
+          },
+          hasMessageDigests: []
+        }]
+      }
+    }]
+  }
+end
+
+def build_cocina_structural_metadata_2
+  {
+    hasMemberOrders: [{
+      members: ['cg767mn6478_1/2542A.jp2']
+    }]
+  }
+end
+
+def build_cocina_structural_metadata_3
+  {
+    contains: [{
+      type: Cocina::Models::Vocab::Resources.image,
+      externalIdentifier: 'wt183gy6220',
+      label: 'File 1',
+      version: 1,
+      structural: {
+        contains: [{
+          type: Cocina::Models::Vocab.file,
+          externalIdentifier: 'wt183gy6220_1',
+          label: 'File 1',
+          filename: 'some_file.pdf',
+          hasMimeType: 'file/pdf',
+          size: 3_182_927,
+          version: 1,
+          access: {},
+          administrative: {
+            publish: false,
+            sdrPreserve: false,
+            shelve: false
+          },
+          hasMessageDigests: []
+        }]
+      }
+    }]
+  }
+end
+
 def build_content_metadata_2
   '<contentMetadata objectId="wt183gy6220">
   </contentMetadata>'
@@ -154,6 +220,13 @@ def build_desc_metadata_1
   <titleInfo>
   <title>Constituent label &amp; A Special character</title>
   </titleInfo></mods>'
+end
+
+def build_cocina_description_metadata_1(druid)
+  {
+    title: [{ value: 'Constituent label &amp; A Special character' }],
+    purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+  }
 end
 
 def build_identity_metadata_with_ckey


### PR DESCRIPTION
## Why was this change made?

Closes #3253 

- Rewrites ThumbnailService to take a Cocina object
- Updates PublicXmlService to use a Cocina object for thumbnails
- Updates UpdateMarcRecordService to use a Cocina object for thumbnails

UpdateMarcRecordService (in progress) and PublicXmlService will be completely rewritten for cocina in follow up issues/PRs.

## How was this change tested?

Updated unit tests

## Which documentation and/or configurations were updated?



