### PR TITLE
Rewrite collection existence validator for cocina

### DIFF
--- a/app/validators/cocina/collection_existence_validator.rb
+++ b/app/validators/cocina/collection_existence_validator.rb
@@ -15,10 +15,10 @@ module Cocina
 
       begin
         collection_ids.each do |collection_id|
-          collection = Dor.find(collection_id)
-          @error = "Expected '#{collection_id}' to be a Collection but it is a #{collection.class}" unless collection.is_a?(Dor::Collection)
+          collection = CocinaObjectStore.find(collection_id)
+          @error = "Expected '#{collection_id}' to be a Collection but it is a #{collection.class}" unless collection.collection?
         end
-      rescue ActiveFedora::ObjectNotFoundError => e
+      rescue CocinaObjectStore::CocinaObjectNotFoundError => e
         @error = "Unable to find collection: '#{e.message}'"
       end
 

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -551,14 +551,22 @@ RSpec.describe 'Create object' do
         end
       end
 
-      let(:collection) { Dor::Collection.new(pid: 'druid:xx888xx7777') }
+      let(:dor_collection) { Dor::Collection.new(pid: 'druid:xx888xx7777') }
+      let(:collection) do
+        Cocina::Models::Collection.new(externalIdentifier: 'druid:xx888xx7777',
+                                       type: Cocina::Models::Vocab.collection,
+                                       label: 'Collection of new maps of Africa',
+                                       version: 1,
+                                       cocinaVersion: '0.0.1',
+                                       access: {})
+      end
 
       before do
         # Allows the CollectionExistenceValidator to find the collection:
-        allow(Dor).to receive(:find).with('druid:xx888xx7777').and_return(Dor::Collection.new)
+        allow(CocinaObjectStore).to receive(:find).with('druid:xx888xx7777').and_return(collection)
 
         allow(Dor::Item).to receive(:new).and_return(item)
-        allow(item).to receive(:collections).and_return([collection])
+        allow(item).to receive(:collections).and_return([dor_collection])
         allow(item).to receive(:save!)
       end
 

--- a/spec/validators/cocina/collection_existence_validator_spec.rb
+++ b/spec/validators/cocina/collection_existence_validator_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::CollectionExistenceValidator do
+  let(:validator) { described_class.new(item) }
+
+  let(:collection_druid) { 'druid:cc111cc1111' }
+  let(:collection) { Dor::Collection.new(pid: collection_druid) }
+
+  before do
+    allow(Dor).to receive(:find).with(collection_druid).and_return(collection)
+  end
+
+  context 'when a dor object does not belong to a collection' do
+    let(:item) do
+      Cocina::Models::DRO.new(
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'The Structure of Scientific Revolutions',
+        type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
+        version: 1,
+        administrative: {
+          hasAdminPolicy: 'druid:df123cd4567'
+        },
+        access: {}
+      )
+    end
+
+    it 'returns true' do
+      expect(validator.valid?).to be true
+    end
+  end
+
+  context 'when a dor object belongs to a collection' do
+    let(:item) do
+      Cocina::Models::DRO.new(
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'The Structure of Scientific Revolutions',
+        type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
+        version: 1,
+        administrative: {
+          hasAdminPolicy: 'druid:df123cd4567'
+        },
+        access: {},
+        structural: {
+          contains: [],
+          isMemberOf: [collection_druid]
+        }
+      )
+    end
+
+    it 'returns true' do
+      expect(validator.valid?).to be true
+    end
+  end
+
+  context 'when a dor object belongs to a collection that is not found' do
+    let(:item) do
+      Cocina::Models::DRO.new(
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'The Structure of Scientific Revolutions',
+        type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
+        version: 1,
+        administrative: {
+          hasAdminPolicy: 'druid:df123cd4567'
+        },
+        access: {},
+        structural: {
+          contains: [],
+          isMemberOf: [collection_druid]
+        }
+      )
+    end
+
+    it 'returns false' do
+      allow(Dor).to receive(:find).with(collection_druid).and_return(nil)
+      expect(validator.valid?).to be false
+    end
+  end
+end

--- a/spec/validators/cocina/collection_existence_validator_spec.rb
+++ b/spec/validators/cocina/collection_existence_validator_spec.rb
@@ -6,10 +6,17 @@ RSpec.describe Cocina::CollectionExistenceValidator do
   let(:validator) { described_class.new(item) }
 
   let(:collection_druid) { 'druid:cc111cc1111' }
-  let(:collection) { Dor::Collection.new(pid: collection_druid) }
+  let(:collection) do
+    Cocina::Models::Collection.new(externalIdentifier: collection_druid,
+                                   type: Cocina::Models::Vocab.collection,
+                                   label: 'Collection of new maps of Africa',
+                                   version: 1,
+                                   cocinaVersion: '0.0.1',
+                                   access: {})
+  end
 
   before do
-    allow(Dor).to receive(:find).with(collection_druid).and_return(collection)
+    allow(CocinaObjectStore).to receive(:find).with(collection_druid).and_return(collection)
   end
 
   context 'when a dor object does not belong to a collection' do
@@ -73,7 +80,7 @@ RSpec.describe Cocina::CollectionExistenceValidator do
     end
 
     it 'returns false' do
-      allow(Dor).to receive(:find).with(collection_druid).and_return(nil)
+      allow(CocinaObjectStore).to receive(:find).with(collection_druid).and_raise(CocinaObjectStore::CocinaObjectNotFoundError)
       expect(validator.valid?).to be false
     end
   end


### PR DESCRIPTION
## Why was this change made?

Fixes #3307 by looking for the collection in the CocinaObjectStore. This also adds a missing test for CollectionExistsenceValidator

## How was this change tested?

Additional unit test.


## Which documentation and/or configurations were updated?



