### PR TITLE
Remove linefeeds from objectLabel in normalization

### DIFF
--- a/app/services/cocina/from_fedora/apo.rb
+++ b/app/services/cocina/from_fedora/apo.rb
@@ -20,7 +20,7 @@ module Cocina
         {
           externalIdentifier: fedora_apo.pid,
           type: Cocina::Models::Vocab.admin_policy,
-          label: fedora_apo.objectLabel.first || fedora_apo.label,
+          label: Label.for(fedora_apo),
           version: fedora_apo.current_version.to_i,
           administrative: build_apo_administrative
         }.tap do |props|

--- a/app/services/cocina/from_fedora/collection.rb
+++ b/app/services/cocina/from_fedora/collection.rb
@@ -20,7 +20,7 @@ module Cocina
         {
           externalIdentifier: fedora_collection.pid,
           type: Cocina::Models::Vocab.collection,
-          label: fedora_collection.objectLabel.first || fedora_collection.label,
+          label: Label.for(fedora_collection),
           version: fedora_collection.current_version.to_i,
           administrative: FromFedora::Administrative.props(fedora_collection),
           access: CollectionAccess.props(fedora_collection.rightsMetadata)

--- a/app/services/cocina/from_fedora/dro.rb
+++ b/app/services/cocina/from_fedora/dro.rb
@@ -56,8 +56,7 @@ module Cocina
         {
           externalIdentifier: fedora_item.pid,
           type: type,
-          # Label may have been truncated, so prefer objectLabel.
-          label: fedora_item.objectLabel.first || fedora_item.label,
+          label: Label.for(fedora_item),
           version: fedora_item.current_version.to_i,
           administrative: FromFedora::Administrative.props(fedora_item),
           access: DROAccess.props(fedora_item.rightsMetadata, fedora_item.embargoMetadata),

--- a/app/services/cocina/from_fedora/label.rb
+++ b/app/services/cocina/from_fedora/label.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Cocina
+  module FromFedora
+    # Creates label from a Fedora object
+    class Label
+      def self.for(fedora_object)
+        # Label may have been truncated, so prefer objectLabel.
+        (fedora_object.objectLabel.first || fedora_object.label)&.delete("\r")
+      end
+    end
+  end
+end

--- a/app/services/cocina/normalizers/identity_normalizer.rb
+++ b/app/services/cocina/normalizers/identity_normalizer.rb
@@ -4,6 +4,7 @@ module Cocina
   module Normalizers
     # Normalizes a Fedora object identity metadata datastream, accounting for differences between Fedora rights and cocina rights that are valid but different
     # when round-tripping.
+    # rubocop:disable Metrics/ClassLength
     class IdentityNormalizer
       include Cocina::Normalizers::Base
 
@@ -41,6 +42,7 @@ module Cocina
         remove_otherid_dissertationid_if_dupe
         add_missing_sourceid_from_otherid_dissertationid
         normalize_source_id_whitespace
+        normalize_label_whitespace
 
         regenerate_ng_xml(ng_xml.to_xml)
       end
@@ -141,6 +143,13 @@ module Cocina
         end
       end
 
+      def normalize_label_whitespace
+        object_label = ng_xml.root.xpath('//objectLabel').first
+        return unless object_label
+
+        object_label.content = object_label.content.delete "\r"
+      end
+
       def add_missing_object_creator
         return if ng_xml.root.xpath('//objectCreator').present?
 
@@ -181,5 +190,6 @@ module Cocina
         diss_id_node.delete('name')
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/spec/services/cocina/from_fedora/label_spec.rb
+++ b/spec/services/cocina/from_fedora/label_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::FromFedora::Label do
+  describe '#for' do
+    let(:label) { described_class.for(item) }
+
+    context 'when an object label' do
+      let(:item) do
+        Dor::Item.new(objectLabel: 'object label', label: 'label label')
+      end
+
+      it 'prefers object label' do
+        expect(label).to eq('object label')
+      end
+    end
+
+    context 'when no object label' do
+      let(:item) do
+        Dor::Item.new(label: 'label label')
+      end
+
+      it 'uses label' do
+        expect(label).to eq('label label')
+      end
+    end
+
+    context 'when label has a CR' do
+      let(:item) do
+        Dor::Item.new(label: "label\r label")
+      end
+
+      it 'removes it' do
+        expect(label).to eq('label label')
+      end
+    end
+  end
+end

--- a/spec/services/cocina/normalizers/identity_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/identity_normalizer_spec.rb
@@ -674,6 +674,23 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
         )
       end
     end
+
+    context 'when there are linefeeds in objectLabel' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <objectId>druid:pk391vm0849</objectId>
+            <objectLabel>Clark's ranch : from homestead to big tree station, 1856-1879&#xD; &#xD; Responsibility:  Gary D. Lowe and John Carpenter. &#xD; Publication: Livermore, California : Gary D. Lowe, 2014.&#xD; Physical description: 107 pages : illustrations ; 23 cm</objectLabel>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes the linefeeds' do
+        text = normalized_ng_xml.xpath('//objectLabel').first.content
+        expect(text).not_to match(/\r/)
+        expect(text).not_to match(/&#xD;/)
+      end
+    end
   end
 
   describe '#remove_otherid_dissertationid_if_dupe' do


### PR DESCRIPTION
## Why was this change made?

Some objects have line feeds in `<objectLabel>`. Line feeds are removed when mapping to Cocina, but line feeds also need to be removed from `<objectLabel>` when normalizing identity metadata.

## How was this change tested?

Unit tests.

`bin/validate-cocina-roundtrip -s 100000 -n -f`

**Before:**

Status (n=100000; not using Missing for success/different/error stats):
  Success:   99907 (99.984%)
  Different: 4 (0.004%)
  Mapping error:     12 (0.012%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     77 (0.077%)
  Bad cache:     0 (0.0%)

**After:**

Status (n=100000; not using Missing for success/different/error stats):
  Success:   99906 (99.983%)
  Different: 3 (0.003%)
  Mapping error:     14 (0.014%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     77 (0.077%)
  Bad cache:     0 (0.0%)

## Which documentation and/or configurations were updated?

Closes #3398

