### PR TITLE
Simplify label setting logic

### DIFF
--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -80,14 +80,10 @@ module Cocina
       @orig_cocina_object ||= Mapper.build(fedora_object, notifier: notifier)
     end
 
-    # rubocop:disable Metrics/AbcSize
     # rubocop:disable Style/GuardClause
     def update_apo
       # fedora_object.source_id = cocina_object.identification.sourceId
-      if has_changed?(:label)
-        Cocina::ToFedora::Identity.apply_label(fedora_object, label: cocina_object.label, overwrite: true)
-        fedora_object.label = truncate_label(cocina_object.label)
-      end
+      Cocina::ToFedora::Identity.apply_label(fedora_object, label: cocina_object.label) if has_changed?(:label)
 
       if has_changed?(:administrative)
         fedora_object.admin_policy_object_id = cocina_object.administrative.hasAdminPolicy
@@ -98,14 +94,10 @@ module Cocina
         Cocina::ToFedora::Roles.write(fedora_object, Array(cocina_object.administrative.roles))
       end
     end
-    # rubocop:enable Metrics/AbcSize
     # rubocop:enable Style/GuardClause
 
     def update_collection
-      if has_changed?(:label)
-        fedora_object.label = truncate_label(cocina_object.label) if has_changed?(:label)
-        Cocina::ToFedora::Identity.apply_label(fedora_object, label: cocina_object.label, overwrite: true)
-      end
+      Cocina::ToFedora::Identity.apply_label(fedora_object, label: cocina_object.label) if has_changed?(:label)
 
       if has_changed?(:administrative)
         Cocina::ToFedora::Identity.apply_release_tags(fedora_object, release_tags: cocina_object.administrative&.releaseTags)
@@ -125,10 +117,7 @@ module Cocina
       fedora_object.admin_policy_object_id = cocina_object.administrative.hasAdminPolicy if has_changed?(:administrative)
       fedora_object.collection_ids = Array.wrap(cocina_object.structural&.isMemberOf).compact if has_changed?(:structural)
 
-      if has_changed?(:label)
-        fedora_object.label = truncate_label(cocina_object.label)
-        Cocina::ToFedora::Identity.apply_label(fedora_object, label: cocina_object.label, overwrite: true)
-      end
+      Cocina::ToFedora::Identity.apply_label(fedora_object, label: cocina_object.label) if has_changed?(:label)
 
       identity_updater = Cocina::ToFedora::Identity.new(fedora_object)
       if has_changed?(:identification)
@@ -238,11 +227,6 @@ module Cocina
       AdministrativeTags.for(pid: pid).select do |tag|
         tag.start_with?(prefix) && tag.count(':') == prefix_count
       end
-    end
-
-    # TODO: duplicate from ObjectCreator
-    def truncate_label(label)
-      label.length > 254 ? label[0, 254] : label
     end
 
     def update_version

--- a/app/services/cocina/to_fedora/identity.rb
+++ b/app/services/cocina/to_fedora/identity.rb
@@ -12,8 +12,8 @@ module Cocina
       # @param [Dor::Item,Dor::Collection,Dor::Etd,Dor::AdminPolicyObject] fedora_object
       # @param [String] label the label for the cocina object.
       # @param [boolean] overwrite the objectLabel if it already exists
-      def self.apply_label(fedora_object, label:, overwrite: false)
-        new(fedora_object).apply_label(label, overwrite: overwrite)
+      def self.apply_label(fedora_object, label:)
+        new(fedora_object).apply_label(label)
       end
 
       # @param [Dor::Item,Dor::Collection,Dor::Etd,Dor::AdminPolicyObject] fedora_object
@@ -38,10 +38,13 @@ module Cocina
         fedora_object.objectType = fedora_object.object_type # This comes from the class definition in dor-services
       end
 
-      def apply_label(label, overwrite: false)
-        return unless fedora_object.objectLabel.empty? || overwrite
-
+      def apply_label(label)
         fedora_object.objectLabel = label
+        fedora_object.label = truncate_label(label) # Truncating is required by Fedora 3
+      end
+
+      def truncate_label(label)
+        label.length > 254 ? label[0, 254] : label
       end
 
       def apply_release_tags(release_tags)

--- a/spec/services/cocina/mapping/identification/agreement_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/agreement_identity_spec.rb
@@ -59,8 +59,7 @@ RSpec.shared_examples 'Agreement Object Identification Fedora Cocina mapping' do
     cocina_dro = Cocina::Models::DRO.new(mapped_cocina_props)
     fedora_agreement = Dor::Agreement.new(pid: cocina_dro.externalIdentifier,
                                           source_id: cocina_dro.identification.sourceId,
-                                          catkey: Cocina::ObjectCreator.new.send(:catkey_for, cocina_dro),
-                                          label: Cocina::ObjectCreator.new.send(:truncate_label, cocina_dro.label))
+                                          catkey: Cocina::ObjectCreator.new.send(:catkey_for, cocina_dro))
     Cocina::ToFedora::Identity.initialize_identity(fedora_agreement)
     Cocina::ToFedora::Identity.apply_label(fedora_agreement, label: cocina_dro.label)
     fedora_agreement.identityMetadata.barcode = cocina_dro.identification.barcode

--- a/spec/services/cocina/mapping/identification/collection_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/collection_identity_spec.rb
@@ -60,8 +60,7 @@ RSpec.shared_examples 'Collection Identification Fedora Cocina mapping' do
     Dor::Collection.new(pid: mapped_cocina_collection.externalIdentifier,
                         admin_policy_object_id: mapped_cocina_collection.administrative.hasAdminPolicy,
                         source_id: mapped_cocina_collection.identification&.sourceId,
-                        catkey: Cocina::ObjectCreator.new.send(:catkey_for, mapped_cocina_collection),
-                        label: Cocina::ObjectCreator.new.send(:truncate_label, mapped_cocina_collection.label))
+                        catkey: Cocina::ObjectCreator.new.send(:catkey_for, mapped_cocina_collection))
   end
   let(:mapped_roundtrip_identity_xml) do
     Cocina::ToFedora::Identity.initialize_identity(mapped_fedora_collection)

--- a/spec/services/cocina/mapping/identification/dro_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/dro_identity_spec.rb
@@ -65,8 +65,7 @@ RSpec.shared_examples 'DRO Identification Fedora Cocina mapping' do
     cocina_dro = Cocina::Models::DRO.new(mapped_cocina_props)
     fedora_item = Dor::Item.new(pid: cocina_dro.externalIdentifier,
                                 source_id: cocina_dro.identification.sourceId,
-                                catkey: Cocina::ObjectCreator.new.send(:catkey_for, cocina_dro),
-                                label: Cocina::ObjectCreator.new.send(:truncate_label, cocina_dro.label))
+                                catkey: Cocina::ObjectCreator.new.send(:catkey_for, cocina_dro))
     Cocina::ToFedora::Identity.initialize_identity(fedora_item)
     Cocina::ToFedora::Identity.apply_label(fedora_item, label: cocina_dro.label)
     Cocina::ToFedora::Identity.apply_release_tags(fedora_item, release_tags: cocina_dro.administrative.releaseTags)

--- a/spec/services/cocina/object_updater_spec.rb
+++ b/spec/services/cocina/object_updater_spec.rb
@@ -72,7 +72,6 @@ RSpec.describe Cocina::ObjectUpdater do
 
         it 'updates label' do
           update
-          expect(item).to have_received(:label=).with('new label')
           expect(Cocina::ToFedora::Identity).to have_received(:apply_label)
         end
       end
@@ -411,13 +410,11 @@ RSpec.describe Cocina::ObjectUpdater do
       end
 
       before do
-        allow(item).to receive(:label=)
         allow(Cocina::ToFedora::Identity).to receive(:apply_label)
       end
 
       it 'updates label' do
         update
-        expect(item).to have_received(:label=).with('new label')
         expect(Cocina::ToFedora::Identity).to have_received(:apply_label)
       end
     end
@@ -822,7 +819,6 @@ RSpec.describe Cocina::ObjectUpdater do
     let(:trial) { true }
 
     before do
-      allow(item).to receive(:label=)
       allow(item).to receive(:admin_policy_object_id=)
       allow(item).to receive(:source_id=)
       allow(item).to receive(:catkey=)
@@ -851,7 +847,6 @@ RSpec.describe Cocina::ObjectUpdater do
       expect(event_factory).not_to have_received(:create)
       expect(AdministrativeTags).not_to have_received(:create)
 
-      expect(item).to have_received(:label=)
       expect(item).to have_received(:admin_policy_object_id=)
       expect(item).to have_received(:source_id=)
       expect(item).to have_received(:catkey=)


### PR DESCRIPTION
## Why was this change made?
We don't need a conditional around when to overwrite the label.


## How was this change tested?

before:
```
[deploy@sdr-deploy dor-services-app]$ bin/validate-cocina-roundtrip -s 100000 -i druids.testbed.txt -f
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99771 (99.853%)
  Different: 133 (0.133%)
  Mapping error:     14 (0.014%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

after
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99777 (99.859%)
  Different: 127 (0.127%)
  Mapping error:     14 (0.014%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
  ```



## Which documentation and/or configurations were updated?



