### PR TITLE
Fix loading of Dor::Agreemnt in cache.

### DIFF
--- a/lib/fedora_loader.rb
+++ b/lib/fedora_loader.rb
@@ -110,7 +110,7 @@ class FedoraLoader
     return Dor::Item if models.include?('info:fedora/afmodel:Etd')
     return Dor::Item if models.include?('info:fedora/afmodel:Eems')
     return Dor::Item if models.include?('info:fedora/afmodel:Eem')
-    return Dor::Item if models.include?('info:fedora/afmodel:Dor_Agreement')
+    return Dor::Agreement if models.include?('info:fedora/afmodel:Dor_Agreement')
 
     # Expected unmapped
     raise ExpectedUnmapped if models.include?('info:fedora/afmodel:Part')


### PR DESCRIPTION
## Why was this change made?
So that agreements can roundtrip.


## How was this change tested?
Local


## Which documentation and/or configurations were updated?



