### PR TITLE
Removes mapping for defaultObjectRights.

### DIFF
--- a/app/services/cocina/from_fedora/apo.rb
+++ b/app/services/cocina/from_fedora/apo.rb
@@ -40,7 +40,6 @@ module Cocina
           registration_workflows = fedora_apo.administrativeMetadata.ng_xml.xpath('//administrativeMetadata/registration/workflow/@id').map(&:value)
           registration_collections = fedora_apo.administrativeMetadata.ng_xml.xpath('//administrativeMetadata/registration/collection/@id').map(&:value)
           dissemination_workflow = fedora_apo.administrativeMetadata.ng_xml.xpath('//administrativeMetadata/dissemination/workflow/@id').text
-          admin[:defaultObjectRights] = fedora_apo.defaultObjectRights.content # Deprecated. Use defaultAccess instead
           admin[:defaultAccess] = APOAccess.props(fedora_apo.defaultObjectRights)
           admin[:disseminationWorkflow] = dissemination_workflow if dissemination_workflow.present?
           admin[:registrationWorkflow] = registration_workflows if registration_workflows.present?

--- a/app/services/deep_equal.rb
+++ b/app/services/deep_equal.rb
@@ -3,10 +3,6 @@
 # Deeply compares two objects, ignoring array order.
 # Based on https://github.com/amogil/rspec-deep-ignore-order-matcher/blob/master/lib/rspec_deep_ignore_order_matcher.rb
 class DeepEqual
-  # TODO: Remove the XML-related bits of the class once we've moved away from defaultObjectRights:
-  #       https://github.com/sul-dlss/dor-services-app/issues/3241
-  XML_KEYS = [:defaultObjectRights].freeze
-
   def self.match?(actual, expected)
     new(actual, expected).match?
   end
@@ -24,10 +20,9 @@ class DeepEqual
 
   attr_reader :actual, :expected
 
-  def objects_match?(actual_obj, expected_obj, xml: false)
+  def objects_match?(actual_obj, expected_obj)
     return arrays_match?(actual_obj, expected_obj) if expected_obj.is_a?(Array) && actual_obj.is_a?(Array)
     return hashes_match?(actual_obj, expected_obj) if expected_obj.is_a?(Hash) && actual_obj.is_a?(Hash)
-    return EquivalentXml.equivalent?(actual_obj, expected_obj) if xml
 
     expected_obj == actual_obj
   end
@@ -47,7 +42,7 @@ class DeepEqual
     return false unless actual_hash.keys.sort == expected_hash.keys.sort
 
     actual_hash.each do |key, value|
-      return false unless objects_match?(value, expected_hash[key], xml: XML_KEYS.include?(key))
+      return false unless objects_match?(value, expected_hash[key])
     end
 
     true

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -874,7 +874,6 @@ RSpec.describe 'Create object' do
                                         purl: 'https://purl.stanford.edu/gg777gg7777'
                                       },
                                       administrative: {
-                                        defaultObjectRights: expected_default_object_rights,
                                         defaultAccess: {
                                           access: 'location-based',
                                           download: 'location-based',
@@ -921,32 +920,6 @@ RSpec.describe 'Create object' do
            <use>
               <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
               <machine type="openDataCommons" uri="http://opendatacommons.org/licenses/by/1.0/">odc-by</machine>
-              <human type="useAndReproduction">Whatever makes you happy</human>
-           </use>
-           <copyright>
-              <human>My copyright statement</human>
-           </copyright>
-        </rightsMetadata>
-      XML
-    end
-
-    let(:expected_default_object_rights) do
-      <<~XML
-        <?xml version="1.0" encoding="UTF-8"?>
-
-        <rightsMetadata>
-           <access type="discover">
-              <machine>
-                 <world/>
-              </machine>
-           </access>
-           <access type="read">
-              <machine>
-                 <location>ars</location>
-              </machine>
-           </access>
-           <use>
-              <license>http://opendatacommons.org/licenses/by/1.0/</license>
               <human type="useAndReproduction">Whatever makes you happy</human>
            </use>
            <copyright>
@@ -1032,7 +1005,6 @@ RSpec.describe 'Create object' do
                                         purl: 'https://purl.stanford.edu/gg777gg7777'
                                       },
                                       administrative: {
-                                        defaultObjectRights: default_object_rights,
                                         defaultAccess: {
                                           access: 'world',
                                           download: 'world'
@@ -1044,8 +1016,6 @@ RSpec.describe 'Create object' do
                                       externalIdentifier: druid)
     end
 
-    let(:default_object_rights) { Dor::DefaultObjectRightsDS.new.content }
-
     let(:data) do
       <<~JSON
         {
@@ -1053,7 +1023,6 @@ RSpec.describe 'Create object' do
           "type":"http://cocina.sul.stanford.edu/models/admin_policy.jsonld",
           "label":"Hydrus","version":1,
           "administrative":{
-            "defaultObjectRights":#{default_object_rights.to_json},
             "hasAdminPolicy":"druid:dd999df4567",
             "hasAgreement":"druid:bc753qt7345"}
           }

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -997,32 +997,6 @@ RSpec.describe 'Update object' do
       end
     end
 
-    let(:default_object_rights_expected) do
-      <<~XML
-        <?xml version="1.0" encoding="UTF-8"?>
-
-        <rightsMetadata>
-           <access type="discover">
-              <machine>
-                 <world/>
-              </machine>
-           </access>
-           <access type="read">
-              <machine>
-                 <location>ars</location>
-              </machine>
-           </access>
-           <use>
-              <license>http://opendatacommons.org/licenses/by/1.0/</license>
-              <human type="useAndReproduction">Whatever makes you happy</human>
-           </use>
-           <copyright>
-              <human>My copyright statement</human>
-           </copyright>
-        </rightsMetadata>
-      XML
-    end
-
     let(:expected) do
       Cocina::Models::AdminPolicy.new(type: Cocina::Models::Vocab.admin_policy,
                                       label: 'This is my label',
@@ -1032,7 +1006,6 @@ RSpec.describe 'Update object' do
                                         purl: 'https://purl.stanford.edu/gg777gg7777'
                                       },
                                       administrative: {
-                                        defaultObjectRights: default_object_rights_expected,
                                         defaultAccess: default_access_expected,
                                         hasAdminPolicy: 'druid:dd999df4567',
                                         hasAgreement: 'druid:bc123df4567',
@@ -1054,7 +1027,6 @@ RSpec.describe 'Update object' do
                                       externalIdentifier: druid)
     end
 
-    let(:default_object_rights) { Dor::DefaultObjectRightsDS.new.content }
     let(:default_access) do
       {
         access: 'location-based',
@@ -1075,7 +1047,6 @@ RSpec.describe 'Update object' do
           "type":"http://cocina.sul.stanford.edu/models/admin_policy.jsonld",
           "label":"This is my label","version":1,
           "administrative":{
-            "defaultObjectRights":#{default_object_rights.to_json},
             "disseminationWorkflow":"assemblyWF",
             "registrationWorkflow":["goobiWF","registrationWF"],
             "collectionsForRegistration":["druid:gg888df4567","druid:bb888gg4444"],
@@ -1121,25 +1092,6 @@ RSpec.describe 'Update object' do
       end
 
       let(:default_access_expected) { default_access.compact }
-
-      let(:default_object_rights_expected) do
-        <<~XML
-          <?xml version="1.0" encoding="UTF-8"?>
-
-          <rightsMetadata>
-             <access type="discover">
-                <machine>
-                   <world/>
-                </machine>
-             </access>
-             <access type="read">
-                <machine>
-                   <world/>
-                </machine>
-             </access>
-          </rightsMetadata>
-        XML
-      end
 
       before do
         # This stubs out Solr:

--- a/spec/services/cocina/mapping/administrative/apo_administrative_spec.rb
+++ b/spec/services/cocina/mapping/administrative/apo_administrative_spec.rb
@@ -218,7 +218,6 @@ RSpec.describe 'APO administrative mappings' do
       let(:agreement_druid) { 'druid:yr951qr4199' }
       let(:cocina) do
         {
-          defaultObjectRights: default_object_rights_xml,
           defaultAccess: {
             access: 'world',
             download: 'world',
@@ -302,7 +301,6 @@ RSpec.describe 'APO administrative mappings' do
       let(:agreement_druid) { 'druid:wn586st0695' }
       let(:cocina) do
         {
-          defaultObjectRights: default_object_rights_xml,
           defaultAccess: {
             access: 'world',
             download: 'world'
@@ -393,7 +391,6 @@ RSpec.describe 'APO administrative mappings' do
       let(:agreement_druid) { 'druid:zh747vq3919' }
       let(:cocina) do
         {
-          defaultObjectRights: default_object_rights_xml,
           defaultAccess: {
             access: 'world',
             download: 'none',
@@ -518,7 +515,6 @@ RSpec.describe 'APO administrative mappings' do
       let(:agreement_druid) { 'druid:xf765cv5573' }
       let(:cocina) do
         {
-          defaultObjectRights: default_object_rights_xml,
           defaultAccess: {
             access: 'world',
             download: 'none',
@@ -667,7 +663,6 @@ RSpec.describe 'APO administrative mappings' do
       let(:agreement_druid) { 'druid:xf765cv5573' }
       let(:cocina) do
         {
-          defaultObjectRights: default_object_rights_xml,
           defaultAccess: {
             access: 'world',
             download: 'none',

--- a/spec/services/cocina/mapping/identification/apo_identity_spec.rb
+++ b/spec/services/cocina/mapping/identification/apo_identity_spec.rb
@@ -197,7 +197,6 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
             hasAdminPolicy: admin_policy_id,
             hasAgreement: agreement_object_id,
             defaultAccess: default_access_props,
-            defaultObjectRights: default_object_rights_xml,
             roles: []
           },
           description: description_props
@@ -249,7 +248,6 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
             hasAdminPolicy: admin_policy_id,
             hasAgreement: agreement_object_id,
             defaultAccess: default_access_props,
-            defaultObjectRights: default_object_rights_xml,
             roles: []
           },
           description: description_props
@@ -303,7 +301,6 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
             hasAdminPolicy: admin_policy_id,
             hasAgreement: agreement_object_id,
             defaultAccess: default_access_props,
-            defaultObjectRights: default_object_rights_xml,
             roles: []
           },
           description: description_props
@@ -350,7 +347,6 @@ RSpec.describe 'Fedora APO identityMetadata <--> Cocina AdminPolicy Identificati
             hasAdminPolicy: admin_policy_id,
             hasAgreement: agreement_object_id,
             defaultAccess: default_access_props,
-            defaultObjectRights: default_object_rights_xml,
             roles: []
           },
           description: description_props

--- a/spec/services/deep_equal_spec.rb
+++ b/spec/services/deep_equal_spec.rb
@@ -24,8 +24,4 @@ RSpec.describe DeepEqual do
     expect(described_class.match?({ a: 'foo', b: ['foo', 'bar'] }, { a: 'foo', b: ['bar', 'foo'] })).to be true
     expect(described_class.match?({ a: 'foo', b: ['foo', 'bar'] }, { a: 'foo', b: ['bar'] })).to be false
   end
-
-  it 'compares xml strings' do
-    expect(described_class.match?({ defaultObjectRights: '<xml>foo!</xml>' }, { defaultObjectRights: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n<xml>foo!</xml>" })).to be true
-  end
 end


### PR DESCRIPTION
closes #3241
closes #3397

## Why was this change made?
DefaultObjectRights is deprecated.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



