### PR TITLE
Fix mapping of parallel carto subjects.

### DIFF
--- a/app/services/cocina/normalizers/mods/subject_normalizer.rb
+++ b/app/services/cocina/normalizers/mods/subject_normalizer.rb
@@ -192,7 +192,7 @@ module Cocina
         end
 
         def normalize_subject_cartographics_for(root_node)
-          carto_subject_nodes = root_node.xpath('mods:subject[mods:cartographics]', mods: ModsNormalizer::MODS_NS)
+          carto_subject_nodes = root_node.xpath('mods:subject[not(@altRepGroup)][mods:cartographics]', mods: ModsNormalizer::MODS_NS)
           return if carto_subject_nodes.empty?
 
           # Create a default carto subject.

--- a/spec/services/cocina/mapping/descriptive/mods/subject_cartographic_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_cartographic_spec.rb
@@ -115,15 +115,15 @@ RSpec.describe 'MODS subject cartographic <--> cocina mappings' do
   end
 
   describe 'Multiple cartographic subjects with altRepGroup' do
-    xit 'not implemented: multiple cartographic subjects with altRepGroup' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
-          <subject altRepGroup="1">
+          <subject altRepGroup="2">
             <cartographics>
               <scale>Scale 1:650,000.</scale>
             </cartographics>
           </subject>
-          <subject altRepGroup="1">
+          <subject altRepGroup="2">
             <cartographics>
               <scale>&#x6BD4;&#x4F8B;&#x5C3A; 1:650,000.</scale>
             </cartographics>


### PR DESCRIPTION
closes #2470

## Why was this change made?



## How was this change tested?
Before:
```
Status (n=250000; not using Missing for success/different/error stats):
  Success:   249976 (99.991%)
  Different: 23 (0.009%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     1 (0.0%)
```

After:
```
Status (n=250000; not using Missing for success/different/error stats):
  Success:   249977 (99.991%)
  Different: 22 (0.009%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     1 (0.0%)
```


## Which documentation and/or configurations were updated?



