### PR TITLE
[HOLD] fix normalization of embargoMetadata

### DIFF
--- a/app/services/cocina/normalizers/base.rb
+++ b/app/services/cocina/normalizers/base.rb
@@ -7,23 +7,6 @@ module Cocina
       def regenerate_ng_xml(xml)
         @ng_xml = Nokogiri::XML(xml) { |config| config.default_xml.noblanks }
       end
-
-      # remove all empty elements that have no attributes and no children, recursively
-      def remove_empty_elements(start_node)
-        return unless start_node
-
-        # remove node if there are no element children, there is no text value and there are no attributes
-        if start_node.elements.size.zero? &&
-           start_node.text.blank? &&
-           start_node.attributes.size.zero? &&
-           start_node.name != 'etal'
-          parent = start_node.parent
-          start_node.remove
-          remove_empty_elements(parent) # need to call again after child has been deleted
-        else
-          start_node.element_children.each { |e| remove_empty_elements(e) }
-        end
-      end
     end
   end
 end

--- a/app/services/cocina/normalizers/embargo_normalizer.rb
+++ b/app/services/cocina/normalizers/embargo_normalizer.rb
@@ -12,16 +12,29 @@ module Cocina
         new(embargo_ng_xml: embargo_ng_xml).normalize
       end
 
+      # @param [Nokogiri::Document] embargo_ng_xml embargo metadata XML to be normalized
+      # @return [Nokogiri::Document] normalized embargo metadata xml
+      def self.normalize_roundtrip(embargo_ng_xml:)
+        new(embargo_ng_xml: embargo_ng_xml).normalize_roundtrip
+      end
+
       def initialize(embargo_ng_xml:)
         @ng_xml = embargo_ng_xml.dup
         @ng_xml.encoding = 'UTF-8' if @ng_xml.respond_to?(:encoding=) # sometimes it's a String (?)
+        regenerate_ng_xml(ng_xml.to_xml)
       end
 
       def normalize
-        return regenerate_ng_xml(ng_xml.to_xml) if normalize_released?
+        return ng_xml.to_xml if normalize_released?
 
         normalize_twentypct
         normalize_empty
+
+        regenerate_ng_xml(ng_xml.to_xml)
+      end
+
+      def normalize_roundtrip
+        normalize_roundtrip_twentypct
 
         regenerate_ng_xml(ng_xml.to_xml)
       end
@@ -31,13 +44,20 @@ module Cocina
       attr_reader :ng_xml
 
       def normalize_empty
-        ng_xml.root.xpath('*[not(text())][not(@*)]').each(&:remove)
+        ng_xml.root.xpath('*[not(text())][not(@*)]').each do |node|
+          node.remove unless node.name == 'releaseAccess' && !node.children.empty?
+        end
         ng_xml.root.remove if ng_xml.root.xpath('*').empty?
       end
 
       def normalize_twentypct
         return if ng_xml.root.xpath('//twentyPctVisibilityStatus[text() = "released"]').blank?
 
+        ng_xml.root.xpath('//twentyPctVisibilityStatus').each(&:remove)
+        ng_xml.root.xpath('//twentyPctVisibilityReleaseDate').each(&:remove)
+      end
+
+      def normalize_roundtrip_twentypct
         ng_xml.root.xpath('//twentyPctVisibilityStatus').each(&:remove)
         ng_xml.root.xpath('//twentyPctVisibilityReleaseDate').each(&:remove)
       end

--- a/app/services/cocina/normalizers/embargo_normalizer.rb
+++ b/app/services/cocina/normalizers/embargo_normalizer.rb
@@ -58,6 +58,8 @@ module Cocina
       end
 
       def normalize_roundtrip_twentypct
+        return unless ng_xml.root
+
         ng_xml.root.xpath('//twentyPctVisibilityStatus').each(&:remove)
         ng_xml.root.xpath('//twentyPctVisibilityReleaseDate').each(&:remove)
       end

--- a/app/services/cocina/normalizers/mods_normalizer.rb
+++ b/app/services/cocina/normalizers/mods_normalizer.rb
@@ -73,6 +73,23 @@ module Cocina
 
       attr_reader :ng_xml, :druid, :label
 
+      # remove all empty elements that have no attributes and no children, recursively
+      def remove_empty_elements(start_node)
+        return unless start_node
+
+        # remove node if there are no element children, there is no text value and there are no attributes
+        if start_node.elements.size.zero? &&
+           start_node.text.blank? &&
+           start_node.attributes.size.zero? &&
+           start_node.name != 'etal'
+          parent = start_node.parent
+          start_node.remove
+          remove_empty_elements(parent) # need to call again after child has been deleted
+        else
+          start_node.element_children.each { |e| remove_empty_elements(e) }
+        end
+      end
+
       def normalize_default_namespace
         xml = ng_xml.to_s
 

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -112,6 +112,8 @@ def norm_roundtrip_datastream_ng_xml_for(dsid, roundtrip_datastream_ng_xml)
     # Additional normalizers to go here.
   when 'contentMetadata'
     Cocina::Normalizers::ContentMetadataNormalizer.normalize_roundtrip(content_ng_xml: roundtrip_datastream_ng_xml)
+  when 'embargoMetadata'
+    Cocina::Normalizers::EmbargoNormalizer.normalize_roundtrip(embargo_ng_xml: roundtrip_datastream_ng_xml)
   else
     roundtrip_datastream_ng_xml
   end

--- a/spec/services/cocina/normalizers/embargo_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/embargo_normalizer_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Cocina::Normalizers::EmbargoNormalizer do
   let(:normalized_ng_xml) { described_class.normalize(embargo_ng_xml: Nokogiri::XML(original_xml)) }
+  let(:normalized_roundtripped_ng_xml) { described_class.normalize_roundtrip(embargo_ng_xml: Nokogiri::XML(original_xml)) }
 
   context 'when released embargo' do
     let(:original_xml) do
@@ -57,27 +58,33 @@ RSpec.describe Cocina::Normalizers::EmbargoNormalizer do
       XML
     end
 
+    let(:expected_xml) do
+      <<~XML
+        <embargoMetadata>
+          <status>embargoed</status>
+          <releaseDate>2022-05-06T00:00:00Z</releaseDate>
+          <releaseAccess>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+          </releaseAccess>
+        </embargoMetadata>
+      XML
+    end
+
     it 'retains the releaseAccess node' do
-      expect(normalized_ng_xml).to be_equivalent_to(
-        <<~XML
-          <embargoMetadata>
-            <status>embargoed</status>
-            <releaseDate>2022-05-06T00:00:00Z</releaseDate>
-            <releaseAccess>
-              <access type="discover">
-                <machine>
-                  <world/>
-                </machine>
-              </access>
-              <access type="read">
-                <machine>
-                  <world/>
-                </machine>
-              </access>
-            </releaseAccess>
-          </embargoMetadata>
-        XML
-      )
+      expect(normalized_ng_xml).to be_equivalent_to(expected_xml)
+    end
+
+    it 'retains the releaseAccess node from roundtripped' do
+      expect(normalized_roundtripped_ng_xml).to be_equivalent_to(expected_xml)
     end
   end
 
@@ -144,6 +151,18 @@ RSpec.describe Cocina::Normalizers::EmbargoNormalizer do
         XML
       )
     end
+
+    it 'always removes twentyPctVisibilityStatus and twentyPctVisibilityReleasedDate from roundtripped' do
+      expect(normalized_roundtripped_ng_xml).to be_equivalent_to(
+        <<~XML
+          <embargoMetadata>
+            <status/>
+            <releaseDate/>
+            <releaseAccess/>
+          </embargoMetadata>
+        XML
+      )
+    end
   end
 
   context 'when twentyPctVisibilityStatus is not "released"' do
@@ -165,6 +184,18 @@ RSpec.describe Cocina::Normalizers::EmbargoNormalizer do
           <embargoMetadata>
             <twentyPctVisibilityStatus>???</twentyPctVisibilityStatus>
             <twentyPctVisibilityReleaseDate>2019-06-03T07:00:00Z</twentyPctVisibilityReleaseDate>
+          </embargoMetadata>
+        XML
+      )
+    end
+
+    it 'always removes twentyPctVisibilityStatus and twentyPctVisibilityReleasedDate from roundtripped' do
+      expect(normalized_roundtripped_ng_xml).to be_equivalent_to(
+        <<~XML
+          <embargoMetadata>
+            <status/>
+            <releaseDate/>
+            <releaseAccess/>
           </embargoMetadata>
         XML
       )


### PR DESCRIPTION
## Why was this change made?

Fixes #3284 - do not blindly remove all `<releaseAccess>` nodes, as some of them may contain important empty nodes.  Test for this was added in #3301 and now passes.

HOLD: re-running validate cocina tests

## How was this change tested?

Existing tests.


## Which documentation and/or configurations were updated?



