### PR TITLE
apo identityMetadatata.xml objectLabel used for cocina label (when objectLabel exists)

### DIFF
--- a/app/services/cocina/from_fedora/apo.rb
+++ b/app/services/cocina/from_fedora/apo.rb
@@ -20,7 +20,7 @@ module Cocina
         {
           externalIdentifier: fedora_apo.pid,
           type: Cocina::Models::Vocab.admin_policy,
-          label: fedora_apo.label,
+          label: fedora_apo.objectLabel.first || fedora_apo.label,
           version: fedora_apo.current_version.to_i,
           administrative: build_apo_administrative
         }.tap do |props|

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -423,7 +423,8 @@ RSpec.describe 'Get the object' do
     context 'when the object exists with minimal metadata' do
       before do
         object.descMetadata.title_info.main_title = 'Hello'
-        object.label = 'foo'
+        object.label = 'foo' # used for TitleBuilderStrategy
+        object.identityMetadata.objectLabel = ['bar'] # checked first for cocina props, Om makes it an array
         object.agreement_object_id = 'druid:bb008zm4587'
       end
 
@@ -435,7 +436,7 @@ RSpec.describe 'Get the object' do
 
         expect(json['externalIdentifier']).to eq 'druid:bc123df4567'
         expect(json['type']).to eq 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld'
-        expect(json['label']).to eq 'foo'
+        expect(json['label']).to eq 'bar'
         expect(json['version']).to eq 1
         expect(json['administrative']['defaultObjectRights']).to match '<rightsMetadata>'
         expect(json['administrative']['registrationWorkflow']).to eq []
@@ -476,7 +477,8 @@ RSpec.describe 'Get the object' do
           </roleMetadata>
         XML
         object.descMetadata.title_info.main_title = 'Hello'
-        object.label = 'foo'
+        object.label = 'foo' # used for TitleBuilderStrategy
+        object.identityMetadata.objectLabel = ['bar'] # checked first for cocina props, Om makes it an array
         object.agreement_object_id = 'druid:bb008zm4587'
       end
 
@@ -488,7 +490,7 @@ RSpec.describe 'Get the object' do
 
         expect(json['externalIdentifier']).to eq 'druid:bc123df4567'
         expect(json['type']).to eq 'http://cocina.sul.stanford.edu/models/admin_policy.jsonld'
-        expect(json['label']).to eq 'foo'
+        expect(json['label']).to eq 'bar'
         expect(json['version']).to eq 1
         expect(json['administrative']['defaultObjectRights']).to match '<rightsMetadata>'
         expect(json['administrative']['registrationWorkflow']).to eq %w[registrationWF goobiWF]

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -984,6 +984,7 @@ RSpec.describe 'Update object' do
         item.descMetadata.title_info.main_title = 'This is my title'
         item.administrativeMetadata.default_workflow = 'myWorkflow'
         item.administrativeMetadata.add_default_collection 'druid:gh333qq4444'
+        item.identityMetadata.objectLabel = 'my original objectLabel'
       end
     end
 
@@ -1015,7 +1016,7 @@ RSpec.describe 'Update object' do
 
     let(:expected) do
       Cocina::Models::AdminPolicy.new(type: Cocina::Models::Vocab.admin_policy,
-                                      label: 'This is my label',
+                                      label: 'my original objectLabel',
                                       version: 1,
                                       description: {
                                         title: [{ value: 'This is my title' }],

--- a/spec/services/cocina/mapping/administrative/apo_administrative_spec.rb
+++ b/spec/services/cocina/mapping/administrative/apo_administrative_spec.rb
@@ -14,7 +14,8 @@ RSpec.shared_examples 'valid APO mappings' do
     instance_double(
       Dor::AdminPolicyObject,
       pid: apo_druid,
-      label: apo_label,
+      label: apo_label, # used for TitleBuilderStrategy
+      objectLabel: [apo_label], # checked first for cocina props, Om makes it an array
       current_version: '1',
       admin_policy_object_id: ur_apo_druid,
       agreement_object_id: agreement_druid,
@@ -148,7 +149,8 @@ RSpec.shared_examples 'valid APO mappings' do
       instance_double(
         Dor::AdminPolicyObject,
         pid: apo_druid,
-        label: apo_label,
+        label: apo_label, # used for TitleBuilderStrategy
+        objectLabel: [apo_label], # checked first for cocina props, Om makes it an array
         current_version: '1',
         admin_policy_object_id: ur_apo_druid,
         agreement_object_id: agreement_druid,

--- a/spec/services/cocina/mapping/identification/apo_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/apo_identity_spec.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples 'APO Identification Fedora Cocina mapping' do
   #  otherId of type uuid -> normalize out
   #  tags -> normalize out
   #  agreementId, adminPolicy -> normalize out (we use RELS-EXT)
-  #  sourceId -> we need to KEEP
+  #  sourceId -> we don't care about Hydrus source_ids, which is all of them for APOs
 
   let(:mods_ng_xml) do
     Nokogiri::XML <<~XML
@@ -38,7 +38,8 @@ RSpec.shared_examples 'APO Identification Fedora Cocina mapping' do
   let(:fedora_apo_mock) do
     instance_double(Dor::AdminPolicyObject,
                     pid: pid,
-                    label: label,
+                    label: label, # used for TitleBuilderStrategy
+                    objectLabel: [object_label], # checked first for cocina props, Om makes it an array
                     current_version: '1',
                     admin_policy_object_id: admin_policy_id,
                     agreement_object_id: agreement_object_id,
@@ -72,7 +73,6 @@ RSpec.shared_examples 'APO Identification Fedora Cocina mapping' do
       Dor::AdminPolicyObject.new(pid: mapped_cocina_props[:externalIdentifier],
                                  admin_policy_object_id: mapped_cocina_props[:administrative][:hasAdminPolicy],
                                  agreement_object_id: mapped_cocina_props[:administrative][:hasAgreement],
-                                 # source_id: cocina_admin_policy.identification.sourceId,
                                  label: mapped_cocina_props[:label])
     end
     let(:mapped_roundtrip_identity_xml) do
@@ -85,7 +85,7 @@ RSpec.shared_examples 'APO Identification Fedora Cocina mapping' do
       expect(mapped_roundtrip_identity_xml).to be_equivalent_to(roundtrip_identity_metadata_xml)
     end
 
-    it 'identityMetadata roundtrips thru cocina maps to normalized original identityMetadata.xml' do
+    it 'identityMetadata roundtripped thru cocina maps to normalized original identityMetadata.xml' do
       expect(mapped_roundtrip_identity_xml).to be_equivalent_to normalized_orig_identity_xml
     end
   end
@@ -94,7 +94,8 @@ RSpec.shared_examples 'APO Identification Fedora Cocina mapping' do
     let(:roundtrip_fedora_apo_mock) do
       instance_double(Dor::AdminPolicyObject,
                       pid: mapped_cocina_props[:externalIdentifier],
-                      label: mapped_cocina_props[:label],
+                      label: label, # used for TitleBuilderStrategy
+                      objectLabel: [mapped_cocina_props[:label]], # checked first for cocina props, Om makes it an array
                       current_version: '1',
                       admin_policy_object_id: mapped_cocina_props[:administrative][:hasAdminPolicy],
                       agreement_object_id: mapped_cocina_props[:administrative][:hasAgreement],
@@ -115,7 +116,8 @@ RSpec.shared_examples 'APO Identification Fedora Cocina mapping' do
     let(:normalized_orig_fedora_apo_mock) do
       instance_double(Dor::AdminPolicyObject,
                       pid: pid,
-                      label: label,
+                      label: label, # used for TitleBuilderStrategy
+                      objectLabel: [object_label], # checked first for cocina props, Om makes it an array
                       current_version: '1',
                       admin_policy_object_id: admin_policy_id,
                       agreement_object_id: agreement_object_id,
@@ -157,6 +159,7 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
     it_behaves_like 'APO Identification Fedora Cocina mapping' do
       let(:pid) { 'druid:zd878cf9993' }
       let(:label) { 'Fondo Lanciani' }
+      let(:object_label) { label }
       let(:admin_policy_id) { 'druid:hv992ry2431' }
       let(:agreement_object_id) { 'druid:zh747vq3919' }
       let(:identity_metadata_xml) do
@@ -164,7 +167,7 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
           <identityMetadata>
             <objectId>#{pid}</objectId>
             <objectCreator>DOR</objectCreator>
-            <objectLabel>#{label}</objectLabel>
+            <objectLabel>#{object_label}</objectLabel>
             <objectType>adminPolicy</objectType>
             <otherId name="uuid">5844f566-282e-11e6-8872-005056a7ed61</otherId>
             <tag>Registered By : caster</tag>
@@ -178,7 +181,7 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
           <identityMetadata>
             <objectId>#{pid}</objectId>
             <objectCreator>DOR</objectCreator>
-            <objectLabel>#{label}</objectLabel>
+            <objectLabel>#{object_label}</objectLabel>
             <objectType>adminPolicy</objectType>
           </identityMetadata>
         XML
@@ -207,12 +210,13 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
     it_behaves_like 'APO Identification Fedora Cocina mapping' do
       let(:pid) { 'druid:bm077td6448' }
       let(:label) { 'Parker Manuscripts' }
+      let(:object_label) { label }
       let(:admin_policy_id) { 'druid:nt592gh9590' }
       let(:agreement_object_id) { 'druid:tx617qp8040' }
       let(:identity_metadata_xml) do
         <<~XML
           <identityMetadata>
-            <objectLabel>#{label}</objectLabel>
+            <objectLabel>#{object_label}</objectLabel>
             <adminPolicy>#{admin_policy_id}</adminPolicy>
             <agreementId>#{agreement_object_id}</agreementId>
             <objectType>adminPolicy</objectType>
@@ -227,7 +231,7 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
       let(:roundtrip_identity_metadata_xml) do
         <<~XML
           <identityMetadata>
-            <objectLabel>#{label}</objectLabel>
+            <objectLabel>#{object_label}</objectLabel>
             <objectType>adminPolicy</objectType>
             <objectId>#{pid}</objectId>
             <objectCreator>DOR</objectCreator>
@@ -258,6 +262,7 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
     it_behaves_like 'APO Identification Fedora Cocina mapping' do
       let(:pid) { 'druid:bk068fh4950' }
       let(:label) { 'APO for Stanford University, Department of Computer Science, Technical Reports' }
+      let(:object_label) { label }
       let(:admin_policy_id) { 'druid:zw306xn5593' }
       let(:agreement_object_id) { 'druid:mc322hh4254' }
       let(:identity_metadata_xml) do
@@ -266,7 +271,7 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
             <sourceId source="Hydrus">adminPolicy-dhartwig-2013-06-10T18:11:42.520Z</sourceId>
             <objectId>#{pid}</objectId>
             <objectCreator>DOR</objectCreator>
-            <objectLabel>#{label}</objectLabel>
+            <objectLabel>#{object_label}</objectLabel>
             <objectType>adminPolicy</objectType>
             <adminPolicy>#{admin_policy_id}</adminPolicy>
             <otherId name="uuid">341b275c-d1f9-11e2-ba42-0050569b3c6e</otherId>
@@ -277,6 +282,53 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
       end
 
       # Hydrus sourceId is removed
+      let(:roundtrip_identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{pid}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>#{object_label}</objectLabel>
+            <objectType>adminPolicy</objectType>
+          </identityMetadata>
+        XML
+      end
+
+      let(:cocina_props) do
+        {
+          externalIdentifier: pid,
+          type: Cocina::Models::Vocab.admin_policy,
+          label: label,
+          version: 1,
+          administrative: {
+            hasAdminPolicy: admin_policy_id,
+            hasAgreement: agreement_object_id,
+            defaultAccess: default_access_props,
+            defaultObjectRights: default_object_rights_xml,
+            roles: []
+          },
+          description: description_props
+        }
+      end
+    end
+  end
+
+  context 'when no objectLabel' do
+    it_behaves_like 'APO Identification Fedora Cocina mapping' do
+      let(:pid) { 'druid:bb666bb6666' }
+      let(:label) { 'not an original object label' }
+      let(:object_label) { nil }
+      let(:admin_policy_id) { 'druid:hv992ry2431' }
+      let(:agreement_object_id) { 'druid:zh747vq3919' }
+      let(:identity_metadata_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>#{pid}</objectId>
+            <objectCreator>DOR</objectCreator>
+            <objectType>adminPolicy</objectType>
+          </identityMetadata>
+        XML
+      end
+
       let(:roundtrip_identity_metadata_xml) do
         <<~XML
           <identityMetadata>


### PR DESCRIPTION
## Why was this change made?

part of #3336 (the same changes for Collection records will be in a separate PR)

APOs should use the existing `objectLabel` in `identityMetadata` for the value of cocina `label` if the `objectLabel` exists.

## How was this change tested?

unit tests and this data:

### This branch (NEW)

Note:  most of the failing APOs still have other roundtrip problems.

```sh
$ bin/validate-cocina-roundtrip -i tmp/druid-lists/druids.apos.txt -f -n

Status (n=1270; not using Missing for success/different/error stats):
  Success:   1055 (83.071%)
  Different: 205 (16.142%)
  Mapping error:     10 (0.787%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     0 (0.0%)
  Bad cache:     0 (0.0%)
````

### main branch (BEFORE)

```sh
Status (n=1270; not using Missing for success/different/error stats):
  Success:   1043 (82.126%)
  Different: 217 (17.087%)
  Mapping error:     10 (0.787%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     0 (0.0%)
  Bad cache:     0 (0.0%)
```



## Which documentation and/or configurations were updated?



