### PR TITLE
remove empty dissemination workflow nodes

### DIFF
--- a/app/services/cocina/normalizers/admin_normalizer.rb
+++ b/app/services/cocina/normalizers/admin_normalizer.rb
@@ -34,9 +34,10 @@ module Cocina
       end
 
       def normalize_empty_registration_and_dissemination
-        # removes any empty nodes like this: <registration/> or <dissemination/>
+        # removes any empty nodes like this: <registration/> or <dissemination/> or <dissemination><workflow id="" /></dissemination>
         ng_xml.root.xpath('//registration[not(node())]').each(&:remove)
         ng_xml.root.xpath('//dissemination[not(node())]').each(&:remove)
+        ng_xml.root.xpath('//dissemination/workflow[@id=""]').each { |node| node.parent.remove }
       end
 
       def normalize_empty_dissemination_workflow

--- a/spec/services/cocina/normalizers/admin_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/admin_normalizer_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Cocina::Normalizers::AdminNormalizer do
     end
 
     context 'when #normalize_empty_registration_and_dissemination' do
+      #  adapted from bb329pr4129
       let(:original_xml) do
         <<~XML
           <administrativeMetadata>
@@ -50,6 +51,9 @@ RSpec.describe Cocina::Normalizers::AdminNormalizer do
             </registration>
             <dissemination>
               <workflow id="someNotEmptyValue"/>
+            </dissemination>
+            <dissemination>
+              <workflow id=""/>
             </dissemination>
             <registration />
             <dissemination />


### PR DESCRIPTION
## Why was this change made?

Fixes #3345 - remove more empty dissemination nodes

## How was this change tested?

- Updated existing similar test with new pattern
- cocina roundtrip validation tests (results shown below)

## Which documentation and/or configurations were updated?



