### PR TITLE
Add date attributes to rabbit messages on created and updated

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -46,7 +46,7 @@ class ObjectsController < ApplicationController
     cocina_object = Cocina::ObjectCreator.create(model_request, assign_doi: params[:assign_doi])
 
     # Broadcast this to a topic
-    Notifications::ObjectCreated.publish(model: cocina_object) if Settings.rabbitmq.enabled
+    Notifications::ObjectCreated.publish(model: cocina_object, created_at: Time.zone.now, modified_at: Time.zone.now) if Settings.rabbitmq.enabled
 
     render status: :created, location: object_path(cocina_object.externalIdentifier), json: cocina_object
   rescue SymphonyReader::ResponseError => e

--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -28,13 +28,8 @@ class CocinaObjectStore
     new.save(cocina_object)
   end
 
-  def find_with_metadata(druid)
-    fedora_to_cocina_find(druid)
-  end
-
   def find(druid)
-    # fedora_to_cocina_find(druid)
-    find_with_metadata(druid).first
+    fedora_to_cocina_find(druid)
   end
 
   def save(cocina_object)
@@ -51,7 +46,7 @@ class CocinaObjectStore
 
   def fedora_to_cocina_find(druid)
     fedora_object = fedora_find(druid)
-    [Cocina::Mapper.build(fedora_object), fedora_object.create_date, fedora_object.modified_date]
+    Cocina::Mapper.build(fedora_object)
   end
 
   def cocina_to_fedora_save(cocina_object)

--- a/app/services/notifications/object_created.rb
+++ b/app/services/notifications/object_created.rb
@@ -4,23 +4,24 @@ module Notifications
   # Send a message to a RabbitMQ exchange that an item has been created.
   # The primary use case here is that the requestor may want to know what druid was assigned to the request.
   class ObjectCreated
-    def self.publish(model:, created_at:)
+    def self.publish(model:, created_at:, modified_at:)
       # Skipping APOs because they don't (yet) have a partOfProject assertion.
       return if model.is_a? Cocina::Models::AdminPolicy
 
       Rails.logger.debug "Publishing Rabbitmq Message for creating #{model.externalIdentifier}"
-      new(model: model, created_at: created_at, channel: RabbitChannel.instance).publish
+      new(model: model, created_at: created_at, modified_at: modified_at, channel: RabbitChannel.instance).publish
       Rails.logger.debug "Published Rabbitmq Message for creating #{model.externalIdentifier}"
     end
 
-    def initialize(model:, created_at:, channel:)
+    def initialize(model:, created_at:, modified_at:, channel:)
       @model = model
       @created_at = created_at
+      @modified_at = modified_at
       @channel = channel
     end
 
     def publish
-      message = { model: model.to_h, created_at: created_at }
+      message = { model: model.to_h, created_at: created_at, modified_at: modified_at }
       # Using the project as a routing key because listeners may only care about their projects.
       exchange.publish(message.to_json, routing_key: model.administrative.partOfProject)
     end
@@ -31,6 +32,6 @@ module Notifications
       channel.topic('sdr.objects.created')
     end
 
-    attr_reader :model, :channel, :created_at
+    attr_reader :model, :channel, :created_at, :modified_at
   end
 end

--- a/app/services/notifications/object_created.rb
+++ b/app/services/notifications/object_created.rb
@@ -21,7 +21,11 @@ module Notifications
     end
 
     def publish
-      message = { model: model.to_h, created_at: created_at, modified_at: modified_at }
+      message = {
+        model: model.to_h,
+        created_at: created_at.to_datetime.httpdate,
+        modified_at: modified_at.to_datetime.httpdate
+      }
       # Using the project as a routing key because listeners may only care about their projects.
       exchange.publish(message.to_json, routing_key: model.administrative.partOfProject)
     end

--- a/app/services/notifications/object_created.rb
+++ b/app/services/notifications/object_created.rb
@@ -4,22 +4,23 @@ module Notifications
   # Send a message to a RabbitMQ exchange that an item has been created.
   # The primary use case here is that the requestor may want to know what druid was assigned to the request.
   class ObjectCreated
-    def self.publish(model:)
+    def self.publish(model:, created_at:)
       # Skipping APOs because they don't (yet) have a partOfProject assertion.
       return if model.is_a? Cocina::Models::AdminPolicy
 
       Rails.logger.debug "Publishing Rabbitmq Message for creating #{model.externalIdentifier}"
-      new(model: model, channel: RabbitChannel.instance).publish
+      new(model: model, created_at: created_at, channel: RabbitChannel.instance).publish
       Rails.logger.debug "Published Rabbitmq Message for creating #{model.externalIdentifier}"
     end
 
-    def initialize(model:, channel:)
+    def initialize(model:, created_at:, channel:)
       @model = model
+      @created_at = created_at
       @channel = channel
     end
 
     def publish
-      message = { model: model.to_h }
+      message = { model: model.to_h, created_at: created_at }
       # Using the project as a routing key because listeners may only care about their projects.
       exchange.publish(message.to_json, routing_key: model.administrative.partOfProject)
     end
@@ -30,6 +31,6 @@ module Notifications
       channel.topic('sdr.objects.created')
     end
 
-    attr_reader :model, :channel
+    attr_reader :model, :channel, :created_at
   end
 end

--- a/app/services/notifications/object_updated.rb
+++ b/app/services/notifications/object_updated.rb
@@ -18,7 +18,11 @@ module Notifications
     end
 
     def publish
-      message = { model: model.to_h, created_at: created_at, modified_at: modified_at }
+      message = {
+        model: model.to_h,
+        created_at: created_at.to_datetime.httpdate,
+        modified_at: modified_at.to_datetime.httpdate
+      }
       exchange.publish(message.to_json, routing_key: routing_key)
     end
 

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -5,11 +5,14 @@ require 'rails_helper'
 RSpec.describe CocinaObjectStore do
   describe 'to Fedora' do
     let(:item) { instance_double(Dor::Item) }
+    let(:date) { Time.zone.now }
     let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid) }
     let(:druid) { 'druid:bc123df4567' }
 
     before do
       allow(ActiveFedora::ContentModel).to receive(:models_asserted_by).and_return(['info:fedora/afmodel:Item'])
+      allow(item).to receive(:create_date).and_return(date)
+      allow(item).to receive(:modified_date).and_return(date)
     end
 
     describe '#find' do
@@ -52,7 +55,7 @@ RSpec.describe CocinaObjectStore do
           expect(described_class.save(cocina_object)).to be updated_cocina_object
           expect(Dor).to have_received(:find).with(druid)
           expect(Cocina::ObjectUpdater).to have_received(:run).with(item, cocina_object)
-          expect(Notifications::ObjectUpdated).to have_received(:publish).with(model: updated_cocina_object)
+          expect(Notifications::ObjectUpdated).to have_received(:publish).with(model: updated_cocina_object, created_at: item.create_date, modified_at: item.modified_date)
         end
       end
 

--- a/spec/services/notifications/object_created_spec.rb
+++ b/spec/services/notifications/object_created_spec.rb
@@ -3,12 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe Notifications::ObjectCreated do
-  subject(:publish) { described_class.publish(model: model) }
+  subject(:publish) { described_class.publish(model: model, created_at: created_at, modified_at: modified_at) }
 
   let(:data) { { data: '455' } }
+  let(:created_at) { '04 Feb 2022' }
+  let(:modified_at) { '04 Feb 2022' }
   let(:administrative) do
     instance_double(Cocina::Models::Administrative, partOfProject: 'h2')
   end
+  let(:message) { '{"model":{"data":"455"},"created_at":"04 Feb 2022","modified_at":"04 Feb 2022"}' }
 
   let(:channel) { instance_double(Notifications::RabbitChannel, topic: topic) }
   let(:topic) { instance_double(Bunny::Exchange, publish: true) }
@@ -25,7 +28,7 @@ RSpec.describe Notifications::ObjectCreated do
 
     it 'is successful' do
       publish
-      expect(topic).to have_received(:publish).with('{"model":{"data":"455"}}', routing_key: 'h2')
+      expect(topic).to have_received(:publish).with(message, routing_key: 'h2')
     end
   end
 

--- a/spec/services/notifications/object_created_spec.rb
+++ b/spec/services/notifications/object_created_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Notifications::ObjectCreated do
   let(:administrative) do
     instance_double(Cocina::Models::Administrative, partOfProject: 'h2')
   end
-  let(:message) { '{"model":{"data":"455"},"created_at":"04 Feb 2022","modified_at":"04 Feb 2022"}' }
+  let(:message) { "{\"model\":{\"data\":\"455\"},\"created_at\":\"#{created_at.to_datetime.httpdate}\",\"modified_at\":\"#{modified_at.to_datetime.httpdate}\"}" }
 
   let(:channel) { instance_double(Notifications::RabbitChannel, topic: topic) }
   let(:topic) { instance_double(Bunny::Exchange, publish: true) }

--- a/spec/services/notifications/object_updated_spec.rb
+++ b/spec/services/notifications/object_updated_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Notifications::ObjectUpdated do
 
   let(:channel) { instance_double(Notifications::RabbitChannel, topic: topic) }
   let(:topic) { instance_double(Bunny::Exchange, publish: true) }
-  let(:message) { '{"model":{"data":"455"},"created_at":"04 Feb 2022","modified_at":"04 Feb 2022"}' }
+  let(:message) { "{\"model\":{\"data\":\"455\"},\"created_at\":\"#{created_at.to_datetime.httpdate}\",\"modified_at\":\"#{modified_at.to_datetime.httpdate}\"}" }
 
   before do
     allow(Notifications::RabbitChannel).to receive(:instance).and_return(channel)

--- a/spec/services/notifications/object_updated_spec.rb
+++ b/spec/services/notifications/object_updated_spec.rb
@@ -3,15 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe Notifications::ObjectUpdated do
-  subject(:publish) { described_class.publish(model: model) }
+  subject(:publish) { described_class.publish(model: model, created_at: created_at, modified_at: modified_at) }
 
   let(:data) { { data: '455' } }
+  let(:created_at) { '04 Feb 2022' }
+  let(:modified_at) { '04 Feb 2022' }
   let(:administrative) do
     instance_double(Cocina::Models::Administrative, partOfProject: 'h2')
   end
 
   let(:channel) { instance_double(Notifications::RabbitChannel, topic: topic) }
   let(:topic) { instance_double(Bunny::Exchange, publish: true) }
+  let(:message) { '{"model":{"data":"455"},"created_at":"04 Feb 2022","modified_at":"04 Feb 2022"}' }
 
   before do
     allow(Notifications::RabbitChannel).to receive(:instance).and_return(channel)
@@ -25,7 +28,7 @@ RSpec.describe Notifications::ObjectUpdated do
 
     it 'is successful' do
       publish
-      expect(topic).to have_received(:publish).with('{"model":{"data":"455"}}', routing_key: 'h2')
+      expect(topic).to have_received(:publish).with(message, routing_key: 'h2')
     end
   end
 
@@ -47,7 +50,7 @@ RSpec.describe Notifications::ObjectUpdated do
 
     it 'is successful' do
       publish
-      expect(topic).to have_received(:publish).with('{"model":{"data":"455"}}', routing_key: 'SDR')
+      expect(topic).to have_received(:publish).with(message, routing_key: 'SDR')
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Closes #3297 by fetching created and modified dates from the existing fedora object (or setting to Time.zone.now on create) and publishing to rabbitmq.


## How was this change tested?

Unit

## Which documentation and/or configurations were updated?



