### PR TITLE
speed up rubocop by ignoring more

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,9 +11,14 @@ AllCops:
     - 'bin/console'
     - 'bin/rails'
     - 'bin/rake'
-    - db/migrate/**
-    - db/schema.rb
-    - vendor/**/*
+    - 'cache/**/*'
+    - 'docs/**/*'
+    - 'db/migrate/**'
+    - 'db/schema.rb'
+    - 'log/**/*'
+    - 'results/**/*'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
 
 Rails:
   Enabled: true


### PR DESCRIPTION
## Why was this change made?

I got sick of waiting for rubocop to run and found out others had the same problem.

## How was this change tested?



## Which documentation and/or configurations were updated?



