### PR TITLE
Refactor application of APO defaults

### DIFF
--- a/app/controllers/admin_policy_defaults_controller.rb
+++ b/app/controllers/admin_policy_defaults_controller.rb
@@ -1,116 +1,15 @@
 # frozen_string_literal: true
 
-# TODO: This controller is doing way too much now. Consider extracting most of what is below into a new service object.
 # Applies the AdminPolicy defaults to a repository object
 class AdminPolicyDefaultsController < ApplicationController
-  ALLOWED_WORKFLOW_STATES = %w[Registered Opened].freeze
-  COLLECTION_ACCESS = {
-    'citation-only' => 'world',
-    'dark' => 'dark',
-    'location-based' => 'world',
-    'stanford' => 'world',
-    'world' => 'world'
-  }.freeze
-  FILE_ACCESS = {
-    'citation-only' => 'dark',
-    'dark' => 'dark',
-    'location-based' => 'location-based',
-    'stanford' => 'stanford',
-    'world' => 'world'
-  }.freeze
-
   before_action :load_cocina_object, only: :apply
 
   def apply
-    return type_error_response unless @cocina_object.dro? || @cocina_object.collection?
-    return workflow_error_response unless current_workflow_state.in?(ALLOWED_WORKFLOW_STATES)
-
-    CocinaObjectStore.save(updated_cocina_object)
+    ApplyAdminPolicyDefaults.apply(cocina_object: @cocina_object)
     head :no_content
-  end
-
-  private
-
-  def current_workflow_state
-    WorkflowClientFactory
-      .build
-      .status(druid: @cocina_object.externalIdentifier, version: @cocina_object.version)
-      .display_simplified
-  end
-
-  def type_error_response
-    json_api_error(
-      status: :bad_request,
-      message: "#{@cocina_object.externalIdentifier} is a #{@cocina_object.class} and this type cannot currently have APO access defaults applied",
-      title: 'Object cannot inherit APO access defaults'
-    )
-  end
-
-  def workflow_error_response
-    json_api_error(
-      status: :unprocessable_entity,
-      message: "#{@cocina_object.externalIdentifier} is in a state in which it cannot be modified (#{current_workflow_state}): " \
-               'APO defaults can only be applied when an object is either registered or opened for versioning',
-      title: 'Object cannot be modified in current state'
-    )
-  end
-
-  def updated_cocina_object
-    access_updated = @cocina_object.new(
-      access: @cocina_object.access.new(default_access_from_apo)
-    )
-    return access_updated unless access_updated.dro? && access_updated.structural&.contains&.any?
-
-    access_updated.new(
-      structural: @cocina_object.structural.new(
-        contains: @cocina_object.structural.contains.map do |file_set|
-          file_set.new(
-            structural: file_set.structural.new(
-              contains: file_set.structural.contains.map do |file|
-                file.new(file_properties(file: file))
-              end
-            )
-          )
-        end
-      )
-    )
-  end
-
-  def file_access_props
-    %i[access controlledDigitalLending download readLocation]
-  end
-
-  def collection_access_props
-    %i[access copyright license useAndReproductionStatement]
-  end
-
-  def file_properties(file:)
-    updated_file_access = default_access_from_apo(file_level: true)
-
-    { access: updated_file_access }.tap do |props|
-      next if updated_file_access[:access] != 'dark'
-
-      props[:administrative] = file.administrative.new(shelve: false)
-    end
-  end
-
-  def default_access_from_apo(file_level: false)
-    default_access = CocinaObjectStore.find(@cocina_object.administrative.hasAdminPolicy)
-                                      .administrative
-                                      .defaultAccess
-                                      .to_h
-                                      .with_indifferent_access
-
-    if file_level
-      return default_access.slice(*file_access_props)
-                           .tap { |access| access[:access] = FILE_ACCESS[access[:access]] }
-    end
-
-    if @cocina_object.collection?
-      return default_access.slice(*collection_access_props)
-                           .tap { |access| access[:access] = COLLECTION_ACCESS[access[:access]] }
-    end
-
-    default_access
+  rescue ApplyAdminPolicyDefaults::UnsupportedObjectTypeError => e
+    json_api_error(status: :bad_request, message: e.message, title: 'Object cannot inherit APO access defaults')
+  rescue ApplyAdminPolicyDefaults::UnsupportedWorkflowStateError => e
+    json_api_error(status: :unprocessable_entity, message: e.message, title: 'Object cannot be modified in current state')
   end
 end

--- a/app/services/apply_admin_policy_defaults.rb
+++ b/app/services/apply_admin_policy_defaults.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+# Applies the AdminPolicy defaults to a repository object
+class ApplyAdminPolicyDefaults
+  class UnsupportedObjectTypeError < StandardError; end
+  class UnsupportedWorkflowStateError < StandardError; end
+
+  ALLOWED_WORKFLOW_STATES = %w[Registered Opened].freeze
+  COLLECTION_ACCESS = {
+    'citation-only' => 'world',
+    'dark' => 'dark',
+    'location-based' => 'world',
+    'stanford' => 'world',
+    'world' => 'world'
+  }.freeze
+  COLLECTION_ACCESS_PROPS = %i[access copyright license useAndReproductionStatement].freeze
+  FILE_ACCESS = {
+    'citation-only' => 'dark',
+    'dark' => 'dark',
+    'location-based' => 'location-based',
+    'stanford' => 'stanford',
+    'world' => 'world'
+  }.freeze
+  FILE_ACCESS_PROPS = %i[access controlledDigitalLending download readLocation].freeze
+
+  def self.apply(cocina_object:)
+    new(cocina_object: cocina_object).apply
+  end
+
+  attr_reader :cocina_object
+
+  def initialize(cocina_object:)
+    @cocina_object = cocina_object
+
+    validate_object_type!
+    validate_workflow_state!
+  end
+
+  def apply
+    CocinaObjectStore.save(updated_cocina_object)
+  end
+
+  private
+
+  def validate_object_type!
+    return if @cocina_object.dro? || @cocina_object.collection?
+
+    raise UnsupportedObjectTypeError, "#{@cocina_object.externalIdentifier} is a #{@cocina_object.class} and this type cannot have APO defaults applied"
+  end
+
+  def validate_workflow_state!
+    return if current_workflow_state.in?(ALLOWED_WORKFLOW_STATES)
+
+    raise UnsupportedWorkflowStateError, <<~ERROR_MESSAGE.chomp
+      #{@cocina_object.externalIdentifier} is in a state in which it cannot be modified \
+      (#{current_workflow_state}): APO defaults can only be applied when an object is either \
+      registered or opened for versioning
+    ERROR_MESSAGE
+  end
+
+  def current_workflow_state
+    WorkflowClientFactory
+      .build
+      .status(druid: @cocina_object.externalIdentifier, version: @cocina_object.version)
+      .display_simplified
+  end
+
+  def updated_cocina_object
+    access_updated = @cocina_object.new(
+      access: @cocina_object.access.new(access_properties_for(type: cocina_type))
+    )
+    return access_updated unless access_updated.dro? && access_updated.structural&.contains&.any?
+
+    access_updated.new(
+      structural: @cocina_object.structural.new(
+        contains: @cocina_object.structural.contains.map do |file_set|
+          file_set.new(
+            structural: file_set.structural.new(
+              contains: file_set.structural.contains.map do |file|
+                file.new(file_properties(file: file))
+              end
+            )
+          )
+        end
+      )
+    )
+  end
+
+  def file_properties(file:)
+    updated_file_access = access_properties_for(type: :file)
+
+    { access: updated_file_access }.tap do |props|
+      next if updated_file_access[:access] != 'dark'
+
+      props[:administrative] = file.administrative.new(shelve: false)
+    end
+  end
+
+  def cocina_type
+    if cocina_object.dro?
+      :dro
+    elsif cocina_object.collection?
+      :collection
+    end
+  end
+
+  def access_properties_for(type:)
+    case type
+    when :file
+      default_access_from_apo.slice(*FILE_ACCESS_PROPS).tap { |access| access[:access] = FILE_ACCESS[access[:access]] }
+    when :collection
+      default_access_from_apo.slice(*COLLECTION_ACCESS_PROPS).tap { |access| access[:access] = COLLECTION_ACCESS[access[:access]] }
+    when :dro
+      default_access_from_apo
+    end
+  end
+
+  def default_access_from_apo
+    CocinaObjectStore
+      .find(@cocina_object.administrative.hasAdminPolicy)
+      .administrative
+      .defaultAccess
+      .to_h
+      .with_indifferent_access
+  end
+end

--- a/spec/requests/apply_admin_policy_defaults_spec.rb
+++ b/spec/requests/apply_admin_policy_defaults_spec.rb
@@ -4,371 +4,57 @@ require 'rails_helper'
 
 RSpec.describe 'Apply APO access defaults to a member item' do
   before do
-    allow(CocinaObjectStore).to receive(:find).with(object_druid).and_return(cocina_object)
-    allow(CocinaObjectStore).to receive(:find).with(apo_druid).and_return(cocina_admin_policy)
-    allow(CocinaObjectStore).to receive(:save)
-    allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+    allow(CocinaObjectStore).to receive(:find)
   end
 
-  let(:apo_druid) { 'druid:df123cd4567' }
-  let(:object_druid) { 'druid:bc123df4567' }
-  let(:cocina_admin_policy) do
-    Cocina::Models::AdminPolicy.new(
-      externalIdentifier: apo_druid,
-      version: 1,
-      type: Cocina::Models::Vocab.admin_policy,
-      label: 'Dummy APO',
-      administrative: {
-        hasAdminPolicy: 'druid:hv992ry2431',
-        hasAgreement: 'druid:bc753qt7345',
-        defaultAccess: default_access
-      }
-    )
-  end
-  let(:cocina_object) do
-    Cocina::Models::DRO.new(
-      externalIdentifier: object_druid,
-      version: 1,
-      type: Cocina::Models::Vocab.object,
-      label: 'Dummy Object',
-      access: {},
-      administrative: { hasAdminPolicy: apo_druid },
-      structural: {
-        contains: [before_file_set]
-      }
-    )
-  end
-  let(:before_file_set) do
-    {
-      externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/234-567-890',
-      version: 1,
-      type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
-      label: 'Page 1',
-      structural: {
-        contains: [
-          {
-            externalIdentifier: 'http://cocina.sul.stanford.edu/file/223-456-789',
-            version: 1,
-            type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
-            filename: '00001.jp2',
-            label: '00001.jp2',
-            hasMimeType: 'image/jp2',
-            administrative: {
-              publish: true,
-              sdrPreserve: true,
-              shelve: true
-            },
-            access: {
-              access: 'stanford',
-              download: 'stanford'
-            },
-            hasMessageDigests: []
-          }
-        ]
-      }
-    }
-  end
-  let(:default_access) do
-    {
-      access: 'world',
-      download: 'world'
-    }
-  end
-  let(:workflow_client) { instance_double(Dor::Workflow::Client, status: status_client) }
-  let(:status_client) { instance_double(Dor::Workflow::Client::Status, display_simplified: workflow_state) }
-  let(:workflow_state) { 'Registered' }
-
-  describe 'object types' do
-    # NOTE: We do not explicitly test DROs here as they are tested elsewhere in this spec.
-    context 'with a collection' do
-      let(:cocina_object) do
-        Cocina::Models::Collection.new(
-          externalIdentifier: object_druid,
-          version: 1,
-          type: Cocina::Models::Vocab.collection,
-          label: 'Dummy Collection',
-          access: {},
-          administrative: { hasAdminPolicy: apo_druid }
-        )
-      end
-
-      it 'copies APO defaultAccess to collection access' do
-        post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
-             headers: { 'Authorization' => "Bearer #{jwt}" }
-        expect(response).to be_successful
-        expect(CocinaObjectStore).to have_received(:save)
-          .once
-          .with(cocina_object_with(access: default_access.slice(:access, :copyright, :license, :useAndReproductionStatement)))
-      end
+  context 'when no exceptions are raised' do
+    before do
+      allow(ApplyAdminPolicyDefaults).to receive(:apply).and_return(nil)
     end
 
-    context 'with an APO' do
-      let(:cocina_object) do
-        Cocina::Models::AdminPolicy.new(
-          externalIdentifier: object_druid,
-          version: 1,
-          type: Cocina::Models::Vocab.admin_policy,
-          label: 'Dummy APO',
-          administrative: {
-            hasAdminPolicy: 'druid:hv992ry2431',
-            hasAgreement: 'druid:bc753qt7345',
-            defaultAccess: default_access
-          }
-        )
-      end
-
-      it 'returns an HTTP 400 response with an error message' do
-        post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
-             headers: { 'Authorization' => "Bearer #{jwt}" }
-        expect(JSON.parse(response.body)['errors'].first['detail']).to include(
-          "#{object_druid} is a Cocina::Models::AdminPolicy and this type cannot currently have APO access defaults applied"
-        )
-        expect(response).not_to be_successful
-        expect(response).to have_http_status(:bad_request)
-        expect(CocinaObjectStore).not_to have_received(:save)
-      end
-    end
-  end
-
-  context 'with a collection (supports subset of access values)' do
-    let(:cocina_object) do
-      Cocina::Models::Collection.new(
-        externalIdentifier: object_druid,
-        version: 1,
-        type: Cocina::Models::Vocab.collection,
-        label: 'Dummy Collection',
-        access: {},
-        administrative: { hasAdminPolicy: apo_druid }
-      )
-    end
-
-    context 'when APO specifies citation-only defaultAccess' do
-      let(:default_access) do
-        {
-          access: 'citation-only',
-          download: 'none'
-        }
-      end
-      let(:expected_access) do
-        {
-          access: 'world'
-        }
-      end
-
-      it 'maps to world collection access' do
-        post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
-             headers: { 'Authorization' => "Bearer #{jwt}" }
-        expect(response).to be_successful
-        expect(CocinaObjectStore).to have_received(:save)
-          .once
-          .with(cocina_object_with(access: expected_access))
-      end
-    end
-
-    context 'when APO specifies location-based defaultAccess' do
-      let(:default_access) do
-        {
-          access: 'location-based',
-          download: 'none',
-          readLocation: 'music'
-        }
-      end
-      let(:expected_access) do
-        {
-          access: 'world'
-        }
-      end
-
-      it 'maps to world collection access' do
-        post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
-             headers: { 'Authorization' => "Bearer #{jwt}" }
-        expect(response).to be_successful
-        expect(CocinaObjectStore).to have_received(:save)
-          .once
-          .with(cocina_object_with(access: expected_access))
-      end
-    end
-
-    context 'when APO specifies Stanford (or CDL) defaultAccess' do
-      let(:default_access) do
-        {
-          access: 'stanford',
-          download: 'none',
-          controlledDigitalLending: true
-        }
-      end
-      let(:expected_access) do
-        {
-          access: 'world'
-        }
-      end
-
-      it 'maps to world collection access' do
-        post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
-             headers: { 'Authorization' => "Bearer #{jwt}" }
-        expect(response).to be_successful
-        expect(CocinaObjectStore).to have_received(:save)
-          .once
-          .with(cocina_object_with(access: expected_access))
-      end
-    end
-
-    context 'when APO specifies dark defaultAccess' do
-      let(:default_access) do
-        {
-          access: 'dark',
-          download: 'none'
-        }
-      end
-      let(:expected_access) do
-        {
-          access: 'dark'
-        }
-      end
-
-      it 'maps to dark collection access' do
-        post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
-             headers: { 'Authorization' => "Bearer #{jwt}" }
-        expect(response).to be_successful
-        expect(CocinaObjectStore).to have_received(:save)
-          .once
-          .with(cocina_object_with(access: expected_access))
-      end
-    end
-  end
-
-  context 'with a DRO lacking structural metadata' do
-    let(:cocina_object) do
-      Cocina::Models::DRO.new(
-        externalIdentifier: object_druid,
-        version: 1,
-        type: Cocina::Models::Vocab.object,
-        label: 'Dummy Object',
-        access: {},
-        administrative: { hasAdminPolicy: apo_druid }
-      )
-    end
-
-    it 'copies APO defaultAccess to item access' do
-      post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
+    it 'returns HTTP 204' do
+      post '/v1/objects/druid:bc123df4567/apply_admin_policy_defaults',
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
-      expect(CocinaObjectStore).to have_received(:save)
-        .once
-        .with(cocina_object_with(access: default_access))
+      expect(response).to have_http_status(:no_content)
     end
   end
 
-  describe 'workflow states' do
-    AdminPolicyDefaultsController::ALLOWED_WORKFLOW_STATES.each do |workflow_state|
-      context "when item is in '#{workflow_state}' state" do
-        let(:workflow_state) { workflow_state }
-
-        context 'when APO picks up default default object rights' do
-          let(:file_set_with_default_access) do
-            {
-              externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/234-567-890',
-              version: 1,
-              type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
-              label: 'Page 1',
-              structural: {
-                contains: [
-                  {
-                    externalIdentifier: 'http://cocina.sul.stanford.edu/file/223-456-789',
-                    version: 1,
-                    type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
-                    filename: '00001.jp2',
-                    label: '00001.jp2',
-                    hasMimeType: 'image/jp2',
-                    administrative: {
-                      publish: true,
-                      sdrPreserve: true,
-                      shelve: true
-                    },
-                    access: default_access,
-                    hasMessageDigests: []
-                  }
-                ]
-              }
-            }
-          end
-
-          it 'copies APO defaultAccess to item access' do
-            post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
-                 headers: { 'Authorization' => "Bearer #{jwt}" }
-            expect(response).to be_successful
-            expect(CocinaObjectStore).to have_received(:save)
-              .once
-              .with(cocina_object_with(access: default_access, structural: { contains: [file_set_with_default_access] }))
-          end
-        end
-
-        context 'when APO specifies custom default object rights' do
-          let(:default_access) do
-            {
-              access: 'dark',
-              download: 'none',
-              useAndReproductionStatement: 'Use at will.',
-              license: 'https://creativecommons.org/licenses/by-nc/3.0/legalcode'
-            }
-          end
-
-          let(:file_set_with_custom_access) do
-            {
-              externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/234-567-890',
-              version: 1,
-              type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
-              label: 'Page 1',
-              structural: {
-                contains: [
-                  {
-                    externalIdentifier: 'http://cocina.sul.stanford.edu/file/223-456-789',
-                    version: 1,
-                    type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
-                    filename: '00001.jp2',
-                    label: '00001.jp2',
-                    hasMimeType: 'image/jp2',
-                    administrative: {
-                      publish: true,
-                      sdrPreserve: true,
-                      shelve: false
-                    },
-                    access: default_access.slice(:access, :download),
-                    hasMessageDigests: []
-                  }
-                ]
-              }
-            }
-          end
-
-          it 'copies APO defaultAccess to item access' do
-            post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
-                 headers: { 'Authorization' => "Bearer #{jwt}" }
-            expect(response).to be_successful
-            expect(CocinaObjectStore).to have_received(:save)
-              .once
-              .with(cocina_object_with(access: default_access, structural: { contains: [file_set_with_custom_access] }))
-          end
-        end
-      end
+  context 'when an object type exception is raised' do
+    before do
+      allow(ApplyAdminPolicyDefaults).to receive(:apply).and_raise(
+        ApplyAdminPolicyDefaults::UnsupportedObjectTypeError,
+        'the error message does not really matter in this context'
+      )
     end
 
-    ['Unknown Status', 'In accessioning', 'Accessioned'].each do |workflow_state|
-      context "when item is in '#{workflow_state}' state" do
-        let(:workflow_state) { workflow_state }
+    it 'returns HTTP 400 with an error message' do
+      post '/v1/objects/druid:bc123df4567/apply_admin_policy_defaults',
+           headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).not_to be_successful
+      expect(response).to have_http_status(:bad_request)
+      expect(JSON.parse(response.body)['errors'].first['detail']).to include(
+        'the error message does not really matter in this context'
+      )
+    end
+  end
 
-        it 'returns an HTTP 422 response with an error message' do
-          post "/v1/objects/#{object_druid}/apply_admin_policy_defaults",
-               headers: { 'Authorization' => "Bearer #{jwt}" }
-          expect(JSON.parse(response.body)['errors'].first['detail']).to include(
-            "is in a state in which it cannot be modified (#{workflow_state}): APO defaults " \
-            'can only be applied when an object is either registered or opened for versioning'
-          )
-          expect(response).not_to be_successful
-          expect(response).to have_http_status(:unprocessable_entity)
-          expect(CocinaObjectStore).not_to have_received(:save)
-        end
-      end
+  context 'when a workflow state exception is raised' do
+    before do
+      allow(ApplyAdminPolicyDefaults).to receive(:apply).and_raise(
+        ApplyAdminPolicyDefaults::UnsupportedWorkflowStateError,
+        'the error message does not really matter in this context'
+      )
+    end
+
+    it 'returns HTTP 422 with an error message' do
+      post '/v1/objects/druid:bc123df4567/apply_admin_policy_defaults',
+           headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).not_to be_successful
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)['errors'].first['detail']).to include(
+        'the error message does not really matter in this context'
+      )
     end
   end
 end

--- a/spec/services/apply_admin_policy_defaults_spec.rb
+++ b/spec/services/apply_admin_policy_defaults_spec.rb
@@ -1,0 +1,369 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplyAdminPolicyDefaults do
+  let(:apo_druid) { 'druid:df123cd4567' }
+  let(:object_druid) { 'druid:bc123df4567' }
+  let(:default_access) do
+    {
+      access: 'world',
+      download: 'world'
+    }
+  end
+  let(:cocina_object) do
+    Cocina::Models::DRO.new(
+      externalIdentifier: object_druid,
+      version: 1,
+      type: Cocina::Models::Vocab.object,
+      label: 'Dummy DRO',
+      access: {},
+      administrative: { hasAdminPolicy: apo_druid }
+    )
+  end
+  let(:workflow_state) { 'Registered' }
+  let(:workflow_client) { instance_double(Dor::Workflow::Client, status: status_client) }
+  let(:status_client) { instance_double(Dor::Workflow::Client::Status, display_simplified: workflow_state) }
+
+  before do
+    allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+  end
+
+  describe '.apply' do
+    let(:instance) { instance_double(described_class, apply: nil) }
+
+    before do
+      allow(described_class).to receive(:new).and_return(instance)
+    end
+
+    it 'calls #apply on a new instance' do
+      described_class.apply(cocina_object: instance_double(Cocina::Models::DRO))
+      expect(instance).to have_received(:apply).once
+    end
+  end
+
+  describe '#new' do
+    context 'with a collection' do
+      let(:cocina_object) do
+        Cocina::Models::Collection.new(
+          externalIdentifier: object_druid,
+          version: 1,
+          type: Cocina::Models::Vocab.collection,
+          label: 'Dummy Collection',
+          access: {},
+          administrative: { hasAdminPolicy: apo_druid }
+        )
+      end
+
+      it 'validates the object type and creates an instance' do
+        expect { described_class.new(cocina_object: cocina_object) }.not_to raise_error
+      end
+    end
+
+    context 'with a DRO' do
+      it 'validates the object type and creates an instance' do
+        expect { described_class.new(cocina_object: cocina_object) }.not_to raise_error
+      end
+    end
+
+    context 'with an APO' do
+      let(:cocina_object) do
+        Cocina::Models::AdminPolicy.new(
+          externalIdentifier: object_druid,
+          version: 1,
+          type: Cocina::Models::Vocab.admin_policy,
+          label: 'Dummy APO',
+          administrative: {
+            hasAdminPolicy: 'druid:hv992ry2431',
+            hasAgreement: 'druid:bc753qt7345',
+            defaultAccess: default_access
+          }
+        )
+      end
+
+      it 'invalidates the object type and raises a custom exception' do
+        expect { described_class.new(cocina_object: cocina_object) }.to raise_error(
+          described_class::UnsupportedObjectTypeError,
+          "#{object_druid} is a Cocina::Models::AdminPolicy and this type cannot have APO defaults applied"
+        )
+      end
+    end
+
+    described_class::ALLOWED_WORKFLOW_STATES.each do |workflow_state|
+      context "with an object in '#{workflow_state}' state" do
+        let(:workflow_state) { workflow_state }
+
+        it 'validates the object type and creates an instance' do
+          expect { described_class.new(cocina_object: cocina_object) }.not_to raise_error
+        end
+      end
+    end
+
+    ['Unknown Status', 'In accessioning', 'Accessioned'].each do |workflow_state|
+      context "with an object in '#{workflow_state}' state" do
+        let(:workflow_state) { workflow_state }
+
+        it 'invalidates the object type and raises a custom exception' do
+          expect { described_class.new(cocina_object: cocina_object) }.to raise_error(
+            described_class::UnsupportedWorkflowStateError,
+            "#{object_druid} is in a state in which it cannot be modified (#{workflow_state}): " \
+            'APO defaults can only be applied when an object is either registered or opened for versioning'
+          )
+        end
+      end
+    end
+  end
+
+  describe '#apply' do
+    let(:instance) { described_class.new(cocina_object: cocina_object) }
+    let(:cocina_admin_policy) do
+      Cocina::Models::AdminPolicy.new(
+        externalIdentifier: apo_druid,
+        version: 1,
+        type: Cocina::Models::Vocab.admin_policy,
+        label: 'Dummy APO',
+        administrative: {
+          hasAdminPolicy: 'druid:hv992ry2431',
+          hasAgreement: 'druid:bc753qt7345',
+          defaultAccess: default_access
+        }
+      )
+    end
+
+    before do
+      allow(CocinaObjectStore).to receive(:find).with(object_druid).and_return(cocina_object)
+      allow(CocinaObjectStore).to receive(:find).with(apo_druid).and_return(cocina_admin_policy)
+      allow(CocinaObjectStore).to receive(:save)
+      instance.apply
+    end
+
+    context 'with a DRO that lack structural metadata' do
+      it 'copies APO defaultAccess to item access' do
+        expect(CocinaObjectStore).to have_received(:save)
+          .once
+          .with(cocina_object_with(access: default_access))
+      end
+    end
+
+    context 'with a collection' do
+      let(:cocina_object) do
+        Cocina::Models::Collection.new(
+          externalIdentifier: object_druid,
+          version: 1,
+          type: Cocina::Models::Vocab.collection,
+          label: 'Dummy Collection',
+          access: {},
+          administrative: { hasAdminPolicy: apo_druid }
+        )
+      end
+
+      context 'when APO specifies citation-only defaultAccess' do
+        let(:default_access) do
+          {
+            access: 'citation-only',
+            download: 'none'
+          }
+        end
+        let(:expected_access) do
+          {
+            access: 'world'
+          }
+        end
+
+        it 'maps to world collection access' do
+          expect(CocinaObjectStore).to have_received(:save)
+            .once
+            .with(cocina_object_with(access: expected_access))
+        end
+      end
+
+      context 'when APO specifies location-based defaultAccess' do
+        let(:default_access) do
+          {
+            access: 'location-based',
+            download: 'none',
+            readLocation: 'music'
+          }
+        end
+        let(:expected_access) do
+          {
+            access: 'world'
+          }
+        end
+
+        it 'maps to world collection access' do
+          expect(CocinaObjectStore).to have_received(:save)
+            .once
+            .with(cocina_object_with(access: expected_access))
+        end
+      end
+
+      context 'when APO specifies Stanford (or CDL) defaultAccess' do
+        let(:default_access) do
+          {
+            access: 'stanford',
+            download: 'none',
+            controlledDigitalLending: true
+          }
+        end
+        let(:expected_access) do
+          {
+            access: 'world'
+          }
+        end
+
+        it 'maps to world collection access' do
+          expect(CocinaObjectStore).to have_received(:save)
+            .once
+            .with(cocina_object_with(access: expected_access))
+        end
+      end
+
+      context 'when APO specifies dark defaultAccess' do
+        let(:default_access) do
+          {
+            access: 'dark',
+            download: 'none'
+          }
+        end
+        let(:expected_access) do
+          {
+            access: 'dark'
+          }
+        end
+
+        it 'maps to dark collection access' do
+          expect(CocinaObjectStore).to have_received(:save)
+            .once
+            .with(cocina_object_with(access: expected_access))
+        end
+      end
+    end
+
+    context 'with a DRO that has structural metadata' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(
+          externalIdentifier: object_druid,
+          version: 1,
+          type: Cocina::Models::Vocab.object,
+          label: 'Dummy Object',
+          access: {},
+          administrative: { hasAdminPolicy: apo_druid },
+          structural: {
+            contains: [before_file_set]
+          }
+        )
+      end
+      let(:before_file_set) do
+        {
+          externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/234-567-890',
+          version: 1,
+          type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+          label: 'Page 1',
+          structural: {
+            contains: [
+              {
+                externalIdentifier: 'http://cocina.sul.stanford.edu/file/223-456-789',
+                version: 1,
+                type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                filename: '00001.jp2',
+                label: '00001.jp2',
+                hasMimeType: 'image/jp2',
+                administrative: {
+                  publish: true,
+                  sdrPreserve: true,
+                  shelve: true
+                },
+                access: {
+                  access: 'stanford',
+                  download: 'stanford'
+                },
+                hasMessageDigests: []
+              }
+            ]
+          }
+        }
+      end
+
+      context 'when APO uses default default rights' do
+        let(:file_set_with_default_access) do
+          {
+            externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/234-567-890',
+            version: 1,
+            type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+            label: 'Page 1',
+            structural: {
+              contains: [
+                {
+                  externalIdentifier: 'http://cocina.sul.stanford.edu/file/223-456-789',
+                  version: 1,
+                  type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                  filename: '00001.jp2',
+                  label: '00001.jp2',
+                  hasMimeType: 'image/jp2',
+                  administrative: {
+                    publish: true,
+                    sdrPreserve: true,
+                    shelve: true
+                  },
+                  access: default_access,
+                  hasMessageDigests: []
+                }
+              ]
+            }
+          }
+        end
+
+        it 'copies APO defaultAccess to item access' do
+          expect(CocinaObjectStore).to have_received(:save)
+            .once
+            .with(cocina_object_with(access: default_access, structural: { contains: [file_set_with_default_access] }))
+        end
+      end
+
+      context 'when APO specifies custom default object rights' do
+        let(:default_access) do
+          {
+            access: 'dark',
+            download: 'none',
+            useAndReproductionStatement: 'Use at will.',
+            license: 'https://creativecommons.org/licenses/by-nc/3.0/legalcode'
+          }
+        end
+        let(:file_set_with_custom_access) do
+          {
+            externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/234-567-890',
+            version: 1,
+            type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+            label: 'Page 1',
+            structural: {
+              contains: [
+                {
+                  externalIdentifier: 'http://cocina.sul.stanford.edu/file/223-456-789',
+                  version: 1,
+                  type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                  filename: '00001.jp2',
+                  label: '00001.jp2',
+                  hasMimeType: 'image/jp2',
+                  administrative: {
+                    publish: true,
+                    sdrPreserve: true,
+                    shelve: false
+                  },
+                  access: default_access.slice(:access, :download),
+                  hasMessageDigests: []
+                }
+              ]
+            }
+          }
+        end
+
+        it 'copies APO defaultAccess to item access' do
+          expect(CocinaObjectStore).to have_received(:save)
+            .once
+            .with(cocina_object_with(access: default_access, structural: { contains: [file_set_with_custom_access] }))
+        end
+      end
+    end
+  end
+end

--- a/spec/support/cocina_matchers.rb
+++ b/spec/support/cocina_matchers.rb
@@ -54,5 +54,5 @@ module CocinaMatchers
 end
 
 RSpec.configure do |config|
-  config.include CocinaMatchers, type: :request
+  config.include CocinaMatchers
 end


### PR DESCRIPTION
## Why was this change made?

The controller was doing too much. The service still doing a lot... but the data model is what it is. 

We could consider further rounds of refactoring in the future. The fact that the new service object is an iceberg (tiny public API, lots of private code) makes me wonder if there aren't more abstractions than can be teased out, but I'm also getting the sense that another round of abstraction might be premature at this point. (I.e., the next abstraction isn't clear to me and I don't want to force it.) Open to ideas if folks would like more further refactoring in this commit.

## How was this change tested?

CI

## Which documentation and/or configurations were updated?

None

