### PR TITLE
Add a method for updating the MODS

### DIFF
--- a/app/controllers/mods_controller.rb
+++ b/app/controllers/mods_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# A controller for the MODS data on an object
+class ModsController < ApplicationController
+  before_action :load_item
+
+  def show
+    render xml: @item.descMetadata.content
+  end
+
+  def update
+    LegacyMetadataService.update_datastream_if_newer(item: @item,
+                                                     datastream_name: 'descMetadata',
+                                                     updated: Time.zone.now,
+                                                     content: request.body.read,
+                                                     event_factory: EventFactory)
+
+    @item.save!
+  rescue LegacyMetadataService::DatastreamValidationError => e
+    json_api_error(status: :unprocessable_entity, message: e.detail, title: e.message)
+  rescue Rubydora::FedoraInvalidRequest
+    json_api_error(status: :service_unavailable, message: 'Invalid Fedora request possibly due to concurrent requests')
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,9 +68,10 @@ Rails.application.routes.draw do
           patch 'legacy', action: :update_legacy_metadata
           get 'dublin_core'
           get 'descriptive'
-          get 'mods'
           get 'public_xml'
         end
+
+        resource :mods, only: %i[update show]
       end
 
       resources :events, only: [:create, :index], defaults: { format: :json }

--- a/openapi.yml
+++ b/openapi.yml
@@ -897,7 +897,23 @@ paths:
         - objects
       summary: Retrieve the source MODS metadata for the object
       description: ''
-      operationId: 'metadata#mods'
+      operationId: 'mods#show'
+      responses:
+        '200':
+          description: OK
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
+    put:
+      tags:
+        - objects
+      summary: Update the source MODS metadata for the object
+      description: ''
+      operationId: 'mods#update'
       responses:
         '200':
           description: OK

--- a/spec/requests/mods_update_spec.rb
+++ b/spec/requests/mods_update_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Update MODS' do
+  let(:object) { Dor::Item.new(pid: 'druid:mk420bs7601') }
+
+  before do
+    object.descMetadata.title_info.main_title = 'Goodbye'
+    allow(Dor).to receive(:find).and_return(object)
+    allow(object).to receive(:save!)
+  end
+
+  context 'with valid xml' do
+    let(:xml) do
+      <<~XML
+        <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <titleInfo>
+            <title>Hello</title>
+          </titleInfo>
+        </mods>
+      XML
+    end
+
+    it 'returns the source MODS xml' do
+      put '/v1/objects/druid:mk420bs7601/metadata/mods',
+          params: xml,
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to be_successful
+      expect(object.descMetadata.title_info.main_title).to eq ['Hello']
+    end
+  end
+
+  context 'with invalid xml' do
+    let(:xml) do
+      <<~XML
+        <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+          <narf />
+        </mods>
+      XML
+    end
+
+    it 'returns the source MODS xml' do
+      put '/v1/objects/druid:mk420bs7601/metadata/mods',
+          params: xml,
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

We want to have a stable API for updating MODS even after we switch to a Cocina based datastore.

Fixes #3282 



## How was this change tested?



## Which documentation and/or configurations were updated?



