### PR TITLE
Generate release tags from cocina instead of fedora

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -17,7 +17,7 @@ class MetadataController < ApplicationController
   end
 
   def public_xml
-    release_tags = ReleaseTags.legacy_for(item: @item)
+    release_tags = ReleaseTags.for(dro_object: @cocina_object)
     service = Publish::PublicXmlService.new(@item, released_for: release_tags, thumbnail_service: ThumbnailService.new(@cocina_object))
     render xml: service
   end

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -17,7 +17,7 @@ class MetadataController < ApplicationController
   end
 
   def public_xml
-    release_tags = ReleaseTags.for(dro_object: @cocina_object)
+    release_tags = ReleaseTags.for(cocina_object: @cocina_object)
     service = Publish::PublicXmlService.new(@item, released_for: release_tags, thumbnail_service: ThumbnailService.new(@cocina_object))
     render xml: service
   end

--- a/app/models/dor/update_marc_record_service.rb
+++ b/app/models/dor/update_marc_record_service.rb
@@ -220,7 +220,7 @@ module Dor
     private
 
     def released_for
-      ::ReleaseTags.for(dro_object: @cocina_object)
+      ::ReleaseTags.for(cocina_object: @cocina_object)
     end
 
     def dor_items_for_constituents

--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -20,7 +20,7 @@ module Publish
       return unpublish unless world_discoverable?
 
       # Retrieve release tags from identityMetadata and all collections this item is a member of
-      release_tags = ReleaseTags.legacy_for(item: item)
+      release_tags = ReleaseTags.for(dro_object: cocina_object)
 
       transfer_metadata(release_tags)
       publish_notify_on_success

--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -20,7 +20,7 @@ module Publish
       return unpublish unless world_discoverable?
 
       # Retrieve release tags from identityMetadata and all collections this item is a member of
-      release_tags = ReleaseTags.for(dro_object: cocina_object)
+      release_tags = ReleaseTags.for(cocina_object: cocina_object)
 
       transfer_metadata(release_tags)
       publish_notify_on_success

--- a/app/services/release_tags.rb
+++ b/app/services/release_tags.rb
@@ -4,27 +4,9 @@
 class ReleaseTags
   # Retrieve the release tags for an item and all the collections that it is a part of
   #
-  # @param dro_object [Cocina::DRO] the DRO to list release tags for
+  # @param cocina_object [Cocina::Models::DRO, Cocina::Models::Collection] the object to list release tags for
   # @return [Hash] (see Dor::ReleaseTags::IdentityMetadata.released_for)
-  def self.for(dro_object:)
-    IdentityMetadata.for(dro_object).released_for({})
+  def self.for(cocina_object:)
+    IdentityMetadata.for(cocina_object).released_for({})
   end
-
-  # Determine if the supplied tag is a valid release node that meets all requirements
-  #
-  # @param tag [Boolean] True or false for the release node
-  # @param attrs [hash] A hash of attributes for the tag, must contain :when, a ISO 8601 timestamp and :who to identify who or what added the tag, :to,
-  # @raise [ArgumentError]  Raises an error of the first fault in the release tag
-  # @return [Boolean] Returns true if no errors found
-  def self.validate_release_attributes(tag, attrs = {})
-    raise ArgumentError, ':when is not iso8601' if attrs[:when].match('\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z').nil?
-
-    [:who, :to, :what].each do |check_attr|
-      next unless attrs[check_attr]
-      raise ArgumentError, "#{check_attr} not supplied as a String" unless attrs[check_attr].is_a? String
-    end
-    raise ArgumentError, ':what must be self or collection' unless %w[self collection].include? attrs[:what]
-    raise ArgumentError, 'the value set for this tag is not a boolean' unless [true, false].include? tag
-  end
-  private_class_method :validate_release_attributes
 end

--- a/app/services/release_tags.rb
+++ b/app/services/release_tags.rb
@@ -4,38 +4,10 @@
 class ReleaseTags
   # Retrieve the release tags for an item and all the collections that it is a part of
   #
-  # @param item [Cocina::DRO] the DRO to list release tags for
+  # @param dro_object [Cocina::DRO] the DRO to list release tags for
   # @return [Hash] (see Dor::ReleaseTags::IdentityMetadata.released_for)
   def self.for(dro_object:)
-    item = Dor.find(dro_object.externalIdentifier)
-    IdentityMetadata.for(item).released_for({})
-  end
-
-  # Retrieve the release tags for an item and all the collections that it is a part of
-  #
-  # @param item [Dor::Item] the item to list release tags for
-  # @return [Hash] (see Dor::ReleaseTags::IdentityMetadata.released_for)
-  def self.legacy_for(item:)
-    IdentityMetadata.for(item).released_for({})
-  end
-
-  # Add a release node for the item
-  # Will use the current time if timestamp not supplied. You can supply a timestap for correcting history, etc if desired
-  # Timestamp will be calculated by the function
-  #
-  # @param work [Dor::Item]  the work to create the release tag for
-  # @param [Hash] params all the other stuff
-  # @option params [Boolean] release: True or false for the release node
-  # @return [Nokogiri::XML::Element] the tag added if successful
-  # @raise [ArgumentError] Raised if attributes are improperly supplied
-  #
-  # @example
-  #  ReleaseTags.create(item, release: true, what: 'self', to: 'Searchworks', who: 'petucket')
-  def self.create(work, attrs)
-    release = attrs.delete(:release)
-    attrs[:when] ||= Time.now.utc.iso8601 # add the timestamp
-    validate_release_attributes(release, attrs)
-    work.identityMetadata.add_value(:release, release.to_s, attrs)
+    IdentityMetadata.for(dro_object).released_for({})
   end
 
   # Determine if the supplied tag is a valid release node that meets all requirements

--- a/spec/dor/update_marc_record_service_spec.rb
+++ b/spec/dor/update_marc_record_service_spec.rb
@@ -116,7 +116,6 @@ RSpec.describe Dor::UpdateMarcRecordService do
   end
 
   before do
-    allow(Dor).to receive(:find).and_return(instance_double(Dor::Item))
     allow(ReleaseTags::IdentityMetadata).to receive(:for).and_return(release_service)
     Settings.release.symphony_path = './spec/fixtures/sdr-purl'
   end

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'Display metadata' do
     end
 
     before do
-      allow(ReleaseTags).to receive(:legacy_for).and_return(
+      allow(ReleaseTags).to receive(:for).and_return(
         'SearchWorks' => { 'release' => true },
         'elsewhere' => { 'release' => false }
       )

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -69,12 +69,13 @@ RSpec.describe 'Get the object' do
 
         embargo = Cocina::Models::Embargo.new(releaseDate: DateTime.parse('2019-09-26T07:00:00Z'), access: 'world', download: 'world')
         Cocina::ToFedora::EmbargoMetadataGenerator.generate(embargo_metadata: object.embargoMetadata, embargo: embargo)
-        # TODO: PETER Mock the cocina structure of release tags instead here
-        # ReleaseTags.create(object, release: true,
-        #                            what: 'self',
-        #                            to: 'Searchworks',
-        #                            who: 'petucket',
-        #                            when: '2014-08-30T01:06:28Z')
+        # add a release tag to our fedora object for this test
+        object.identityMetadata.add_value(:release, true, {
+                                            what: 'self',
+                                            to: 'Searchworks',
+                                            who: 'petucket',
+                                            when: '2014-08-30T01:06:28Z'
+                                          })
       end
 
       let(:collection) { Dor::Collection.new(pid: 'druid:xx888xx7777') }

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -69,11 +69,12 @@ RSpec.describe 'Get the object' do
 
         embargo = Cocina::Models::Embargo.new(releaseDate: DateTime.parse('2019-09-26T07:00:00Z'), access: 'world', download: 'world')
         Cocina::ToFedora::EmbargoMetadataGenerator.generate(embargo_metadata: object.embargoMetadata, embargo: embargo)
-        ReleaseTags.create(object, release: true,
-                                   what: 'self',
-                                   to: 'Searchworks',
-                                   who: 'petucket',
-                                   when: '2014-08-30T01:06:28Z')
+        # TODO: PETER Mock the cocina structure of release tags instead here
+        # ReleaseTags.create(object, release: true,
+        #                            what: 'self',
+        #                            to: 'Searchworks',
+        #                            who: 'petucket',
+        #                            when: '2014-08-30T01:06:28Z')
       end
 
       let(:collection) { Dor::Collection.new(pid: 'druid:xx888xx7777') }

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Publish::MetadataTransferService do
   let(:description) do
     {
       title: [{ value: 'Constituent label &amp; A Special character' }],
-      purl: "https://purl.stanford.edu/#{pid.gsub('druid:', '')}"
+      purl: "https://purl.stanford.edu/#{pid}"
     }
   end
   let(:cocina_object) do
@@ -230,7 +230,7 @@ RSpec.describe Publish::MetadataTransferService do
     context 'when purl-fetcher is not configured' do
       let(:purl_root) { Dir.mktmpdir }
       let(:changes_dir) { Dir.mktmpdir }
-      let(:changes_file) { File.join(changes_dir, item.pid.gsub('druid:', '')) }
+      let(:changes_file) { File.join(changes_dir, pid) }
 
       before do
         allow(Settings).to receive(:purl_services_url).and_return(nil)

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Publish::MetadataTransferService do
                                                 }
                                               ] })
   end
-  let(:cocina_object_collection) do
+  let(:cocina_collection) do
     Cocina::Models::Collection.new(externalIdentifier: 'druid:xh235dd9059',
                                    type: Cocina::Models::Vocab.collection,
                                    label: 'some collection object',
@@ -87,7 +87,7 @@ RSpec.describe Publish::MetadataTransferService do
     before do
       allow(OpenURI).to receive(:open_uri).with("https://purl-test.stanford.edu/#{pid}.xml").and_return('<xml/>')
       allow(CocinaObjectStore).to receive(:find).with("druid:#{pid}").and_return(cocina_object)
-      allow(CocinaObjectStore).to receive(:find).with('druid:xh235dd9059').and_return(cocina_object_collection) # collection object
+      allow(CocinaObjectStore).to receive(:find).with('druid:xh235dd9059').and_return(cocina_collection) # collection object
       allow(ThumbnailService).to receive(:new).and_return(thumbnail_service)
     end
 

--- a/spec/services/release_tags/identity_metadata_spec.rb
+++ b/spec/services/release_tags/identity_metadata_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ReleaseTags::IdentityMetadata do
   let(:pid) { 'druid:bb004bn8654' }
   let(:collection_pid) { 'druid:xh235dd9059' }
   let(:apo_id) { 'druid:qv648vd4392' }
-  let(:dro_object) do
+  let(:cocina_item) do
     Cocina::Models::DRO.new(externalIdentifier: pid,
                             type: Cocina::Models::Vocab.object,
                             label: 'Bryar 250 Trans-American: July 9-10',
@@ -39,7 +39,7 @@ RSpec.describe ReleaseTags::IdentityMetadata do
                                                 }
                                               ] })
   end
-  let(:releases) { described_class.for(dro_object) }
+  let(:releases) { described_class.for(cocina_item) }
   let(:bryar_trans_am_admin_tags) { AdministrativeTags.for(pid: pid) }
   let(:array_of_times) do
     ['2015-01-06 23:33:47Z', '2015-01-07 23:33:47Z', '2015-01-08 23:33:47Z', '2015-01-09 23:33:47Z'].map { |x| Time.parse(x).iso8601 }
@@ -136,7 +136,7 @@ RSpec.describe ReleaseTags::IdentityMetadata do
     subject(:release_tags) { releases.release_tags }
 
     context 'for an item that does not have any release tags' do
-      let(:dro_object) do
+      let(:cocina_item) do
         Cocina::Models::DRO.new(externalIdentifier: pid,
                                 type: Cocina::Models::Vocab.object,
                                 label: 'Bryar 250 Trans-American: July 9-10',

--- a/spec/services/release_tags_spec.rb
+++ b/spec/services/release_tags_spec.rb
@@ -3,47 +3,33 @@
 require 'rails_helper'
 
 RSpec.describe ReleaseTags do
-  before do
-    described_class.create(work, release: true, what: 'self', when: '2018-11-30T22:41:35Z', to: 'SearchWorks')
-  end
-
-  let(:druid) { 'druid:aa123bb7890' }
-  let(:work) { Dor::Item.new(pid: druid) }
-
-  describe '.legacy_for' do
-    it 'returns the hash of release tags' do
-      expect(described_class.legacy_for(item: work)).to eq(
-        'SearchWorks' => {
-          'release' => true
-        }
-      )
-    end
-  end
-
   describe '.for' do
-    let(:dro_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid) }
-
-    before do
-      allow(Dor).to receive(:find).and_return(work)
+    let(:dro_object) do
+      Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                              type: Cocina::Models::Vocab.object,
+                              label: 'Some Label',
+                              version: 1,
+                              identification: {},
+                              access: {},
+                              structural: {},
+                              administrative: { hasAdminPolicy: 'druid:fg890hx1234',
+                                                releaseTags: [
+                                                  {
+                                                    who: 'dhartwig',
+                                                    what: 'collection',
+                                                    date: '2019-01-18T17:03:35.000+00:00',
+                                                    to: 'Searchworks',
+                                                    release: true
+                                                  }
+                                                ] })
     end
 
     it 'returns the hash of release tags' do
       expect(described_class.for(dro_object: dro_object)).to eq(
-        'SearchWorks' => {
+        'Searchworks' => {
           'release' => true
         }
       )
-      expect(Dor).to have_received(:find).with(druid)
-    end
-  end
-
-  describe '.create' do
-    it 'creates a plain directory in the workspace when passed no source directory' do
-      expect(work.identityMetadata.to_xml).to be_equivalent_to <<-XML
-        <identityMetadata>
-          <release what="self" when="2018-11-30T22:41:35Z" to="SearchWorks">true</release>
-        </identityMetadata>
-      XML
     end
   end
 end

--- a/spec/services/release_tags_spec.rb
+++ b/spec/services/release_tags_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ReleaseTags do
   describe '.for' do
-    let(:dro_object) do
+    let(:cocina_item) do
       Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
                               type: Cocina::Models::Vocab.object,
                               label: 'Some Label',
@@ -25,7 +25,7 @@ RSpec.describe ReleaseTags do
     end
 
     it 'returns the hash of release tags' do
-      expect(described_class.for(dro_object: dro_object)).to eq(
+      expect(described_class.for(cocina_object: cocina_item)).to eq(
         'Searchworks' => {
           'release' => true
         }


### PR DESCRIPTION
## Why was this change made?

Fixes #3335 

- rewrite `ReleaseTags` to use cocina instead of fedora
- adjust all tests that used to mock fedora to instead mock cocina
- get rid of unused `#create` method (that was only used in tests)
- some refactoring of the tests to avoid duplication of pids
- revert `legacy_for` methods added here since they should no longer be needed: https://github.com/sul-dlss/dor-services-app/pull/3350

Note: I believe release tags are created in argo here: https://github.com/sul-dlss/argo/blob/main/app/jobs/release_object_job.rb#L55-L83   

So we should not need to the `#create` method I removed.

Todo:
~~- fix up `./spec/requests/show_object_spec.rb` to remove the dependency on the `ReleaseTags#create` method and instead mock the data in some way~~
~~- fix up `./spec/services/release_tags/identity_metadata_spec.rb` to remove all of the mocked Fedora calls/data and replace with mocked cocina objects~~

## How was this change tested?

Updated the relevant existing tests


## Which documentation and/or configurations were updated?



