### PR TITLE
normalize imageData in contentMetadata

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -40,6 +40,7 @@ module Cocina
         normalize_attr
         normalize_publish
         normalize_empty_xml
+        normalize_image_data
 
         regenerate_ng_xml(ng_xml.to_s)
       end
@@ -75,6 +76,14 @@ module Cocina
 
       def remove_location
         ng_xml.root.xpath('//location[@type="url"]').each(&:remove)
+      end
+
+      def normalize_image_data
+        # remove empty width and heigh attributes from imageData, e.g. <imageData width="" height=""/>
+        # then remove any totally empty imageData nodes, e.g. <imageData/>
+        ng_xml.root.xpath('//imageData[@height=""]').each { |node| node.remove_attribute('height') }
+        ng_xml.root.xpath('//imageData[@width=""]').each { |node| node.remove_attribute('width') }
+        ng_xml.root.xpath('//imageData[not(text())][not(@*)]').each(&:remove)
       end
 
       def normalize_object_id(druid)

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -180,6 +180,71 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       end
     end
 
+    context 'when normalizing imageData' do
+      # adapted from druid:bb101rd7954
+      let(:original_xml) do
+        <<~XML
+          <contentMetadata objectId="druid:bb101rd7954" type="image">
+            <resource type="image">
+              <label>Image 1</label>
+              <file id="Thumbs.db" mimetype="image/vnd.fpx" size="17408" preserve="yes" publish="no" shelve="no">
+                <checksum type="md5">99c8d3026749b6103f20c911ea102339</checksum>
+                <checksum type="sha1">f73a49b173c741b540170a4f3aa64b87988d4db7</checksum>
+                <imageData width="" height="" size="500"/>
+              </file>
+            </resource>
+            <resource type="image">
+              <label>Image 2</label>
+              <file id="Thumbs2.db" mimetype="image/vnd.fpx" size="17408" preserve="yes" publish="no" shelve="no">
+                <checksum type="md5">99c8d3026749b6103f20c911ea102339</checksum>
+                <checksum type="sha1">f73a49b173c741b540170a4f3aa64b87988d4db7</checksum>
+                <imageData width="" height=""/>
+              </file>
+            </resource>
+            <resource type="image">
+              <label>Image 3</label>
+              <file id="Thumbs3.db" mimetype="image/vnd.fpx" size="17408" preserve="yes" publish="no" shelve="no">
+                <checksum type="md5">99c8d3026749b6103f20c911ea102339</checksum>
+                <checksum type="sha1">f73a49b173c741b540170a4f3aa64b87988d4db7</checksum>
+                <imageData/>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      end
+
+      it 'removes blank width and height attributes and blank imageData nodes' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <contentMetadata objectId="druid:bb101rd7954" type="image">
+              <resource type="image">
+                <label>Image 1</label>
+                <file id="Thumbs.db" mimetype="image/vnd.fpx" size="17408" preserve="yes" publish="no" shelve="no">
+                  <checksum type="md5">99c8d3026749b6103f20c911ea102339</checksum>
+                  <checksum type="sha1">f73a49b173c741b540170a4f3aa64b87988d4db7</checksum>
+                  <imageData size="500"/>
+                </file>
+              </resource>
+              <resource type="image">
+                <label>Image 2</label>
+                <file id="Thumbs2.db" mimetype="image/vnd.fpx" size="17408" preserve="yes" publish="no" shelve="no">
+                  <checksum type="md5">99c8d3026749b6103f20c911ea102339</checksum>
+                  <checksum type="sha1">f73a49b173c741b540170a4f3aa64b87988d4db7</checksum>
+                </file>
+              </resource>
+              <resource type="image">
+                <label>Image 3</label>
+                <file id="Thumbs3.db" mimetype="image/vnd.fpx" size="17408" preserve="yes" publish="no" shelve="no">
+                  <checksum type="md5">99c8d3026749b6103f20c911ea102339</checksum>
+                  <checksum type="sha1">f73a49b173c741b540170a4f3aa64b87988d4db7</checksum>
+                </file>
+              </resource>
+            </contentMetadata>
+          XML
+        )
+      end
+    end
+
     context 'when normalizing format' do
       let(:original_xml) do
         <<~XML


### PR DESCRIPTION
## Why was this change made?

Fixes #3243 - normalize blank <imageData> nodes and remove blank width and height attributes from contentMetadata

## How was this change tested?

Added a new test
See `validate-cocina-roundtrip` results below

## Which documentation and/or configurations were updated?



