### PR TITLE
Make CocinaObjectStore an instantiable class.

### DIFF
--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -14,7 +14,7 @@ class CocinaObjectStore
   # @raise [Cocina::Mapper::UnexpectedBuildError] raised when an mapping error occurs. This error will no longer be raised when Fedora is removed.
   # @raise [CocinaObjectNotFoundError] raised when the requested Cocina object is not found.
   def self.find(druid)
-    fedora_to_cocina_find(druid)
+    new.find(druid)
   end
 
   # Normalizes, validates, and updates a Cocina object in the datastore.
@@ -25,6 +25,14 @@ class CocinaObjectStore
   # @raise [CocinaObjectNotFoundError] raised if the cocina object does not already exist in the datastore. This error will no longer be raised when support create.
   # @return [Cocina::Models::DRO, Cocina::Models::Collection, Cocina::Models::AdminPolicy] normalized cocina object
   def self.save(cocina_object)
+    new.save(cocina_object)
+  end
+
+  def find(druid)
+    fedora_to_cocina_find(druid)
+  end
+
+  def save(cocina_object)
     updated_cocina_object = cocina_to_fedora_save(cocina_object)
 
     # Broadcast this update action to a topic
@@ -32,24 +40,23 @@ class CocinaObjectStore
     updated_cocina_object
   end
 
-  # The *fedora* methods are private. They are invoked by the above public methods.
-  # In later steps in the migration, they will be replaced by the *ar* methods.
+  private
 
-  def self.fedora_to_cocina_find(druid)
+  # In later steps in the migration, the *fedora* methods will be replaced by the *ar* methods.
+
+  def fedora_to_cocina_find(druid)
     fedora_object = fedora_find(druid)
     Cocina::Mapper.build(fedora_object)
   end
-  private_class_method :fedora_to_cocina_find
 
-  def self.cocina_to_fedora_save(cocina_object)
+  def cocina_to_fedora_save(cocina_object)
     # Currently this only supports an update, not a save.
     fedora_object = fedora_find(cocina_object.externalIdentifier)
     # Updating produces a different Cocina object than it was provided.
     Cocina::ObjectUpdater.run(fedora_object, cocina_object)
   end
-  private_class_method :cocina_to_fedora_save
 
-  def self.fedora_find(druid)
+  def fedora_find(druid)
     item = Dor.find(druid)
     models = ActiveFedora::ContentModel.models_asserted_by(item)
     item = item.adapt_to(Etd) if models.include?('info:fedora/afmodel:Etd')
@@ -57,15 +64,14 @@ class CocinaObjectStore
   rescue ActiveFedora::ObjectNotFoundError
     raise CocinaObjectNotFoundError
   end
-  private_class_method :fedora_find
 
-  # The *ar* methods are private. In later steps in the migration, they will be invoked by the
+  # The *ar* methods are private. In later steps in the migration, the *ar* methods will be invoked by the
   # above public methods.
 
   # Find a Cocina object persisted by ActiveRecord.
   # @param [String] druid to find
   # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]
-  def self.ar_to_cocina_find(druid)
+  def ar_to_cocina_find(druid)
     cocina_object = Dro.find_by(external_identifier: druid)&.to_cocina ||
                     AdminPolicy.find_by(external_identifier: druid)&.to_cocina ||
                     Collection.find_by(external_identifier: druid)&.to_cocina
@@ -74,12 +80,11 @@ class CocinaObjectStore
 
     cocina_object
   end
-  private_class_method :ar_to_cocina_find
 
   # Persist a Cocina object with ActiveRecord.
   # @param [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy] cocina_object
   # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]
-  def self.cocina_to_ar_save(cocina_object)
+  def cocina_to_ar_save(cocina_object)
     model_clazz = case cocina_object
                   when Cocina::Models::AdminPolicy
                     AdminPolicy
@@ -93,5 +98,4 @@ class CocinaObjectStore
     model_clazz.upsert_cocina(cocina_object)
     cocina_object
   end
-  private_class_method :cocina_to_ar_save
 end

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -69,10 +69,12 @@ RSpec.describe CocinaObjectStore do
   end
 
   describe 'to ActiveRecord' do
+    let(:store) { described_class.new }
+
     describe '#ar_to_cocina_find' do
       context 'when object is not found in datastore' do
         it 'raises' do
-          expect { described_class.send(:ar_to_cocina_find, 'druid:bc123df4567') }.to raise_error(CocinaObjectStore::CocinaObjectNotFoundError)
+          expect { store.send(:ar_to_cocina_find, 'druid:bc123df4567') }.to raise_error(CocinaObjectStore::CocinaObjectNotFoundError)
         end
       end
 
@@ -80,7 +82,7 @@ RSpec.describe CocinaObjectStore do
         let(:ar_cocina_object) { create(:dro) }
 
         it 'returns Cocina::Models::DRO' do
-          expect(described_class.send(:ar_to_cocina_find, ar_cocina_object.external_identifier)).to be_a(Cocina::Models::DRO)
+          expect(store.send(:ar_to_cocina_find, ar_cocina_object.external_identifier)).to be_a(Cocina::Models::DRO)
         end
       end
 
@@ -88,7 +90,7 @@ RSpec.describe CocinaObjectStore do
         let(:ar_cocina_object) { create(:admin_policy) }
 
         it 'returns Cocina::Models::AdminPolicy' do
-          expect(described_class.send(:ar_to_cocina_find, ar_cocina_object.external_identifier)).to be_a(Cocina::Models::AdminPolicy)
+          expect(store.send(:ar_to_cocina_find, ar_cocina_object.external_identifier)).to be_a(Cocina::Models::AdminPolicy)
         end
       end
 
@@ -96,12 +98,14 @@ RSpec.describe CocinaObjectStore do
         let(:ar_cocina_object) { create(:collection) }
 
         it 'returns Cocina::Models::Collection' do
-          expect(described_class.send(:ar_to_cocina_find, ar_cocina_object.external_identifier)).to be_a(Cocina::Models::Collection)
+          expect(store.send(:ar_to_cocina_find, ar_cocina_object.external_identifier)).to be_a(Cocina::Models::Collection)
         end
       end
     end
 
     describe '#cocina_to_ar_save' do
+      let(:store) { described_class.new }
+
       context 'when object is a DRO' do
         let(:cocina_object) do
           Cocina::Models::DRO.new({
@@ -117,7 +121,7 @@ RSpec.describe CocinaObjectStore do
 
         it 'saves to datastore' do
           expect(Dro.find_by(external_identifier: cocina_object.externalIdentifier)).to be_nil
-          expect(described_class.send(:cocina_to_ar_save, cocina_object)).to be(cocina_object)
+          expect(store.send(:cocina_to_ar_save, cocina_object)).to be(cocina_object)
           expect(Dro.find_by(external_identifier: cocina_object.externalIdentifier)).not_to be_nil
         end
       end
@@ -136,7 +140,7 @@ RSpec.describe CocinaObjectStore do
 
         it 'saves to datastore' do
           expect(AdminPolicy.find_by(external_identifier: cocina_object.externalIdentifier)).to be_nil
-          expect(described_class.send(:cocina_to_ar_save, cocina_object)).to be(cocina_object)
+          expect(store.send(:cocina_to_ar_save, cocina_object)).to be(cocina_object)
           expect(AdminPolicy.find_by(external_identifier: cocina_object.externalIdentifier)).not_to be_nil
         end
       end
@@ -155,7 +159,7 @@ RSpec.describe CocinaObjectStore do
 
         it 'saves to datastore' do
           expect(Collection.find_by(external_identifier: cocina_object.externalIdentifier)).to be_nil
-          expect(described_class.send(:cocina_to_ar_save, cocina_object)).to be(cocina_object)
+          expect(store.send(:cocina_to_ar_save, cocina_object)).to be(cocina_object)
           expect(Collection.find_by(external_identifier: cocina_object.externalIdentifier)).not_to be_nil
         end
       end


### PR DESCRIPTION
## Why was this change made?
For roundtrip validation, I'm going to need to inject the CocinaObjectStore, which makes more sense as an instantiable class.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



