### PR TITLE
Removing missing name type warning.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/from_fedora/descriptive/contributor.rb
@@ -74,19 +74,7 @@ module Cocina
         end
 
         def build_name_nodes(name_nodes)
-          name_nodes.each do |name_node|
-            notifier.warn('Missing or empty name type attribute') if missing_name_type?(name_node)
-          end
           NameBuilder.build(name_elements: name_nodes, notifier: notifier).presence
-        end
-
-        def missing_name_type?(name_node)
-          name_node['type'].blank? &&
-            name_node['xlink:href'].blank? &&
-            name_node.xpath('mods:etal', mods: DESC_METADATA_NS).empty? &&
-            name_node.ancestors('relatedItem').empty? &&
-            name_node['valueURI'].blank? &&
-            name_node.xpath('mods:role/mods:roleTerm[text() = "event"]', mods: DESC_METADATA_NS).empty?
         end
 
         def adjust_primary(contributors)

--- a/app/services/cocina/from_fedora/descriptive/subject.rb
+++ b/app/services/cocina/from_fedora/descriptive/subject.rb
@@ -345,10 +345,7 @@ module Cocina
 
           return nil if node['xlink:href'] && node.children.empty?
 
-          unless name_type
-            notifier.warn('Subject contains a <name> element without a type attribute') unless node['xlink:href']
-            return 'name'
-          end
+          return 'name' unless name_type
 
           return 'topic' if name_type.casecmp('topic').zero?
 

--- a/spec/services/cocina/from_fedora/descriptive/subject_name_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/subject_name_spec.rb
@@ -179,11 +179,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
       XML
     end
 
-    before do
-      allow(notifier).to receive(:warn)
-    end
-
-    it 'builds the cocina data structure and warns' do
+    it 'builds the cocina data structure' do
       expect(build).to eq [
         {
           source:
@@ -196,7 +192,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Subject do
           value: 'Stanford University. Libraries.'
         }
       ]
-      expect(notifier).to have_received(:warn).with('Subject contains a <name> element without a type attribute')
     end
   end
 

--- a/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
@@ -55,8 +55,6 @@ RSpec.describe 'MODS name <--> cocina mappings' do
           ]
         }
       end
-
-      let(:warnings) { [Notification.new(msg: 'Missing or empty name type attribute')] }
     end
   end
 
@@ -2315,7 +2313,6 @@ RSpec.describe 'MODS name <--> cocina mappings' do
 
       let(:warnings) do
         [
-          Notification.new(msg: 'Missing or empty name type attribute'),
           Notification.new(msg: 'name/namePart missing value'),
           Notification.new(msg: 'Missing name/namePart element')
         ]
@@ -2685,7 +2682,6 @@ RSpec.describe 'MODS name <--> cocina mappings' do
 
         let(:warnings) do
           [
-            Notification.new(msg: 'Missing or empty name type attribute'),
             Notification.new(msg: 'name/namePart missing value'),
             Notification.new(msg: 'Missing name/namePart element')
           ]
@@ -2736,7 +2732,6 @@ RSpec.describe 'MODS name <--> cocina mappings' do
 
         let(:warnings) do
           [
-            Notification.new(msg: 'Missing or empty name type attribute'),
             Notification.new(msg: 'name/namePart missing value'),
             Notification.new(msg: 'Missing name/namePart element')
           ]
@@ -2870,7 +2865,6 @@ RSpec.describe 'MODS name <--> cocina mappings' do
 
         let(:warnings) do
           [
-            Notification.new(msg: 'Missing or empty name type attribute'),
             Notification.new(msg: 'Missing name/namePart element')
           ]
         end


### PR DESCRIPTION
## Why was this change made?
Resolves #2794 to remove missing name type error.

## How was this change tested?
Unit tests. I don't think this affects roundtripping, but if that's useful as a check, let me know and I'll run it. 

## Which documentation and/or configurations were updated?



