### PR TITLE
Require legacy updates to produce valid cocina before save.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::API
     json_api_error(status: :unprocessable_entity,
                    title: 'Unexpected Cocina::Mapper.build error',
                    message: e.cause,
-                   meta: { backtrace: e.cause.backtrace })
+                   meta: { backtrace: e.cause&.backtrace })
   end
 
   before_action :check_auth_token

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -48,9 +48,12 @@ class MetadataController < ApplicationController
                                                        event_factory: EventFactory)
     end
 
+    # Mapping before save to guard against invalid cocina objects.
+    cocina_object = Cocina::Mapper.build(@item)
+
     @item.save!
     if Settings.rabbitmq.enabled
-      Notifications::ObjectUpdated.publish(model: Cocina::Mapper.build(@item),
+      Notifications::ObjectUpdated.publish(model: cocina_object,
                                            created_at: @item.create_date,
                                            modified_at: @item.modified_date)
     end

--- a/app/controllers/mods_controller.rb
+++ b/app/controllers/mods_controller.rb
@@ -15,9 +15,13 @@ class ModsController < ApplicationController
                                                      content: request.body.read,
                                                      event_factory: EventFactory)
 
+    # Mapping before save to guard against invalid cocina objects.
+    cocina_object = Cocina::Mapper.build(@item)
+
     @item.save!
+
     if Settings.rabbitmq.enabled
-      Notifications::ObjectUpdated.publish(model: Cocina::Mapper.build(@item),
+      Notifications::ObjectUpdated.publish(model: cocina_object,
                                            created_at: @item.create_date,
                                            modified_at: @item.modified_date)
     end

--- a/spec/requests/legacy_metadata_update_spec.rb
+++ b/spec/requests/legacy_metadata_update_spec.rb
@@ -206,4 +206,19 @@ RSpec.describe 'Update the legacy (datastream) metadata' do
       expect(item).not_to have_received(:save!)
     end
   end
+
+  context 'when invalid cocina' do
+    before do
+      allow(Cocina::Mapper).to receive(:build).and_raise(Cocina::Mapper::UnexpectedBuildError, ' #/components/schemas/DRO missing required parameters')
+    end
+
+    it 'returns error' do
+      patch "/v1/objects/#{item.pid}/metadata/legacy",
+            params: data,
+            headers: { 'Authorization' => "Bearer #{jwt}", 'CONTENT_TYPE' => 'application/json' }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to match(/Unexpected Cocina::Mapper.build error/)
+      expect(item).not_to have_received(:save!)
+    end
+  end
 end

--- a/spec/requests/mods_update_spec.rb
+++ b/spec/requests/mods_update_spec.rb
@@ -10,6 +10,16 @@ RSpec.describe 'Update MODS' do
                   admin_policy_object_id: 'druid:dd999df4567')
   end
 
+  let(:xml) do
+    <<~XML
+      <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <titleInfo>
+          <title>Hello</title>
+        </titleInfo>
+      </mods>
+    XML
+  end
+
   before do
     object.descMetadata.title_info.main_title = 'Goodbye'
     allow(Dor).to receive(:find).and_return(object)
@@ -19,16 +29,6 @@ RSpec.describe 'Update MODS' do
   end
 
   context 'with valid xml' do
-    let(:xml) do
-      <<~XML
-        <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-          <titleInfo>
-            <title>Hello</title>
-          </titleInfo>
-        </mods>
-      XML
-    end
-
     it 'updates the source MODS xml' do
       put '/v1/objects/druid:mk420bs7601/metadata/mods',
           params: xml,
@@ -54,6 +54,22 @@ RSpec.describe 'Update MODS' do
           params: xml,
           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  context 'when invalid cocina' do
+    before do
+      allow(Cocina::Mapper).to receive(:build).and_raise(Cocina::Mapper::UnexpectedBuildError, ' #/components/schemas/DRO missing required parameters')
+    end
+
+    it 'returns error' do
+      put '/v1/objects/druid:mk420bs7601/metadata/mods',
+          params: xml,
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to match(/Unexpected Cocina::Mapper.build error/)
+      expect(object).not_to have_received(:save!)
     end
   end
 end


### PR DESCRIPTION
closes #3426

## Why was this change made?
To prevent users from producing bad data when editing datastreams.


## How was this change tested?
Unit, qa


## Which documentation and/or configurations were updated?



