### PR TITLE
Warn on non-geo items with geoMetadata ds.

### DIFF
--- a/app/services/cocina/mapper.rb
+++ b/app/services/cocina/mapper.rb
@@ -31,7 +31,7 @@ module Cocina
     # @param [Dor::Abstract] item the Fedora object to convert to a cocina object
     def initialize(item, notifier: nil)
       @item = item
-      @notifier = notifier
+      @notifier = notifier || FromFedora::DataErrorNotifier.new(druid: item.pid)
     end
 
     # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -141,6 +141,19 @@ RSpec.describe Cocina::Mapper do
         expect(cocina_model).to be_kind_of Cocina::Models::DRO
         expect(cocina_model.geographic.iso19139).to be_equivalent_to iso19139
       end
+
+      context 'when item is not geo' do
+        let(:content_type) { 'file' }
+
+        before do
+          allow(Honeybadger).to receive(:notify)
+        end
+
+        it 'builds and notifies' do
+          expect(cocina_model.geographic.iso19139).to be_equivalent_to iso19139
+          expect(Honeybadger).to have_received(:notify).with('[DATA WARNING] Non-geo object has geo metadata', { tags: 'data_warning', context: { druid: 'druid:mx000xm0000' } })
+        end
+      end
     end
 
     context 'when item has identityMetadata objectLabel' do

--- a/spec/services/cocina/mapping/identification/agreement_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/agreement_identity_spec.rb
@@ -45,7 +45,8 @@ RSpec.shared_examples 'Agreement Object Identification Fedora Cocina mapping' do
                     descMetadata: Dor::DescMetadataDS.from_xml(mods_xml),
                     embargoMetadata: Dor::EmbargoMetadataDS.new,
                     contentMetadata: Dor::ContentMetadataDS.new,
-                    rightsMetadata: Dor::RightsMetadataDS.new)
+                    rightsMetadata: Dor::RightsMetadataDS.new,
+                    geoMetadata: Dor::GeoMetadataDS.new)
   end
   let(:mapped_cocina_props) { Cocina::FromFedora::DRO.props(fedora_agreement_mock) }
   let(:normalized_orig_identity_xml) do
@@ -129,7 +130,8 @@ RSpec.shared_examples 'Agreement Object Identification Fedora Cocina mapping' do
                       descMetadata: Dor::DescMetadataDS.from_xml(mods_xml),
                       embargoMetadata: Dor::EmbargoMetadataDS.new,
                       contentMetadata: Dor::ContentMetadataDS.new,
-                      rightsMetadata: Dor::RightsMetadataDS.new)
+                      rightsMetadata: Dor::RightsMetadataDS.new,
+                      geoMetadata: Dor::GeoMetadataDS.new)
     end
     let(:roundtrip_cocina_props) { Cocina::FromFedora::DRO.props(roundtrip_fedora_agreement_mock) }
 
@@ -160,7 +162,8 @@ RSpec.shared_examples 'Agreement Object Identification Fedora Cocina mapping' do
                       descMetadata: Dor::DescMetadataDS.from_xml(mods_xml),
                       embargoMetadata: Dor::EmbargoMetadataDS.new,
                       contentMetadata: Dor::ContentMetadataDS.new,
-                      rightsMetadata: Dor::RightsMetadataDS.new)
+                      rightsMetadata: Dor::RightsMetadataDS.new,
+                      geoMetadata: Dor::GeoMetadataDS.new)
     end
     let(:roundtrip_cocina_props) { Cocina::FromFedora::DRO.props(normalized_orig_fedora_agreement_mock) }
 


### PR DESCRIPTION
refs #3395

## Why was this change made?
Map existing items that are non-geo content type but have geo metadata and provide warning.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



