### PR TITLE
Cocinize virtual object creation

### DIFF
--- a/app/models/dor/update_marc_record_service.rb
+++ b/app/models/dor/update_marc_record_service.rb
@@ -6,6 +6,10 @@ require 'shellwords'
 module Dor
   # rubocop:disable Metrics/ClassLength
   class UpdateMarcRecordService
+    def self.update(cocina_object, thumbnail_service:)
+      new(cocina_object, thumbnail_service: thumbnail_service).update
+    end
+
     # objects goverened by these APOs (ETD and EEMs) will get indicator 2 = 0, else 1
     BORN_DIGITAL_APOS = %w(druid:bx911tp9024 druid:jj305hm5259).freeze
 

--- a/app/services/reset_content_metadata_service.rb
+++ b/app/services/reset_content_metadata_service.rb
@@ -1,33 +1,57 @@
 # frozen_string_literal: true
 
-# Clears the contentMetadata datastream to the default, wiping out any members,
-# and severing relationships bidirectionally.
-#
-# NOTE: item MUST allow modification, or `save!` will raise error
+# Clears member orders from structural metadata within the Cocina cocina_item data model and adds new constituents
 class ResetContentMetadataService
-  DEFAULT_ITEM_TYPE = 'image'
-
-  attr_reader :item, :type
-
-  def initialize(item:, type: DEFAULT_ITEM_TYPE)
-    @item = item
-    @type = type
+  def self.reset(cocina_item:, constituent_druids: [])
+    new(cocina_item: cocina_item).reset(constituent_druids: constituent_druids)
   end
 
-  def reset
-    disown_current_constituents!
+  attr_reader :cocina_item, :notifier
 
-    item.contentMetadata.content = "<contentMetadata objectId='#{item.id}' type='#{type}'/>"
-    item.save!
+  def initialize(cocina_item:)
+    @cocina_item = cocina_item
+    @notifier = Cocina::FromFedora::DataErrorNotifier.new(druid: cocina_item.externalIdentifier)
+  end
+
+  # @return [Cocina::Models::DRO] updated cocina object
+  def reset(constituent_druids: [])
+    flag_multiple_member_orders!
+
+    member_orders = if constituent_druids.empty?
+                      empty_member_orders
+                    else
+                      empty_member_orders + regenerated_member_order(constituent_druids)
+                    end
+
+    cocina_item.new(structural: new_structural(member_orders))
   end
 
   private
 
-  def disown_current_constituents!
-    item.contentMetadata.ng_xml.xpath('//resource/relationship/@objectId').map(&:content).each do |constituent_id|
-      constituent = Dor::Item.find(constituent_id)
-      constituent.clear_relationship(:is_constituent_of)
-      constituent.save! if constituent.relationships_are_dirty?
-    end
+  def flag_multiple_member_orders!
+    member_orders = cocina_item.structural&.hasMemberOrders&.count { |order| order.members.any? }
+    return if member_orders.nil? || member_orders < 2
+
+    notifier.error("item #{cocina_item.externalIdentifier} has multiple member orders")
+  end
+
+  def empty_member_orders
+    Array(cocina_item.structural&.hasMemberOrders&.select { |order| order.members.empty? })
+  end
+
+  def new_structural(member_orders)
+    return Cocina::Models::DROStructural.new(hasMemberOrders: member_orders) if cocina_item.structural.nil?
+
+    cocina_item.structural.new(
+      hasMemberOrders: member_orders
+    )
+  end
+
+  def regenerated_member_order(constituent_druids)
+    [
+      {
+        members: constituent_druids
+      }
+    ]
   end
 end

--- a/spec/dor/update_marc_record_service_spec.rb
+++ b/spec/dor/update_marc_record_service_spec.rb
@@ -120,6 +120,30 @@ RSpec.describe Dor::UpdateMarcRecordService do
     Settings.release.symphony_path = './spec/fixtures/sdr-purl'
   end
 
+  describe '.update' do
+    let(:instance) { described_class.new(cocina_object, thumbnail_service: thumbnail_service) }
+    let(:cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: druid,
+                              type: Cocina::Models::Vocab.object,
+                              label: dro_object_label,
+                              version: 1,
+                              description: descriptive_metadata_basic,
+                              identification: identity_metadata_basic,
+                              access: {},
+                              administrative: { hasAdminPolicy: apo_druid })
+    end
+
+    before do
+      allow(described_class).to receive(:new).and_return(instance)
+      allow(instance).to receive(:update)
+    end
+
+    it 'invokes #update on a new instance' do
+      described_class.update(cocina_object, thumbnail_service: thumbnail_service)
+      expect(instance).to have_received(:update).once
+    end
+  end
+
   context 'for a druid without a catkey' do
     let(:cocina_object) do
       Cocina::Models::DRO.new(externalIdentifier: druid,

--- a/spec/services/constituent_service_spec.rb
+++ b/spec/services/constituent_service_spec.rb
@@ -3,131 +3,121 @@
 require 'rails_helper'
 
 RSpec.describe ConstituentService do
-  let(:virtual_object_content) do
-    <<~XML
-      <contentMetadata objectId="druid:virtual_object1" type="image">
-        <resource sequence="1" id="wrongthing_1" type="image">
-          <relationship type="alsoAvailableAs" objectId="druid:wrongthing"/>
-        </resource>
-      </contentMetadata>
-    XML
-  end
-
-  let(:virtual_object) do
-    Dor::Item.new(pid: 'druid:virtual_object1').tap do |item|
-      item.contentMetadata.content = virtual_object_content
-    end
-  end
-
-  let(:constituent1) do
-    Dor::Item.new(pid: 'druid:constituent1').tap do |item|
-      item.contentMetadata.content = <<~XML
-        <contentMetadata>
-          <resource id="bb000kg4251_1" sequence="1" type="image">
-            <file id="bb000kg4251.jpg" mimetype="image/jpeg" size="1347965" preserve="yes" publish="no" shelve="no">
-            </file>
-          </resource>
-        </contentMetadata>
-      XML
-    end
-  end
-
-  let(:constituent2) do
-    Dor::Item.new(pid: 'druid:constituent2').tap do |item|
-      item.contentMetadata.content = <<~XML
-        <contentMetadata>
-          <resource id="bb000ff1111_1" sequence="1" type="image">
-            <file id="bb000ff1111.jpg" mimetype="image/jpeg" size="999" preserve="yes" publish="yes" shelve="no">
-            </file>
-          </resource>
-        </contentMetadata>
-      XML
-    end
-  end
-
   describe '#add' do
-    subject(:add) { instance.add(constituent_druids: [constituent1.id, constituent2.id]) }
-
-    let(:instance) do
-      described_class.new(virtual_object_druid: virtual_object.id, event_factory: event_factory)
-    end
+    let(:constituent_druids) { ['druid:xh235dd9059'] }
     let(:event_factory) { class_double(EventFactory) }
-    let(:namespaceless) { virtual_object.id.sub('druid:', '') }
+    let(:item_errors) { {} }
+    let(:mock_item) do
+      Cocina::Models::DRO.new(
+        type: Cocina::Models::Vocab.object,
+        label: 'Dummy',
+        version: 1,
+        administrative: { hasAdminPolicy: 'druid:dd999df2345' },
+        access: {},
+        externalIdentifier: 'druid:kh875jg9754'
+      )
+    end
+    let(:open_for_versioning) { true }
+    let(:service) { described_class.new(virtual_object_druid: virtual_object_druid, event_factory: event_factory) }
+    let(:virtual_object) do
+      Cocina::Models::DRO.new(
+        type: Cocina::Models::Vocab.object,
+        label: 'Dummy',
+        version: 1,
+        administrative: { hasAdminPolicy: 'druid:dd999df2345' },
+        access: {},
+        externalIdentifier: virtual_object_druid
+      )
+    end
+    let(:virtual_object_druid) { 'druid:bc123df4567' }
 
     before do
-      allow(virtual_object).to receive_messages(save!: true)
-      allow(constituent1).to receive_messages(save!: true)
-      allow(constituent2).to receive_messages(save!: true)
-
-      # Used in ContentMetadataDS#add_virtual_resource
-      allow(virtual_object.contentMetadata).to receive(:pid).and_return('druid:virtual_object1')
-
-      allow(ItemQueryService).to receive(:find_combinable_item).with('druid:virtual_object1').and_return(virtual_object)
-      allow(ItemQueryService).to receive(:find_combinable_item).with('druid:constituent1').and_return(constituent1)
-      allow(ItemQueryService).to receive(:find_combinable_item).with('druid:constituent2').and_return(constituent2)
-
-      # Stub `#reset_metadata!` because ResetContentMetadataService is tested in its own spec
-      allow(instance).to receive(:reset_metadata!)
+      allow(ItemQueryService).to receive(:find_combinable_item).and_return(virtual_object)
+      allow(ItemQueryService).to receive(:validate_combinable_items).and_return(item_errors)
+      allow(VersionService).to receive(:open?).and_return(open_for_versioning)
+      allow(VersionService).to receive(:open)
+      allow(VersionService).to receive(:close)
+      allow(ResetContentMetadataService).to receive(:reset)
+      allow(CocinaObjectStore).to receive(:save)
+      allow(CocinaObjectStore).to receive(:find).and_return(mock_item)
+      allow(SynchronousIndexer).to receive(:reindex_remotely)
+      allow(Publish::MetadataTransferService).to receive(:publish)
+      allow(Dor::UpdateMarcRecordService).to receive(:update)
     end
 
-    context 'when the virtual_object is open for modification' do
-      let(:cocina_object) { instance_double(Cocina::Models::DRO) }
+    context 'when one or more items are not combinable' do
+      let(:item_errors) { { virtual_object_druid => ["Item #{virtual_object_druid} is dark"] } }
 
-      before do
-        allow(VersionService).to receive(:open?).and_return(true)
-        allow(VersionService).to receive(:open)
-        allow(VersionService).to receive(:close)
-        allow(constituent1).to receive(:clear_relationship)
-        allow(constituent2).to receive(:clear_relationship)
-        allow(Cocina::Mapper).to receive(:build).and_return(cocina_object)
-        add
-      end
-
-      it 'merges objects' do
-        expect(instance).to have_received(:reset_metadata!).with(virtual_object).once
-        expect(constituent1).to have_received(:clear_relationship).once
-        expect(constituent2).to have_received(:clear_relationship).once
-        expect(constituent1.object_relations[:is_constituent_of]).to eq [virtual_object]
-        expect(constituent2.object_relations[:is_constituent_of]).to eq [virtual_object]
-        expect(VersionService).to have_received(:open?).exactly(3).times
+      it 'returns hash with errors' do
+        expect(service.add(constituent_druids: constituent_druids)).to eq(item_errors)
+        expect(VersionService).not_to have_received(:open?)
         expect(VersionService).not_to have_received(:open)
-        expect(VersionService).to have_received(:close).with(anything,
-                                                             {
-                                                               description: described_class::VERSION_CLOSE_DESCRIPTION,
-                                                               significance: described_class::VERSION_CLOSE_SIGNIFICANCE
-                                                             },
-                                                             event_factory: event_factory).exactly(3).times
+        expect(VersionService).not_to have_received(:close)
+        expect(ResetContentMetadataService).not_to have_received(:reset)
+        expect(CocinaObjectStore).not_to have_received(:save)
+        expect(SynchronousIndexer).not_to have_received(:reindex_remotely)
       end
     end
 
-    context 'when the virtual_object is not combinable' do
-      before do
-        allow(ItemQueryService).to receive(:validate_combinable_items)
-          .with(virtual_object: virtual_object.id, constituents: [constituent1.id, constituent2.id])
-          .and_return(virtual_object.id => ['that is a nope for constituent2'])
-      end
+    context 'when virtual object is not open for versioning' do
+      let(:open_for_versioning) { false }
 
-      it 'merges nothing' do
-        expect(add).to eq(virtual_object.id => ['that is a nope for constituent2'])
-        expect(virtual_object.contentMetadata.content).to be_equivalent_to(virtual_object_content)
-        expect(constituent1.object_relations[:is_constituent_of]).to be_empty
-        expect(constituent2.object_relations[:is_constituent_of]).to be_empty
+      it 'opens virtual object for versioning' do
+        service.add(constituent_druids: constituent_druids)
+        expect(VersionService).to have_received(:open).once
       end
     end
 
-    context 'when a constituent is not combinable' do
-      before do
-        allow(ItemQueryService).to receive(:validate_combinable_items)
-          .with(virtual_object: virtual_object.id, constituents: [constituent1.id, constituent2.id])
-          .and_return(constituent1.id => 'not modifiable message')
+    it 'resets structural metadata of virtual object to given constituents' do
+      service.add(constituent_druids: constituent_druids)
+      expect(ResetContentMetadataService).to have_received(:reset).once
+    end
+
+    it 'closes open version' do
+      service.add(constituent_druids: constituent_druids)
+      expect(VersionService).to have_received(:close).once
+    end
+
+    it 'indexes virtual object synchronously' do
+      service.add(constituent_druids: constituent_druids)
+      expect(SynchronousIndexer).to have_received(:reindex_remotely).once
+    end
+
+    it 'publishes constituents' do
+      service.add(constituent_druids: constituent_druids)
+      expect(CocinaObjectStore).to have_received(:find).exactly(constituent_druids.count).times
+      expect(Publish::MetadataTransferService).to have_received(:publish).exactly(constituent_druids.count).times
+      expect(Dor::UpdateMarcRecordService).not_to have_received(:update)
+    end
+
+    context 'when constituents have catkeys' do
+      let(:mock_item) do
+        Cocina::Models::DRO.new(
+          type: Cocina::Models::Vocab.object,
+          label: 'Dummy',
+          version: 1,
+          administrative: { hasAdminPolicy: 'druid:dd999df2345' },
+          access: {},
+          externalIdentifier: 'druid:kh875jg9754',
+          identification: {
+            catalogLinks: [
+              {
+                catalog: 'symphony',
+                catalogRecordId: '12345'
+              }
+            ]
+          }
+        )
       end
 
-      it 'does not merge any constituents' do
-        expect(add).to eq(constituent1.id => 'not modifiable message')
-        expect(virtual_object.contentMetadata.content).to be_equivalent_to(virtual_object_content)
-        expect(constituent1.object_relations[:is_constituent_of]).to be_empty
-        expect(constituent2.object_relations[:is_constituent_of]).to be_empty
+      it 'updates MARC' do
+        service.add(constituent_druids: constituent_druids)
+        expect(Dor::UpdateMarcRecordService).to have_received(:update).exactly(constituent_druids.count).times
       end
+    end
+
+    it 'returns nil' do
+      expect(service.add(constituent_druids: constituent_druids)).to be_nil
     end
   end
 end

--- a/spec/support/cocina_matchers.rb
+++ b/spec/support/cocina_matchers.rb
@@ -51,6 +51,8 @@ module CocinaMatchers
       end
     end
   end
+
+  alias_matcher :match_cocina_object_with, :cocina_object_with
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Fixes #3331
Fixes #3177

## Why was this change made?

This commit Cocinizes the major components involved in virtual object creation. It includes the following:

* Convert from Fedora to Cocina:
  * `ConstituentService`
  * `ItemQueryService`
  * `ResetContentMetadataService`
* `ConstituentService` now triggers synchronous indexing of virtual objects to record the relationship in Solr, which is used subsequently when (re-)publishing constituents so their public XML includes this relationship
* `ConstituentService` also updates the MARC records for any constituent objects which have catkeys
* Add new validations to the `ItemQueryService` preventing virtual objects from having themselves as constituents, making sure all virtual objects and constituents are DROs/items, and disallowing constituents from being virtual objects themselves
* Tweak `ObjectUpdater` so it does not wipe out `structural.hasMemberOrders`
* Add `.update` to `Dor::UpdateMarcRecordService` for easier testing
* Regenerate Rubocop to-dos

## How was this change tested?

CI + QA

## Which documentation and/or configurations were updated?

None
