### PR TITLE
Normalizing stacks out of contentMetadata root.

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -34,6 +34,7 @@ module Cocina
         remove_format
         remove_geodata
         remove_id
+        remove_stacks
         normalize_object_id(druid)
         normalize_reading_order(druid)
         normalize_label_attr
@@ -110,6 +111,12 @@ module Cocina
         return if ng_xml.root['id'].blank?
 
         ng_xml.root.delete('id')
+      end
+
+      def remove_stacks
+        return if ng_xml.root['stacks'].blank?
+
+        ng_xml.root.delete('stacks')
       end
 
       def normalize_reading_order(druid)

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -596,4 +596,34 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       )
     end
   end
+
+  context 'when normalizing contentMetadata node with stacks' do
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata type="file" stacks="/web-archiving-stacks/data/collections/mm553tf6423" id="druid:bb035tg0974">
+          <resource type="file">
+            <file dataType="ARC" publish="no" shelve="yes" preserve="yes" id="CDL-20140226165709-00000-tanager.ucop.edu-00460137.arc.gz" size="50674265" mimetype="application/octet-stream">
+              <checksum type="MD5">fec654ee17994c1ea3807fd7a6428321</checksum>
+              <checksum type="SHA1">835753729f41968bc9e45c6cd1c1156fc6673812</checksum>
+            </file>
+          </resource>
+        </contentMetadata>
+      XML
+    end
+
+    it 'removes stacks from root element' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <contentMetadata type="file" objectId="druid:bb035tg0974">
+            <resource type="file">
+              <file dataType="ARC" publish="no" shelve="yes" preserve="yes" id="CDL-20140226165709-00000-tanager.ucop.edu-00460137.arc.gz" size="50674265" mimetype="application/octet-stream">
+                <checksum type="MD5">fec654ee17994c1ea3807fd7a6428321</checksum>
+                <checksum type="SHA1">835753729f41968bc9e45c6cd1c1156fc6673812</checksum>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?
Resolves #3121 to remove "stacks" attribute from contentMetadata root. 

## How was this change tested?
Added test and ran unit tests. Results of `bin/validate-cocina-roundtrip -s 100000 -i druids.testbed.txt ` are unchanged. 

Before:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   96320 (96.399%)
  Different: 3598 (3.601%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

After
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   96320 (96.399%)
  Different: 3598 (3.601%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

## Which documentation and/or configurations were updated?
n/a


