### PR TITLE
Add type attribute to contentMetadata when missing on normalization

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -43,6 +43,7 @@ module Cocina
         normalize_publish
         normalize_checksum
         normalize_empty_xml
+        normalize_content_file_type
         normalize_image_data
 
         regenerate_ng_xml(ng_xml.to_s)
@@ -170,6 +171,13 @@ module Cocina
       def normalize_empty_xml
         # some objects have <xml> instead of <contentMetadata>, e.g. normalize <xml type="file"/> --> <contentMetadata type="file"/>
         ng_xml.root.xpath('//xml[not(text())]').each { |node| node.name = 'contentMetadata' }
+      end
+
+      def normalize_content_file_type
+        # set the type attribute on the contentMetadata node when it's missing
+        ng_xml.root.xpath('//contentMetadata[not(@type)]').each do |node|
+          node['type'] = 'file'
+        end
       end
 
       def remove_external_resource_id

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -80,6 +80,22 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
     end
   end
 
+  context 'when normalizing objectId with no type' do
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata objectId="bk689jd2364" />
+      XML
+    end
+
+    it 'prefixes with druid:' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <contentMetadata objectId="druid:bk689jd2364" type="file" />
+        XML
+      )
+    end
+  end
+
   context 'when normalizing missing objectId' do
     let(:original_xml) do
       <<~XML


### PR DESCRIPTION
## Why was this change made?

Closes #3324 by adding `type="file"` to contentMetadata root nodes that are missing it.

## How was this change tested?

Unit test added
Roundtrip validation is currently running (n=100000)

## Which documentation and/or configurations were updated?



