### PR TITLE
add new created_at header to openapi

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1189,6 +1189,9 @@ paths:
             Last-Modified:
               schema:
                 type: string
+            X-Created-At:
+              schema:
+                type: string
         '422':
           description: Unprocessable Entity
           content:


### PR DESCRIPTION
## Why was this change made?

New header was added here: https://github.com/sul-dlss/dor-services-app/pull/3198/files and is now used here: https://github.com/sul-dlss/dor_indexing_app/pull/722 .... add to openapi

## How was this change tested?

existing tests

## Which documentation and/or configurations were updated?



