### PR TITLE
Normalizing out provider_checksum in contentMetadata.

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -37,6 +37,7 @@ module Cocina
         remove_id
         remove_stacks
         remove_empty_labels
+        remove_provider_checksum
         normalize_object_id(druid)
         normalize_reading_order(druid)
         normalize_label_attr
@@ -128,6 +129,10 @@ module Cocina
         return if ng_xml.root['stacks'].blank?
 
         ng_xml.root.delete('stacks')
+      end
+
+      def remove_provider_checksum
+        ng_xml.root.xpath('//resource/file/provider_checksum').each(&:remove)
       end
 
       def normalize_reading_order(druid)

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -734,4 +734,49 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       )
     end
   end
+
+  context 'when normalizing contentMetadata files with provider_checksum' do
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata objectId="druid:bw260mc4853" type="image">
+          <resource type="image">
+            <label>Item 1</label>
+            <file publish="no" shelve="no" preserve="yes" id="00008460_0001.tif" mimetype="image/tiff" size="502704556">
+              <provider_checksum type="md5">71d813393ab0699fa58c26b9490a159e</provider_checksum>
+              <checksum type="md5">71d813393ab0699fa58c26b9490a159e</checksum>
+              <checksum type="sha1">efe7d6b501be9a5503817d19a3ec9072c9331cba</checksum>
+              <imageData width="14785" height="11322"/>
+            </file>
+            <file id="00008460_0001.jp2" mimetype="image/jp2" size="31529801" preserve="no" publish="yes" shelve="yes">
+              <checksum type="md5">ad6ddf7db816bcb1579fae80351a092d</checksum>
+              <checksum type="sha1">3bbab77d76bcc261d1d2ef0765d75fe5919d84e8</checksum>
+              <imageData width="14785" height="11322"/>
+            </file>
+          </resource>
+        </contentMetadata>
+      XML
+    end
+
+    it 'removes provider_checksum' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <contentMetadata objectId="druid:bw260mc4853" type="image">
+            <resource type="image">
+              <label>Item 1</label>
+              <file publish="no" shelve="no" preserve="yes" id="00008460_0001.tif" mimetype="image/tiff" size="502704556">
+                <checksum type="md5">71d813393ab0699fa58c26b9490a159e</checksum>
+                <checksum type="sha1">efe7d6b501be9a5503817d19a3ec9072c9331cba</checksum>
+                <imageData width="14785" height="11322"/>
+              </file>
+              <file id="00008460_0001.jp2" mimetype="image/jp2" size="31529801" preserve="no" publish="yes" shelve="yes">
+                <checksum type="md5">ad6ddf7db816bcb1579fae80351a092d</checksum>
+                <checksum type="sha1">3bbab77d76bcc261d1d2ef0765d75fe5919d84e8</checksum>
+                <imageData width="14785" height="11322"/>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made?
Resolves #3318. Removes provider_checksum from contentMetadata/resource/file. 

## How was this change tested?
Added spec and unit tests. Running `bin/validate-cocina-roundtrip -s 100000 -i druids.testbed.txt ` on sdr-deploy has the different rate go up, so trying to figure that out by comparing with run on main. DRAFT until then. 

Before
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   97152 (97.232%)
  Different: 2766 (2.768%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

After
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   96610 (96.689%)
  Different: 3308 (3.311%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)

```


## Which documentation and/or configurations were updated?



