### PR TITLE
Move mapper error rescue to application_controller.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,14 @@ class ApplicationController < ActionController::API
     }, status: :bad_request
   end
 
+  # No longer be necessary when remove Fedora.
+  rescue_from(Cocina::Mapper::UnexpectedBuildError) do |e|
+    json_api_error(status: :unprocessable_entity,
+                   title: 'Unexpected Cocina::Mapper.build error',
+                   message: e.cause,
+                   meta: { backtrace: e.cause.backtrace })
+  end
+
   before_action :check_auth_token
 
   TOKEN_HEADER = 'Authorization'


### PR DESCRIPTION
## Why was this change made?
Every controller that uses cocina needs to have this error rescued, not just the objects_controller.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



