### PR TITLE
Unpack names with displayForm into parallelValue

### DIFF
--- a/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe 'MODS name <--> cocina mappings' do
     # NOTE: name identifiers that are uris, for mods mapping purposes are 'value' rather than uri
     #  in identifier and nameIdentifier mods doesn't distinguish between a uri and other non-uri identifiers
 
-    xit 'updated mapping' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <name type="personal" usage="primary">


### PR DESCRIPTION
## Why was this change made?

To ensure that names with displayForm elements are unpacked into parallelValues.

## How was this change tested?



## Which documentation and/or configurations were updated?


closes #3215 
