### PR TITLE
Remove embargo twentyPct elements when released

### DIFF
--- a/app/services/cocina/normalizers/embargo_normalizer.rb
+++ b/app/services/cocina/normalizers/embargo_normalizer.rb
@@ -20,6 +20,7 @@ module Cocina
       def normalize
         return regenerate_ng_xml(ng_xml.to_xml) if normalize_released?
 
+        normalize_twentypct
         normalize_empty
 
         regenerate_ng_xml(ng_xml.to_xml)
@@ -32,6 +33,13 @@ module Cocina
       def normalize_empty
         ng_xml.root.xpath('*[not(text())][not(@*)]').each(&:remove)
         ng_xml.root.remove if ng_xml.root.xpath('*').empty?
+      end
+
+      def normalize_twentypct
+        return if ng_xml.root.xpath('//twentyPctVisibilityStatus[text() = "released"]').blank?
+
+        ng_xml.root.xpath('//twentyPctVisibilityStatus').each(&:remove)
+        ng_xml.root.xpath('//twentyPctVisibilityReleaseDate').each(&:remove)
       end
 
       def normalize_released?

--- a/spec/services/cocina/normalizers/embargo_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/embargo_normalizer_spec.rb
@@ -75,4 +75,50 @@ RSpec.describe Cocina::Normalizers::EmbargoNormalizer do
       )
     end
   end
+
+  context 'when twentyPctVisibilityStatus is released' do
+    let(:original_xml) do
+      <<~XML
+        <embargoMetadata>
+          <status/>
+          <releaseDate/>
+          <releaseAccess/>
+          <twentyPctVisibilityStatus>released</twentyPctVisibilityStatus>
+          <twentyPctVisibilityReleaseDate>2019-06-03T07:00:00Z</twentyPctVisibilityReleaseDate>
+        </embargoMetadata>
+      XML
+    end
+
+    it 'removes twentyPctVisibilityStatus and twentyPctVisibilityReleasedDate' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+        XML
+      )
+    end
+  end
+
+  context 'when twentyPctVisibilityStatus is not "released"' do
+    let(:original_xml) do
+      <<~XML
+        <embargoMetadata>
+          <status/>
+          <releaseDate/>
+          <releaseAccess/>
+          <twentyPctVisibilityStatus>???</twentyPctVisibilityStatus>
+          <twentyPctVisibilityReleaseDate>2019-06-03T07:00:00Z</twentyPctVisibilityReleaseDate>
+        </embargoMetadata>
+      XML
+    end
+
+    it "doesn't removes twentyPctVisibilityStatus and twentyPctVisibilityReleasedDate" do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <embargoMetadata>
+            <twentyPctVisibilityStatus>???</twentyPctVisibilityStatus>
+            <twentyPctVisibilityReleaseDate>2019-06-03T07:00:00Z</twentyPctVisibilityReleaseDate>
+          </embargoMetadata>
+        XML
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?

The embargo metadata should not include `twentyPctVisibilityStatus` and `twentyPctVisibilityReleaseDate` when `twentyPctVisibilityStatus` is `released`.

Closes #3285 

Note: I left a question in #3285 which may be relevant for the review.

## How was this change tested?

Unit tests, and roundtrip testing on sdr-deploy.

### Before

```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   96282 (96.365%)
  Different: 3632 (3.635%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     86 (0.086%)
  Bad cache:     0 (0.0%)
```

### After

```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   96284 (96.367%)
  Different: 3630 (3.633%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     86 (0.086%)
  Bad cache:     0 (0.0%)
```

## Which documentation and/or configurations were updated?

