### PR TITLE
Overwrite identity objectLabel on update.

### DIFF
--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -85,7 +85,7 @@ module Cocina
     def update_apo
       # fedora_object.source_id = cocina_object.identification.sourceId
       if has_changed?(:label)
-        Cocina::ToFedora::Identity.apply_label(fedora_object, label: cocina_object.label)
+        Cocina::ToFedora::Identity.apply_label(fedora_object, label: cocina_object.label, overwrite: true)
         fedora_object.label = truncate_label(cocina_object.label)
       end
 
@@ -104,7 +104,7 @@ module Cocina
     def update_collection
       if has_changed?(:label)
         fedora_object.label = truncate_label(cocina_object.label) if has_changed?(:label)
-        Cocina::ToFedora::Identity.apply_label(fedora_object, label: cocina_object.label)
+        Cocina::ToFedora::Identity.apply_label(fedora_object, label: cocina_object.label, overwrite: true)
       end
 
       if has_changed?(:administrative)
@@ -127,7 +127,7 @@ module Cocina
 
       if has_changed?(:label)
         fedora_object.label = truncate_label(cocina_object.label)
-        Cocina::ToFedora::Identity.apply_label(fedora_object, label: cocina_object.label)
+        Cocina::ToFedora::Identity.apply_label(fedora_object, label: cocina_object.label, overwrite: true)
       end
 
       identity_updater = Cocina::ToFedora::Identity.new(fedora_object)

--- a/app/services/cocina/to_fedora/identity.rb
+++ b/app/services/cocina/to_fedora/identity.rb
@@ -11,8 +11,9 @@ module Cocina
 
       # @param [Dor::Item,Dor::Collection,Dor::Etd,Dor::AdminPolicyObject] fedora_object
       # @param [String] label the label for the cocina object.
-      def self.apply_label(fedora_object, label:)
-        new(fedora_object).apply_label(label)
+      # @param [boolean] overwrite the objectLabel if it already exists
+      def self.apply_label(fedora_object, label:, overwrite: false)
+        new(fedora_object).apply_label(label, overwrite: overwrite)
       end
 
       # @param [Dor::Item,Dor::Collection,Dor::Etd,Dor::AdminPolicyObject] fedora_object
@@ -37,8 +38,8 @@ module Cocina
         fedora_object.objectType = fedora_object.object_type # This comes from the class definition in dor-services
       end
 
-      def apply_label(label)
-        return unless fedora_object.objectLabel.empty?
+      def apply_label(label, overwrite: false)
+        return unless fedora_object.objectLabel.empty? || overwrite
 
         fedora_object.objectLabel = label
       end

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -1025,7 +1025,7 @@ RSpec.describe 'Update object' do
 
     let(:expected) do
       Cocina::Models::AdminPolicy.new(type: Cocina::Models::Vocab.admin_policy,
-                                      label: 'my original objectLabel',
+                                      label: 'This is my label',
                                       version: 1,
                                       description: {
                                         title: [{ value: 'This is my title' }],


### PR DESCRIPTION
refs #3408

## Why was this change made?
So that objectLabels can be updated.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



