### PR TITLE
Normalize otherid labels

### DIFF
--- a/app/services/cocina/normalizers/identity_normalizer.rb
+++ b/app/services/cocina/normalizers/identity_normalizer.rb
@@ -34,6 +34,7 @@ module Cocina
         normalize_source_id_whitespace
         normalize_release_tags
         normalize_object_creator
+        normalize_out_labels
 
         regenerate_ng_xml(ng_xml.to_xml)
       end
@@ -122,6 +123,10 @@ module Cocina
           id.remove if seen.include? id.text
           seen.add id.text
         end
+      end
+
+      def normalize_out_labels
+        ng_xml.root.xpath('//otherId[@name="label"]').each(&:remove)
       end
 
       def normalize_release_tags

--- a/bin/reports/report-identity-otherids_labels
+++ b/bin/reports/report-identity-otherids_labels
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+def check(ng_xml)
+  ng_xml.root.xpath('//otherId[@name="label"]').map(&:content).join(', ').presence
+end
+
+Report.new(name: 'identity-otherids_labels', dsid: 'identityMetadata', report_func: method(:check)).run

--- a/spec/services/cocina/normalizers/identity_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/identity_normalizer_spec.rb
@@ -520,4 +520,27 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
       )
     end
   end
+
+  context 'when there are otherId labels' do
+    let(:original_xml) do
+      <<~XML
+        <identityMetadata>
+          <otherId name="catkey">12345</otherId>
+          <otherId name="label">90125</otherId>
+          <otherId name="label">24601</otherId>
+        </identityMetadata>
+      XML
+    end
+
+    it 'removes them' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <identityMetadata>
+            <objectCreator>DOR</objectCreator>
+            <otherId name="catkey">12345</otherId>
+          </identityMetadata>
+        XML
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

A decision was made not to map otherId[@name="label"]. This PR tests that they are removed during normalization, and also does the removal.

## How was this change tested?

Unit tests. Here is before/after roundtrip report from sdr-deploy:

Before:

```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   96092 (96.174%)
  Different: 3822 (3.825%)
  Mapping error:     1 (0.001%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     85 (0.085%)
  Bad cache:     0 (0.0%)
```

After:

```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   96099 (96.181%)
  Different: 3815 (3.818%)
  Mapping error:     1 (0.001%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     85 (0.085%)
  Bad cache:     0 (0.0%)
```

## Which documentation and/or configurations were updated?



