### PR TITLE
For metadata_transfer_service, use the item you have.

### DIFF
--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -10,7 +10,7 @@ module Publish
 
     def initialize(item)
       @item = item
-      @cocina_object = CocinaObjectStore.find(@item.pid)
+      @cocina_object = Cocina::Mapper.build(@item)
       @thumbnail_service = ThumbnailService.new(@cocina_object)
     end
 


### PR DESCRIPTION
## Why was this change made?
The item should not be re-retrieved just to get Cocina.


## How was this change tested?



## Which documentation and/or configurations were updated?



