### PR TITLE
add objectLabel node with value from fedora object if not in datastream

### DIFF
--- a/app/services/cocina/normalizers/identity_normalizer.rb
+++ b/app/services/cocina/normalizers/identity_normalizer.rb
@@ -8,12 +8,14 @@ module Cocina
       include Cocina::Normalizers::Base
 
       # @param [Nokogiri::Document] identity_ng_xml identity metadata XML to be normalized
+      # @param [String] label the object label to add when normalizing
       # @return [Nokogiri::Document] normalized identity metadata xml
-      def self.normalize(identity_ng_xml:)
-        new(identity_ng_xml: identity_ng_xml).normalize
+      def self.normalize(identity_ng_xml:, label:)
+        new(identity_ng_xml: identity_ng_xml, label: label).normalize
       end
 
-      def initialize(identity_ng_xml:)
+      def initialize(identity_ng_xml:, label:)
+        @label = label
         @ng_xml = identity_ng_xml.dup
         @ng_xml.encoding = 'UTF-8' if @ng_xml.respond_to?(:encoding=) # sometimes it's a String (?)
       end
@@ -36,6 +38,7 @@ module Cocina
         normalize_object_creator
         normalize_out_labels
         normalize_apo_source_id
+        normalize_label
 
         regenerate_ng_xml(ng_xml.to_xml)
       end
@@ -156,6 +159,15 @@ module Cocina
         object_creator_node = Nokogiri::XML::Node.new('objectCreator', ng_xml)
         object_creator_node.content = 'DOR'
         ng_xml.root << object_creator_node
+      end
+
+      # add fedora object label if no object label is present
+      def normalize_label
+        return if ng_xml.root.xpath('//objectLabel').present?
+
+        object_label_node = Nokogiri::XML::Node.new('objectLabel', ng_xml)
+        object_label_node.content = @label
+        ng_xml.root << object_label_node
       end
     end
   end

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -97,7 +97,7 @@ def norm_orig_datastream_ng_xml_for(dsid, orig_datastream_ng_xml, druid, label, 
   when 'contentMetadata'
     Cocina::Normalizers::ContentMetadataNormalizer.normalize(druid: druid, content_ng_xml: orig_datastream_ng_xml)
   when 'identityMetadata'
-    Cocina::Normalizers::IdentityNormalizer.normalize(identity_ng_xml: orig_datastream_ng_xml, label: MetadataService.label_from_mods(fedora_obj.descMetadata.ng_xml))
+    Cocina::Normalizers::IdentityNormalizer.normalize(identity_ng_xml: orig_datastream_ng_xml, label: label)
   when 'embargoMetadata'
     Cocina::Normalizers::EmbargoNormalizer.normalize(embargo_ng_xml: orig_datastream_ng_xml)
   when 'roleMetadata'

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -97,7 +97,7 @@ def norm_orig_datastream_ng_xml_for(dsid, orig_datastream_ng_xml, druid, label, 
   when 'contentMetadata'
     Cocina::Normalizers::ContentMetadataNormalizer.normalize(druid: druid, content_ng_xml: orig_datastream_ng_xml)
   when 'identityMetadata'
-    Cocina::Normalizers::IdentityNormalizer.normalize(identity_ng_xml: orig_datastream_ng_xml)
+    Cocina::Normalizers::IdentityNormalizer.normalize(identity_ng_xml: orig_datastream_ng_xml, label: MetadataService.label_from_mods(fedora_obj.descMetadata.ng_xml))
   when 'embargoMetadata'
     Cocina::Normalizers::EmbargoNormalizer.normalize(embargo_ng_xml: orig_datastream_ng_xml)
   when 'roleMetadata'

--- a/spec/services/cocina/mapping/identification/agreement_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/agreement_identity_spec.rb
@@ -52,7 +52,7 @@ RSpec.shared_examples 'Agreement Object Identification Fedora Cocina mapping' do
     # the starting identityMetadata.xml is normalized to address discrepancies found against identityMetadata roundtripped
     #  from data store (Fedora) and back, per Andrew's specifications.
     #  E.g., <adminPolicy> is removed as that information will not be carried over and is retrieved from RELS-EXT
-    Cocina::Normalizers::IdentityNormalizer.normalize(identity_ng_xml: Nokogiri::XML(identity_metadata_xml)).to_xml
+    Cocina::Normalizers::IdentityNormalizer.normalize(identity_ng_xml: Nokogiri::XML(identity_metadata_xml), label: label).to_xml
   end
   let(:roundtrip_identity_md_xml) { defined?(roundtrip_identity_metadata_xml) ? roundtrip_identity_metadata_xml : identity_metadata_xml }
   let(:roundtrip_fedora_agreement) do

--- a/spec/services/cocina/mapping/identification/apo_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/apo_identity_spec.rb
@@ -53,7 +53,7 @@ RSpec.shared_examples 'APO Identification Fedora Cocina mapping' do
     # the starting identityMetadata.xml is normalized to address discrepancies found against identityMetadata roundtripped
     #  from data store (Fedora) and back, per Andrew's specifications.
     #  E.g., <adminPolicy> is removed as that information will not be carried over and is retrieved from RELS-EXT
-    Cocina::Normalizers::IdentityNormalizer.normalize(identity_ng_xml: Nokogiri::XML(identity_metadata_xml)).to_xml
+    Cocina::Normalizers::IdentityNormalizer.normalize(identity_ng_xml: Nokogiri::XML(identity_metadata_xml), label: label).to_xml
   end
   let(:roundtrip_identity_metadata_xml) { defined?(roundtrip_identity_metadata_xml) ? roundtrip_identity_metadata_xml : identity_metadata_xml }
 

--- a/spec/services/cocina/mapping/identification/collection_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/collection_identity_spec.rb
@@ -51,7 +51,7 @@ RSpec.shared_examples 'Collection Identification Fedora Cocina mapping' do
     # the starting identityMetadata.xml is normalized to address discrepancies found against identityMetadata roundtripped
     #  from data store (Fedora) and back, per Andrew's specifications.
     #  E.g., <adminPolicy> is removed as that information will not be carried over and is retrieved from RELS-EXT
-    Cocina::Normalizers::IdentityNormalizer.normalize(identity_ng_xml: Nokogiri::XML(identity_metadata_xml)).to_xml
+    Cocina::Normalizers::IdentityNormalizer.normalize(identity_ng_xml: Nokogiri::XML(identity_metadata_xml), label: label).to_xml
   end
   let(:roundtrip_identity_md_xml) { defined?(roundtrip_identity_metadata_xml) ? roundtrip_identity_metadata_xml : identity_metadata_xml }
   let(:mapped_cocina_collection) { Cocina::Models::Collection.new(mapped_cocina_props) }

--- a/spec/services/cocina/mapping/identification/dro_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/dro_identity_spec.rb
@@ -58,7 +58,7 @@ RSpec.shared_examples 'DRO Identification Fedora Cocina mapping' do
     # the starting identityMetadata.xml is normalized to address discrepancies found against identityMetadata roundtripped
     #  from data store (Fedora) and back, per Andrew's specifications.
     #  E.g., <citationTitle> and <citationCreator> are removed
-    Cocina::Normalizers::IdentityNormalizer.normalize(identity_ng_xml: Nokogiri::XML(identity_metadata_xml)).to_xml
+    Cocina::Normalizers::IdentityNormalizer.normalize(identity_ng_xml: Nokogiri::XML(identity_metadata_xml), label: label).to_xml
   end
   let(:roundtrip_identity_md_xml) { defined?(roundtrip_identity_metadata_xml) ? roundtrip_identity_metadata_xml : identity_metadata_xml }
   let(:roundtrip_fedora_item) do

--- a/spec/services/cocina/normalizers/identity_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/identity_normalizer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::Normalizers::IdentityNormalizer do
-  let(:normalized_ng_xml) { described_class.normalize(identity_ng_xml: Nokogiri::XML(original_xml)) }
+  let(:normalized_ng_xml) { described_class.normalize(identity_ng_xml: Nokogiri::XML(original_xml), label: 'Some cool object label') }
 
   context 'when #normalize_apo_source_id' do
     context 'with an adminPolicy object with a sourceId' do
@@ -24,7 +24,8 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
               <objectId>druid:bk068fh4950</objectId>
               <objectType>adminPolicy</objectType>
               <objectCreator>DOR</objectCreator>
-              </identityMetadata>
+              <objectLabel>Some cool object label</objectLabel>
+            </identityMetadata>
           XML
         )
       end
@@ -46,6 +47,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
           <identityMetadata>
              <sourceId source="sul">M0443_S2_D-K_B9_F33_011</sourceId>
              <objectCreator>DOR</objectCreator>
+             <objectLabel>Some cool object label</objectLabel>
           </identityMetadata>
         XML
       )
@@ -70,6 +72,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
               <sourceId source="foo">bar</sourceId>
               <otherId name="dissertationid">0000000666</otherId>
               <objectCreator>DOR</objectCreator>
+              <objectLabel>Some cool object label</objectLabel>
             </identityMetadata>
           XML
         )
@@ -91,6 +94,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
             <identityMetadata>
               <sourceId source="dissertationid">0000000666</sourceId>
               <objectCreator>DOR</objectCreator>
+              <objectLabel>Some cool object label</objectLabel>
             </identityMetadata>
           XML
         )
@@ -146,6 +150,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
             <identityMetadata>
               <otherId name="catkey">666</otherId>
               <objectCreator>DOR</objectCreator>
+              <objectLabel>Some cool object label</objectLabel>
             </identityMetadata>
           XML
         )
@@ -172,6 +177,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
               <objectId>foo</objectId>
               <otherId name="catkey">666</otherId>
               <objectCreator>DOR</objectCreator>
+              <objectLabel>Some cool object label</objectLabel>
             </identityMetadata>
           XML
         )
@@ -198,6 +204,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
               <objectId>foo</objectId>
               <otherId name="catkey">666</otherId>
               <objectCreator>DOR</objectCreator>
+              <objectLabel>Some cool object label</objectLabel>
             </identityMetadata>
           XML
         )
@@ -224,6 +231,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
               <objectId>foo</objectId>
               <otherId name="catkey">666</otherId>
               <objectCreator>DOR</objectCreator>
+              <objectLabel>Some cool object label</objectLabel>
             </identityMetadata>
           XML
         )
@@ -249,6 +257,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
               <objectId>foo</objectId>
               <otherId name="catkey">666</otherId>
               <objectCreator>DOR</objectCreator>
+              <objectLabel>Some cool object label</objectLabel>
             </identityMetadata>
           XML
         )
@@ -520,6 +529,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
           <identityMetadata>
             <otherId name="catkey">90125</otherId>
             <objectCreator>DOR</objectCreator>
+            <objectLabel>Some cool object label</objectLabel>
           </identityMetadata>
         XML
       )
@@ -542,6 +552,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
           <identityMetadata>
             <otherId name="previous_catkey">90125</otherId>
             <objectCreator>DOR</objectCreator>
+            <objectLabel>Some cool object label</objectLabel>
           </identityMetadata>
         XML
       )
@@ -586,6 +597,7 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
           <identityMetadata>
             <objectCreator>DOR</objectCreator>
             <otherId name="catkey">12345</otherId>
+            <objectLabel>Some cool object label</objectLabel>
           </identityMetadata>
         XML
       )
@@ -608,9 +620,59 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
           <identityMetadata>
             <objectCreator>DOR</objectCreator>
             <objectType>item</objectType>
+            <objectLabel>Some cool object label</objectLabel>
           </identityMetadata>
         XML
       )
+    end
+  end
+
+  describe '#normalize_label' do
+    context 'when there is no objectLabel' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectCreator>DOR</objectCreator>
+            <objectType>item</objectType>
+          </identityMetadata>
+        XML
+      end
+
+      it 'adds the passed in label' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectCreator>DOR</objectCreator>
+              <objectType>item</objectType>
+              <objectLabel>Some cool object label</objectLabel>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
+
+    context 'when there is an existing objectLabel' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectCreator>DOR</objectCreator>
+            <objectType>item</objectType>
+            <objectLabel>Do not change me</objectLabel>
+          </identityMetadata>
+        XML
+      end
+
+      it 'does not replace with the passed in label' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <identityMetadata>
+              <objectCreator>DOR</objectCreator>
+              <objectType>item</objectType>
+              <objectLabel>Do not change me</objectLabel>
+            </identityMetadata>
+          XML
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #3320 - if missing when normalizing, add objectLabel to identityMetadata using value pulled from fedora object

## How was this change tested?

- Added new unit tests
- roundtrip validation on server


## Which documentation and/or configurations were updated?



