### PR TITLE
Normalize and complete mapping of readingOrder

### DIFF
--- a/app/services/cocina/from_fedora/dro_structural.rb
+++ b/app/services/cocina/from_fedora/dro_structural.rb
@@ -55,7 +55,7 @@ module Cocina
 
       def create_member_order
         viewing_direction = ViewingDirectionHelper.viewing_direction(druid: fedora_item.pid, content_ng_xml: fedora_item.contentMetadata.ng_xml)
-        return unless viewing_direction
+        viewing_direction ||= 'left-to-right'
 
         [{ viewingDirection: viewing_direction }]
       end

--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -115,13 +115,17 @@ module Cocina
       def normalize_reading_order(druid)
         return if ng_xml.root['type'] != 'book'
         return if ng_xml.root.xpath('//bookData[@readingOrder]').present?
-        return if ng_xml.root.xpath('//resource').empty?
 
         reading_direction = Cocina::FromFedora::ViewingDirectionHelper.viewing_direction(druid: druid, content_ng_xml: ng_xml)
-        return unless reading_direction
+        fedora_reading_direction = case reading_direction
+                                   when nil, 'left-to-right'
+                                     'ltr'
+                                   else
+                                     'rtl'
+                                   end
 
         book_data_node = Nokogiri::XML::Node.new('bookData', ng_xml)
-        book_data_node['readingOrder'] = reading_direction == 'left-to-right' ? 'ltr' : 'rtl'
+        book_data_node['readingOrder'] = fedora_reading_direction
         ng_xml.root << book_data_node
       end
 

--- a/spec/services/cocina/mapping/access/dro_access_spec.rb
+++ b/spec/services/cocina/mapping/access/dro_access_spec.rb
@@ -77,7 +77,7 @@ RSpec.shared_examples 'DRO Access Fedora Cocina mapping' do
           },
           label: ''
         }
-      ]
+      ], hasMemberOrders: [{ viewingDirection: 'left-to-right' }]
     }
   end
 

--- a/spec/services/cocina/mapping/structural/dro_structural_spec.rb
+++ b/spec/services/cocina/mapping/structural/dro_structural_spec.rb
@@ -108,6 +108,7 @@ RSpec.describe 'Fedora item content metadata <--> Cocina DRO structural mappings
       let(:content_xml) do
         <<~XML
           <contentMetadata type="book" objectId="#{druid}">
+            <bookData readingOrder="ltr"/>
             <resource sequence="1" type="file" id="folder1PuSu">
               <label>Folder 1</label>
               <file mimetype="text/plain" shelve="yes" publish="yes" size="7888" preserve="no" id="folder1PuSu/story1u.txt">
@@ -253,7 +254,7 @@ RSpec.describe 'Fedora item content metadata <--> Cocina DRO structural mappings
                                                   access: { access: 'world', download: 'world' },
                                                   administrative: { publish: true, sdrPreserve: true, shelve: false },
                                                   hasMimeType: 'text/plain' }] },
-                       label: '' }] }
+                       label: '' }], hasMemberOrders: [{ viewingDirection: 'left-to-right' }] }
       end
     end
   end
@@ -264,6 +265,7 @@ RSpec.describe 'Fedora item content metadata <--> Cocina DRO structural mappings
       let(:content_xml) do
         <<~XML
           <contentMetadata type="book" objectId="#{druid}">
+            <bookData readingOrder="ltr"/>
             <resource sequence="1" type="file" id="folder1PuSu">
               <attr type="label">Folder 1</attr>
               <file mimetype="text/plain" shelve="yes" publish="yes" size="7888" preserve="no" id="folder1PuSu/story1u.txt">
@@ -278,6 +280,7 @@ RSpec.describe 'Fedora item content metadata <--> Cocina DRO structural mappings
       let(:roundtrip_content_xml) do
         <<~XML
           <contentMetadata type="book" objectId="#{druid}">
+            <bookData readingOrder="ltr"/>
             <resource sequence="1" type="file" id="folder1PuSu">
               <label>Folder 1</label>
               <file mimetype="text/plain" shelve="yes" publish="yes" size="7888" preserve="no" id="folder1PuSu/story1u.txt">
@@ -305,7 +308,7 @@ RSpec.describe 'Fedora item content metadata <--> Cocina DRO structural mappings
                                                   access: { access: 'world', download: 'world' },
                                                   administrative: { publish: true, sdrPreserve: false, shelve: true },
                                                   hasMimeType: 'text/plain' }] },
-                       label: 'Folder 1' }] }
+                       label: 'Folder 1' }], hasMemberOrders: [{ viewingDirection: 'left-to-right' }] }
       end
     end
   end
@@ -315,6 +318,7 @@ RSpec.describe 'Fedora item content metadata <--> Cocina DRO structural mappings
       let(:content_xml) do
         <<~XML
           <contentMetadata type="book" objectId="#{druid}">
+            <bookData readingOrder="ltr"/>
             <resource sequence="1" type="file" id="folder1PuSu">
               <label>Folder 1</label>
               <file mimetype="" shelve="yes" publish="yes" size="7888" preserve="no" id="folder1PuSu/story1u.txt">
@@ -341,7 +345,7 @@ RSpec.describe 'Fedora item content metadata <--> Cocina DRO structural mappings
                                                                       { type: 'md5', digest: 'e2837b9f02e0b0b76f526eeb81c7aa7b' }],
                                                   access: { access: 'world', download: 'world' },
                                                   administrative: { publish: true, sdrPreserve: false, shelve: true } }] },
-                       label: 'Folder 1' }] }
+                       label: 'Folder 1' }], hasMemberOrders: [{ viewingDirection: 'left-to-right' }] }
       end
     end
   end

--- a/spec/services/cocina/mapping/structural/dro_structural_spec.rb
+++ b/spec/services/cocina/mapping/structural/dro_structural_spec.rb
@@ -369,6 +369,7 @@ RSpec.describe 'Fedora item content metadata <--> Cocina DRO structural mappings
       let(:roundtrip_content_xml) do
         <<~XML
           <contentMetadata type="book" objectId="#{druid}">
+            <bookData readingOrder="ltr"/>
             <resource sequence="1" type="file" id="folder1PuSu">
               <label>Folder 1</label>
               <file mimetype="text/plain" shelve="yes" publish="yes" size="7888" preserve="no" id="folder1PuSu/story1u.txt">
@@ -396,7 +397,7 @@ RSpec.describe 'Fedora item content metadata <--> Cocina DRO structural mappings
                                                   access: { access: 'world', download: 'world' },
                                                   administrative: { publish: true, sdrPreserve: false, shelve: true },
                                                   hasMimeType: 'text/plain' }] },
-                       label: 'Folder 1' }] }
+                       label: 'Folder 1' }], hasMemberOrders: [{ viewingDirection: 'left-to-right' }] }
       end
     end
   end

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -150,8 +150,14 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
         allow(AdministrativeTags).to receive(:content_type).and_return(['Book (ltr)'])
       end
 
-      it 'does nothing' do
-        expect(normalized_ng_xml).to be_equivalent_to(original_xml)
+      it 'does not add resources but adds bookData' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <contentMetadata objectId="druid:bb035tg0974" type="book">
+              <bookData readingOrder="ltr"/>
+            </contentMetadata>
+          XML
+        )
       end
     end
 
@@ -234,6 +240,7 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
                 <imageData/>
               </file>
             </resource>
+          </contentMetadata>
         XML
       end
 
@@ -263,6 +270,7 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
                   <checksum type="sha1">f73a49b173c741b540170a4f3aa64b87988d4db7</checksum>
                 </file>
               </resource>
+            </contentMetadata>
           XML
         )
       end

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -180,6 +180,31 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       end
     end
 
+    context 'when reading missing and book right-to-left' do
+      let(:original_xml) do
+        <<~XML
+          <contentMetadata objectId="druid:bb035tg0974" type="book">
+            <resource sequence="1" type="page" />
+          </contentMetadata>
+        XML
+      end
+
+      before do
+        allow(AdministrativeTags).to receive(:content_type).and_return(['Book (rtl)'])
+      end
+
+      it 'adds a "rtl" reading order' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <contentMetadata objectId="druid:bb035tg0974" type="book">
+              <bookData readingOrder="rtl"/>
+              <resource type="page" />
+            </contentMetadata>
+          XML
+        )
+      end
+    end
+
     context 'when normalizing imageData' do
       # adapted from druid:bb101rd7954
       let(:original_xml) do
@@ -209,7 +234,6 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
                 <imageData/>
               </file>
             </resource>
-          </contentMetadata>
         XML
       end
 
@@ -239,7 +263,6 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
                   <checksum type="sha1">f73a49b173c741b540170a4f3aa64b87988d4db7</checksum>
                 </file>
               </resource>
-            </contentMetadata>
           XML
         )
       end


### PR DESCRIPTION
## Why was this change made?
Resolves #3128 to map hasMemberOrders > viewingDirection for all books and normalize readingOrder and bookData to all Fedora book objects. 

## How was this change tested?
Added tests and unit tests pass. `bin/validate-cocina-roundtrip -s 100000 druids.testbed.txt`:

Before:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   95561 (95.64%)
  Different: 4355 (4.359%)
  Mapping error:     1 (0.001%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     83 (0.083%)
  Bad cache:     0 (0.0%)
```

After
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   95976 (96.056%)
  Different: 3940 (3.943%)
  Mapping error:     1 (0.001%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     83 (0.083%)
  Bad cache:     0 (0.0%)
```
The one record with a mapping_error in both runs is druid:cz289fm3599, which doesn't seem to be in Argo anymore? 

## Which documentation and/or configurations were updated?



