### PR TITLE
Fix report-rels-apo_agreement_ids test.

### DIFF
--- a/bin/reports/report-rels-apo_agreement_ids
+++ b/bin/reports/report-rels-apo_agreement_ids
@@ -9,7 +9,10 @@ HYDRA_NS = 'http://projecthydra.org/ns/relations#'
 FEDORA_NS = 'info:fedora/fedora-system:def/model#'
 
 def check(ng_xml)
-  ng_xml.root.xpath('//fedora:hasModel/@rdf:resource="info:fedora/afmodel:Hydrus_AdminPolicyObject" and not(//hydra:referencesAgreement)', hydra: HYDRA_NS, fedora: FEDORA_NS, rdf: RDF_NS)
+  ng_xml.root.xpath(
+    '//fedora:hasModel[@rdf:resource="info:fedora/afmodel:Hydrus_AdminPolicyObject" ' \
+    'or @rdf:resource="info:fedora/afmodel:Dor_AdminPolicyObject"] and not(//hydra:referencesAgreement)', hydra: HYDRA_NS, fedora: FEDORA_NS, rdf: RDF_NS
+  )
 end
 
 Report.new(name: 'rels_apo_without_agreement_ids', dsid: 'RELS-EXT', report_func: method(:check)).run


### PR DESCRIPTION
## Why was this change made?
The existing test was not finding all APOs.


## How was this change tested?
Local


## Which documentation and/or configurations were updated?



