### PR TITLE
remove empty labels; do not create new ones

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -36,6 +36,7 @@ module Cocina
         remove_geodata
         remove_id
         remove_stacks
+        remove_empty_labels
         normalize_object_id(druid)
         normalize_reading_order(druid)
         normalize_label_attr
@@ -72,6 +73,10 @@ module Cocina
 
       def remove_resource_data
         ng_xml.root.xpath('//resource[@data]').each { |resource_node| resource_node.delete('data') }
+      end
+
+      def remove_empty_labels
+        ng_xml.root.xpath('//label[not(text())][not(@*)]').each(&:remove)
       end
 
       def remove_sequence
@@ -144,9 +149,11 @@ module Cocina
 
       def normalize_label_attr
         ng_xml.root.xpath('//attr[@type="label"] | //attr[@name="label"]').each do |attr_node|
-          label_node = Nokogiri::XML::Node.new('label', ng_xml)
-          label_node.content = attr_node.content
-          attr_node.parent << label_node
+          if attr_node.content.present? # don't create new blank labels
+            label_node = Nokogiri::XML::Node.new('label', ng_xml)
+            label_node.content = attr_node.content
+            attr_node.parent << label_node
+          end
           attr_node.remove
         end
       end

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -42,6 +42,67 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
     end
   end
 
+  context 'when normalizing labels' do
+    # adapted from dm559qb5551 and fm402pc0937
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata type="file" objectId="druid:dm559qb5551">
+          <resource id="dm559qb5551_3" type="permissions" objectId="druid:gc571ym3095">
+            <attr name="label"/>
+            <file id="OSA_Copyright_Statement.pdf" mimetype="application/pdf" size="128546" shelve="yes" publish="no" preserve="yes">
+              <checksum type="md5">6b7b69c16a839fbb17e94c7cc5ec1467</checksum>
+              <checksum type="sha1">0ebbc2d45e1b03df31d57accd8e442f2a8188b5a</checksum>
+            </file>
+          </resource>
+          <resource id="dm559qb5551_4" type="permissions" objectId="druid:rw602tg5136">
+            <attr name="label">Some cool label</attr>
+            <file id="copyxfer.pdf" mimetype="application/pdf" size="57053" shelve="yes" publish="no" preserve="yes">
+              <checksum type="md5">036df64941635bcfa525fe3faf86d84f</checksum>
+              <checksum type="sha1">87fc2454991de4f60f26c1f6fa4b51b4e7c913f3</checksum>
+            </file>
+          </resource>
+          <resource id="http://cocina.sul.stanford.edu/fileSet/18dabbd3-16fb-42be-9833-5da5401129a1" sequence="1" type="file">
+            <label/>
+            <file id="2021 March Off Highway Vehicles.pdf" mimetype="application/pdf" size="75211" publish="yes" shelve="yes" preserve="yes">
+              <checksum type="sha1">f715cfa0f2a2cdd0fc14aa73a3e75326babe9ec4</checksum>
+              <checksum type="md5">f3118304673f2135e3c37a6a233034b7</checksum>
+            </file>
+          </resource>
+        </contentMetadata>
+      XML
+    end
+
+    let(:expected_xml) do
+      <<~XML
+        <contentMetadata type="file" objectId="druid:dm559qb5551">
+          <resource type="permissions">
+            <file id="OSA_Copyright_Statement.pdf" mimetype="application/pdf" size="128546" shelve="yes" publish="no" preserve="yes">
+              <checksum type="md5">6b7b69c16a839fbb17e94c7cc5ec1467</checksum>
+              <checksum type="sha1">0ebbc2d45e1b03df31d57accd8e442f2a8188b5a</checksum>
+            </file>
+          </resource>
+          <resource type="permissions">
+            <label>Some cool label</label>
+            <file id="copyxfer.pdf" mimetype="application/pdf" size="57053" shelve="yes" publish="no" preserve="yes">
+              <checksum type="md5">036df64941635bcfa525fe3faf86d84f</checksum>
+              <checksum type="sha1">87fc2454991de4f60f26c1f6fa4b51b4e7c913f3</checksum>
+            </file>
+          </resource>
+          <resource type="file">
+            <file id="2021 March Off Highway Vehicles.pdf" mimetype="application/pdf" size="75211" publish="yes" shelve="yes" preserve="yes">
+              <checksum type="sha1">f715cfa0f2a2cdd0fc14aa73a3e75326babe9ec4</checksum>
+              <checksum type="md5">f3118304673f2135e3c37a6a233034b7</checksum>
+            </file>
+          </resource>
+        </contentMetadata>
+      XML
+    end
+
+    it 'removes empty <label /> and <attr name="label"> nodes' do
+      expect(normalized_ng_xml).to be_equivalent_to(expected_xml)
+    end
+  end
+
   context 'when normalizing resource objectids' do
     let(:original_xml) do
       <<~XML


### PR DESCRIPTION
## Why was this change made?

Fixes #3321 - normalize/remove empty labels (and do not create new empty ones in existing normalization)

## How was this change tested?

- New unit test
- Running roundtrip validation on sdr-deploy (results below) : 0.015% improvement! 🥇 

## Which documentation and/or configurations were updated?



