### PR TITLE
Adds migration script for cocina, versions, and events.

### DIFF
--- a/app/services/cocina_migration_service.rb
+++ b/app/services/cocina_migration_service.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Migrates Fedora objects to Cocina objects persisted in the DB.
+class CocinaMigrationService
+  def self.migrate(fedora_object)
+    new(fedora_object).migrate
+  end
+
+  def initialize(fedora_object)
+    @fedora_object = fedora_object
+  end
+
+  def migrate
+    return if CocinaObjectStore.new.ar_exists?(fedora_object.pid)
+
+    @cocina_object = Cocina::Mapper.build(fedora_object)
+    save
+  end
+
+  private
+
+  attr_reader :fedora_object, :cocina_object
+
+  def save
+    model_clazz = case cocina_object
+                  when Cocina::Models::AdminPolicy
+                    AdminPolicy
+                  when Cocina::Models::DRO
+                    Dro
+                  when Cocina::Models::Collection
+                    Collection
+                  else
+                    raise CocinaObjectStoreError, "unsupported type #{cocina_object&.type}"
+                  end
+    model_hash = model_clazz.to_model_hash(cocina_object).merge(created_at: created_at, updated_at: updated_at)
+    model_clazz.create(model_hash)
+  end
+
+  def created_at
+    fedora_object.create_date.to_datetime
+  end
+
+  def updated_at
+    fedora_object.modified_date.to_datetime
+  end
+end

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../config/environment'
+require 'optparse'
+
+options = { druids: [], input: 'druids.txt' }
+parser = OptionParser.new do |option_parser|
+  option_parser.banner = 'Usage: bin/migrate [options]'
+
+  option_parser.on('-sSAMPLE', '--sample SAMPLE', Integer, 'Sample size, otherwise all druids.')
+  option_parser.on('-dDRUIDS', '--druids DRUIDS', Array, 'List of druids (instead of druids.txt).')
+  option_parser.on('-iFILENAME', '--input FILENAME', String, 'File containing list of druids (instead of druids.txt).')
+  option_parser.on('-h', '--help', 'Displays help.') do
+    puts option_parser
+    exit
+  end
+end
+parser.parse!(into: options)
+
+def migrate(druid)
+  fedora_obj = CocinaObjectStore.new.fedora_find(druid)
+
+  EventsMigrationService.migrate(fedora_obj)
+  # To be enabled after #3311
+  # VersionMigrationService.migrate(fedora_obj)
+  CocinaMigrationService.migrate(fedora_obj)
+  'success'
+rescue CocinaObjectStore::CocinaObjectNotFoundError
+  'missing'
+rescue StandardError
+  'error'
+end
+
+if options[:druids].empty?
+  druids = File.read(options[:input]).split
+  druids = druids.take(options[:sample]) if options[:sample]
+else
+  druids = options[:druids]
+end
+
+File.open('migration_results.txt', 'w') do |file|
+  druids.each_with_index do |druid, index|
+    print "Migrating #{druid} #{index + 1} of #{druids.size}: "
+    result = migrate(druid)
+    puts result
+    file.write("#{druid}=#{result}\n")
+  end
+end

--- a/spec/services/cocina_migration_service_spec.rb
+++ b/spec/services/cocina_migration_service_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CocinaMigrationService do
+  describe '#migrate' do
+    let(:druid) { 'druid:hv992ry2431' }
+    let(:fedora_object) { instance_double(Dor::Item, pid: druid, create_date: '2021-05-24T21:55:33.337Z', modified_date: '2022-05-24T21:55:33.337Z') }
+
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(type: Cocina::Models::Vocab.image,
+                              label: 'Test image',
+                              version: 1,
+                              access: {
+                                access: 'world',
+                                download: 'none',
+                                copyright: 'All rights reserved unless otherwise indicated.',
+                                useAndReproductionStatement: 'Property rights reside with the repository...'
+                              },
+                              description: {
+                                title: [{ value: 'A test image' }],
+                                purl: 'https://purl.stanford.edu/hv992ry2431'
+                              },
+                              administrative: {
+                                hasAdminPolicy: 'druid:dd999df4567',
+                                partOfProject: 'Google Books'
+                              },
+                              identification: {
+                                sourceId: 'googlebooks:999999',
+                                barcode: '36105036289127'
+                              },
+                              externalIdentifier: druid,
+                              structural: {})
+    end
+
+    let(:cocina_object_store) { instance_double(CocinaObjectStore) }
+
+    before do
+      allow(CocinaObjectStore).to receive(:new).and_return(cocina_object_store)
+      allow(cocina_object_store).to receive(:cocina_to_ar_save)
+      allow(Cocina::Mapper).to receive(:build).and_return(cocina_object)
+    end
+
+    context 'when already migrated' do
+      before do
+        allow(cocina_object_store).to receive(:ar_exists?).and_return(true)
+      end
+
+      it 'returns' do
+        described_class.migrate(fedora_object)
+
+        expect(Cocina::Mapper).not_to have_received(:build)
+      end
+    end
+
+    context 'when migration needed' do
+      before do
+        allow(cocina_object_store).to receive(:ar_exists?).and_return(false)
+      end
+
+      it 'maps and persists' do
+        described_class.migrate(fedora_object)
+        expect(Cocina::Mapper).to have_received(:build).with(fedora_object)
+        ar_cocina_object = Dro.find_by(external_identifier: druid)
+        expect(ar_cocina_object.label).to eq('Test image')
+        expect(ar_cocina_object.created_at).to eq('2021-05-24 21:55:33 UTC')
+        expect(ar_cocina_object.updated_at).to eq('2022-05-24 21:55:33 UTC')
+      end
+    end
+  end
+end

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -40,6 +40,29 @@ RSpec.describe CocinaObjectStore do
       end
     end
 
+    describe '#exists?' do
+      context 'when DRO is found' do
+        before do
+          allow(Dor).to receive(:find).and_return(item)
+        end
+
+        it 'returns true' do
+          expect(described_class.exists?(druid)).to be(true)
+          expect(Dor).to have_received(:find).with(druid)
+        end
+      end
+
+      context 'when DRO is not found' do
+        before do
+          allow(Dor).to receive(:find).and_raise(ActiveFedora::ObjectNotFoundError)
+        end
+
+        it 'returns false' do
+          expect(described_class.exists?(druid)).to be(false)
+        end
+      end
+    end
+
     describe '#save' do
       context 'when object is found in datastore' do
         let(:updated_cocina_object) { instance_double(Cocina::Models::DRO) }
@@ -102,6 +125,38 @@ RSpec.describe CocinaObjectStore do
 
         it 'returns Cocina::Models::Collection' do
           expect(store.send(:ar_to_cocina_find, ar_cocina_object.external_identifier)).to be_a(Cocina::Models::Collection)
+        end
+      end
+    end
+
+    describe '#ar_exists?' do
+      context 'when object is not found in datastore' do
+        it 'returns false' do
+          expect(store.ar_exists?('druid:bc123df4567')).to be(false)
+        end
+      end
+
+      context 'when object is a DRO' do
+        let(:ar_cocina_object) { create(:dro) }
+
+        it 'returns true' do
+          expect(store.ar_exists?(ar_cocina_object.external_identifier)).to be(true)
+        end
+      end
+
+      context 'when object is an AdminPolicy' do
+        let(:ar_cocina_object) { create(:admin_policy) }
+
+        it 'returns true' do
+          expect(store.ar_exists?(ar_cocina_object.external_identifier)).to be(true)
+        end
+      end
+
+      context 'when object is a Collection' do
+        let(:ar_cocina_object) { create(:collection) }
+
+        it 'returns true' do
+          expect(store.ar_exists?(ar_cocina_object.external_identifier)).to be(true)
         end
       end
     end


### PR DESCRIPTION
closes #3351

## Why was this change made?
To allow migration from Fedora to Cocina.


## How was this change tested?
Unit, QA


## Which documentation and/or configurations were updated?



