### PR TITLE
Rewrite ApoExistenceValidator for cocina objects

### DIFF
--- a/app/validators/cocina/apo_existence_validator.rb
+++ b/app/validators/cocina/apo_existence_validator.rb
@@ -12,9 +12,9 @@ module Cocina
     # @return [Boolean] false if the APO is not in the repository
     def valid?
       begin
-        apo = Dor.find(apo_id)
-        @error = "Expected '#{apo_id}' to be an AdminPolicy but it is a #{apo.class}" unless apo.is_a?(Dor::AdminPolicyObject)
-      rescue ActiveFedora::ObjectNotFoundError
+        apo = CocinaObjectStore.find(apo_id)
+        @error = "Expected '#{apo_id}' to be an AdminPolicy but it is a #{apo.class}" unless apo.admin_policy?
+      rescue CocinaObjectStore::CocinaObjectNotFoundError
         @error = "Unable to find adminPolicy '#{apo_id}'"
       end
 

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -3,13 +3,22 @@
 require 'rails_helper'
 
 RSpec.describe 'Create object' do
-  let(:apo) { Dor::AdminPolicyObject.new(pid: 'druid:dd999df4567') }
+  let(:minimal_cocina_admin_policy) do
+    Cocina::Models::AdminPolicy.new({
+                                      cocinaVersion: '0.0.1',
+                                      externalIdentifier: 'druid:dd999df4567',
+                                      type: Cocina::Models::Vocab.admin_policy,
+                                      label: 'Test Admin Policy',
+                                      version: 1,
+                                      administrative: { hasAdminPolicy: 'druid:hy787xj5878', hasAgreement: 'druid:bb033gt0615' }
+                                    })
+  end
   let(:data) { item.to_json }
   let(:druid) { 'druid:gg777gg7777' }
 
   before do
     allow(Dor::SuriService).to receive(:mint_id).and_return(druid)
-    allow(Dor).to receive(:find).and_return(apo)
+    allow(CocinaObjectStore).to receive(:find).with('druid:dd999df4567').and_return(minimal_cocina_admin_policy)
     allow(Cocina::ActiveFedoraPersister).to receive(:store)
     stub_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:gg777gg7777')
   end

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -3,14 +3,35 @@
 require 'rails_helper'
 
 RSpec.describe 'Create object' do
-  let(:apo) { Dor::AdminPolicyObject.new(pid: 'druid:dd999df4567') }
+  let(:apo) do
+    Cocina::Models::AdminPolicy.new({
+                                      cocinaVersion: '0.0.1',
+                                      externalIdentifier: 'druid:dd999df4567',
+                                      type: Cocina::Models::Vocab.admin_policy,
+                                      label: 'Test Admin Policy',
+                                      version: 1,
+                                      administrative: {
+                                        hasAdminPolicy: 'druid:hy787xj5878',
+                                        hasAgreement: 'druid:bb033gt0615',
+                                        defaultAccess: default_access
+                                      }
+                                    })
+  end
+  let(:default_access) do
+    {
+      access: 'world',
+      download: 'none',
+      copyright: 'All rights reserved unless otherwise indicated.',
+      useAndReproductionStatement: 'Property rights reside with the repository...'
+    }
+  end
   let(:data) { item.to_json }
   let(:druid) { 'druid:gg777gg7777' }
   let(:search_result) { [] }
 
   before do
     allow(Dor::SuriService).to receive(:mint_id).and_return(druid)
-    allow(Dor).to receive(:find).and_return(apo)
+    allow(CocinaObjectStore).to receive(:find).with('druid:dd999df4567').and_return(apo)
     allow(Cocina::ActiveFedoraPersister).to receive(:store)
     stub_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:gg777gg7777')
     allow(Dor::SearchService).to receive(:query_by_id).and_return(search_result)
@@ -769,6 +790,12 @@ RSpec.describe 'Create object' do
           "structural":{"hasMemberOrders":[{"viewingDirection":"right-to-left"}]}}
       JSON
     end
+    let(:default_access) do
+      {
+        access: 'world',
+        download: 'world'
+      }
+    end
 
     before do
       allow(Dor::SearchService).to receive(:query_by_id).and_return([])
@@ -1037,6 +1064,13 @@ RSpec.describe 'Create object' do
           "structural":{"hasMemberOrders":[{"viewingDirection":"right-to-left"}]}}
       JSON
     end
+    let(:default_access) do
+      {
+        access: 'stanford',
+        download: 'none',
+        controlledDigitalLending: false
+      }
+    end
 
     before do
       allow(Dor::SearchService).to receive(:query_by_id).and_return([])
@@ -1091,6 +1125,13 @@ RSpec.describe 'Create object' do
           "structural":{"hasMemberOrders":[{"viewingDirection":"right-to-left"}]}}
       JSON
     end
+    let(:default_access) do
+      {
+        access: 'location-based',
+        download: 'location-based',
+        readLocation: 'm&m'
+      }
+    end
 
     before do
       allow(Dor::SearchService).to receive(:query_by_id).and_return([])
@@ -1143,6 +1184,12 @@ RSpec.describe 'Create object' do
           "structural":{"hasMemberOrders":[{"viewingDirection":"right-to-left"}]}}
       JSON
     end
+    let(:default_access) do
+      {
+        access: 'world',
+        download: 'none'
+      }
+    end
 
     before do
       allow(Dor::SearchService).to receive(:query_by_id).and_return([])
@@ -1192,6 +1239,12 @@ RSpec.describe 'Create object' do
             "structural":{}}
         JSON
       end
+      let(:default_access) do
+        {
+          access: 'dark',
+          download: 'none'
+        }
+      end
 
       it 'registers the object' do
         post '/v1/objects',
@@ -1230,6 +1283,12 @@ RSpec.describe 'Create object' do
             "identification":{"sourceId":"googlebooks:999999"}}
         JSON
       end
+      let(:default_access) do
+        {
+          access: 'dark',
+          download: 'none'
+        }
+      end
 
       it 'registers the object' do
         post '/v1/objects',
@@ -1246,12 +1305,7 @@ RSpec.describe 'Create object' do
         Cocina::Models::DRO.new(type: Cocina::Models::Vocab.object,
                                 label: 'This is my label',
                                 version: 1,
-                                access: {
-                                  access: 'world',
-                                  download: 'world',
-                                  copyright: 'resides with the creators',
-                                  useAndReproductionStatement: 'You can use it'
-                                },
+                                access: {},
                                 administrative: { hasAdminPolicy: 'druid:dd999df4567' },
                                 identification: { sourceId: 'googlebooks:999999' },
                                 externalIdentifier: 'druid:gg777gg7777',
@@ -1275,28 +1329,11 @@ RSpec.describe 'Create object' do
             "structural":{}}
         JSON
       end
-
-      before do
-        apo.defaultObjectRights.content = <<~XML
-          <rightsMetadata>
-            <access type="discover">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <access type="read">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <use>
-              <human type="useAndReproduction">You can use it</human>
-            </use>
-            <copyright>
-              <human>resides with the creators</human>
-            </copyright>
-          </rightsMetadata>
-        XML
+      let(:default_access) do
+        {
+          access: 'dark',
+          download: 'none'
+        }
       end
 
       it 'inherits access, copyright and use statement from the admin policy' do
@@ -1343,6 +1380,12 @@ RSpec.describe 'Create object' do
           "structural":{}}
       JSON
     end
+    let(:default_access) do
+      {
+        access: 'dark',
+        download: 'none'
+      }
+    end
 
     it 'registers the object and does not create process tag' do
       post '/v1/objects',
@@ -1387,6 +1430,12 @@ RSpec.describe 'Create object' do
           "identification":{"sourceId":"warc:999999"},
           "structural":{}}
       JSON
+    end
+    let(:default_access) do
+      {
+        access: 'dark',
+        download: 'none'
+      }
     end
 
     it 'registers the object and creates process tag' do

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Update object' do
   before do
     allow(Dor).to receive(:find).with(druid).and_return(item)
-    allow(Dor).to receive(:find).with(apo_druid).and_return(apo)
+    allow(CocinaObjectStore).to receive(:find).with(apo_druid).and_return(apo)
     allow(item).to receive(:save!)
     allow(item).to receive(:new_record?).and_return(false)
 
@@ -23,7 +23,16 @@ RSpec.describe 'Update object' do
   end
 
   let(:collection) { Dor::Collection.new(pid: 'druid:xx888xx7777') }
-  let(:apo) { Dor::AdminPolicyObject.new(pid: apo_druid) }
+  let(:apo) do
+    Cocina::Models::AdminPolicy.new({
+                                      cocinaVersion: '0.0.1',
+                                      externalIdentifier: apo_druid,
+                                      type: Cocina::Models::Vocab.admin_policy,
+                                      label: 'Test Admin Policy',
+                                      version: 1,
+                                      administrative: { hasAdminPolicy: 'druid:hy787xj5878', hasAgreement: 'druid:bb033gt0615' }
+                                    })
+  end
   let!(:item) do
     Dor::Item.new(pid: druid,
                   source_id: 'googlebooks:111111',

--- a/spec/services/cocina/object_creator_spec.rb
+++ b/spec/services/cocina/object_creator_spec.rb
@@ -6,6 +6,16 @@ RSpec.describe Cocina::ObjectCreator do
   subject(:result) { described_class.create(request, persister: persister, assign_doi: assign_doi) }
 
   let(:apo) { 'druid:bz845pv2292' }
+  let(:minimal_cocina_admin_policy) do
+    Cocina::Models::AdminPolicy.new({
+                                      cocinaVersion: '0.0.1',
+                                      externalIdentifier: 'druid:bz845pv2292',
+                                      type: Cocina::Models::Vocab.admin_policy,
+                                      label: 'Test Admin Policy',
+                                      version: 1,
+                                      administrative: { hasAdminPolicy: 'druid:hy787xj5878', hasAgreement: 'druid:bb033gt0615' }
+                                    })
+  end
   let(:persister) { class_double(Cocina::ActiveFedoraPersister, store: nil) }
   let(:request) { Cocina::Models.build_request(params) }
   let(:assign_doi) { false }
@@ -13,6 +23,7 @@ RSpec.describe Cocina::ObjectCreator do
   before do
     allow(Dor::SearchService).to receive(:query_by_id).and_return([])
     allow(Dor).to receive(:find).with(apo).and_return(Dor::AdminPolicyObject.new)
+    allow(CocinaObjectStore).to receive(:find).with('druid:bz845pv2292').and_return(minimal_cocina_admin_policy)
     allow(Dor::SuriService).to receive(:mint_id).and_return('druid:mb046vj7485')
     allow(RefreshMetadataAction).to receive(:run) do |args|
       args[:fedora_object].descMetadata.mods_title = 'foo'
@@ -202,6 +213,7 @@ RSpec.describe Cocina::ObjectCreator do
     context "when the collection doesn't exist" do
       before do
         allow(Dor).to receive(:find).and_raise(ActiveFedora::ObjectNotFoundError)
+        allow(CocinaObjectStore).to receive(:find).and_raise(CocinaObjectStore::CocinaObjectNotFoundError)
       end
 
       let(:params) do

--- a/spec/validators/cocina/apo_existence_validator_spec.rb
+++ b/spec/validators/cocina/apo_existence_validator_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::ApoExistenceValidator do
+  let(:validator) { described_class.new(item) }
+
+  let(:apo_druid) { 'druid:jt959wc5586' }
+  let(:apo) do
+    Cocina::Models::AdminPolicy.new({ cocinaVersion: '0.0.1',
+                                      externalIdentifier: apo_druid,
+                                      type: Cocina::Models::Vocab.admin_policy,
+                                      label: 'Test Admin Policy',
+                                      version: 1,
+                                      administrative: { hasAdminPolicy: 'druid:hy787xj5878', hasAgreement: 'druid:bb033gt0615' },
+                                      description: {
+                                        title: [{ value: 'Test Admin Policy' }],
+                                        purl: 'https://purl.stanford.edu/jt959wc5586'
+                                      } })
+  end
+
+  before do
+    allow(CocinaObjectStore).to receive(:find).with(apo_druid).and_return(apo)
+  end
+
+  context 'with a dor object with a valid APO' do
+    let(:item) do
+      Cocina::Models::DRO.new(
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'The Structure of Scientific Revolutions',
+        type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
+        version: 1,
+        administrative: {
+          hasAdminPolicy: apo_druid
+        },
+        access: {}
+      )
+    end
+
+    it 'returns true' do
+      expect(validator.valid?).to be true
+    end
+  end
+
+  context 'when a dor object as an APO that is not found' do
+    let(:item) do
+      Cocina::Models::DRO.new(
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'The Structure of Scientific Revolutions',
+        type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
+        version: 1,
+        administrative: {
+          hasAdminPolicy: 'druid:df123cd4567'
+        },
+        access: {}
+      )
+    end
+
+    it 'returns false' do
+      allow(CocinaObjectStore).to receive(:find).with('druid:df123cd4567').and_raise(CocinaObjectStore::CocinaObjectNotFoundError)
+      expect(validator.valid?).to be false
+    end
+  end
+
+  context 'when a dor object as an APO druid that is not an APO' do
+    let(:collection_druid) { 'druid:cc111cc1111' }
+    let(:collection) do
+      Cocina::Models::Collection.new(externalIdentifier: collection_druid,
+                                     type: Cocina::Models::Vocab.collection,
+                                     label: 'Collection of new maps of Africa',
+                                     version: 1,
+                                     cocinaVersion: '0.0.1',
+                                     access: {})
+    end
+    let(:item) do
+      Cocina::Models::DRO.new(
+        externalIdentifier: 'druid:bc123df4567',
+        label: 'The Structure of Scientific Revolutions',
+        type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
+        version: 1,
+        administrative: {
+          hasAdminPolicy: collection_druid
+        },
+        access: {}
+      )
+    end
+
+    before do
+      allow(CocinaObjectStore).to receive(:find).with(collection_druid).and_return(collection)
+    end
+
+    it 'returns false' do
+      expect(validator.valid?).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

Fixes #3306 by using CocinaObjectStore to verify the existence of an APO

## How was this change tested?

Update unit tests
Adds a unit test for ApoExistenceValidator that was missing.

## Which documentation and/or configurations were updated?



