### PR TITLE
Extract catkey instead of model definition for set in 856

### DIFF
--- a/app/models/dor/update_marc_record_service.rb
+++ b/app/models/dor/update_marc_record_service.rb
@@ -164,7 +164,7 @@ module Dor
         cons_obj_id = cons_obj_druid.sub('druid:', '')
         cons_obj_title = cons_obj.description.title.first.value
         catkey = cons_obj.identification&.catalogLinks&.find { |link| link.catalog == 'symphony' }
-        "|xset:#{cons_obj_id}:#{catkey}:#{cons_obj_title}"
+        "|xset:#{cons_obj_id}:#{catkey&.catalogRecordId}:#{cons_obj_title}"
       end.join
     end
 

--- a/spec/dor/update_marc_record_service_spec.rb
+++ b/spec/dor/update_marc_record_service_spec.rb
@@ -186,7 +186,8 @@ RSpec.describe Dor::UpdateMarcRecordService do
                                      label: collection_label,
                                      version: 1,
                                      description: descriptive_metadata_basic,
-                                     access: {})
+                                     access: {},
+                                     identification: identity_metadata_collection)
     end
     let(:release_data) { { 'Searchworks' => { 'release' => true } } }
 
@@ -228,7 +229,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
       it 'generates a single symphony record' do
         # rubocop:disable Layout/LineLength
         expect(generate_symphony_records).to eq [
-          "8832162\tbc123dg9393\t.856. 41|uhttps://purl.stanford.edu/bc123dg9393|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:bc123dg9393%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:cc111cc1111::Constituent label & A Special character|xrights:world"
+          "8832162\tbc123dg9393\t.856. 41|uhttps://purl.stanford.edu/bc123dg9393|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:bc123dg9393%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111:8832162:Collection label|xset:cc111cc1111:8832162:Constituent label & A Special character|xrights:world"
         ]
       end
     end
@@ -248,7 +249,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
       it 'generates symphony record with a z subfield' do
         expect(generate_symphony_records).to match_array [
-          "8832162\tbc123dg9393\t.856. 41|zAvailable to Stanford-affiliated users.|uhttps://purl.stanford.edu/bc123dg9393|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:bc123dg9393%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:cc111cc1111::Constituent label & A Special character|xrights:group=stanford"
+          "8832162\tbc123dg9393\t.856. 41|zAvailable to Stanford-affiliated users.|uhttps://purl.stanford.edu/bc123dg9393|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:bc123dg9393%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111:8832162:Collection label|xset:cc111cc1111:8832162:Constituent label & A Special character|xrights:group=stanford"
         ]
       end
     end
@@ -270,7 +271,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
         expect(generate_symphony_records).to match_array [
           "123\tbc123dg9393\t",
           "456\tbc123dg9393\t",
-          "8832162\tbc123dg9393\t.856. 41|uhttps://purl.stanford.edu/bc123dg9393|xSDR-PURL|xitem|xfile:bc123dg9393%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111::Collection label|xset:cc111cc1111::Constituent label & A Special character|xrights:world"
+          "8832162\tbc123dg9393\t.856. 41|uhttps://purl.stanford.edu/bc123dg9393|xSDR-PURL|xitem|xfile:bc123dg9393%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111:8832162:Collection label|xset:cc111cc1111:8832162:Constituent label & A Special character|xrights:world"
         ]
       end
     end


### PR DESCRIPTION
## Why was this change made?

Fixes #3369 

## How was this change tested?

Updated unit test


## Which documentation and/or configurations were updated?



