### PR TITLE
Normalize group when outside of a role node

### DIFF
--- a/app/services/cocina/normalizers/role_normalizer.rb
+++ b/app/services/cocina/normalizers/role_normalizer.rb
@@ -21,6 +21,7 @@ module Cocina
         normalize_empty_name_nodes
         normalize_identitifer_nodes
         normalize_object_id
+        normalize_group_without_role
         regenerate_ng_xml(ng_xml.to_xml)
       end
 
@@ -46,6 +47,10 @@ module Cocina
         ng_xml.root.xpath('//roleMetadata[@objectId]').each do |node|
           node.delete('objectId')
         end
+      end
+
+      def normalize_group_without_role
+        ng_xml.root.xpath('//roleMetadata/group').each(&:remove)
       end
     end
   end

--- a/bin/reports/report-role-groups
+++ b/bin/reports/report-role-groups
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+def has_group_no_role?(ng_xml)
+  ng_xml.root.xpath('//roleMetadata/group').present?
+end
+
+Report.new(name: 'role-group-without-role', dsid: 'roleMetadata', report_func: method(:has_group_no_role?)).run

--- a/spec/services/cocina/normalizers/role_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/role_normalizer_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Cocina::Normalizers::RoleNormalizer do
       <<~XML
         <roleMetadata objectId="druid:qv648vd4392">
           <role type="dor-apo-manager">
-            </group>
             <person>
               <identifier type="person">sunetid:petucket</identifier>
               <name/>
@@ -28,7 +27,6 @@ RSpec.describe Cocina::Normalizers::RoleNormalizer do
         <<~XML
           <roleMetadata>
             <role type="dor-apo-manager">
-              </group>
               <person>
                 <identifier type="sunetid">petucket</identifier>
               </person>
@@ -47,7 +45,6 @@ RSpec.describe Cocina::Normalizers::RoleNormalizer do
       <<~XML
         <roleMetadata objectId="druid:qv648vd4392">
           <role type="dor-apo-manager">
-            </group>
             <person>
               <identifier type="person">sunetid:petucket</identifier>
             </person>
@@ -64,13 +61,43 @@ RSpec.describe Cocina::Normalizers::RoleNormalizer do
         <<~XML
           <roleMetadata>
             <role type="dor-apo-manager">
-              </group>
               <person>
                 <identifier type="sunetid">petucket</identifier>
               </person>
               <group>
                 <identifier type="workgroup">sdr:metadata-staff</identifier>
               </group>
+            </role>
+          </roleMetadata>
+        XML
+      )
+    end
+  end
+
+  context 'when #normalize_group_without_role on APO like objects' do
+    let(:original_xml) do
+      <<~XML
+        <roleMetadata objectId="druid:qv648vd4392">
+          <role type="dor-apo-manager">
+            <person>
+              <identifier type="person">sunetid:petucket</identifier>
+            </person>
+          </role>
+          <group>
+            <identifier type="workgroup">sdr:metadata-staff</identifier>
+          </group>
+        </roleMetadata>
+      XML
+    end
+
+    it 'removes the group node outside of the role node' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <roleMetadata>
+            <role type="dor-apo-manager">
+              <person>
+                <identifier type="sunetid">petucket</identifier>
+              </person>
             </role>
           </roleMetadata>
         XML


### PR DESCRIPTION
## Why was this change made?

Fixes #3319 by removing group nodes that are outside of role nodes. This typically only happens for APOs.

## How was this change tested?

Unit test updated.
Pending roundtrip validation.

Round trip using `druids.apos.txt`:
Before:
```Status (n=1270; not using Missing for success/different/error stats):
  Success:   748 (58.898%)
  Different: 515 (40.551%)
  Mapping error:     7 (0.551%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     0 (0.0%)
  Bad cache:     0 (0.0%)
```

After:
```
Status (n=1270; not using Missing for success/different/error stats):
  Success:   1015 (79.921%)
  Different: 248 (19.528%)
  Mapping error:     7 (0.551%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     0 (0.0%)
  Bad cache:     0 (0.0%)
```

A general N=50K roundtrip:

```
Status (n=50000; not using Missing for success/different/error stats):
  Success:   48434 (97.296%)
  Different: 1346 (2.704%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     220 (0.44%)
  Bad cache:     0 (0.0%)
```

AFTER:
```
Status (n=50000; not using Missing for success/different/error stats):
  Success:   48439 (97.306%)
  Different: 1341 (2.694%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     220 (0.44%)
  Bad cache:     0 (0.0%)
```
## Which documentation and/or configurations were updated?



