### PR TITLE
Map name subjects with affiliations and genres

### DIFF
--- a/spec/services/cocina/mapping/descriptive/mods/subject_name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/subject_name_spec.rb
@@ -189,16 +189,16 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
   end
 
   describe 'Name subject with affiliation' do
-    # nx523gb3191
-    xit 'not implemented in cocina>MODS direction' do
+    # nx523gb3191, bg593yv1090, fx440zw7882
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <subject authority="lcsh">
             <name type="personal">
-              <namePart>O'Connor, Sandra Day</namePart>
-              <namePart type="date">1930-</namePart>
-              <affiliation>Stanford Law School graduate, LL.B. (1952)</affiliation>
+              <namePart>Wolff, Miriam</namePart>
+              <affiliation>Stanford Law School graduate, J.D. (1940)</affiliation>
             </name>
+            <genre>Interviews</genre>
           </subject>
         XML
       end
@@ -207,24 +207,23 @@ RSpec.describe 'MODS subject name <--> cocina mappings' do
         {
           subject: [
             {
-              type: 'person',
               source: {
                 code: 'lcsh'
               },
               structuredValue: [
                 {
-                  value: 'O\'Connor, Sandra Day',
-                  type: 'name'
+                  value: 'Wolff, Miriam',
+                  type: 'person',
+                  note: [
+                    {
+                      value: 'Stanford Law School graduate, J.D. (1940)',
+                      type: 'affiliation'
+                    }
+                  ]
                 },
                 {
-                  value: '1930-',
-                  type: 'life dates'
-                }
-              ],
-              note: [
-                {
-                  value: 'Stanford Law School graduate, LL.B. (1952)',
-                  type: 'affiliation'
+                  value: 'Interviews',
+                  type: 'genre'
                 }
               ]
             }


### PR DESCRIPTION
Fixes #3039

# Before

```
$ bin/validate-desc-cocina-roundtrip -r -s 350000 -f
On branch name: main (commit: 797681e7)...
Status (n=350000; not using Missing for success/different/error stats):
  Success:   349974 (99.993%)
  Different: 23 (0.007%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     3 (0.001%)
```

# After

```
$ bin/validate-desc-cocina-roundtrip -r -s 350000 -f
On branch name: subject-name-affiliation#3039 (commit: 30d0026a)...
Status (n=350000; not using Missing for success/different/error stats):
  Success:   349982 (99.995%)
  Different: 17 (0.005%)
  To Cocina error:     0 (0.0%)
  To Fedora error:     0 (0.0%)
  MODS normalizer error:     0 (0.0%)
  Missing (no descMetadata):     1 (0.0%)

```