### PR TITLE
Allow ReleaseTags to accept cocina objects.

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -17,7 +17,7 @@ class MetadataController < ApplicationController
   end
 
   def public_xml
-    release_tags = ReleaseTags.for(item: @item)
+    release_tags = ReleaseTags.legacy_for(item: @item)
     service = Publish::PublicXmlService.new(@item, released_for: release_tags, thumbnail_service: ThumbnailService.new(@cocina_object))
     render xml: service
   end

--- a/app/models/dor/update_marc_record_service.rb
+++ b/app/models/dor/update_marc_record_service.rb
@@ -212,7 +212,7 @@ module Dor
     private
 
     def released_for
-      ::ReleaseTags.for(item: @druid_obj)
+      ::ReleaseTags.for(dro_object: @druid_obj)
     end
 
     def dor_items_for_constituents

--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -20,7 +20,7 @@ module Publish
       return unpublish unless world_discoverable?
 
       # Retrieve release tags from identityMetadata and all collections this item is a member of
-      release_tags = ReleaseTags.for(item: item)
+      release_tags = ReleaseTags.legacy_for(item: item)
 
       transfer_metadata(release_tags)
       publish_notify_on_success

--- a/app/services/release_tags.rb
+++ b/app/services/release_tags.rb
@@ -4,9 +4,18 @@
 class ReleaseTags
   # Retrieve the release tags for an item and all the collections that it is a part of
   #
+  # @param item [Cocina::DRO] the DRO to list release tags for
+  # @return [Hash] (see Dor::ReleaseTags::IdentityMetadata.released_for)
+  def self.for(dro_object:)
+    item = Dor.find(dro_object.externalIdentifier)
+    IdentityMetadata.for(item).released_for({})
+  end
+
+  # Retrieve the release tags for an item and all the collections that it is a part of
+  #
   # @param item [Dor::Item] the item to list release tags for
   # @return [Hash] (see Dor::ReleaseTags::IdentityMetadata.released_for)
-  def self.for(item:)
+  def self.legacy_for(item:)
     IdentityMetadata.for(item).released_for({})
   end
 

--- a/spec/dor/update_marc_record_service_spec.rb
+++ b/spec/dor/update_marc_record_service_spec.rb
@@ -116,6 +116,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
   end
 
   before do
+    allow(Dor).to receive(:find).and_return(instance_double(Dor::Item))
     allow(ReleaseTags::IdentityMetadata).to receive(:for).and_return(release_service)
     Settings.release.symphony_path = './spec/fixtures/sdr-purl'
   end

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'Display metadata' do
     end
 
     before do
-      allow(ReleaseTags).to receive(:for).and_return(
+      allow(ReleaseTags).to receive(:legacy_for).and_return(
         'SearchWorks' => { 'release' => true },
         'elsewhere' => { 'release' => false }
       )

--- a/spec/services/release_tags_spec.rb
+++ b/spec/services/release_tags_spec.rb
@@ -4,19 +4,36 @@ require 'rails_helper'
 
 RSpec.describe ReleaseTags do
   before do
-    # allow(Dor::SuriService).to receive(:mint_id).and_return('druid:aa123bb7890')
     described_class.create(work, release: true, what: 'self', when: '2018-11-30T22:41:35Z', to: 'SearchWorks')
   end
 
-  let(:work) { Dor::Item.new(pid: 'druid:aa123bb7890') }
+  let(:druid) { 'druid:aa123bb7890' }
+  let(:work) { Dor::Item.new(pid: druid) }
 
-  describe '.for' do
+  describe '.legacy_for' do
     it 'returns the hash of release tags' do
-      expect(described_class.for(item: work)).to eq(
+      expect(described_class.legacy_for(item: work)).to eq(
         'SearchWorks' => {
           'release' => true
         }
       )
+    end
+  end
+
+  describe '.for' do
+    let(:dro_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid) }
+
+    before do
+      allow(Dor).to receive(:find).and_return(work)
+    end
+
+    it 'returns the hash of release tags' do
+      expect(described_class.for(dro_object: dro_object)).to eq(
+        'SearchWorks' => {
+          'release' => true
+        }
+      )
+      expect(Dor).to have_received(:find).with(druid)
     end
   end
 


### PR DESCRIPTION
closes #3348

## Why was this change made?
UpdateMarcRecordService uses ReleaseTags, but has already been cocina-ized.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



