### PR TITLE
normalize objectId out of administrativeMetadata.xml for roundtripping

### DIFF
--- a/app/services/cocina/normalizers/admin_normalizer.rb
+++ b/app/services/cocina/normalizers/admin_normalizer.rb
@@ -21,6 +21,7 @@ module Cocina
         normalize_desc_metadata_nodes
         normalize_empty_registration_and_dissemination
         normalize_empty_dissemination_workflow
+        normalize_object_id
         regenerate_ng_xml(ng_xml.to_xml)
       end
 
@@ -44,6 +45,12 @@ module Cocina
         # remove dissemination workflow node with empty id attribute and then remove dissemination node
         ng_xml.root.xpath('//dissemination/workflow[@id=""]').each(&:remove)
         ng_xml.root.xpath('//dissemination[not(*)]').each(&:remove)
+      end
+
+      def normalize_object_id
+        ng_xml.root.xpath('/administrativeMetadata[@objectId]').each do |node|
+          node.delete('objectId')
+        end
       end
     end
   end

--- a/spec/services/cocina/normalizers/admin_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/admin_normalizer_spec.rb
@@ -39,10 +39,31 @@ RSpec.describe Cocina::Normalizers::AdminNormalizer do
         XML
       )
     end
+  end
 
-    context 'when #normalize_empty_registration_and_dissemination' do
-      #  adapted from bb329pr4129
-      let(:original_xml) do
+  context 'when #normalize_empty_registration_and_dissemination' do
+    #  adapted from bb329pr4129
+    let(:original_xml) do
+      <<~XML
+        <administrativeMetadata>
+          <registration>
+            <workflow id="goobiWF"/>
+            <collection id="druid:fm742nb7315"/>
+          </registration>
+          <dissemination>
+            <workflow id="someNotEmptyValue"/>
+          </dissemination>
+          <dissemination>
+            <workflow id=""/>
+          </dissemination>
+          <registration />
+          <dissemination />
+        </administrativeMetadata>
+      XML
+    end
+
+    it 'removes unncessary empty registration and dissemination nodes' do
+      expect(normalized_ng_xml).to be_equivalent_to(
         <<~XML
           <administrativeMetadata>
             <registration>
@@ -52,50 +73,53 @@ RSpec.describe Cocina::Normalizers::AdminNormalizer do
             <dissemination>
               <workflow id="someNotEmptyValue"/>
             </dissemination>
-            <dissemination>
-              <workflow id=""/>
-            </dissemination>
-            <registration />
-            <dissemination />
           </administrativeMetadata>
         XML
-      end
+      )
+    end
+  end
 
-      it 'removes unncessary empty registration and dissemination nodes' do
-        expect(normalized_ng_xml).to be_equivalent_to(
-          <<~XML
-            <administrativeMetadata>
-              <registration>
-                <workflow id="goobiWF"/>
-                <collection id="druid:fm742nb7315"/>
-              </registration>
-              <dissemination>
-                <workflow id="someNotEmptyValue"/>
-              </dissemination>
-            </administrativeMetadata>
-          XML
-        )
-      end
+  context 'when #normalize_empty_dissemination_workflow' do
+    let(:original_xml) do
+      <<~XML
+        <administrativeMetadata>
+          <dissemination>
+            <workflow id=""/>
+          </dissemination>
+        </administrativeMetadata>
+      XML
     end
 
-    context 'when #normalize_empty_dissemination_workflow' do
-      let(:original_xml) do
+    it 'removes dissemination nodes' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <administrativeMetadata/>
+        XML
+      )
+    end
+  end
+
+  context 'when #normalize_object_id' do
+    let(:original_xml) do
+      <<~XML
+        <administrativeMetadata objectId="druid:cg616xd9084">
+          <dissemination>
+            <workflow id="someNotEmptyValue"/>
+          </dissemination>
+        </administrativeMetadata>
+      XML
+    end
+
+    it 'removes dissemination nodes' do
+      expect(normalized_ng_xml).to be_equivalent_to(
         <<~XML
           <administrativeMetadata>
             <dissemination>
-              <workflow id=""/>
+              <workflow id="someNotEmptyValue"/>
             </dissemination>
           </administrativeMetadata>
         XML
-      end
-
-      it 'removes dissemination nodes' do
-        expect(normalized_ng_xml).to be_equivalent_to(
-          <<~XML
-            <administrativeMetadata/>
-          XML
-        )
-      end
+      )
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

Closes #3360

## How was this change tested?

unit tests and roundtripping.  

### APOs

It affects 40 APOs per ticket;  the there are still other APO roundtripping problems.

```$ bin/validate-cocina-roundtrip -i tmp/druid-lists/druids.apos.txt -f -n```

THIS BRANCH (with change)

```
Status (n=1270; not using Missing for success/different/error stats):
  Success:   1057 (83.228%)
  Different: 203 (15.984%)
  Mapping error:     10 (0.787%)
```

MAIN BRANCH (before change)

```
Status (n=1270; not using Missing for success/different/error stats):
  Success:   1055 (83.071%)
  Different: 205 (16.142%)
  Mapping error:     10 (0.787%)
```

### Collections

```$ bin/validate-cocina-roundtrip -i tmp/druid-lists/druids.collections.txt -f -n```

THIS BRANCH (with change)

```
Status (n=2687; not using Missing for success/different/error stats):
  Success:   2676 (99.591%)
  Different: 11 (0.409%)
```

MAIN BRANCH (before change)

```
Status (n=2687; not using Missing for success/different/error stats):
  Success:   2676 (99.591%)
  Different: 11 (0.409%)
```

### DROs (and other friends)

```$ bin/validate-cocina-roundtrip -i tmp/druid-lists/druids.testbed.txt -f -n -s 10000```

THIS BRANCH (with change)

```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9989 (99.97%)
  Different: 0 (0.0%)
  Mapping error:     3 (0.03%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     8 (0.08%)
  Bad cache:     0 (0.0%)
```

MAIN BRANCH (before change)

```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9989 (99.97%)
  Different: 0 (0.0%)
  Mapping error:     3 (0.03%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     8 (0.08%)
  Bad cache:     0 (0.0%)
```



