### PR TITLE
Remove objectId from roleMetadata during normalization

### DIFF
--- a/app/services/cocina/normalizers/role_normalizer.rb
+++ b/app/services/cocina/normalizers/role_normalizer.rb
@@ -20,6 +20,7 @@ module Cocina
       def normalize
         normalize_empty_name_nodes
         normalize_identitifer_nodes
+        normalize_object_id
         regenerate_ng_xml(ng_xml.to_xml)
       end
 
@@ -38,6 +39,12 @@ module Cocina
             node.content = node.content.delete_prefix('sunetid:')
             node['type'] = 'sunetid'
           end
+        end
+      end
+
+      def normalize_object_id
+        ng_xml.root.xpath('//roleMetadata[@objectId]').each do |node|
+          node.delete('objectId')
         end
       end
     end

--- a/spec/services/cocina/normalizers/role_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/role_normalizer_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Cocina::Normalizers::RoleNormalizer do
     it 'removes empty <name> nodes' do
       expect(normalized_ng_xml).to be_equivalent_to(
         <<~XML
-          <roleMetadata objectId="druid:qv648vd4392">
+          <roleMetadata>
             <role type="dor-apo-manager">
               </group>
               <person>
@@ -62,7 +62,7 @@ RSpec.describe Cocina::Normalizers::RoleNormalizer do
     it 'converts <identifier> type="person" and prefix "sunetid:" to <identifier> type="sunetid" and removes prefix' do
       expect(normalized_ng_xml).to be_equivalent_to(
         <<~XML
-          <roleMetadata objectId="druid:qv648vd4392">
+          <roleMetadata>
             <role type="dor-apo-manager">
               </group>
               <person>


### PR DESCRIPTION
## Why was this change made?

Closes #3341 by removing the `objectId` attribute from the `roleMetadata` datastream on roundtrip validation.

Before:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   96892 (97.318%)
  Different: 2670 (2.682%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     1 (0.001%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     437 (0.437%)
  Bad cache:     0 (0.0%)
```

After:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   96892 (97.318%)
  Different: 2670 (2.682%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     1 (0.001%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     437 (0.437%)
  Bad cache:     0 (0.0%)
```
## How was this change tested?

Unit test updated
validate-cocina-roundtrip

## Which documentation and/or configurations were updated?



