### PR TITLE
Normalize out dissemination nodes with empty workflow ids.

### DIFF
--- a/app/services/cocina/normalizers/admin_normalizer.rb
+++ b/app/services/cocina/normalizers/admin_normalizer.rb
@@ -20,6 +20,7 @@ module Cocina
       def normalize
         normalize_desc_metadata_nodes
         normalize_empty_registration_and_dissemination
+        normalize_empty_dissemination_workflow
         regenerate_ng_xml(ng_xml.to_xml)
       end
 
@@ -33,9 +34,15 @@ module Cocina
       end
 
       def normalize_empty_registration_and_dissemination
-        # removes any empty nodes like this: <registration/> or <dissemation/>
+        # removes any empty nodes like this: <registration/> or <dissemination/>
         ng_xml.root.xpath('//registration[not(node())]').each(&:remove)
         ng_xml.root.xpath('//dissemination[not(node())]').each(&:remove)
+      end
+
+      def normalize_empty_dissemination_workflow
+        # remove dissemination workflow node with empty id attribute and then remove dissemination node
+        ng_xml.root.xpath('//dissemination/workflow[@id=""]').each(&:remove)
+        ng_xml.root.xpath('//dissemination[not(*)]').each(&:remove)
       end
     end
   end

--- a/spec/services/cocina/normalizers/admin_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/admin_normalizer_spec.rb
@@ -73,5 +73,25 @@ RSpec.describe Cocina::Normalizers::AdminNormalizer do
         )
       end
     end
+
+    context 'when #normalize_empty_dissemination_workflow' do
+      let(:original_xml) do
+        <<~XML
+          <administrativeMetadata>
+            <dissemination>
+              <workflow id=""/>
+            </dissemination>
+          </administrativeMetadata>
+        XML
+      end
+
+      it 'removes dissemination nodes' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <administrativeMetadata/>
+          XML
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?
Resolves #3325 to normalize out empty workflows within dissemination nodes. 

## How was this change tested?
Added test and unit tests. Running `bin/validate-cocina-roundtrip -s 100000 -i druids.testbed.txt ` has no change. 

Before
``` 
Success:   97152 (97.232%)
  Different: 2766 (2.768%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

After
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   97152 (97.232%)
  Different: 2766 (2.768%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

## Which documentation and/or configurations were updated?



