### PR TITLE
Name subjects with subelements, role, displayForm, and subject subdivision

### DIFF
--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -435,22 +435,12 @@ module Cocina
           parallel_subject_values = Array(value.parallelValue)
           display_values, parallel_subject_values = parallel_subject_values.partition { |par_value| par_value.type == 'display' }
 
-          if parallel_subject_values.size == 1
-            parallel_subject_value = parallel_subject_values.first
-            if parallel_subject_value.structuredValue.present?
-              write_structured_person(value, parallel_subject_value, type: value.type, display_values: display_values)
-            else
-              write_person(value, parallel_subject_value, display_values: display_values)
-            end
-          end
-          return unless parallel_subject_values.size > 1
-
-          parallel_subject_values.each do |parallel_value|
-            if parallel_value.structuredValue.present?
-              write_structured_person(value, parallel_value, type: value.type, display_values: display_values)
-            else
-              write_person(value, parallel_value, display_values: display_values)
-            end
+          # there will not be more than one parallelValue within a structuredValue
+          parallel_subject_value = parallel_subject_values.first
+          if parallel_subject_value.structuredValue.present?
+            write_structured_person(value, parallel_subject_value, type: value.type, display_values: display_values)
+          else
+            write_person(value, parallel_subject_value, display_values: display_values)
           end
         end
       end

--- a/app/services/cocina/to_fedora/descriptive/subject.rb
+++ b/app/services/cocina/to_fedora/descriptive/subject.rb
@@ -89,6 +89,7 @@ module Cocina
         end
 
         # rubocop:disable Metrics/PerceivedComplexity
+        # rubocop:disable Metrics/CyclomaticComplexity
         def write_structured_or_grouped(subject, subject_value, alt_rep_group: nil, type: nil, display_values: nil)
           type ||= subject_value.type || subject.type
           xml.subject(structured_attributes_for(subject_value, type, alt_rep_group: alt_rep_group)) do
@@ -106,6 +107,8 @@ module Cocina
                 if FromFedora::Descriptive::Contributor::ROLES.value?(value.type)
                   if value.structuredValue.present?
                     write_structured_person(subject, value, display_values: display_values)
+                  elsif value.parallelValue.present?
+                    write_parallel_structured_person(value)
                   else
                     write_person(subject, value, display_values: display_values)
                   end
@@ -118,6 +121,7 @@ module Cocina
           end
         end
         # rubocop:enable Metrics/PerceivedComplexity
+        # rubocop:enable Metrics/CyclomaticComplexity
 
         def write_title(subject_value)
           title = subject_value.to_h
@@ -425,6 +429,29 @@ module Cocina
 
         def edition(version)
           version.split.first.gsub(DEORDINAL_REGEX, '')
+        end
+
+        def write_parallel_structured_person(value)
+          parallel_subject_values = Array(value.parallelValue)
+          display_values, parallel_subject_values = parallel_subject_values.partition { |par_value| par_value.type == 'display' }
+
+          if parallel_subject_values.size == 1
+            parallel_subject_value = parallel_subject_values.first
+            if parallel_subject_value.structuredValue.present?
+              write_structured_person(value, parallel_subject_value, type: value.type, display_values: display_values)
+            else
+              write_person(value, parallel_subject_value, display_values: display_values)
+            end
+          end
+          return unless parallel_subject_values.size > 1
+
+          parallel_subject_values.each do |parallel_value|
+            if parallel_value.structuredValue.present?
+              write_structured_person(value, parallel_value, type: value.type, display_values: display_values)
+            else
+              write_person(value, parallel_value, display_values: display_values)
+            end
+          end
         end
       end
       # rubocop:enable Metrics/ClassLength

--- a/spec/services/cocina/mapping/descriptive/mods/subject_name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_name_spec.rb
@@ -733,14 +733,14 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
   end
 
   describe 'Name subject with subelements, role, displayForm, and subject subdivision' do
-    xit 'not implemented in cocina>MODS direction' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <subject>
             <name type="personal">
               <role>
-                <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/dpc">Depicted</roleTerm>
-                <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/dpc">dpc</roleTerm>
+                <roleTerm type="text" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/dpc">Depicted</roleTerm>
+                <roleTerm type="code" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" valueURI="http://id.loc.gov/vocabulary/relators/dpc">dpc</roleTerm>
               </role>
               <namePart type="family">Andrada</namePart>
               <namePart type="given">Leitao, Francisco d'</namePart>

--- a/spec/services/cocina/to_fedora/descriptive/subject_name_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_name_spec.rb
@@ -275,4 +275,67 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
       XML
     end
   end
+
+  context 'with multiple person parallelValues' do
+    let(:subjects) do
+      [
+        Cocina::Models::DescriptiveValue.new(
+          {
+            structuredValue: [
+              {
+                parallelValue: [
+                  {
+                    structuredValue: [
+                      {
+                        value: 'Andrada',
+                        type: 'surname'
+                      },
+                      {
+                        value: 'Leitao, Francisco d\'',
+                        type: 'forename'
+                      },
+                      {
+                        value: '17th C.',
+                        type: 'life dates'
+                      }
+                    ]
+                  },
+                  {
+                    value: 'Andrada, L. F.',
+                    type: 'surname'
+                  },
+                  {
+                    value: 'Andrada, Leitao, Francisco d\', 17th C.',
+                    type: 'display'
+                  }
+                ],
+                type: 'person'
+              }
+            ]
+          }
+        )
+      ]
+    end
+
+    it 'builds the xml' do
+      expect(xml).to be_equivalent_to <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://www.loc.gov/mods/v3" version="3.6"
+          xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <subject>
+            <name type="personal">
+              <namePart type="family">Andrada</namePart>
+              <namePart type="given">Leitao, Francisco d'</namePart>
+              <namePart type="date">17th C.</namePart>
+              <displayForm>Andrada, Leitao, Francisco d', 17th C.</displayForm>
+            </name>
+            <name type="personal">
+              <namePart type="family">Andrada, L. F.</namePart>
+              <displayForm>Andrada, Leitao, Francisco d', 17th C.</displayForm>
+            </name>
+          </subject>
+        </mods>
+      XML
+    end
+  end
 end

--- a/spec/services/cocina/to_fedora/descriptive/subject_name_spec.rb
+++ b/spec/services/cocina/to_fedora/descriptive/subject_name_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
     end
   end
 
-  context 'with multiple person parallelValues' do
+  context 'with person parallelValue and no structuredValue' do
     let(:subjects) do
       [
         Cocina::Models::DescriptiveValue.new(
@@ -285,31 +285,19 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
               {
                 parallelValue: [
                   {
-                    structuredValue: [
-                      {
-                        value: 'Andrada',
-                        type: 'surname'
-                      },
-                      {
-                        value: 'Leitao, Francisco d\'',
-                        type: 'forename'
-                      },
-                      {
-                        value: '17th C.',
-                        type: 'life dates'
-                      }
-                    ]
-                  },
-                  {
-                    value: 'Andrada, L. F.',
+                    value: 'Holbein, Han, 1497-1543',
                     type: 'surname'
                   },
                   {
-                    value: 'Andrada, Leitao, Francisco d\', 17th C.',
+                    value: 'Holbein, Han, 1497-1543',
                     type: 'display'
                   }
                 ],
                 type: 'person'
+              },
+              {
+                value: 'Homes and haunts',
+                type: 'topic'
               }
             ]
           }
@@ -324,15 +312,10 @@ RSpec.describe Cocina::ToFedora::Descriptive::Subject do
           xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
           <subject>
             <name type="personal">
-              <namePart type="family">Andrada</namePart>
-              <namePart type="given">Leitao, Francisco d'</namePart>
-              <namePart type="date">17th C.</namePart>
-              <displayForm>Andrada, Leitao, Francisco d', 17th C.</displayForm>
+              <namePart type="family">Holbein, Han, 1497-1543</namePart>
+              <displayForm>Holbein, Han, 1497-1543</displayForm>
             </name>
-            <name type="personal">
-              <namePart type="family">Andrada, L. F.</namePart>
-              <displayForm>Andrada, Leitao, Francisco d', 17th C.</displayForm>
-            </name>
+            <topic>Homes and haunts</topic>
           </subject>
         </mods>
       XML


### PR DESCRIPTION
## Why was this change made?
Resolves #2733. (Second half was already addressed by #3276.) Maps back to MODS when Cocina has a name subject with structuredValue > parallelValue > structuredValue.

## How was this change tested?
Added spec and ran unit tests. I had to disable Metrics/CyclometricComplexity on one existing method. (It's disabled on other methods in this mapping already.) Wondering if I should be trying to refactor that, or create a ticket for it?

Ran `bin/validate-desc-cocina-roundtrip -s 100000 -i druids.testbed.txt` and no change. 

Before:
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   99985 (99.985%)
  Different: 15 (0.015%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     0 (0.0%)
```

After:
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   99985 (99.985%)
  Different: 15 (0.015%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     0 (0.0%)
```

## Which documentation and/or configurations were updated?



