### PR TITLE
Remove the ActiveFedora dependency from public_cocina_service

### DIFF
--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -28,11 +28,12 @@ module Publish
 
     private
 
-    attr_reader :item
+    attr_reader :item, :cocina_object
 
     # @raise [Dor::DataError]
     def transfer_metadata(release_tags)
-      transfer_to_document_store(PublicCocinaService.create(item), 'cocina.json')
+      public_cocina = PublicCocinaService.create(cocina_object)
+      transfer_to_document_store(public_cocina.to_json, 'cocina.json')
       transfer_to_document_store(PublicXmlService.new(item, released_for: release_tags, thumbnail_service: @thumbnail_service).to_xml, 'public')
       transfer_to_document_store(PublicDescMetadataService.new(item).to_xml, 'mods')
     end

--- a/app/services/publish/public_cocina_service.rb
+++ b/app/services/publish/public_cocina_service.rb
@@ -3,8 +3,7 @@
 module Publish
   # Filters out the non-public parts of cocina for publishing to purl
   class PublicCocinaService
-    def self.create(item)
-      cocina = Cocina::Mapper.build(item)
+    def self.create(cocina)
       new(cocina).build
     end
 
@@ -16,12 +15,12 @@ module Publish
     # remove any file_set that doesn't have at least one published file
     # remove partOfProject (similar to how we remove tags from identityMetadata)
     def build
-      return cocina.to_json unless cocina.dro?
+      return cocina unless cocina.dro?
 
       build_structural
 
       cocina.new(structural: build_structural,
-                 administrative: build_administrative).to_json
+                 administrative: build_administrative)
     end
 
     private

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Publish::MetadataTransferService do
                             description: description,
                             identification: {},
                             access: {},
+                            structural: { contains: [] },
                             administrative: { hasAdminPolicy: 'druid:fg890hx1234' })
   end
   let(:thumbnail_service) { ThumbnailService.new(cocina_object) }

--- a/spec/services/publish/public_cocina_service_spec.rb
+++ b/spec/services/publish/public_cocina_service_spec.rb
@@ -3,66 +3,126 @@
 require 'rails_helper'
 
 RSpec.describe Publish::PublicCocinaService do
-  subject(:json) { JSON.parse(create) }
+  subject(:json) { JSON.parse(create.to_json) }
 
-  let(:create) { described_class.create(fedora_obj) }
+  let(:create) { described_class.create(cocina_item) }
 
-  let(:fedora_obj) do
-    Dor::Item.new(
-      pid: 'druid:hz651dj0129',
-      source_id: 'sul:50807230',
-      label: 'Census of India 1931',
-      admin_policy_object_id: 'druid:xk494bv8475'
-    ).tap do |i|
-      i.descMetadata.mods_title = 'Census of India, 1931'
-      i.contentMetadata.content = content_metadata
-    end
-  end
-
-  let(:content_metadata) do
-    <<~XML
-      <contentMetadata objectId="hz651dj0129" type="book">
-        <resource id="hz651dj0129_1" sequence="1" type="page">
-          <label>Page 1</label>
-          <file id="50807230_0001.tif" mimetype="image/tiff" size="56987913" preserve="yes" publish="no" shelve="no">
-            <checksum type="md5">6618d3d35e6adbc5625405cd244f6bda</checksum>
-            <checksum type="sha1">4af78fde7fd8099ac7e3fee3a58332b1d268d244</checksum>
-            <imageData width="3544" height="5360"/>
-          </file>
-          <file id="50807230_0001.jp2" mimetype="image/jp2" size="3575822" preserve="no" publish="no" shelve="no">
-            <checksum type="md5">c99fae3c4c53e40824e710440f08acb9</checksum>
-            <checksum type="sha1">0a089200032d209e9b3e7f7768dd35323a863fcc</checksum>
-            <imageData width="3544" height="5360"/>
-          </file>
-        </resource>
-        <resource id="hz651dj0129_2" sequence="2" type="page">
-          <label>Page 2</label>
-          <file id="50807230_0002.tif" mimetype="image/tiff" size="31525443" preserve="yes" publish="no" shelve="no">
-            <checksum type="md5">010f88d1e40a6f81badde34e00c4ab5d</checksum>
-            <checksum type="sha1">46308444f201bec15857ac9338c2b6060f518ca5</checksum>
-            <imageData width="5736" height="5496"/>
-          </file>
-          <file id="50807230_0002.jp2" mimetype="image/jp2" size="5920056" preserve="no" publish="yes" shelve="yes">
-            <checksum type="md5">08544fe844c45eebb552f280709af564</checksum>
-            <checksum type="sha1">4691466371691f774151574d1cf97ed73ba45d2c</checksum>
-            <imageData width="5736" height="5496"/>
-          </file>
-        </resource>
-        <resource id="hz651dj0129_3" sequence="3" type="page">
-          <label>Page 3</label>
-          <file id="50807230_0003.tif" mimetype="image/tiff" size="31525443" preserve="yes" publish="no" shelve="no">
-            <checksum type="md5">0b43cedb0c8beb030e7c0e87a7ae46ae</checksum>
-            <checksum type="sha1">6b1fc3618c2c195ccc99432491e3a864b2df02af</checksum>
-            <imageData width="5736" height="5496"/>
-          </file>
-          <file id="50807230_0003.jp2" mimetype="image/jp2" size="5920374" preserve="no" publish="yes" shelve="yes">
-            <checksum type="md5">a9acee40e54bc6da6cee1388f7cc33e9</checksum>
-            <checksum type="sha1">9c62ab0930a8e3540b7c151c3e52e8b7732e9c2e</checksum>
-            <imageData width="5736" height="5496"/>
-          </file>
-        </resource>
-      </contentMetadata>
-    XML
+  let(:cocina_item) do
+    Cocina::Models::DRO.new(
+      { cocinaVersion: '0.65.1', type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
+        externalIdentifier: 'druid:hz651dj0129',
+        label: 'Census of India 1931',
+        version: 1,
+        access: { access: 'dark', download: 'none' },
+        administrative: { hasAdminPolicy: 'druid:xk494bv8475', releaseTags: [] },
+        description: { title: [{ value: 'Census of India, 1931' }],
+                       purl: 'https://purl.stanford.edu/hz651dj0129' },
+        identification: { sourceId: 'sul:50807230' },
+        structural: {
+          contains: [
+            {
+              type: 'http://cocina.sul.stanford.edu/models/resources/page.jsonld',
+              externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/63a5295e-356e-428c-8ec7-894643efdeda',
+              label: 'Page 1', version: 1,
+              structural: {
+                contains: [
+                  {
+                    type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                    externalIdentifier: 'http://cocina.sul.stanford.edu/file/f44c645d-c469-4345-b9b6-38eeb7f15dd3',
+                    label: '50807230_0001.tif', filename: '50807230_0001.tif', size: 56_987_913,
+                    version: 1, hasMimeType: 'image/tiff',
+                    hasMessageDigests: [
+                      { type: 'sha1', digest: '4af78fde7fd8099ac7e3fee3a58332b1d268d244' },
+                      { type: 'md5', digest: '6618d3d35e6adbc5625405cd244f6bda' }
+                    ],
+                    access: { access: 'dark', download: 'none' },
+                    administrative: { publish: false, sdrPreserve: true, shelve: false },
+                    presentation: { height: 5360, width: 3544 }
+                  }, {
+                    type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                    externalIdentifier: 'http://cocina.sul.stanford.edu/file/8861aa09-416f-4890-8786-1dd45d2b6297',
+                    label: '50807230_0001.jp2', filename: '50807230_0001.jp2', size: 3_575_822,
+                    version: 1,
+                    hasMimeType: 'image/jp2',
+                    hasMessageDigests: [
+                      { type: 'sha1', digest: '0a089200032d209e9b3e7f7768dd35323a863fcc' },
+                      { type: 'md5', digest: 'c99fae3c4c53e40824e710440f08acb9' }
+                    ],
+                    access: { access: 'dark', download: 'none' },
+                    administrative: { publish: false, sdrPreserve: false, shelve: false },
+                    presentation: { height: 5360, width: 3544 }
+                  }
+                ]
+              }
+            }, {
+              type: 'http://cocina.sul.stanford.edu/models/resources/page.jsonld',
+              externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/fdd60abb-76c0-4450-8276-0b6fb145dcc5',
+              label: 'Page 2', version: 1,
+              structural: {
+                contains: [
+                  { type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                    externalIdentifier: 'http://cocina.sul.stanford.edu/file/4c53e83b-6d45-435a-8323-299ded33800f',
+                    label: '50807230_0002.tif', filename: '50807230_0002.tif', size: 31_525_443, version: 1,
+                    hasMimeType: 'image/tiff',
+                    hasMessageDigests: [
+                      { type: 'sha1', digest: '46308444f201bec15857ac9338c2b6060f518ca5' },
+                      { type: 'md5', digest: '010f88d1e40a6f81badde34e00c4ab5d' }
+                    ],
+                    access: { access: 'dark', download: 'none' },
+                    administrative: { publish: false, sdrPreserve: true, shelve: false },
+                    presentation: { height: 5496, width: 5736 } }, {
+                      type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                      externalIdentifier: 'http://cocina.sul.stanford.edu/file/bf2dd98c-8c9e-4802-ae28-8f60bb31b360',
+                      label: '50807230_0002.jp2', filename: '50807230_0002.jp2', size: 5_920_056, version: 1,
+                      hasMimeType: 'image/jp2',
+                      hasMessageDigests: [
+                        { type: 'sha1', digest: '4691466371691f774151574d1cf97ed73ba45d2c' },
+                        { type: 'md5', digest: '08544fe844c45eebb552f280709af564' }
+                      ],
+                      access: { access: 'dark', download: 'none' },
+                      administrative: { publish: true, sdrPreserve: false, shelve: true },
+                      presentation: { height: 5496, width: 5736 }
+                    }
+                ]
+              }
+            }, {
+              type: 'http://cocina.sul.stanford.edu/models/resources/page.jsonld',
+              externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/0b7db5f1-e12d-446c-acbc-a46361f5a06d',
+              label: 'Page 3', version: 1,
+              structural: {
+                contains: [
+                  {
+                    type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                    externalIdentifier: 'http://cocina.sul.stanford.edu/file/8bbfdff7-1765-475a-a858-3b138c2eb31a',
+                    label: '50807230_0003.tif', filename: '50807230_0003.tif', size: 31_525_443, version: 1,
+                    hasMimeType: 'image/tiff',
+                    hasMessageDigests: [
+                      { type: 'sha1', digest: '6b1fc3618c2c195ccc99432491e3a864b2df02af' },
+                      { type: 'md5', digest: '0b43cedb0c8beb030e7c0e87a7ae46ae' }
+                    ],
+                    access: { access: 'dark', download: 'none' },
+                    administrative: { publish: false, sdrPreserve: true, shelve: false },
+                    presentation: { height: 5496, width: 5736 }
+                  }, {
+                    type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                    externalIdentifier: 'http://cocina.sul.stanford.edu/file/0a532f3b-e473-4b68-b2fc-93436eb41240',
+                    label: '50807230_0003.jp2', filename: '50807230_0003.jp2', size: 5_920_374, version: 1,
+                    hasMimeType: 'image/jp2',
+                    hasMessageDigests: [
+                      { type: 'sha1', digest: '9c62ab0930a8e3540b7c151c3e52e8b7732e9c2e' },
+                      { type: 'md5', digest: 'a9acee40e54bc6da6cee1388f7cc33e9' }
+                    ],
+                    access: { access: 'dark', download: 'none' },
+                    administrative: { publish: true, sdrPreserve: false, shelve: true },
+                    presentation: { height: 5496, width: 5736 }
+                  }
+                ]
+              }
+            }
+          ],
+          hasMemberOrders: [{ viewingDirection: 'left-to-right' }]
+        } }
+    )
   end
 
   it 'discards the non-published filesets and files' do


### PR DESCRIPTION
## Why was this change made?
This gets us closer to being able to remove the activefedora dependency from PublicXmlService
Ref #3329 


## How was this change tested?



## Which documentation and/or configurations were updated?



