### PR TITLE
[SPIKE] Use blocks to run report functions

### DIFF
--- a/bin/reports/report-content-file_deliver
+++ b/bin/reports/report-content-file_deliver
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def has_file_deliver?(ng_xml)
+Report.new(name: 'content-file-deliver', dsid: 'contentMetadata').run do |ng_xml|
   ng_xml.root.xpath('//file/@deliver').present?
 end
-
-Report.new(name: 'content-file-deliver', dsid: 'contentMetadata', report_func: method(:has_file_deliver?)).run

--- a/bin/reports/report-content-missing_mimeType
+++ b/bin/reports/report-content-missing_mimeType
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def missing_mime_type?(ng_xml)
+Report.new(name: 'content-missing_mimeType', dsid: 'contentMetadata').run do |ng_xml|
   ng_xml.root.xpath('//file[not(@mimetype)]').present?
 end
-
-Report.new(name: 'content-missing_mimeType', dsid: 'contentMetadata', report_func: method(:missing_mime_type?)).run

--- a/bin/reports/report-content-missing_size
+++ b/bin/reports/report-content-missing_size
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def missing_size?(ng_xml)
+Report.new(name: 'content-missing_size', dsid: 'contentMetadata').run do |ng_xml|
   ng_xml.root.xpath('//file[not(@size)]').present?
 end
-
-Report.new(name: 'content-missing_size', dsid: 'contentMetadata', report_func: method(:missing_size?)).run

--- a/bin/reports/report-content-not_in_sequence
+++ b/bin/reports/report-content-not_in_sequence
@@ -4,10 +4,8 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def not_in_sequence?(ng_xml)
+Report.new(name: 'content-not_in_sequence', dsid: 'contentMetadata').run do |ng_xml|
   resource_nodes = ng_xml.root.xpath('//resource[@sequence]').to_a
   sorted_resource_nodes = resource_nodes.sort_by { |resource_node| resource_node[:sequence].to_i }
   resource_nodes != sorted_resource_nodes
 end
-
-Report.new(name: 'content-not_in_sequence', dsid: 'contentMetadata', report_func: method(:not_in_sequence?)).run

--- a/bin/reports/report-content-objectid
+++ b/bin/reports/report-content-objectid
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def has_resource_objectid?(ng_xml)
+Report.new(name: 'content-resource-objectid', dsid: 'contentMetadata').run do |ng_xml|
   ng_xml.root.xpath('//resource/@objectId').present?
 end
-
-Report.new(name: 'content-resource-objectid', dsid: 'contentMetadata', report_func: method(:has_resource_objectid?)).run

--- a/bin/reports/report-content-thumb
+++ b/bin/reports/report-content-thumb
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def has_resource_thumb?(ng_xml)
+Report.new(name: 'content-resource-thumb', dsid: 'contentMetadata').run do |ng_xml|
   ng_xml.root.xpath('//resource/@thumb').present?
 end
-
-Report.new(name: 'content-resource-thumb', dsid: 'contentMetadata', report_func: method(:has_resource_thumb?)).run

--- a/bin/reports/report-content-virtual
+++ b/bin/reports/report-content-virtual
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def virtual?(ng_xml)
+Report.new(name: 'content-virtual', dsid: 'contentMetadata').run do |ng_xml|
   ng_xml.root.xpath('//externalFile').present?
 end
-
-Report.new(name: 'content-virtual', dsid: 'contentMetadata', report_func: method(:virtual?)).run

--- a/bin/reports/report-desc-abstract_displayLabels
+++ b/bin/reports/report-desc-abstract_displayLabels
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/unique_report'
 
-def abstract_display_labels(ng_xml)
+UniqueReport.new(name: 'desc-abstract_displayLabels', dsid: 'descMetadata').run do |ng_xml|
   ng_xml.root.xpath('//mods:abstract/@displayLabel', mods: MODS_NS).map(&:content)
 end
-
-UniqueReport.new(name: 'desc-abstract_displayLabels', dsid: 'descMetadata', report_func: method(:abstract_display_labels)).run

--- a/bin/reports/report-desc-abstract_types
+++ b/bin/reports/report-desc-abstract_types
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/unique_report'
 
-def abstract_types(ng_xml)
+UniqueReport.new(name: 'desc-abstract_types', dsid: 'descMetadata').run do |ng_xml|
   ng_xml.root.xpath('//mods:abstract/@type', mods: MODS_NS).map(&:content)
 end
-
-UniqueReport.new(name: 'desc-abstract_types', dsid: 'descMetadata', report_func: method(:abstract_types)).run

--- a/bin/reports/report-desc-attrs_spaces
+++ b/bin/reports/report-desc-attrs_spaces
@@ -4,11 +4,9 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def attributes_start_with_spaces?(ng_xml)
+Report.new(name: 'desc-attrs_spaces', dsid: 'descMetadata').run do |ng_xml|
   bad_elements = ng_xml.root.xpath('//*[(starts-with(@*, " "))]')
   return false if bad_elements.empty?
 
   bad_elements.map(&:to_s).join('; ')
 end
-
-Report.new(name: 'desc-attrs_spaces', dsid: 'descMetadata', report_func: method(:attributes_start_with_spaces?)).run

--- a/bin/reports/report-desc-bad_event_type
+++ b/bin/reports/report-desc-bad_event_type
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def bad_event_type?(ng_xml)
+Report.new(name: 'desc-bad_event_type', dsid: 'descMetadata').run do |ng_xml|
   ng_xml.root.xpath('mods:originInfo[@eventType = "Production" or @eventType = "publisher"]', mods: MODS_NS).present?
 end
-
-Report.new(name: 'desc-bad_event_type', dsid: 'descMetadata', report_func: method(:bad_event_type?)).run

--- a/bin/reports/report-desc-bad_value_uri
+++ b/bin/reports/report-desc-bad_value_uri
@@ -4,11 +4,9 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def elements_with_bad_value_uri(ng_xml)
+Report.new(name: 'desc-bad_value_uri', dsid: 'descMetadata').run do |ng_xml|
   bad_elements = ng_xml.root.xpath('mods:*[@valueURI and not(starts-with(@valueURI, "http"))]', mods: MODS_NS)
   return false if bad_elements.empty?
 
   bad_elements.map(&:name).uniq.join(', ')
 end
-
-Report.new(name: 'desc-bad_value_uri', dsid: 'descMetadata', report_func: method(:elements_with_bad_value_uri)).run

--- a/bin/reports/report-desc-date_other
+++ b/bin/reports/report-desc-date_other
@@ -4,7 +4,7 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def date_other(ng_xml)
+Report.new(name: 'desc-date_other', dsid: 'descMetadata').run do |ng_xml|
   date_other_types = Set.new
   ng_xml.root.xpath('mods:originInfo/mods:dateOther', mods: MODS_NS).each do |element|
     date_other_types << "#{element['type'] || 'NONE'} - #{element.parent['eventType'] || 'NONE'}"
@@ -13,5 +13,3 @@ def date_other(ng_xml)
 
   date_other_types.to_a.join(', ')
 end
-
-Report.new(name: 'desc-date_other', dsid: 'descMetadata', report_func: method(:date_other)).run

--- a/bin/reports/report-desc-different_places
+++ b/bin/reports/report-desc-different_places
@@ -4,7 +4,7 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def different_places?(ng_xml)
+Report.new(name: 'desc-different_places', dsid: 'descMetadata').run do |ng_xml|
   # any place which has a placeTerm type=code and placeTerm type=text where authority is present and authorityURI or valueURI contains id.loc.gov/authorities
   ng_xml.root.xpath('//mods:place[count(mods:placeTerm) = 2]', mods: MODS_NS).each do |place_node|
     code_place_term = place_node.xpath('//mods:placeTerm[@type="code"]', mods: MODS_NS).first
@@ -18,5 +18,3 @@ def different_places?(ng_xml)
   end
   false
 end
-
-Report.new(name: 'desc-different_places', dsid: 'descMetadata', report_func: method(:different_places?)).run

--- a/bin/reports/report-desc-element_spaces
+++ b/bin/reports/report-desc-element_spaces
@@ -4,11 +4,9 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def elements_start_with_spaces?(ng_xml)
+Report.new(name: 'desc-element_spaces', dsid: 'descMetadata').run do |ng_xml|
   bad_elements = ng_xml.root.xpath('//mods:*[name() != "mods:identifier" and not(*) and text() and (starts-with(text(), " "))]', mods: MODS_NS)
   return false if bad_elements.empty?
 
   bad_elements.map(&:to_s).join('; ')
 end
-
-Report.new(name: 'desc-element_spaces', dsid: 'descMetadata', report_func: method(:elements_start_with_spaces?)).run

--- a/bin/reports/report-desc-marcgac
+++ b/bin/reports/report-desc-marcgac
@@ -4,7 +4,12 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def bad_marcgac?(ng_xml)
+Report.new(name: 'desc-marcgac', dsid: 'descMetadata').run do |ng_xml|
+  def code_for(geo_node)
+    # This matches the actual normalization in cocina mapping and indexing.
+    geo_node.text.sub(/-+$/, '').gsub(/[^\w-]/, '')
+  end
+
   bad_marcgac = []
 
   # The target mods is subject/geographicCode with authority="marcgac" on either element.
@@ -18,10 +23,3 @@ def bad_marcgac?(ng_xml)
   end
   bad_marcgac.present? ? bad_marcgac.join(', ') : nil
 end
-
-def code_for(geo_node)
-  # This matches the actual normalization in cocina mapping and indexing.
-  geo_node.text.sub(/-+$/, '').gsub(/[^\w-]/, '')
-end
-
-Report.new(name: 'desc-marcgac', dsid: 'descMetadata', report_func: method(:bad_marcgac?)).run

--- a/bin/reports/report-desc-metadata_toolkit
+++ b/bin/reports/report-desc-metadata_toolkit
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def metadata_toolkit?(ng_xml)
+Report.new(name: 'desc-metadata_toolkit', dsid: 'descMetadata').run do |ng_xml|
   ng_xml.root.xpath('//mods:recordContentSource[contains(text(), "Metadata ToolKit")]', mods: MODS_NS).present?
 end
-
-Report.new(name: 'desc-metadata_toolkit', dsid: 'descMetadata', report_func: method(:metadata_toolkit?)).run

--- a/bin/reports/report-desc-mods_34_from_marc
+++ b/bin/reports/report-desc-mods_34_from_marc
@@ -4,9 +4,7 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def mods_34_from_marc?(ng_xml)
+Report.new(name: 'desc-mods_34_from_marc', dsid: 'descMetadata').run do |ng_xml|
   ng_xml.root['version'] == '3.4' &&
     ng_xml.root.xpath('mods:recordInfo/mods:recordIdentifier[starts-with(text(), "a")]', mods: MODS_NS).present?
 end
-
-Report.new(name: 'desc-mods_34_from_marc', dsid: 'descMetadata', report_func: method(:mods_34_from_marc?)).run

--- a/bin/reports/report-desc-mods_attrs
+++ b/bin/reports/report-desc-mods_attrs
@@ -4,17 +4,15 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-# rubocop:disable Layout/LineLength
-MODS_ATTRS = %w[ID access altFormat altRepGroup altType areaType authority authorityURI calendar citySectionType collection contentType dateLastAccessed displayLabel edition encoding eventType generator invalid keyDate lang level manuscript nameTitleGroup note objectPart order otherType otherTypeAuth otherTypeAuthURI otherTypeURI period point qualifier regionType script shareable source supplied transliteration type typeURI unit unitType usage valueURI version].freeze
-# rubocop:enable Layout/LineLength
+Report.new(name: 'desc-mods_attrs', dsid: 'descMetadata').run do |ng_xml|
+  # rubocop:disable Layout/LineLength
+  mods_attrs = %w[ID access altFormat altRepGroup altType areaType authority authorityURI calendar citySectionType collection contentType dateLastAccessed displayLabel edition encoding eventType generator invalid keyDate lang level manuscript nameTitleGroup note objectPart order otherType otherTypeAuth otherTypeAuthURI otherTypeURI period point qualifier regionType script shareable source supplied transliteration type typeURI unit unitType usage valueURI version].freeze
+  # rubocop:enable Layout/LineLength
 
-def check_attrs(ng_xml)
   bad_attrs = Set.new
   ng_xml.xpath('//@*').each do |attr|
     # Namespace is nil for MODS
-    bad_attrs << attr.name if MODS_ATTRS.exclude?(attr.name) && attr.namespace.nil?
+    bad_attrs << attr.name if mods_attrs.exclude?(attr.name) && attr.namespace.nil?
   end
   bad_attrs.present? ? bad_attrs.to_a.join(', ') : false
 end
-
-Report.new(name: 'desc-mods_attrs', dsid: 'descMetadata', report_func: method(:check_attrs)).run

--- a/bin/reports/report-desc-mods_elements
+++ b/bin/reports/report-desc-mods_elements
@@ -4,16 +4,14 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-# rubocop:disable Layout/LineLength
-MODS_ELEMENTS = %w[abstract accessCondition affiliation alternativeName area caption cartographicExtension cartographics city citySection classification continent coordinates copyInformation copyrightDate country county date dateCaptured dateCreated dateIssued dateModified dateOther dateValid description descriptionStandard detail digitalOrigin displayForm edition electronicLocator end enumerationAndChronology etal extension extent extraTerrestrialArea form frequency genre geographic geographicCode hierarchicalGeographic holdingExternal holdingSimple identifier internetMediaType island issuance itemIdentifier language languageOfCataloging languageTerm list location mods modsCollection name nameIdentifier namePart nonSort note number occupation originInfo part partName partNumber physicalDescription physicalLocation place placeTerm projection province publisher recordChangeDate recordContentSource recordCreationDate recordIdentifier recordInfo recordInfoNote recordOrigin reformattingQuality region relatedItem role roleTerm scale scriptTerm shelfLocator start state subLocation subTitle subject tableOfContents targetAudience temporal territory text title titleInfo topic total typeOfResource url].freeze
-# rubocop:enable Layout/LineLength
+Report.new(name: 'desc-mods_elements', dsid: 'descMetadata').run do |ng_xml|
+  # rubocop:disable Layout/LineLength
+  mods_elements = %w[abstract accessCondition affiliation alternativeName area caption cartographicExtension cartographics city citySection classification continent coordinates copyInformation copyrightDate country county date dateCaptured dateCreated dateIssued dateModified dateOther dateValid description descriptionStandard detail digitalOrigin displayForm edition electronicLocator end enumerationAndChronology etal extension extent extraTerrestrialArea form frequency genre geographic geographicCode hierarchicalGeographic holdingExternal holdingSimple identifier internetMediaType island issuance itemIdentifier language languageOfCataloging languageTerm list location mods modsCollection name nameIdentifier namePart nonSort note number occupation originInfo part partName partNumber physicalDescription physicalLocation place placeTerm projection province publisher recordChangeDate recordContentSource recordCreationDate recordIdentifier recordInfo recordInfoNote recordOrigin reformattingQuality region relatedItem role roleTerm scale scriptTerm shelfLocator start state subLocation subTitle subject tableOfContents targetAudience temporal territory text title titleInfo topic total typeOfResource url].freeze
+  # rubocop:enable Layout/LineLength
 
-def check_elements(ng_xml)
   bad_elements = Set.new
   ng_xml.xpath('//mods:*', mods: MODS_NS).each do |element|
-    bad_elements << element.name if MODS_ELEMENTS.exclude?(element.name)
+    bad_elements << element.name if mods_elements.exclude?(element.name)
   end
   bad_elements.present? ? bad_elements.to_a.join(', ') : false
 end
-
-Report.new(name: 'desc-mods_elements', dsid: 'descMetadata', report_func: method(:check_elements)).run

--- a/bin/reports/report-desc-multi_langterms
+++ b/bin/reports/report-desc-multi_langterms
@@ -5,9 +5,7 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 # Records where <language> includes multiple instances of <languageTerm type="text"> or <languageTerm type="code"> (more than one code or term within same language element).
-def multiple_langterms?(ng_xml)
+Report.new(name: 'desc-multi_langterms', dsid: 'descMetadata').run do |ng_xml|
   ng_xml.root.xpath('//mods:language[count(mods:languageTerm[@type="text"]) > 1]', mods: MODS_NS).present? ||
     ng_xml.root.xpath('//mods:language[count(mods:languageTerm[@type="code"]) > 1]', mods: MODS_NS).present?
 end
-
-Report.new(name: 'desc-multi_langterms', dsid: 'descMetadata', report_func: method(:multiple_langterms?)).run

--- a/bin/reports/report-desc-note_types
+++ b/bin/reports/report-desc-note_types
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/unique_report'
 
-def note_types(ng_xml)
+UniqueReport.new(name: 'desc-note_types', dsid: 'descMetadata').run do |ng_xml|
   ng_xml.root.xpath('//mods:note/@type', mods: MODS_NS).map(&:content)
 end
-
-UniqueReport.new(name: 'desc-note_types', dsid: 'descMetadata', report_func: method(:note_types)).run

--- a/bin/reports/report-desc-parts
+++ b/bin/reports/report-desc-parts
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def has_part?(ng_xml)
+Report.new(name: 'desc-parts', dsid: 'descMetadata').run do |ng_xml|
   ng_xml.root.xpath('//mods:part', mods: MODS_NS).present?
 end
-
-Report.new(name: 'desc-parts', dsid: 'descMetadata', report_func: method(:has_part?)).run

--- a/bin/reports/report-desc-titles-translated
+++ b/bin/reports/report-desc-titles-translated
@@ -8,9 +8,6 @@ require_relative '../../lib/report'
 #   a) titleInfo has the attribute type="translated" and
 #   b) titleInfo has the attribute "transliteration" with any value.
 # Include titleInfo at any level of the hierarchy (inside subject and relatedItem for example).
-
-def translated_title(ng_xml)
+Report.new(name: 'desc-titles-translated', dsid: 'descMetadata').run do |ng_xml|
   ng_xml.root.xpath('mods:titleInfo[@type="translated"]|mods:titleInfo[@transliteration]', mods: MODS_NS).any?
 end
-
-Report.new(name: 'desc-titles-translated', dsid: 'descMetadata', report_func: method(:translated_title)).run

--- a/bin/reports/report-desc-xlink_href
+++ b/bin/reports/report-desc-xlink_href
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def has_xlink_href?(ng_xml)
+Report.new(name: 'desc-xlink_href', dsid: 'descMetadata').run do |ng_xml|
   ng_xml.xpath('//mods:*[@xlink:href]', mods: MODS_NS, xlink: 'http://www.w3.org/1999/xlink').present?
 end
-
-Report.new(name: 'desc-xlink_href', dsid: 'descMetadata', report_func: method(:has_xlink_href?)).run

--- a/bin/reports/report-identity-multi_catkeys
+++ b/bin/reports/report-identity-multi_catkeys
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def check(ng_xml)
+Report.new(name: 'identity-multi_catkeys', dsid: 'identityMetadata').run do |ng_xml|
   ng_xml.root.xpath('//otherId[@name="catkey"]').map(&:text).uniq.length > 1
 end
-
-Report.new(name: 'identity-multi_catkeys', dsid: 'identityMetadata', report_func: method(:check)).run

--- a/bin/reports/report-identity-other_ids
+++ b/bin/reports/report-identity-other_ids
@@ -4,10 +4,8 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-KNOWN_OTHER_IDS = %w[catkey barcode uuid shelfseq callseq label dissertationid previous_catkey symphony mdtoolkit].freeze
+Report.new(name: 'identity-other_ids', dsid: 'identityMetadata').run do |ng_xml|
+  known_other_ids = %w[catkey barcode uuid shelfseq callseq label dissertationid previous_catkey symphony mdtoolkit].freeze
 
-def other_ids(ng_xml)
-  ng_xml.root.xpath('//otherId/@name').map(&:content).reject { |name| KNOWN_OTHER_IDS.include?(name) }.join(', ').presence
+  ng_xml.root.xpath('//otherId/@name').map(&:content).reject { |name| known_other_ids.include?(name) }.join(', ').presence
 end
-
-Report.new(name: 'identity-other_ids', dsid: 'identityMetadata', report_func: method(:other_ids)).run

--- a/bin/reports/report-identity-otherids_labels
+++ b/bin/reports/report-identity-otherids_labels
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def check(ng_xml)
+Report.new(name: 'identity-otherids_labels', dsid: 'identityMetadata').run do |ng_xml|
   ng_xml.root.xpath('//otherId[@name="label"]').map(&:content).join(', ').presence
 end
-
-Report.new(name: 'identity-otherids_labels', dsid: 'identityMetadata', report_func: method(:check)).run

--- a/bin/reports/report-identity-source_id
+++ b/bin/reports/report-identity-source_id
@@ -5,9 +5,7 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 # Records where <otherId> has name="dissertationid" and also <sourceId> has source that's not "dissertation"
-def has_sourceid_notdissid?(ng_xml)
+Report.new(name: 'no-sourceid-dissid', dsid: 'identityMetadata').run do |ng_xml|
   ng_xml.root.xpath('//otherId[@name="dissertationid"]').present? &&
     ng_xml.root.xpath('//sourceId[@source!="dissertation"]').present?
 end
-
-Report.new(name: 'no-sourceid-dissid', dsid: 'identityMetadata', report_func: method(:has_sourceid_notdissid?)).run

--- a/bin/reports/report-rels-apo_agreement_ids
+++ b/bin/reports/report-rels-apo_agreement_ids
@@ -4,15 +4,13 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-RDF_NS = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
-HYDRA_NS = 'http://projecthydra.org/ns/relations#'
-FEDORA_NS = 'info:fedora/fedora-system:def/model#'
+Report.new(name: 'rels_apo_without_agreement_ids', dsid: 'RELS-EXT').run do |ng_xml|
+  rdf_ns = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+  hydra_ns = 'http://projecthydra.org/ns/relations#'
+  fedora_ns = 'info:fedora/fedora-system:def/model#'
 
-def check(ng_xml)
   ng_xml.root.xpath(
     '//fedora:hasModel[@rdf:resource="info:fedora/afmodel:Hydrus_AdminPolicyObject" ' \
-    'or @rdf:resource="info:fedora/afmodel:Dor_AdminPolicyObject"] and not(//hydra:referencesAgreement)', hydra: HYDRA_NS, fedora: FEDORA_NS, rdf: RDF_NS
+    'or @rdf:resource="info:fedora/afmodel:Dor_AdminPolicyObject"] and not(//hydra:referencesAgreement)', hydra: hydra_ns, fedora: fedora_ns, rdf: rdf_ns
   )
 end
-
-Report.new(name: 'rels_apo_without_agreement_ids', dsid: 'RELS-EXT', report_func: method(:check)).run

--- a/bin/reports/report-rights-access_condition
+++ b/bin/reports/report-rights-access_condition
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def has_access_condition?(ng_xml)
+Report.new(name: 'rights-access_condition', dsid: 'rightsMetadata').run do |ng_xml|
   ng_xml.root.xpath('accessCondition').present?
 end
-
-Report.new(name: 'rights-access_condition', dsid: 'rightsMetadata', report_func: method(:has_access_condition?)).run

--- a/bin/reports/report-rights-missing_use
+++ b/bin/reports/report-rights-missing_use
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def missing_use?(ng_xml)
+Report.new(name: 'rights-missing_use', dsid: 'rightsMetadata').run do |ng_xml|
   ng_xml.root.xpath('human | machine').present?
 end
-
-Report.new(name: 'rights-missing_use', dsid: 'rightsMetadata', report_func: method(:missing_use?)).run

--- a/bin/reports/report-role-groups
+++ b/bin/reports/report-role-groups
@@ -4,8 +4,6 @@
 require_relative '../../config/environment'
 require_relative '../../lib/report'
 
-def has_group_no_role?(ng_xml)
+Report.new(name: 'role-group-without-role', dsid: 'roleMetadata').run do |ng_xml|
   ng_xml.root.xpath('//roleMetadata/group').present?
 end
-
-Report.new(name: 'role-group-without-role', dsid: 'roleMetadata', report_func: method(:has_group_no_role?)).run


### PR DESCRIPTION
## Why was this change made?

To aspire to more Rubyish conventions.

## How was this change tested?

Ran a changed report on sdr-deploy (for virtual objects) and it worked.

## Which documentation and/or configurations were updated?

None
