### PR TITLE
Remove sourceId for adminPolicy objects

### DIFF
--- a/app/services/cocina/normalizers/identity_normalizer.rb
+++ b/app/services/cocina/normalizers/identity_normalizer.rb
@@ -35,6 +35,7 @@ module Cocina
         normalize_release_tags
         normalize_object_creator
         normalize_out_labels
+        normalize_apo_source_id
 
         regenerate_ng_xml(ng_xml.to_xml)
       end
@@ -42,6 +43,12 @@ module Cocina
       private
 
       attr_reader :ng_xml
+
+      def normalize_apo_source_id
+        return unless ng_xml.root.xpath('//objectType').text == 'adminPolicy'
+
+        ng_xml.root.xpath('//sourceId').each(&:remove)
+      end
 
       def normalize_source_id_whitespace
         ng_xml.root.xpath('//sourceId').each do |source_node|

--- a/spec/services/cocina/normalizers/identity_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/identity_normalizer_spec.rb
@@ -5,6 +5,32 @@ require 'rails_helper'
 RSpec.describe Cocina::Normalizers::IdentityNormalizer do
   let(:normalized_ng_xml) { described_class.normalize(identity_ng_xml: Nokogiri::XML(original_xml)) }
 
+  context 'when #normalize_apo_source_id' do
+    context 'with an adminPolicy object with a sourceId' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <sourceId source="Hydrus">adminPolicy-dhartwig-2013-06-10T18:11:42.520Z</sourceId>
+            <objectId>druid:bk068fh4950</objectId>
+            <objectType>adminPolicy</objectType>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes the sourceId' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectId>druid:bk068fh4950</objectId>
+              <objectType>adminPolicy</objectType>
+              <objectCreator>DOR</objectCreator>
+              </identityMetadata>
+          XML
+        )
+      end
+    end
+  end
+
   context 'when #normalize_source_id_whitespace' do
     let(:original_xml) do
       <<~XML


### PR DESCRIPTION
## Why was this change made?

Closes #3154 by removing the sourceId from identityMetadata for admin policy objects.

Before included identityMetadata differences that are no longer reported in the results.:

```
Difference found for identityMetadata
Diff for identityMetadata:
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <identityMetadata>
-  <sourceId source="Hydrus">adminPolicy-dhartwig-2013-06-10T18:11:42.520Z</sourceId>
   <objectId>druid:bk068fh4950</objectId>
   <objectCreator>DOR</objectCreator>
-  <objectLabel>APO for Stanford University, Department of Computer Science, Technical Reports</objectLabel>
   <objectType>adminPolicy</objectType>
+  <objectLabel>APO for Stanford University, Department of Computer Science, Technical Reports</objectLabel>
 </identityMetadata>
 
+

Original XML for identityMetadata:
<?xml version="1.0"?>
<identityMetadata>
  <sourceId source="Hydrus">adminPolicy-dhartwig-2013-06-10T18:11:42.520Z</sourceId>
  <objectId>druid:bk068fh4950</objectId>
  <objectCreator>DOR</objectCreator>
  <objectLabel>APO for Stanford University, Department of Computer Science, Technical Reports</objectLabel>
  <objectType>adminPolicy</objectType>
  <adminPolicy>druid:zw306xn5593</adminPolicy>
  <otherId name="uuid">341b275c-d1f9-11e2-ba42-0050569b3c6e</otherId>
  <tag>Project : Hydrus</tag>
  <tag>Remediated By : 4.6.6.2</tag>
</identityMetadata>


Normalized original XML for identityMetadata:
<?xml version="1.0" encoding="UTF-8"?>
<identityMetadata>
  <sourceId source="Hydrus">adminPolicy-dhartwig-2013-06-10T18:11:42.520Z</sourceId>
  <objectId>druid:bk068fh4950</objectId>
  <objectCreator>DOR</objectCreator>
  <objectLabel>APO for Stanford University, Department of Computer Science, Technical Reports</objectLabel>
  <objectType>adminPolicy</objectType>
</identityMetadata>


Roundtripped XML for identityMetadata:
<?xml version="1.0"?>
<identityMetadata>
  <objectId>druid:bk068fh4950</objectId>
  <objectCreator>DOR</objectCreator>
  <objectType>adminPolicy</objectType>
  <objectLabel>APO for Stanford University, Department of Computer Science, Technical Reports</objectLabel>
</identityMetadata>
```
## How was this change tested?

Unit.


## Which documentation and/or configurations were updated?



