### PR TITLE
Implementing subject name specs.

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -217,12 +217,17 @@ module Cocina
           xml.classification value, attrs
         end
 
+        # Write nodes within MODS subject
         def write_topic(subject, subject_value, is_parallel: false, type: nil, subject_values_have_same_authority: true)
           type ||= subject_value.type
           topic_attributes = topic_attributes_for(subject, subject_value, type, is_parallel: is_parallel, subject_values_have_same_authority: subject_values_have_same_authority)
           case type
           when 'person'
             xml.name topic_attributes.merge(type: 'personal') do
+              xml.namePart(subject_value.value) if subject_value.value
+            end
+          when 'name'
+            xml.name topic_attributes do
               xml.namePart(subject_value.value) if subject_value.value
             end
           when 'title'

--- a/spec/services/cocina/mapping/descriptive/mods/subject_name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_name_spec.rb
@@ -1140,13 +1140,13 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
   end
 
   describe 'Name subject without name type' do
-    xit 'not implemented' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <subject>
             <name>
               <namePart>Coutts, Peter, -1889</namePart>
-            <name>
+            </name>
           </subject>
         XML
       end
@@ -1165,7 +1165,7 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
   end
 
   describe 'Multiscript name subject without name type' do
-    xit 'not implemented' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <subject altRepGroup="1">
@@ -1203,7 +1203,7 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
 
   describe 'Name subject without name type and subdivisions' do
     # druid:zf880vq0424
-    xit 'not implemented' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <subject authority="lcsh">
@@ -1215,21 +1215,6 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
             <geographic>Palo Alto</geographic>
             <genre>Pictorial works</genre>
           </subject>
-        XML
-      end
-
-      let(:roundtrip_mods) do
-        <<~XML
-          <subject authority="lcsh">
-            <name>
-              <namePart>Coutts, Peter, -1889</namePart>
-            </name>
-            <topic>Homes and haunts</topic>
-            <geographic>California</geographic>
-            <geographic>Palo Alto</geographic>
-            <genre>Pictorial works</genre>
-          </subject>
-          <genre>Pictorial works</genre>
         XML
       end
 
@@ -1262,12 +1247,6 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
               source: {
                 code: 'lcsh'
               }
-            }
-          ],
-          form: [
-            {
-              value: 'Pictorial works',
-              type: 'genre'
             }
           ]
         }


### PR DESCRIPTION
## Why was this change made?

Partially addresses #2733. Remaining mapping to be handled in separate PR. 

## How was this change tested?
Unit tests pass. No change with `bin/validate-desc-cocina-roundtrip -s 100000 -i druids.testbed.txt`

Before
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99984 (99.984%)
  Different: 16 (0.016%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     0 (0.0%)
```

After
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99984 (99.984%)
  Different: 16 (0.016%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     0 (0.0%)
```

## Which documentation and/or configurations were updated?



