### PR TITLE
Cocina-izes VersionService. Stores version data in db.

### DIFF
--- a/app/models/object_version.rb
+++ b/app/models/object_version.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# Version history for an object.
+# version should correspond with version in cocina model.
+class ObjectVersion < ApplicationRecord
+  # @param [String] druid
+  # @param [Symbol] significance which part of the version tag to increment
+  #  :major, :minor, :admin (see VersionTag#increment)
+  # @param [String] description optional text describing version change
+  # @return [ObjectVersion] created ObjectVersion
+  def self.increment_version(druid, significance: nil, description: nil)
+    if ObjectVersion.exists?(druid: druid)
+      current_object_version = current_version(druid)
+      current_tag = VersionTag.parse(current_object_version.tag)
+
+      new_version = current_object_version.version + 1
+      new_tag = significance && current_tag ? current_tag.increment(significance).to_s : nil
+      new_description = description
+    else
+      new_version = 1
+      new_tag = '1.0.0'
+      new_description = 'Initial Version'
+    end
+    ObjectVersion.create(druid: druid, version: new_version, tag: new_tag, description: new_description)
+  end
+
+  # Compares the current_version with the passed in known_version (usually SDRs version)
+  #   If the known_version is greater than the current version, then all version nodes greater than the known_version are removed,
+  #   then the current_version is incremented.  This repairs the case where a previous call to open a new verison
+  #   updates the versionMetadata datastream, but versioningWF is not initiated.  Prevents the versions from getting
+  #   out of synch with SDR
+  #
+  # @param [String] druid
+  # @param [Integer] known_version object version you wish to synch to, usually SDR's version
+  # @param [Symbol] significance which part of the version tag to increment
+  #  :major, :minor, :admin (see VersionTag#increment)
+  # @param [String] description optional text describing version change
+  # @return [ObjectVersion] created ObjectVersion
+  def self.sync_then_increment_version(druid, known_version, significance: nil, description: nil)
+    current_version = current_version(druid)&.version || 0
+
+    raise Dor::Exception, "Cannot sync to a version greater than current: #{current_version}, requested #{known_version}" if current_version < known_version
+
+    ObjectVersion.where(druid: druid).where('version > ?', known_version).destroy_all if current_version > known_version
+
+    increment_version(druid, significance: significance, description: description)
+  end
+
+  # @param [String] druid
+  # @param [Symbol] significance which part of the version tag to increment
+  #  :major, :minor, :admin (see VersionTag#increment)
+  # @param [String] description optional text describing version change
+  # @return [ObjectVersion] created ObjectVersion
+  def self.update_current_version(druid, significance: nil, description: nil)
+    return if significance.nil? && description.nil?
+
+    current_object_version = current_version(druid)
+
+    return if current_object_version.nil? || current_object_version.version == 1
+
+    current_object_version.description = description if description
+
+    if significance
+      # Greatest version with a tag.
+      last_object_version = ObjectVersion.where(druid: druid).where.not(tag: nil, version: current_object_version.version).order(version: :desc).first
+      last_tag = VersionTag.parse(last_object_version.tag)
+      current_object_version.tag = last_tag.increment(significance).to_s
+    end
+
+    current_object_version.save!
+  end
+
+  # @param [String] druid
+  # @return [Boolean] returns true if the current version has a tag and a description, false otherwise
+  def self.current_version_closeable?(druid)
+    current_object_version = current_version(druid)
+    (current_object_version&.tag && current_object_version&.description).present?
+  end
+
+  # @return [ObjectVersion] current ObjectVersion
+  def self.current_version(druid)
+    ObjectVersion.where(druid: druid).order(version: :desc).first
+  end
+end

--- a/app/models/version_tag.rb
+++ b/app/models/version_tag.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Model for a semantic version tag.
+# From https://github.com/sul-dlss/dor-services/blob/main/lib/dor/datastreams/version_metadata_ds.rb
+class VersionTag
+  include Comparable
+
+  attr_reader :major, :minor, :admin
+
+  def <=>(other)
+    diff = @major <=> other.major
+    return diff if diff != 0
+
+    diff = @minor <=> other.minor
+    return diff if diff != 0
+
+    @admin <=> other.admin
+  end
+
+  # @param [String] raw_tag the value of the tag attribute from a Version node
+  def self.parse(raw_tag)
+    return nil unless raw_tag =~ /(\d+)\.(\d+)\.(\d+)/
+
+    VersionTag.new Regexp.last_match(1), Regexp.last_match(2), Regexp.last_match(3)
+  end
+
+  def initialize(maj, min, adm)
+    @major = maj.to_i
+    @minor = min.to_i
+    @admin = adm.to_i
+  end
+
+  # @param [Symbol] sig which part of the version tag to increment
+  #  :major, :minor, :admin
+  def increment(sig)
+    case sig
+    when :major
+      @major += 1
+      @minor = 0
+      @admin = 0
+    when :minor
+      @minor += 1
+      @admin = 0
+    when :admin
+      @admin += 1
+    end
+    self
+  end
+
+  def to_s
+    "#{@major}.#{@minor}.#{admin}"
+  end
+end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -35,6 +35,9 @@ module Cocina
         SynchronousIndexer.reindex_remotely(fedora_object.pid)
 
         event_factory.create(druid: fedora_object.pid, event_type: 'registration', data: cocina_object.to_h)
+
+        # This creates version 1.0.0 (Initial Version)
+        ObjectVersion.increment_version(fedora_object.pid)
       end
 
       # This will rebuild the cocina model from fedora, which shows we are only returning persisted data

--- a/app/services/item_query_service.rb
+++ b/app/services/item_query_service.rb
@@ -31,8 +31,9 @@ class ItemQueryService
     query_service = ItemQueryService.new(id: druid)
     query_service.item do |item|
       workflow_errors = errors_for(item.id, item.current_version)
+      cocina_object = Cocina::Mapper.build(item)
       raise UncombinableItemError, "Item #{item.pid} has workflow errors: #{workflow_errors.join('; ')}" if workflow_errors.any?
-      raise UncombinableItemError, "Item #{item.pid} is not open or openable" unless VersionService.open?(item) || VersionService.can_open?(item)
+      raise UncombinableItemError, "Item #{item.pid} is not open or openable" unless VersionService.open?(cocina_object) || VersionService.can_open?(cocina_object)
       raise UncombinableItemError, "Item #{item.pid} is dark" if item.rightsMetadata.dra_object.dark?
       raise UncombinableItemError, "Item #{item.pid} is citation_only" if item.rightsMetadata.dra_object.citation_only?
     end

--- a/app/services/version_migration_service.rb
+++ b/app/services/version_migration_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Migrates version history from the versionMetadata datastream to the db.
+# This service can be removed once migration of the version history is complete for all objects.
+class VersionMigrationService
+  def self.migrate(fedora_object)
+    new(fedora_object).migrate
+  end
+
+  def self.find_and_migrate(druid)
+    new(Dor.find(druid)).migrate
+  end
+
+  def initialize(fedora_object)
+    @fedora_object = fedora_object
+  end
+
+  def migrate
+    return if ObjectVersion.exists?(druid: fedora_object.pid)
+
+    (1..current_version).each do |version|
+      ObjectVersion.create(druid: fedora_object.pid,
+                           version: version,
+                           tag: tag_for(version),
+                           description: description_for(version))
+    end
+  end
+
+  private
+
+  attr_reader :fedora_object
+
+  def version_md
+    @version_md ||= fedora_object.versionMetadata
+  end
+
+  def current_version
+    @current_version ||= version_md.current_version_id.to_i
+  end
+
+  def tag_for(version)
+    version_md.tag_for_version(version.to_s).presence
+  end
+
+  def description_for(version)
+    version_md.description_for_version(version.to_s).presence
+  end
+end

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -2,28 +2,28 @@
 
 # Open and close versions
 class VersionService
-  def self.open(work, opts = {}, event_factory:)
-    new(work, event_factory: event_factory).open(opts)
+  def self.open(cocina_object, opts = {}, event_factory:)
+    new(cocina_object, event_factory: event_factory).open(opts)
   end
 
-  def self.can_open?(work, opts = {})
-    new(work).can_open?(opts)
+  def self.can_open?(cocina_object, opts = {})
+    new(cocina_object).can_open?(opts)
   end
 
-  def self.open?(work)
-    new(work).open_for_versioning?
+  def self.open?(cocina_object)
+    new(cocina_object).open_for_versioning?
   end
 
-  def self.close(work, opts = {}, event_factory:)
-    new(work, event_factory: event_factory).close(opts)
+  def self.close(cocina_object, opts = {}, event_factory:)
+    new(cocina_object, event_factory: event_factory).close(opts)
   end
 
-  def self.in_accessioning?(work)
-    new(work).accessioning?
+  def self.in_accessioning?(cocina_object)
+    new(cocina_object).accessioning?
   end
 
-  def initialize(work, event_factory: nil)
-    @work = work
+  def initialize(cocina_object, event_factory: nil)
+    @cocina_object = cocina_object
     @event_factory = event_factory
   end
 
@@ -33,33 +33,31 @@ class VersionService
   # @option opts [String] :significance set significance (major/minor/patch) of version change
   # @option opts [String] :description set description of version change
   # @option opts [String] :opening_user_name add opening username to the events datastream
+  # @return [Cocina::Models::DRO, Cocina::Models::AdminPolicy, Cocina::Models::Collection] updated cocina object
   # @raise [Dor::Exception] if the object hasn't been accessioned, or if a version is already opened
   # @raise [Preservation::Client::Error] if bad response from preservation catalog.
-  # rubocop:disable Metrics/AbcSize
   def open(opts = {})
-    vmd_ds = work.versionMetadata
+    # This can be removed after migration.
+    VersionMigrationService.find_and_migrate(druid)
+
     ensure_openable!(opts[:assume_accessioned])
     if Settings.version_service.sync_with_preservation
       sdr_version = retrieve_version_from_preservation
-      vmd_ds.sync_then_increment_version sdr_version
+      new_object_version = ObjectVersion.sync_then_increment_version(druid, sdr_version)
     else
       # This is for testing when we don't have the SDR container available
-      vmd_ds.increment_version
+      new_object_version = ObjectVersion.increment_version(druid)
     end
-    vmd_ds.save unless work.new_record?
+    update_cocina_object = cocina_object
+    update_cocina_object = CocinaObjectStore.save(cocina_object.new(version: new_object_version.version)) if cocina_object.version != new_object_version.version
 
-    workflow_client.create_workflow_by_name(work.pid, 'versioningWF', version: work.current_version)
+    workflow_client.create_workflow_by_name(druid, 'versioningWF', version: new_object_version.version.to_s)
 
-    return if (opts.keys & open_options_requiring_work_save).empty?
+    ObjectVersion.update_current_version(druid, description: opts[:description], significance: opts[:significance].to_sym) if opts[:description] && opts[:significance]
 
-    work.events.add_event('open', opts[:opening_user_name], "Version #{vmd_ds.current_version_id} opened") if opts[:opening_user_name]
-
-    vmd_ds.update_current_version(description: opts[:description], significance: opts[:significance].to_sym) if opts[:description] && opts[:significance]
-
-    work.save!
-    event_factory.create(druid: work.pid, event_type: 'version_open', data: { who: opts[:opening_user_name], version: work.current_version })
+    event_factory.create(druid: druid, event_type: 'version_open', data: { who: opts[:opening_user_name], version: new_object_version.version.to_s })
+    update_cocina_object
   end
-  # rubocop:enable Metrics/AbcSize
 
   # Determines whether a new version can be opened for an object.
   # @param [Hash] opts optional params
@@ -84,29 +82,25 @@ class VersionService
   # @option opts [Boolean] :start_accession set to true if you want accessioning to start (default), false otherwise
   # @raise [Dor::Exception] if the object hasn't been opened for versioning, or if accessionWF has
   #   already been instantiated or the current version is missing a tag or description
-  # rubocop:disable Metrics/AbcSize
   def close(opts = {})
-    unless opts.empty?
-      work.versionMetadata.update_current_version(description: opts[:description], significance: opts[:significance].to_sym) if opts[:description] && opts[:significance]
+    # This can be removed after migration.
+    VersionMigrationService.find_and_migrate(druid)
 
-      work.versionMetadata.save
-    end
+    ObjectVersion.update_current_version(druid, description: opts[:description], significance: opts[:significance].to_sym) if opts[:description] && opts[:significance]
 
-    raise Dor::Exception, "latest version in versionMetadata for #{work.pid} requires tag and description before it can be closed" unless work.versionMetadata.current_version_closeable?
-    raise Dor::Exception, "Trying to close version on #{work.pid} which is not opened for versioning" unless open_for_versioning?
-    raise Dor::Exception, "Trying to close version on #{work.pid} which has active assemblyWF" if active_assembly_wf?
-    raise Dor::Exception, "accessionWF already created for versioned object #{work.pid}" if accessioning?
+    raise Dor::Exception, "latest version in versionMetadata for #{druid} requires tag and description before it can be closed" unless ObjectVersion.current_version_closeable?(druid)
+    raise Dor::Exception, "Trying to close version on #{druid} which is not opened for versioning" unless open_for_versioning?
+    raise Dor::Exception, "Trying to close version on #{druid} which has active assemblyWF" if active_assembly_wf?
+    raise Dor::Exception, "accessionWF already created for versioned object #{druid}" if accessioning?
 
     # Default to creating accessionWF when calling close_version
     create_accession_wf = opts.fetch(:start_accession, true)
-    workflow_client.close_version(druid: work.pid,
-                                  version: work.current_version,
+    workflow_client.close_version(druid: druid,
+                                  version: cocina_object.version.to_s,
                                   create_accession_wf: create_accession_wf)
-    work.events.add_event('close', opts[:user_name], "Version #{work.current_version} closed") if opts[:user_name]
-    work.save!
-    event_factory.create(druid: work.pid, event_type: 'version_close', data: { who: opts[:user_name], version: work.current_version })
+
+    event_factory.create(druid: druid, event_type: 'version_close', data: { who: opts[:user_name], version: cocina_object.version.to_s })
   end
-  # rubocop:enable Metrics/AbcSize
 
   # Performs checks on whether a new version can be opened for an object
   # @return [Void]
@@ -118,7 +112,7 @@ class VersionService
     # The accessioned milestone is the last step of the accessionWF.
     # During local development, we need a way to open a new version even if the object has not been accessioned.
     raise(Dor::Exception, 'Object net yet accessioned') unless
-        assume_accessioned || workflow_client.lifecycle(druid: work.pid, milestone_name: 'accessioned')
+        assume_accessioned || workflow_client.lifecycle(druid: druid, milestone_name: 'accessioned')
     # Raised when the current version has any incomplete wf steps and there is a versionWF.
     # The open milestone is part of the versioningWF.
     raise Dor::VersionAlreadyOpenError, 'Object already opened for versioning' if open_for_versioning?
@@ -132,7 +126,7 @@ class VersionService
   # @raise [Dor::Exception] if Preservation returns 404 when queried.
   # @raise [Preservation::Client::Error] if bad response from preservation catalog.
   def retrieve_version_from_preservation
-    Preservation::Client.objects.current_version(work.pid)
+    Preservation::Client.objects.current_version(druid)
   rescue Preservation::Client::NotFoundError
     raise Dor::Exception, 'Preservation (SDR) is not yet answering queries about this object. ' \
                           "When an object has just been transferred, Preservation isn't immediately ready to answer queries."
@@ -141,7 +135,7 @@ class VersionService
   # Checks if current version has any incomplete wf steps and there is a versionWF
   # @return [Boolean] true if object is open for versioning
   def open_for_versioning?
-    return true if workflow_client.active_lifecycle(druid: work.pid, milestone_name: 'opened', version: work.current_version)
+    return true if workflow_client.active_lifecycle(druid: druid, milestone_name: 'opened', version: cocina_object.version.to_s)
 
     false
   end
@@ -149,24 +143,24 @@ class VersionService
   # Checks if the current version has any incomplete wf steps and there is an accessionWF.
   # @return [Boolean] true if object is currently being accessioned
   def accessioning?
-    return true if workflow_client.active_lifecycle(druid: work.pid, milestone_name: 'submitted', version: work.current_version)
+    return true if workflow_client.active_lifecycle(druid: druid, milestone_name: 'submitted', version: cocina_object.version.to_s)
 
     false
   end
 
-  attr_reader :work, :event_factory
+  attr_reader :cocina_object, :event_factory
 
   private
 
-  def open_options_requiring_work_save
-    [:opening_user_name, :significance, :description]
-  end
-
   def active_assembly_wf?
-    return true if workflow_client.workflow_status(druid: work.pid, version: work.current_version, workflow: 'assemblyWF', process: 'accessioning-initiate') == 'waiting'
+    return true if workflow_client.workflow_status(druid: druid, version: cocina_object.version.to_s, workflow: 'assemblyWF', process: 'accessioning-initiate') == 'waiting'
   end
 
   def workflow_client
     @workflow_client ||= WorkflowClientFactory.build
+  end
+
+  def druid
+    cocina_object.externalIdentifier
   end
 end

--- a/db/migrate/20220203155057_create_object_version.rb
+++ b/db/migrate/20220203155057_create_object_version.rb
@@ -1,0 +1,14 @@
+class CreateObjectVersion < ActiveRecord::Migration[5.2]
+  def change
+    create_table :object_versions do |t|
+      t.string :druid, null: false
+      t.integer :version, null: false      
+      t.string :tag
+      t.string :description
+      t.timestamps
+    end
+
+    add_index :object_versions, :druid
+    add_index :object_versions, [:druid, :version], unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -247,6 +247,40 @@ ALTER SEQUENCE public.events_id_seq OWNED BY public.events.id;
 
 
 --
+-- Name: object_versions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.object_versions (
+    id bigint NOT NULL,
+    druid character varying NOT NULL,
+    version integer NOT NULL,
+    tag character varying,
+    description character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: object_versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.object_versions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: object_versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.object_versions_id_seq OWNED BY public.object_versions.id;
+
+
+--
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -329,6 +363,13 @@ ALTER TABLE ONLY public.events ALTER COLUMN id SET DEFAULT nextval('public.event
 
 
 --
+-- Name: object_versions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.object_versions ALTER COLUMN id SET DEFAULT nextval('public.object_versions_id_seq'::regclass);
+
+
+--
 -- Name: tag_labels id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -389,6 +430,14 @@ ALTER TABLE ONLY public.dros
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: object_versions object_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.object_versions
+    ADD CONSTRAINT object_versions_pkey PRIMARY KEY (id);
 
 
 --
@@ -471,6 +520,20 @@ CREATE INDEX index_events_on_event_type ON public.events USING btree (event_type
 
 
 --
+-- Name: index_object_versions_on_druid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_object_versions_on_druid ON public.object_versions USING btree (druid);
+
+
+--
+-- Name: index_object_versions_on_druid_and_version; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_object_versions_on_druid_and_version ON public.object_versions USING btree (druid, version);
+
+
+--
 -- Name: index_tag_labels_on_tag; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -502,6 +565,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200521153735'),
 ('20220131194025'),
 ('20220131194359'),
-('20220131194912');
+('20220131194912'),
+('20220203155057');
 
 

--- a/spec/models/object_version_spec.rb
+++ b/spec/models/object_version_spec.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ObjectVersion, type: :model do
+  let(:druid) { 'druid:xz456jk0987' }
+
+  describe '#current_version' do
+    before do
+      described_class.create(druid: druid, version: 1, tag: '1.0.0')
+      described_class.create(druid: druid, version: 2, tag: '1.1.0')
+    end
+
+    it 'returns current version' do
+      expect(described_class.current_version(druid).tag).to eq('1.1.0')
+    end
+  end
+
+  describe '#increment_version' do
+    it 'increments version' do
+      first_version = described_class.increment_version(druid)
+      expect(first_version.version).to eq(1)
+      expect(first_version.tag).to eq('1.0.0')
+      expect(first_version.description).to eq('Initial Version')
+
+      # With description and significance
+      second_version = described_class.increment_version(druid, significance: :minor, description: 'An update')
+      expect(second_version.version).to eq(2)
+      expect(second_version.tag).to eq('1.1.0')
+      expect(second_version.description).to eq('An update')
+
+      # Without description or significance
+      third_version = described_class.increment_version(druid)
+      expect(third_version.version).to eq(3)
+      expect(third_version.tag).to be_nil
+      expect(third_version.description).to be_nil
+
+      # Minor is ignored since last tag is null.
+      # This replicates the current logic from https://github.com/sul-dlss/dor-services/blob/main/lib/dor/datastreams/version_metadata_ds.rb#L100
+      fourth_version = described_class.increment_version(druid, significance: :minor, description: 'An update')
+      expect(fourth_version.version).to eq(4)
+      expect(fourth_version.tag).to eq(nil)
+      expect(fourth_version.description).to eq('An update')
+    end
+  end
+
+  describe '#sync_then_increment_version' do
+    before do
+      described_class.create(druid: druid, version: 1, tag: '1.0.0')
+      described_class.create(druid: druid, version: 2, tag: '1.1.0')
+    end
+
+    context 'when in sync' do
+      it 'increments version' do
+        new_version = described_class.sync_then_increment_version(druid, 2, significance: :minor, description: 'An update')
+        expect(new_version.version).to eq(3)
+        expect(new_version.tag).to eq('1.2.0')
+        expect(new_version.description).to eq('An update')
+        expect(described_class.where(druid: druid).size).to eq(3)
+      end
+    end
+
+    context 'when extra versions' do
+      it 'deletes extra version' do
+        new_version = described_class.sync_then_increment_version(druid, 1, significance: :major, description: 'An update')
+        expect(new_version.version).to eq(2)
+        expect(new_version.tag).to eq('2.0.0')
+        expect(new_version.description).to eq('An update')
+        expect(described_class.where(druid: druid).size).to eq(2)
+      end
+    end
+
+    context 'when missing versions' do
+      it 'raises' do
+        expect { described_class.sync_then_increment_version(druid, 3) }.to raise_error(Dor::Exception)
+      end
+    end
+  end
+
+  describe '#update_version' do
+    context 'when description and significance not provided' do
+      before do
+        described_class.create(druid: druid, version: 1, tag: '1.0.0')
+        described_class.create(druid: druid, version: 2, tag: '1.1.0')
+      end
+
+      it 'does nothing' do
+        described_class.update_current_version(druid)
+        object_version = described_class.find_by(druid: druid, version: 2)
+        expect(object_version.tag).to eq('1.1.0')
+        expect(object_version.description).to be_nil
+      end
+    end
+
+    context 'when no current object version' do
+      it 'does nothing' do
+        described_class.update_current_version(druid, significance: :major)
+        expect(described_class.exists?(druid: druid)).to be(false)
+      end
+    end
+
+    context 'when current version is 1' do
+      before do
+        described_class.create(druid: druid, version: 1, tag: '1.0.0')
+      end
+
+      it 'does not update' do
+        described_class.update_current_version(druid: druid, significance: :minor)
+        expect(described_class.find_by(druid: druid, version: 1).version).to eq(1)
+      end
+    end
+
+    context 'when a description is provided' do
+      before do
+        described_class.create(druid: druid, version: 1, tag: '1.0.0')
+        described_class.create(druid: druid, version: 2, tag: '1.1.0')
+      end
+
+      it 'updates description' do
+        described_class.update_current_version(druid, description: 'an update')
+        expect(described_class.find_by(druid: druid, version: 2).description).to eq('an update')
+      end
+    end
+
+    context 'when current version has a tag' do
+      before do
+        described_class.create(druid: druid, version: 1, tag: '1.0.0')
+        described_class.create(druid: druid, version: 2, tag: '1.1.0')
+      end
+
+      it 'updates tag ignoring current tag' do
+        described_class.update_current_version(druid, significance: :major)
+        expect(described_class.find_by(druid: druid, version: 2).tag).to eq('2.0.0')
+      end
+    end
+
+    context 'when current version does not have a tag' do
+      before do
+        described_class.create(druid: druid, version: 1, tag: '1.0.0')
+        described_class.create(druid: druid, version: 2)
+      end
+
+      it 'updates tag' do
+        described_class.update_current_version(druid, significance: :minor)
+        expect(described_class.find_by(druid: druid, version: 2).tag).to eq('1.1.0')
+      end
+    end
+  end
+
+  describe '#current_version_closeable?' do
+    context 'when it has a description and tag' do
+      before do
+        described_class.create(druid: druid, version: 1, tag: '1.0.0', description: 'Initial Version')
+      end
+
+      it 'is closeable' do
+        expect(described_class.current_version_closeable?(druid)).to be(true)
+      end
+    end
+
+    context 'when it does not have a description' do
+      before do
+        described_class.create(druid: druid, version: 1, tag: '1.0.0')
+      end
+
+      it 'is not closeable' do
+        expect(described_class.current_version_closeable?(druid)).to be(false)
+      end
+    end
+
+    context 'when it does not have a tag' do
+      before do
+        described_class.create(druid: druid, version: 1, description: 'Initial Version')
+      end
+
+      it 'is not closeable' do
+        expect(described_class.current_version_closeable?(druid)).to be(false)
+      end
+    end
+  end
+end

--- a/spec/models/version_tag_spec.rb
+++ b/spec/models/version_tag_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# From https://github.com/sul-dlss/dor-services/blob/main/spec/datastreams/version_tag_spec.rb
+RSpec.describe VersionTag do
+  describe '.parse' do
+    it 'parses a String into a VersionTag object' do
+      t = described_class.parse('1.1.0')
+      expect(t.major).to eq(1)
+      expect(t.minor).to eq(1)
+      expect(t.admin).to eq(0)
+    end
+  end
+
+  describe '#increment' do
+    let(:tag) { described_class.parse('1.2.3')  }
+
+    it 'adds 1 to major and zeros out minor and admin when :major is passed in' do
+      tag.increment(:major)
+      expect(tag.major).to eq(2)
+      expect(tag.minor).to eq(0)
+      expect(tag.admin).to eq(0)
+    end
+
+    it 'adds 1 to minor and zeros out admin when :minor is passed in' do
+      tag.increment(:minor)
+      expect(tag.minor).to eq(3)
+      expect(tag.admin).to eq(0)
+    end
+
+    it 'adds 1 to admin when :admin is passed in' do
+      tag.increment(:admin)
+      expect(tag.admin).to eq(4)
+    end
+  end
+
+  describe 'ordering' do
+    it 'handles <, >, == comparisons' do
+      v1 = described_class.new(1, 1, 0)
+      v2 = described_class.new(1, 1, 2)
+      expect(v1).to be < v2
+
+      v3 = described_class.new(0, 1, 1)
+      expect(v1).to be > v3
+
+      v4 = described_class.new(1, 1, 0)
+      expect(v1).to eq(v4)
+    end
+  end
+end

--- a/spec/requests/authorization_spec.rb
+++ b/spec/requests/authorization_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Authorization' do
-  let(:object) { instance_double(Dor::Item, current_version: '5') }
+  let(:cocina_object) { instance_double(Cocina::Models::DRO, version: 5) }
 
   before do
-    allow(Dor).to receive(:find).and_return(object)
+    allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
     allow(Honeybadger).to receive(:notify)
     allow(Honeybadger).to receive(:context)
   end

--- a/spec/requests/start_accession_spec.rb
+++ b/spec/requests/start_accession_spec.rb
@@ -4,15 +4,15 @@ require 'rails_helper'
 
 RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
   let(:druid) { 'druid:mx123qw2323' }
-  let(:object) { Dor::Item.new(pid: druid) }
+  let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, version: 1) }
   let(:workflow_client) { instance_double(Dor::Workflow::Client, create_workflow_by_name: true) }
   let(:default_start_accession_workflow) { ObjectsController.new.send(:default_start_accession_workflow) }
   let(:event_factory) { { event_factory: EventFactory } }
 
   before do
-    allow(Dor).to receive(:find).and_return(object)
+    allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
     allow(VersionService).to receive(:close)
-    allow(VersionService).to receive(:open)
+    allow(VersionService).to receive(:open).and_return(cocina_object)
     allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
   end
 
@@ -27,7 +27,7 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
       post "/v1/objects/#{druid}/accession",
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
-      expect(workflow_client).to have_received(:create_workflow_by_name).with(object.pid, default_start_accession_workflow, version: '1')
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, default_start_accession_workflow, version: '1')
       expect(VersionService).not_to have_received(:open)
       expect(VersionService).not_to have_received(:close)
     end
@@ -38,7 +38,7 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
            params: params,
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
-      expect(workflow_client).to have_received(:create_workflow_by_name).with(object.pid, 'accessionWF', version: '1')
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'accessionWF', version: '1')
       expect(VersionService).not_to have_received(:open)
       expect(VersionService).not_to have_received(:close)
     end
@@ -55,9 +55,9 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
     it 'opens and closes a version and starts default workflow' do
       post "/v1/objects/#{druid}/accession",
            headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(workflow_client).to have_received(:create_workflow_by_name).with(object.pid, default_start_accession_workflow, version: '1')
-      expect(VersionService).to have_received(:open).with(object, base_params, event_factory)
-      expect(VersionService).to have_received(:close).with(object, base_params.merge('start_accession' => false), event_factory)
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, default_start_accession_workflow, version: '1')
+      expect(VersionService).to have_received(:open).with(cocina_object, base_params, event_factory)
+      expect(VersionService).to have_received(:close).with(cocina_object, base_params.merge('start_accession' => false), event_factory)
     end
 
     it 'can override the default workflow' do
@@ -65,9 +65,9 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
       post "/v1/objects/#{druid}/accession",
            params: params,
            headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(workflow_client).to have_received(:create_workflow_by_name).with(object.pid, 'accessionWF', version: '1')
-      expect(VersionService).to have_received(:open).with(object, base_params.merge(params), event_factory)
-      expect(VersionService).to have_received(:close).with(object, base_params.merge(params).merge('start_accession' => false), event_factory)
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'accessionWF', version: '1')
+      expect(VersionService).to have_received(:open).with(cocina_object, base_params.merge(params), event_factory)
+      expect(VersionService).to have_received(:close).with(cocina_object, base_params.merge(params).merge('start_accession' => false), event_factory)
     end
   end
 
@@ -83,9 +83,9 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
     it 'closes a version and starts default workflow' do
       post "/v1/objects/#{druid}/accession",
            headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(workflow_client).to have_received(:create_workflow_by_name).with(object.pid, default_start_accession_workflow, version: '1')
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, default_start_accession_workflow, version: '1')
       expect(VersionService).not_to have_received(:open)
-      expect(VersionService).to have_received(:close).with(object, base_params.merge('start_accession' => false), event_factory)
+      expect(VersionService).to have_received(:close).with(cocina_object, base_params.merge('start_accession' => false), event_factory)
     end
   end
 

--- a/spec/requests/versions_inventory_spec.rb
+++ b/spec/requests/versions_inventory_spec.rb
@@ -4,24 +4,15 @@ require 'rails_helper'
 
 RSpec.describe 'Release tags' do
   let(:druid) { 'druid:mx123qw2323' }
-  let(:object) { Dor::Item.new(pid: druid) }
+  let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, version: 3) }
 
   before do
-    allow(Dor).to receive(:find).and_return(object)
+    allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
+    allow(VersionMigrationService).to receive(:find_and_migrate)
 
-    object.versionMetadata.content = <<~XML
-      <versionMetadata objectId="druid:bq653yd1233">
-        <version versionId="1" tag="1.0.0">
-          <description>Initial Version</description>
-        </version>
-        <version versionId="2" tag="2.0.0">
-          <description>pre-assembly re-accession</description>
-        </version>
-        <version versionId="3" tag="3.0.0">
-          <description>pre-assembly re-accession</description>
-        </version>
-      </versionMetadata>
-    XML
+    ObjectVersion.create(druid: druid, version: 1, tag: '1.0.0', description: 'Initial Version')
+    ObjectVersion.create(druid: druid, version: 2, tag: '2.0.0', description: 'pre-assembly re-accession')
+    ObjectVersion.create(druid: druid, version: 3, tag: '3.0.0', description: 'pre-assembly re-accession')
   end
 
   it 'returns a 200' do

--- a/spec/services/cocina/object_updater_spec.rb
+++ b/spec/services/cocina/object_updater_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Cocina::ObjectUpdater do
 
   let(:trial) { false }
 
+  let(:version_metadata) { instance_double(Dor::VersionMetadataDS, increment_version: nil) }
+
   before do
     allow(Cocina::Mapper).to receive(:build).and_return(orig_cocina_object)
     allow(Cocina::ApoExistenceValidator).to receive(:new).and_return(instance_double(Cocina::ApoExistenceValidator, valid?: true))
@@ -38,7 +40,8 @@ RSpec.describe Cocina::ObjectUpdater do
       instance_double(Dor::AdminPolicyObject, pid: 'druid:bc123df4567',
                                               save!: nil,
                                               administrativeMetadata: double,
-                                              descMetadata: desc_metadata)
+                                              descMetadata: desc_metadata,
+                                              versionMetadata: version_metadata)
     end
 
     let(:desc_metadata) { double }
@@ -149,6 +152,44 @@ RSpec.describe Cocina::ObjectUpdater do
         end
       end
     end
+
+    context 'when updating version' do
+      before do
+        allow(item).to receive(:current_version).and_return('1', '2')
+      end
+
+      context 'when version has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:version] = 2
+          end
+        end
+
+        it 'update versions' do
+          update
+          expect(version_metadata).to have_received(:increment_version)
+        end
+      end
+
+      context 'when version has not changed' do
+        it 'update versions' do
+          update
+          expect(version_metadata).not_to have_received(:increment_version)
+        end
+      end
+
+      context 'when a version mismatch' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:version] = 3
+          end
+        end
+
+        it 'raises' do
+          expect { update }.to raise_error('Incremented version of 2 is not expected version 3')
+        end
+      end
+    end
   end
 
   context 'when a collection' do
@@ -168,6 +209,7 @@ RSpec.describe Cocina::ObjectUpdater do
 
     before do
       allow(item).to receive(:save!)
+      allow(item).to receive(:versionMetadata).and_return(version_metadata)
     end
 
     context 'when updating label' do
@@ -286,6 +328,44 @@ RSpec.describe Cocina::ObjectUpdater do
         end
       end
     end
+
+    context 'when updating version' do
+      before do
+        allow(item).to receive(:current_version).and_return('1', '2')
+      end
+
+      context 'when version has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:version] = 2
+          end
+        end
+
+        it 'update versions' do
+          update
+          expect(version_metadata).to have_received(:increment_version)
+        end
+      end
+
+      context 'when version has not changed' do
+        it 'update versions' do
+          update
+          expect(version_metadata).not_to have_received(:increment_version)
+        end
+      end
+
+      context 'when a version mismatch' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:version] = 3
+          end
+        end
+
+        it 'raises' do
+          expect { update }.to raise_error('Incremented version of 2 is not expected version 3')
+        end
+      end
+    end
   end
 
   context 'when a DRO' do
@@ -296,7 +376,8 @@ RSpec.describe Cocina::ObjectUpdater do
                                  contentMetadata: content_metadata,
                                  descMetadata: desc_metadata,
                                  identityMetadata: identity_metadata,
-                                 geoMetadata: geo_metadata)
+                                 geoMetadata: geo_metadata,
+                                 versionMetadata: version_metadata)
     end
 
     let(:content_metadata) { double }
@@ -663,6 +744,44 @@ RSpec.describe Cocina::ObjectUpdater do
         end
       end
     end
+
+    context 'when updating version' do
+      before do
+        allow(item).to receive(:current_version).and_return('1', '2')
+      end
+
+      context 'when version has changed' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:version] = 2
+          end
+        end
+
+        it 'update versions' do
+          update
+          expect(version_metadata).to have_received(:increment_version)
+        end
+      end
+
+      context 'when version has not changed' do
+        it 'update versions' do
+          update
+          expect(version_metadata).not_to have_received(:increment_version)
+        end
+      end
+
+      context 'when a version mismatch' do
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:version] = 3
+          end
+        end
+
+        it 'raises' do
+          expect { update }.to raise_error('Incremented version of 2 is not expected version 3')
+        end
+      end
+    end
   end
 
   context 'when a trial' do
@@ -671,7 +790,8 @@ RSpec.describe Cocina::ObjectUpdater do
                                  label: 'orig label',
                                  contentMetadata: content_metadata,
                                  descMetadata: desc_metadata,
-                                 identityMetadata: identity_metadata)
+                                 identityMetadata: identity_metadata,
+                                 current_version: '1')
     end
 
     let(:content_metadata) { double }

--- a/spec/services/item_query_service_spec.rb
+++ b/spec/services/item_query_service_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ItemQueryService do
 
   let(:druid) { 'bc123df4567' }
   let(:item) { instantiate_fixture('druid:bc123df4567', Dor::Item) }
+  let(:cocina_object) { instance_double(Cocina::Models::DRO) }
   let(:workflow_client) { instance_double(Dor::Workflow::Client, workflow_routes: workflow_routes) }
   let(:workflow_routes) { instance_double(Dor::Workflow::Client::WorkflowRoutes, all_workflows: workflows_response) }
   let(:workflows_response) do
@@ -16,9 +17,10 @@ RSpec.describe ItemQueryService do
 
   before do
     allow(Dor::Item).to receive(:find).and_return(item)
-    allow(VersionService).to receive(:can_open?).with(item).and_return(true)
-    allow(VersionService).to receive(:open?).with(item).and_return(true)
+    allow(VersionService).to receive(:can_open?).with(cocina_object).and_return(true)
+    allow(VersionService).to receive(:open?).with(cocina_object).and_return(true)
     allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+    allow(Cocina::Mapper).to receive(:build).with(item).and_return(cocina_object)
   end
 
   describe '.find_combinable_item' do
@@ -31,8 +33,8 @@ RSpec.describe ItemQueryService do
     end
 
     it 'raises error if object is neither open nor openable' do
-      allow(VersionService).to receive(:can_open?).with(item).and_return(false)
-      allow(VersionService).to receive(:open?).with(item).and_return(false)
+      allow(VersionService).to receive(:can_open?).with(cocina_object).and_return(false)
+      allow(VersionService).to receive(:open?).with(cocina_object).and_return(false)
       expect { service.find_combinable_item('bc123df4567') }.to raise_error(described_class::UncombinableItemError, 'Item druid:bc123df4567 is not open or openable')
     end
 
@@ -61,6 +63,8 @@ RSpec.describe ItemQueryService do
   describe '.validate_combinable_items' do
     let(:item2) { instantiate_fixture('druid:xh235dd9059', Dor::Item) }
     let(:item3) { instantiate_fixture('druid:hj097bm8879', Dor::Item) }
+    let(:cocina_object2) { instance_double(Cocina::Models::DRO, externalIdentifier: 'druid:xh235dd9059') }
+    let(:cocina_object3) { instance_double(Cocina::Models::DRO, externalIdentifier: 'druid:hj097bm8879') }
     let(:dark_rights) { instance_double(Dor::RightsAuth, dark?: true, citation_only?: false) }
     let(:citation_only_rights) { instance_double(Dor::RightsAuth, dark?: false, citation_only?: true) }
     let(:permissive_rights) { instance_double(Dor::RightsAuth, dark?: false, citation_only?: false) }
@@ -72,10 +76,12 @@ RSpec.describe ItemQueryService do
     before do
       allow(Dor::Item).to receive(:find).with('druid:xh235dd9059').and_return(item2)
       allow(Dor::Item).to receive(:find).with('druid:hj097bm8879').and_return(item3)
+      allow(VersionService).to receive(:can_open?).and_return(true)
+      allow(VersionService).to receive(:open?).and_return(true)
+      allow(Cocina::Mapper).to receive(:build).with(item2).and_return(cocina_object2)
+      allow(Cocina::Mapper).to receive(:build).with(item3).and_return(cocina_object3)
       [item, item2, item3].each do |i|
         allow(i).to receive(:rightsMetadata).and_return(permissive_rights_ds)
-        allow(VersionService).to receive(:can_open?).with(i).and_return(true)
-        allow(VersionService).to receive(:open?).with(i).and_return(true)
       end
     end
 
@@ -97,8 +103,8 @@ RSpec.describe ItemQueryService do
 
     context 'when any objects are both not open and not openable' do
       before do
-        allow(VersionService).to receive(:open?).with(item).and_return(false)
-        allow(VersionService).to receive(:can_open?).with(item).and_return(false)
+        allow(VersionService).to receive(:open?).with(cocina_object).and_return(false)
+        allow(VersionService).to receive(:can_open?).with(cocina_object).and_return(false)
       end
 
       it 'returns a single error if one object does not allow modification' do

--- a/spec/services/version_migration_service_spec.rb
+++ b/spec/services/version_migration_service_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VersionMigrationService do
+  let(:druid) { 'druid:fd953pg7906' }
+
+  let(:item) do
+    Dor::Item.new(pid: druid).tap do |item|
+      item.versionMetadata.content = version_xml
+    end
+  end
+
+  let(:version_xml) do
+    <<~XML
+      <versionMetadata objectId="#{druid}">
+        <version tag="1.0.0" versionId="1">
+          <description>Initial Version</description>
+        </version>
+        <version tag="1.0.1" versionId="2">
+          <description>reaccession to preserve geoMetadata in SDR</description>
+        </version>
+        <version tag="1.1.0" versionId="3">
+          <description>update object rights</description>
+        </version>
+        <version tag="1.2.0" versionId="4">
+          <description>set rights</description>
+        </version>
+        <version tag="1.3.0" versionId="5">
+          <description>Apply APO defaults</description>
+        </version>
+        <version tag="1.4.0" versionId="6">
+          <description/>
+        </version>
+        <version tag="1.5.0" versionId="7">
+          <description/>
+        </version>
+        <version tag="1.6.0" versionId="8">
+          <description>update APO</description>
+        </version>
+        <version tag="1.7.0" versionId="9">
+          <description/>
+        </version>
+        <version tag="1.8.0" versionId="10">
+          <description/>
+        </version>
+        <version tag="1.9.0" versionId="11">
+          <description/>
+        </version>
+        <version tag="1.10.0" versionId="12">
+          <description/>
+        </version>
+      </versionMetadata>
+    XML
+  end
+
+  context 'when migration not yet performed' do
+    it 'populates versions' do
+      described_class.migrate(item)
+      expect(ObjectVersion.where(druid: druid).size).to eq(12)
+      first_version = ObjectVersion.find_by(druid: druid, version: 1)
+      expect(first_version.tag).to eq('1.0.0')
+      expect(first_version.description).to eq('Initial Version')
+
+      current_version = ObjectVersion.find_by(druid: druid, version: 12)
+      expect(current_version.tag).to eq('1.10.0')
+      expect(current_version.description).to be_nil
+    end
+  end
+
+  context 'when migration already performed' do
+    before do
+      ObjectVersion.create(druid: druid, version: 1, tag: '1.0.0')
+    end
+
+    it 'does not populate versions' do
+      expect(ObjectVersion.where(druid: druid).size).to eq(1)
+      described_class.migrate(item)
+      expect(ObjectVersion.where(druid: druid).size).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
closes #3170

## Why was this change made?
Version metadata is being moved from the version datastream to the DB.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



