### PR TITLE
Cocina-izes shelving service. 

### DIFF
--- a/app/jobs/shelve_job.rb
+++ b/app/jobs/shelve_job.rb
@@ -10,7 +10,7 @@ class ShelveJob < ApplicationJob
     background_job_result.processing!
 
     begin
-      item = Dor.find(druid)
+      cocina_object = CocinaObjectStore.find(druid)
 
       # Disabling validation until pre-assembly and WAS handle this correctly.
       # validator = validator_for?(item)
@@ -24,7 +24,7 @@ class ShelveJob < ApplicationJob
       #                                                         detail: "Not all files have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}" }] })
       # end
 
-      ShelvingService.shelve(item)
+      ShelvingService.shelve(cocina_object)
 
       # Shelving can take a long time and can cause the database connections to get stale.
       # So reset to avoid: ActiveRecord::StatementInvalid: PG::ConnectionBad: PQconsumeInput() could not receive data from server: Connection timed out : BEGIN

--- a/spec/jobs/shelve_job_spec.rb
+++ b/spec/jobs/shelve_job_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe ShelveJob, type: :job do
 
   let(:druid) { 'druid:mk420bs7601' }
   let(:result) { create(:background_job_result) }
-  let(:item) { instance_double(Dor::Item) }
+  let(:cocina_object) { instance_double(Cocina::Models::DRO) }
   let(:validator) { instance_double(Cocina::ValidateDarkService, valid?: valid, invalid_filenames: invalid_filenames) }
   let(:valid) { true }
   let(:invalid_filenames) { [] }
 
   before do
-    allow(Dor).to receive(:find).with(druid).and_return(item)
+    allow(CocinaObjectStore).to receive(:find).with(druid).and_return(cocina_object)
     allow(result).to receive(:processing!)
     allow(EventFactory).to receive(:create)
     allow(Cocina::Mapper).to receive(:build)
@@ -32,7 +32,7 @@ RSpec.describe ShelveJob, type: :job do
     end
 
     it 'invokes the ShelvingService' do
-      expect(ShelvingService).to have_received(:shelve).with(item).once
+      expect(ShelvingService).to have_received(:shelve).with(cocina_object).once
     end
 
     it 'marks the job as complete' do
@@ -56,7 +56,7 @@ RSpec.describe ShelveJob, type: :job do
     it 'marks the job as errored' do
       perform
       expect(result).to have_received(:processing!).once
-      expect(ShelvingService).to have_received(:shelve).with(item).once
+      expect(ShelvingService).to have_received(:shelve).with(cocina_object).once
       expect(LogFailureJob).to have_received(:perform_later)
         .with(druid: druid,
               background_job_result: result,

--- a/spec/services/shelving_service_spec.rb
+++ b/spec/services/shelving_service_spec.rb
@@ -3,18 +3,66 @@
 require 'rails_helper'
 
 RSpec.describe ShelvingService do
-  let(:service) { described_class.new(work) }
-  let(:work) { shelvable_item.new(pid: druid) }
+  let(:druid) { 'druid:ng782rw8378' }
 
-  let(:shelvable_item) do
-    Dor::Item
+  let(:cocina_object) do
+    instance_double(Cocina::Models::DRO, externalIdentifier: druid, structural: structural, type: Cocina::Models::Vocab.book)
+  end
+
+  let(:structural) do
+    Cocina::Models::DROStructural.new(
+      { contains: [{ externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/8d17c28b-5b3e-477e-912c-f168a1f4213f',
+                     type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+                     version: 1,
+                     structural: { contains: [{ externalIdentifier: 'http://cocina.sul.stanford.edu/file/be451fd9-7908-4559-9e81-8d6f496a3181',
+                                                type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                                                label: 'folder1PuSu/story1u.txt',
+                                                filename: 'folder1PuSu/story1u.txt',
+                                                size: 7888,
+                                                version: 1,
+                                                hasMessageDigests: [{ type: 'sha1',
+                                                                      digest: '61dfac472b7904e1413e0cbf4de432bda2a97627' },
+                                                                    { type: 'md5', digest: 'e2837b9f02e0b0b76f526eeb81c7aa7b' }],
+                                                access: { access: 'world', download: 'world' },
+                                                administrative: { publish: true, sdrPreserve: false, shelve: true },
+                                                hasMimeType: 'text/plain' }] },
+                     label: 'Folder 1' }],
+        isMemberOf: collections }
+    )
+  end
+
+  let(:collections) { ['druid:bb077hj4590'] }
+
+  let(:content_metadata) do
+    <<~XML
+      <contentMetadata type="book" objectId="#{druid}">
+        <resource sequence="1" type="file" id="folder1PuSu">
+          <label>Folder 1</label>
+          <file mimetype="text/plain" shelve="yes" publish="yes" size="7888" preserve="no" id="folder1PuSu/story1u.txt">
+            <checksum type="md5">e2837b9f02e0b0b76f526eeb81c7aa7b</checksum>
+            <checksum type="sha1">61dfac472b7904e1413e0cbf4de432bda2a97627</checksum>
+          </file>
+        </resource>
+      </contentMetadata>
+    XML
   end
 
   let(:stacks_root) { Dir.mktmpdir }
   let(:workspace_root) { Dir.mktmpdir }
+  let(:mock_diff) { instance_double(Moab::FileGroupDifference) }
+  let(:workflow_client) { instance_double(Dor::Workflow::Client, workflows: workflows) }
+  let(:workflows) { ['accessionWF', 'registrationWF'] }
+  let(:stacks_object_pathname) { Pathname(DruidTools::StacksDruid.new(druid, stacks_root).path) }
 
   before do
+    allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
     allow(Dor::Config.stacks).to receive_messages(local_stacks_root: stacks_root, local_workspace_root: workspace_root)
+    allow(Cocina::ToFedora::ContentMetadataGenerator).to receive(:generate).and_return(content_metadata)
+    allow(Preservation::Client.objects).to receive(:shelve_content_diff).and_return(mock_diff)
+    allow(ShelvableFilesStager).to receive(:stage)
+    allow(DigitalStacksService).to receive(:remove_from_stacks)
+    allow(DigitalStacksService).to receive(:rename_in_stacks)
+    allow(DigitalStacksService).to receive(:shelve_to_stacks)
   end
 
   after do
@@ -22,70 +70,50 @@ RSpec.describe ShelvingService do
     FileUtils.remove_entry workspace_root
   end
 
-  describe '.shelve' do
-    let(:druid) { 'druid:ng782rw8378' }
-    let(:mock_diff) { instance_double(Moab::FileGroupDifference) }
-
-    before do
-      allow(described_class).to receive(:new).and_return(service)
-      # stub the shelve_diff method which is unit tested below
-      allow(Preservation::Client.objects).to receive(:shelve_content_diff).and_return(mock_diff)
-      allow(ShelvableFilesStager).to receive(:stage).with(druid, work.contentMetadata.content, mock_diff, Pathname)
-    end
-
+  context 'when structural present' do
     it 'pushes file changes for shelve-able files into the stacks' do
       stacks_object_pathname = Pathname(DruidTools::StacksDruid.new(druid, stacks_root).path)
       # make sure the DigitalStacksService is getting the correct delete, rename, and shelve requests
       # (These methods are unit tested in digital_stacks_service_spec.rb)
-      expect(DigitalStacksService).to receive(:remove_from_stacks).with(stacks_object_pathname, mock_diff)
-      expect(DigitalStacksService).to receive(:rename_in_stacks).with(stacks_object_pathname, mock_diff)
-      expect(DigitalStacksService).to receive(:shelve_to_stacks).with(Pathname, stacks_object_pathname, mock_diff)
-      described_class.shelve(work)
+      described_class.shelve(cocina_object)
+      expect(ShelvableFilesStager).to have_received(:stage).with(druid, content_metadata, mock_diff, Pathname)
+      expect(DigitalStacksService).to have_received(:remove_from_stacks).with(stacks_object_pathname, mock_diff)
+      expect(DigitalStacksService).to have_received(:rename_in_stacks).with(stacks_object_pathname, mock_diff)
+      expect(DigitalStacksService).to have_received(:shelve_to_stacks).with(Pathname, stacks_object_pathname, mock_diff)
+      expect(Cocina::ToFedora::ContentMetadataGenerator).to have_received(:generate).with(druid: druid, structural: structural, type: Cocina::Models::Vocab.book)
     end
   end
 
-  describe '#shelve_diff' do
-    subject(:result) { service.send(:shelve_diff) }
+  context 'when structural absent' do
+    let(:structural) { nil }
 
-    let(:druid) { 'druid:jq937jp0017' }
-
-    context 'when contentMetadata exists' do
-      before do
-        allow(Preservation::Client.objects).to receive(:shelve_content_diff)
-      end
-
-      it 'retrieves the differences between the current contentMetadata and preservation via preservation-client gem' do
-        service.send(:shelve_diff)
-        expect(Preservation::Client.objects).to have_received(:shelve_content_diff).with(druid: druid, content_metadata: work.contentMetadata.content)
-      end
-    end
-
-    context 'when contentMetadata does not exist' do
-      it 'raises an error' do
-        work.datastreams.delete 'contentMetadata'
-        expect { result }.to raise_error(Dor::Exception)
-      end
+    it 'raises' do
+      expect { described_class.shelve(cocina_object) }.to raise_error(Dor::Exception)
     end
   end
 
-  describe '#stacks_location' do
-    subject(:location) { service.send(:stacks_location) }
+  context 'when a web archive' do
+    let(:workflows) { %w[accessionWF registrationWF wasCrawlPreassemblyWF] }
+    let(:stacks_object_pathname) { Pathname('/web-archiving-stacks/data/collections/bb077hj4590/ng/782/rw/8378') }
 
-    let(:druid) { 'druid:xy123xy1234' }
-
-    it 'returns the default stack' do
-      work.contentMetadata.content = '<contentMetadata/>'
-      expect(location).to eq stacks_root
+    it 'pushes file changes for shelve-able files into the stacks' do
+      # make sure the DigitalStacksService is getting the correct delete, rename, and shelve requests
+      # (These methods are unit tested in digital_stacks_service_spec.rb)
+      described_class.shelve(cocina_object)
+      expect(ShelvableFilesStager).to have_received(:stage).with(druid, content_metadata, mock_diff, Pathname)
+      expect(DigitalStacksService).to have_received(:remove_from_stacks).with(stacks_object_pathname, mock_diff)
+      expect(DigitalStacksService).to have_received(:rename_in_stacks).with(stacks_object_pathname, mock_diff)
+      expect(DigitalStacksService).to have_received(:shelve_to_stacks).with(Pathname, stacks_object_pathname, mock_diff)
+      expect(Cocina::ToFedora::ContentMetadataGenerator).to have_received(:generate).with(druid: druid, structural: structural, type: Cocina::Models::Vocab.book)
     end
+  end
 
-    it 'returns the absolute stack' do
-      work.contentMetadata.content = '<contentMetadata stacks="/specialstacks"/>'
-      expect(location).to eq '/specialstacks'
-    end
+  context 'when a web archive without collection' do
+    let(:workflows) { %w[accessionWF registrationWF wasCrawlPreassemblyWF] }
+    let(:collections) { [] }
 
-    it 'returns a relative stack' do
-      work.contentMetadata.content = '<contentMetadata stacks="specialstacks"/>'
-      expect { location }.to raise_error(RuntimeError)
+    it 'raises' do
+      expect { described_class.shelve(cocina_object) }.to raise_error(Dor::Exception)
     end
   end
 end


### PR DESCRIPTION
Also, stop getting web archiving stacks location from stacks attribute.

closes #3082.

## Why was this change made?
So that the stacks attribute in content metadata can be deprecated.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



