### PR TITLE
Fix versioning for accession endpoint.

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -103,7 +103,7 @@ class ObjectsController < ApplicationController
     # if this is an existing versionable object, open and close it without starting accessionWF
     if VersionService.can_open?(@cocina_object, params)
       updated_cocina_object = VersionService.open(@cocina_object, params, event_factory: EventFactory)
-      VersionService.close(@cocina_object, params.merge(start_accession: false), event_factory: EventFactory)
+      VersionService.close(updated_cocina_object, params.merge(start_accession: false), event_factory: EventFactory)
     # if this is an existing accessioned object that is currently open, just close it without starting accessionWF
     elsif VersionService.open?(@cocina_object)
       VersionService.close(@cocina_object, params.merge(start_accession: false), event_factory: EventFactory)

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -82,6 +82,7 @@ class VersionService
   # @option opts [Boolean] :start_accession set to true if you want accessioning to start (default), false otherwise
   # @raise [Dor::Exception] if the object hasn't been opened for versioning, or if accessionWF has
   #   already been instantiated or the current version is missing a tag or description
+  # rubocop:disable Metrics/AbcSize
   def close(opts = {})
     # This can be removed after migration.
     VersionMigrationService.find_and_migrate(druid)
@@ -89,8 +90,8 @@ class VersionService
     ObjectVersion.update_current_version(druid, description: opts[:description], significance: opts[:significance].to_sym) if opts[:description] && opts[:significance]
 
     raise Dor::Exception, "latest version in versionMetadata for #{druid} requires tag and description before it can be closed" unless ObjectVersion.current_version_closeable?(druid)
-    raise Dor::Exception, "Trying to close version on #{druid} which is not opened for versioning" unless open_for_versioning?
-    raise Dor::Exception, "Trying to close version on #{druid} which has active assemblyWF" if active_assembly_wf?
+    raise Dor::Exception, "Trying to close version #{cocina_object.version} on #{druid} which is not opened for versioning" unless open_for_versioning?
+    raise Dor::Exception, "Trying to close version #{cocina_object.version} on #{druid} which has active assemblyWF" if active_assembly_wf?
     raise Dor::Exception, "accessionWF already created for versioned object #{druid}" if accessioning?
 
     # Default to creating accessionWF when calling close_version
@@ -101,6 +102,7 @@ class VersionService
 
     event_factory.create(druid: druid, event_type: 'version_close', data: { who: opts[:user_name], version: cocina_object.version.to_s })
   end
+  # rubocop:enable Metrics/AbcSize
 
   # Performs checks on whether a new version can be opened for an object
   # @return [Void]

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe VersionService do
       end
 
       it 'raises an exception' do
-        expect { close }.to raise_error(Dor::Exception, "Trying to close version on #{druid} which is not opened for versioning")
+        expect { close }.to raise_error(Dor::Exception, "Trying to close version 2 on #{druid} which is not opened for versioning")
       end
     end
 
@@ -313,7 +313,7 @@ RSpec.describe VersionService do
       end
 
       it 'raises an exception' do
-        expect { close }.to raise_error(Dor::Exception, "Trying to close version on #{druid} which has active assemblyWF")
+        expect { close }.to raise_error(Dor::Exception, "Trying to close version 2 on #{druid} which has active assemblyWF")
         expect(workflow_client).to have_received(:workflow_status).with(hash_including(workflow: 'assemblyWF'))
       end
     end


### PR DESCRIPTION
## Why was this change made?
Versioning was not being performed correctly because a version open check was failing. See https://app.honeybadger.io/projects/50568/faults/83981315


## How was this change tested?
Unit, By Andrew on stage.


## Which documentation and/or configurations were updated?



