### PR TITLE
Prevent invalid access from being copied from an APO to a collection

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -203,11 +203,14 @@ module Cocina
       apo = CocinaObjectStore.find(cocina_object.administrative.hasAdminPolicy)
       return cocina_object unless apo.administrative.respond_to?(:defaultAccess) && apo.administrative.defaultAccess
 
-      embargo = cocina_object.access&.embargo
       default_access = apo.administrative.defaultAccess
-      # Add embargo into the DROAccess node if one exists
-      default_access = Cocina::Models::DROAccess.new(default_access.to_h.merge({ embargo: embargo })) if embargo
-      cocina_object.new(access: default_access)
+      updated_access = if cocina_object.collection?
+                         # Collection access only supports dark or world, but default access is more complicated
+                         cocina_object.access.new(access: default_access.access == 'dark' ? 'dark' : 'world')
+                       else
+                         cocina_object.access.new(default_access.to_h)
+                       end
+      cocina_object.new(access: updated_access)
     end
 
     def truncate_label(label)

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -10,10 +10,19 @@ RSpec.describe 'Create object' do
                                       type: Cocina::Models::Vocab.admin_policy,
                                       label: 'Test Admin Policy',
                                       version: 1,
-                                      administrative: { hasAdminPolicy: 'druid:hy787xj5878', hasAgreement: 'druid:bb033gt0615' }
+                                      administrative: {
+                                        hasAdminPolicy: 'druid:hy787xj5878',
+                                        hasAgreement: 'druid:bb033gt0615',
+                                        defaultAccess: {
+                                          access: 'world',
+                                          download: 'world'
+                                        }
+                                      }
                                     })
   end
-  let(:data) { item.to_json }
+  let(:label) { 'This is my label' }
+  let(:title) { 'This is my title' }
+  let(:expected_label) { label }
   let(:druid) { 'druid:gg777gg7777' }
 
   before do
@@ -23,10 +32,74 @@ RSpec.describe 'Create object' do
     stub_request(:post, 'https://dor-indexing-app.example.edu/dor/reindex/druid:gg777gg7777')
   end
 
-  context 'when a collection is provided' do
-    let(:label) { 'This is my label' }
-    let(:title) { 'This is my title' }
-    let(:expected_label) { label }
+  context 'when the catkey is provided and save is successful' do
+    let(:expected_label) { title } # label derived from catalog data
+    let(:data) do
+      <<~JSON
+        {
+          "cocinaVersion":"0.0.1",
+          "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
+          "label":"#{label}","version":1,"access":{},
+          "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
+          "description":{"title":[{"value":"#{title}"}]},
+          "identification":#{identification.to_json}}
+      JSON
+    end
+
+    let(:expected) do
+      Cocina::Models::Collection.new(type: Cocina::Models::Vocab.collection,
+                                     label: expected_label,
+                                     version: 1,
+                                     description: {
+                                       title: [{ value: title }],
+                                       purl: 'https://purl.stanford.edu/gg777gg7777'
+                                     },
+                                     administrative: {
+                                       hasAdminPolicy: 'druid:dd999df4567'
+                                     },
+                                     identification: identification,
+                                     externalIdentifier: druid,
+                                     access: {
+                                       access: 'world'
+                                     })
+    end
+
+    let(:identification) do
+      {
+        catalogLinks: [
+          { catalog: 'symphony', catalogRecordId: '8888' }
+        ]
+      }
+    end
+    let(:mods_from_symphony) do
+      <<~XML
+        <mods xmlns:xlink="http://www.w3.org/1999/xlink"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns="http://www.loc.gov/mods/v3" version="3.3"
+              xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
+          <titleInfo>
+            <title>#{title}</title>
+          </titleInfo>
+        </mods>
+      XML
+    end
+
+    before do
+      allow(MetadataService).to receive(:fetch).and_return(mods_from_symphony)
+    end
+
+    it 'creates the collection' do
+      post '/v1/objects',
+           params: data,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+      expect(response.body).to equal_cocina_model(expected)
+      expect(response.status).to eq(201)
+      expect(response.location).to eq "/v1/objects/#{druid}"
+      expect(MetadataService).to have_received(:fetch).with('catkey:8888')
+    end
+  end
+
+  context 'when the catkey is not provided and save is successful' do
     let(:expected) do
       Cocina::Models::Collection.new(type: Cocina::Models::Vocab.collection,
                                      label: expected_label,
@@ -43,8 +116,11 @@ RSpec.describe 'Create object' do
                                        partOfProject: 'Hydrus'
                                      },
                                      externalIdentifier: druid,
-                                     access: {})
+                                     access: {
+                                       access: 'world'
+                                     })
     end
+
     let(:data) do
       <<~JSON
         {
@@ -58,161 +134,94 @@ RSpec.describe 'Create object' do
       JSON
     end
 
-    context 'when the catkey is provided and save is successful' do
-      let(:expected_label) { title } # label derived from catalog data
-      let(:data) do
-        <<~JSON
-          {
-            "cocinaVersion":"0.0.1",
-            "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
-            "label":"#{label}","version":1,"access":{},
-            "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
-            "description":{"title":[{"value":"#{title}"}]},
-            "identification":#{identification.to_json}}
-        JSON
-      end
+    it 'creates the collection' do
+      post '/v1/objects',
+           params: data,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+      expect(response.body).to equal_cocina_model(expected)
+      expect(response.status).to eq(201)
+      expect(response.location).to eq "/v1/objects/#{druid}"
+    end
+  end
 
-      let(:expected) do
-        Cocina::Models::Collection.new(type: Cocina::Models::Vocab.collection,
-                                       label: expected_label,
-                                       version: 1,
-                                       description: {
-                                         title: [{ value: title }],
-                                         purl: 'https://purl.stanford.edu/gg777gg7777'
-                                       },
-                                       administrative: {
-                                         hasAdminPolicy: 'druid:dd999df4567'
-                                       },
-                                       identification: identification,
-                                       externalIdentifier: druid,
-                                       access: {})
-      end
-
-      let(:identification) do
+  context 'when a description including summary note (abstract) is provided' do
+    let(:data) do
+      <<~JSON
         {
-          catalogLinks: [
-            { catalog: 'symphony', catalogRecordId: '8888' }
-          ]
-        }
-      end
-      let(:mods_from_symphony) do
-        <<~XML
-          <mods xmlns:xlink="http://www.w3.org/1999/xlink"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xmlns="http://www.loc.gov/mods/v3" version="3.3"
-                xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
-            <titleInfo>
-              <title>#{title}</title>
-            </titleInfo>
-          </mods>
-        XML
-      end
-
-      before do
-        allow(MetadataService).to receive(:fetch).and_return(mods_from_symphony)
-      end
-
-      it 'creates the collection' do
-        post '/v1/objects',
-             params: data,
-             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to equal_cocina_model(expected)
-        expect(response.status).to eq(201)
-        expect(response.location).to eq "/v1/objects/#{druid}"
-        expect(MetadataService).to have_received(:fetch).with('catkey:8888')
-      end
-    end
-
-    context 'when the catkey is not provided and save is successful' do
-      it 'creates the collection' do
-        post '/v1/objects',
-             params: data,
-             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to equal_cocina_model(expected)
-        expect(response.status).to eq(201)
-        expect(response.location).to eq "/v1/objects/#{druid}"
-      end
-    end
-
-    context 'when a description including summary note (abstract) is provided' do
-      let(:data) do
-        <<~JSON
-          {
-            "cocinaVersion":"0.0.1",
-            "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
-            "label":"#{label}",
-            "version":1,
-            "access":{},
-            "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
-            "description":{
-              "title":[{"value":"#{title}"}],
-              "note":[{"value":"coll abstract","type":"abstract"}]
-              }
+          "cocinaVersion":"0.0.1",
+          "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
+          "label":"#{label}",
+          "version":1,
+          "access":{},
+          "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
+          "description":{
+            "title":[{"value":"#{title}"}],
+            "note":[{"value":"coll abstract","type":"abstract"}]
             }
-        JSON
-      end
-      let(:expected) do
-        Cocina::Models::Collection.new(type: Cocina::Models::Vocab.collection,
-                                       label: expected_label,
-                                       version: 1,
-                                       access: { access: 'dark' },
-                                       administrative: {
-                                         hasAdminPolicy: 'druid:dd999df4567'
-                                       },
-                                       description: {
-                                         title: [{ value: title }],
-                                         note: [{ value: 'coll abstract', type: 'abstract' }],
-                                         purl: Purl.for(druid: druid)
-                                       },
-                                       externalIdentifier: druid)
-      end
-
-      it 'creates the collection with populated description title and note' do
-        post '/v1/objects',
-             params: data,
-             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to equal_cocina_model(expected)
-        expect(response.status).to eq(201)
-        expect(response.location).to eq "/v1/objects/#{druid}"
-      end
+          }
+      JSON
+    end
+    let(:expected) do
+      Cocina::Models::Collection.new(type: Cocina::Models::Vocab.collection,
+                                     label: expected_label,
+                                     version: 1,
+                                     access: { access: 'world' },
+                                     administrative: {
+                                       hasAdminPolicy: 'druid:dd999df4567'
+                                     },
+                                     description: {
+                                       title: [{ value: title }],
+                                       note: [{ value: 'coll abstract', type: 'abstract' }],
+                                       purl: Purl.for(druid: druid)
+                                     },
+                                     externalIdentifier: druid)
     end
 
-    context 'when access is provided' do
-      let(:data) do
-        <<~JSON
-          {
-            "cocinaVersion":"0.0.1",
-            "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
-            "label":"#{label}",
-            "version":1,
-            "access":{ "access": "world" },
-            "administrative":{"hasAdminPolicy":"druid:dd999df4567"}
-            }
-        JSON
-      end
-      let(:expected) do
-        Cocina::Models::Collection.new(type: Cocina::Models::Vocab.collection,
-                                       label: expected_label,
-                                       version: 1,
-                                       access: { access: 'world' },
-                                       administrative: {
-                                         hasAdminPolicy: 'druid:dd999df4567'
-                                       },
-                                       description: {
-                                         title: [{ value: expected_label }],
-                                         purl: 'https://purl.stanford.edu/gg777gg7777'
-                                       },
-                                       externalIdentifier: druid)
-      end
+    it 'creates the collection with populated description title and note' do
+      post '/v1/objects',
+           params: data,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+      expect(response.body).to equal_cocina_model(expected)
+      expect(response.status).to eq(201)
+      expect(response.location).to eq "/v1/objects/#{druid}"
+    end
+  end
 
-      it 'creates the collection with populated access' do
-        post '/v1/objects',
-             params: data,
-             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.body).to equal_cocina_model(expected)
-        expect(response.status).to eq(201)
-        expect(response.location).to eq "/v1/objects/#{druid}"
-      end
+  context 'when access is provided' do
+    let(:data) do
+      <<~JSON
+        {
+          "cocinaVersion":"0.0.1",
+          "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
+          "label":"#{label}",
+          "version":1,
+          "access":{ "access": "world" },
+          "administrative":{"hasAdminPolicy":"druid:dd999df4567"}
+          }
+      JSON
+    end
+    let(:expected) do
+      Cocina::Models::Collection.new(type: Cocina::Models::Vocab.collection,
+                                     label: expected_label,
+                                     version: 1,
+                                     access: { access: 'world' },
+                                     administrative: {
+                                       hasAdminPolicy: 'druid:dd999df4567'
+                                     },
+                                     description: {
+                                       title: [{ value: expected_label }],
+                                       purl: 'https://purl.stanford.edu/gg777gg7777'
+                                     },
+                                     externalIdentifier: druid)
+    end
+
+    it 'creates the collection with populated access' do
+      post '/v1/objects',
+           params: data,
+           headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
+      expect(response.body).to equal_cocina_model(expected)
+      expect(response.status).to eq(201)
+      expect(response.location).to eq "/v1/objects/#{druid}"
     end
   end
 end

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -1325,6 +1325,7 @@ RSpec.describe 'Create object' do
             "type":"http://cocina.sul.stanford.edu/models/object.jsonld",
             "label":"This is my label","version":1,
             "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
+            "access":{},
             "identification":{"sourceId":"googlebooks:999999"},
             "structural":{}}
         JSON


### PR DESCRIPTION

## Why was this change made?

Previously creating a collection with an APO that had default access would cause the server to raise an error because collections have no embargo property. This arose in https://github.com/sul-dlss/dor-services-app/commit/6c93258bced43d07647fd60bfd01305b09be2dd9

Fixes https://github.com/sul-dlss/argo/issues/3097

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?



