### PR TITLE
Return nil for ckeys when identification node is empty or not included

### DIFF
--- a/app/models/dor/update_marc_record_service.rb
+++ b/app/models/dor/update_marc_record_service.rb
@@ -21,6 +21,8 @@ module Dor
     end
 
     def ckeys?
+      return unless @druid_obj.identification
+
       @druid_obj.identification.catalogLinks.find { |link| link.catalog.include?('symphony') }.present?
     end
 

--- a/spec/dor/update_marc_record_service_spec.rb
+++ b/spec/dor/update_marc_record_service_spec.rb
@@ -328,6 +328,49 @@ RSpec.describe Dor::UpdateMarcRecordService do
         expect(generate_symphony_records).to match_array ["8832162\tcc111cc1111\t.856. 41|uhttps://purl.stanford.edu/cc111cc1111|xSDR-PURL|xhttp://cocina.sul.stanford.edu/models/collection.jsonld|xrights:world"]
       end
     end
+
+    context 'when an collection object does not include idenfitication' do
+      let(:access) do
+        {
+          access: 'world'
+        }
+      end
+      let(:cocina_object) do
+        Cocina::Models::Collection.new(externalIdentifier: collection_druid,
+                                       type: Cocina::Models::Vocab.collection,
+                                       label: collection_label,
+                                       version: 1,
+                                       description: descriptive_metadata_basic,
+                                       access: access,
+                                       administrative: { hasAdminPolicy: apo_druid })
+      end
+
+      it 'generates an empty symphony record' do
+        expect(generate_symphony_records).to match_array []
+      end
+    end
+
+    context 'when an collection object includes empty idenfitication' do
+      let(:access) do
+        {
+          access: 'world'
+        }
+      end
+      let(:cocina_object) do
+        Cocina::Models::Collection.new(externalIdentifier: collection_druid,
+                                       type: Cocina::Models::Vocab.collection,
+                                       label: collection_label,
+                                       version: 1,
+                                       description: descriptive_metadata_basic,
+                                       access: access,
+                                       identification: {},
+                                       administrative: { hasAdminPolicy: apo_druid })
+      end
+
+      it 'generates an empty symphony record' do
+        expect(generate_symphony_records).to match_array []
+      end
+    end
   end
 
   describe '.write_symphony_records' do


### PR DESCRIPTION
## Why was this change made?

Part of #3346 

https://app.honeybadger.io/projects/50568/faults/83916162

## How was this change tested?

Updated Unit test.

## Which documentation and/or configurations were updated?



