### PR TITLE
FactoryBot dro and collection fixtures have unique druids by default

### DIFF
--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -3,17 +3,13 @@
 FactoryBot.define do
   factory :collection do
     cocina_version { '0.0.1' }
-    external_identifier { 'druid:hp308wm0436' }
+    external_identifier { generate(:unique_druid) }
     collection_type { Cocina::Models::Vocab.collection }
     label { 'Test Collection' }
     version { 1 }
     access do
       { access: 'world' }
     end
-  end
-
-  factory :collection_unique_druid, parent: :collection do
-    external_identifier { generate(:unique_druid) }
   end
 
   trait :with_collection_identification do

--- a/spec/factories/dros.rb
+++ b/spec/factories/dros.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :dro do
     cocina_version { '0.0.1' }
-    external_identifier { 'druid:xz456jk0987' }
+    external_identifier { generate(:unique_druid) }
     content_type { Cocina::Models::Vocab.book }
     label { 'Test DRO' }
     version { 1 }
@@ -13,10 +13,6 @@ FactoryBot.define do
     administrative do
       { hasAdminPolicy: 'druid:hy787xj5878' }
     end
-  end
-
-  factory :dro_unique_druid, parent: :dro do
-    external_identifier { generate(:unique_druid) }
   end
 
   trait :with_dro_identification do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Collection do
+  let(:druid) { 'druid:hp308wm0436' }
   let(:minimal_cocina_collection) do
     Cocina::Models::Collection.new({
                                      cocinaVersion: '0.0.1',
-                                     externalIdentifier: 'druid:hp308wm0436',
+                                     externalIdentifier: druid,
                                      type: Cocina::Models::Vocab.collection,
                                      label: 'Test Collection',
                                      version: 1,
@@ -17,7 +18,7 @@ RSpec.describe Collection do
   let(:cocina_collection) do
     Cocina::Models::Collection.new({
                                      cocinaVersion: '0.0.1',
-                                     externalIdentifier: 'druid:hp308wm0436',
+                                     externalIdentifier: druid,
                                      type: Cocina::Models::Vocab.collection,
                                      label: 'Test Collection',
                                      version: 1,
@@ -33,7 +34,7 @@ RSpec.describe Collection do
 
   describe 'to_cocina' do
     context 'with minimal collection' do
-      let(:collection) { create(:collection) }
+      let(:collection) { create(:collection, external_identifier: druid) }
 
       it 'returns a Cocina::Model::Collection' do
         expect(collection.to_cocina).to eq(minimal_cocina_collection)
@@ -41,7 +42,7 @@ RSpec.describe Collection do
     end
 
     context 'with complete Collection' do
-      let(:collection) { create(:collection, :with_administrative, :with_collection_description, :with_collection_identification) }
+      let(:collection) { create(:collection, :with_administrative, :with_collection_description, :with_collection_identification, external_identifier: druid) }
 
       it 'returns a Cocina::Model::Collection' do
         expect(collection.to_cocina).to eq(cocina_collection)

--- a/spec/models/dro_spec.rb
+++ b/spec/models/dro_spec.rb
@@ -3,10 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Dro do
+  let(:druid) { 'druid:xz456jk0987' }
+
   let(:minimal_cocina_dro) do
     Cocina::Models::DRO.new({
                               cocinaVersion: '0.0.1',
-                              externalIdentifier: 'druid:xz456jk0987',
+                              externalIdentifier: druid,
                               type: Cocina::Models::Vocab.book,
                               label: 'Test DRO',
                               version: 1,
@@ -18,7 +20,7 @@ RSpec.describe Dro do
   let(:cocina_dro) do
     Cocina::Models::DRO.new({
                               cocinaVersion: '0.0.1',
-                              externalIdentifier: 'druid:xz456jk0987',
+                              externalIdentifier: druid,
                               type: Cocina::Models::Vocab.book,
                               label: 'Test DRO',
                               version: 1,
@@ -66,7 +68,7 @@ RSpec.describe Dro do
 
   describe 'to_cocina' do
     context 'with minimal DRO' do
-      let(:dro) { create(:dro) }
+      let(:dro) { create(:dro, external_identifier: druid) }
 
       it 'returns a Cocina::Model::DRO' do
         expect(dro.to_cocina).to eq(minimal_cocina_dro)
@@ -74,7 +76,7 @@ RSpec.describe Dro do
     end
 
     context 'with complete DRO' do
-      let(:dro) { create(:dro, :with_dro_description, :with_dro_identification, :with_structural, :with_geographic) }
+      let(:dro) { create(:dro, :with_dro_description, :with_dro_identification, :with_structural, :with_geographic, external_identifier: druid) }
 
       it 'returns a Cocina::Model::DRO' do
         expect(dro.to_cocina).to eq(cocina_dro)

--- a/spec/requests/collections_for_object_spec.rb
+++ b/spec/requests/collections_for_object_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Get the object' do
     end
   end
 
-  let(:collection_records) { [create(:collection_unique_druid)] }
+  let(:collection_records) { [create(:collection)] }
   let(:collections) { collection_records.map(&:to_cocina) }
 
   let(:expected) do
@@ -21,7 +21,7 @@ RSpec.describe 'Get the object' do
     }
   end
 
-  let(:dro_record) { create(:dro_unique_druid, :with_structural, isMemberOf: collections.map(&:externalIdentifier)) }
+  let(:dro_record) { create(:dro, :with_structural, isMemberOf: collections.map(&:externalIdentifier)) }
   let(:dro) { dro_record.to_cocina }
 
   let(:response_model) { JSON.parse(response.body).deep_symbolize_keys }
@@ -47,7 +47,7 @@ RSpec.describe 'Get the object' do
   end
 
   describe 'more than one collection' do
-    let(:collection_records) { [create(:collection_unique_druid), create(:collection_unique_druid)] }
+    let(:collection_records) { [create(:collection), create(:collection)] }
 
     it 'returns an empty array for collections' do
       get "/v1/objects/#{dro.externalIdentifier}/query/collections",


### PR DESCRIPTION
## Why was this change made?

reduces number of fixtures and defaults to using unique druids for each object, which is slightly more realistic

## How was this change tested?

unit

## Which documentation and/or configurations were updated?

n/a