### PR TITLE
Remove redundant explicit call to Nokogiri root node in reports

### DIFF
--- a/bin/reports/report-content-file_deliver
+++ b/bin/reports/report-content-file_deliver
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'content-file-deliver', dsid: 'contentMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//file/@deliver').present?
+  ng_xml.xpath('//file/@deliver').present?
 end

--- a/bin/reports/report-content-missing_mimeType
+++ b/bin/reports/report-content-missing_mimeType
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'content-missing_mimeType', dsid: 'contentMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//file[not(@mimetype)]').present?
+  ng_xml.xpath('//file[not(@mimetype)]').present?
 end

--- a/bin/reports/report-content-missing_size
+++ b/bin/reports/report-content-missing_size
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'content-missing_size', dsid: 'contentMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//file[not(@size)]').present?
+  ng_xml.xpath('//file[not(@size)]').present?
 end

--- a/bin/reports/report-content-not_in_sequence
+++ b/bin/reports/report-content-not_in_sequence
@@ -5,7 +5,7 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'content-not_in_sequence', dsid: 'contentMetadata').run do |ng_xml|
-  resource_nodes = ng_xml.root.xpath('//resource[@sequence]').to_a
+  resource_nodes = ng_xml.xpath('//resource[@sequence]').to_a
   sorted_resource_nodes = resource_nodes.sort_by { |resource_node| resource_node[:sequence].to_i }
   resource_nodes != sorted_resource_nodes
 end

--- a/bin/reports/report-content-objectid
+++ b/bin/reports/report-content-objectid
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'content-resource-objectid', dsid: 'contentMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//resource/@objectId').present?
+  ng_xml.xpath('//resource/@objectId').present?
 end

--- a/bin/reports/report-content-thumb
+++ b/bin/reports/report-content-thumb
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'content-resource-thumb', dsid: 'contentMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//resource/@thumb').present?
+  ng_xml.xpath('//resource/@thumb').present?
 end

--- a/bin/reports/report-content-virtual
+++ b/bin/reports/report-content-virtual
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'content-virtual', dsid: 'contentMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//externalFile').present?
+  ng_xml.xpath('//externalFile').present?
 end

--- a/bin/reports/report-desc-abstract_displayLabels
+++ b/bin/reports/report-desc-abstract_displayLabels
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/unique_report'
 
 UniqueReport.new(name: 'desc-abstract_displayLabels', dsid: 'descMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//mods:abstract/@displayLabel', mods: MODS_NS).map(&:content)
+  ng_xml.xpath('//mods:abstract/@displayLabel', mods: MODS_NS).map(&:content)
 end

--- a/bin/reports/report-desc-abstract_types
+++ b/bin/reports/report-desc-abstract_types
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/unique_report'
 
 UniqueReport.new(name: 'desc-abstract_types', dsid: 'descMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//mods:abstract/@type', mods: MODS_NS).map(&:content)
+  ng_xml.xpath('//mods:abstract/@type', mods: MODS_NS).map(&:content)
 end

--- a/bin/reports/report-desc-attrs_spaces
+++ b/bin/reports/report-desc-attrs_spaces
@@ -5,7 +5,7 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'desc-attrs_spaces', dsid: 'descMetadata').run do |ng_xml|
-  bad_elements = ng_xml.root.xpath('//*[(starts-with(@*, " "))]')
+  bad_elements = ng_xml.xpath('//*[(starts-with(@*, " "))]')
   return false if bad_elements.empty?
 
   bad_elements.map(&:to_s).join('; ')

--- a/bin/reports/report-desc-bad_event_type
+++ b/bin/reports/report-desc-bad_event_type
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'desc-bad_event_type', dsid: 'descMetadata').run do |ng_xml|
-  ng_xml.root.xpath('mods:originInfo[@eventType = "Production" or @eventType = "publisher"]', mods: MODS_NS).present?
+  ng_xml.xpath('mods:originInfo[@eventType = "Production" or @eventType = "publisher"]', mods: MODS_NS).present?
 end

--- a/bin/reports/report-desc-bad_value_uri
+++ b/bin/reports/report-desc-bad_value_uri
@@ -5,7 +5,7 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'desc-bad_value_uri', dsid: 'descMetadata').run do |ng_xml|
-  bad_elements = ng_xml.root.xpath('mods:*[@valueURI and not(starts-with(@valueURI, "http"))]', mods: MODS_NS)
+  bad_elements = ng_xml.xpath('mods:*[@valueURI and not(starts-with(@valueURI, "http"))]', mods: MODS_NS)
   return false if bad_elements.empty?
 
   bad_elements.map(&:name).uniq.join(', ')

--- a/bin/reports/report-desc-date_other
+++ b/bin/reports/report-desc-date_other
@@ -6,7 +6,7 @@ require_relative '../../lib/report'
 
 Report.new(name: 'desc-date_other', dsid: 'descMetadata').run do |ng_xml|
   date_other_types = Set.new
-  ng_xml.root.xpath('mods:originInfo/mods:dateOther', mods: MODS_NS).each do |element|
+  ng_xml.xpath('mods:originInfo/mods:dateOther', mods: MODS_NS).each do |element|
     date_other_types << "#{element['type'] || 'NONE'} - #{element.parent['eventType'] || 'NONE'}"
   end
   return false if date_other_types.empty?

--- a/bin/reports/report-desc-different_places
+++ b/bin/reports/report-desc-different_places
@@ -6,7 +6,7 @@ require_relative '../../lib/report'
 
 Report.new(name: 'desc-different_places', dsid: 'descMetadata').run do |ng_xml|
   # any place which has a placeTerm type=code and placeTerm type=text where authority is present and authorityURI or valueURI contains id.loc.gov/authorities
-  ng_xml.root.xpath('//mods:place[count(mods:placeTerm) = 2]', mods: MODS_NS).each do |place_node|
+  ng_xml.xpath('//mods:place[count(mods:placeTerm) = 2]', mods: MODS_NS).each do |place_node|
     code_place_term = place_node.xpath('//mods:placeTerm[@type="code"]', mods: MODS_NS).first
     text_place_term = place_node.xpath('//mods:placeTerm[@type="text"]', mods: MODS_NS).first
     next unless code_place_term && text_place_term

--- a/bin/reports/report-desc-element_spaces
+++ b/bin/reports/report-desc-element_spaces
@@ -5,7 +5,7 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'desc-element_spaces', dsid: 'descMetadata').run do |ng_xml|
-  bad_elements = ng_xml.root.xpath('//mods:*[name() != "mods:identifier" and not(*) and text() and (starts-with(text(), " "))]', mods: MODS_NS)
+  bad_elements = ng_xml.xpath('//mods:*[name() != "mods:identifier" and not(*) and text() and (starts-with(text(), " "))]', mods: MODS_NS)
   return false if bad_elements.empty?
 
   bad_elements.map(&:to_s).join('; ')

--- a/bin/reports/report-desc-marcgac
+++ b/bin/reports/report-desc-marcgac
@@ -13,11 +13,11 @@ Report.new(name: 'desc-marcgac', dsid: 'descMetadata').run do |ng_xml|
   bad_marcgac = []
 
   # The target mods is subject/geographicCode with authority="marcgac" on either element.
-  ng_xml.root.xpath('//mods:subject/mods:geographicCode[@authority="marcgac"]', mods: MODS_NS).map do |geo_node|
+  ng_xml.xpath('//mods:subject/mods:geographicCode[@authority="marcgac"]', mods: MODS_NS).map do |geo_node|
     code = code_for(geo_node)
     bad_marcgac << code unless Marc::Vocab::GeographicArea.fetch(code, nil)
   end
-  ng_xml.root.xpath('//mods:subject[@authority="marcgac"]/mods:geographicCode', mods: MODS_NS).map do |geo_node|
+  ng_xml.xpath('//mods:subject[@authority="marcgac"]/mods:geographicCode', mods: MODS_NS).map do |geo_node|
     code = code_for(geo_node)
     bad_marcgac << code unless Marc::Vocab::GeographicArea.fetch(code, nil)
   end

--- a/bin/reports/report-desc-metadata_toolkit
+++ b/bin/reports/report-desc-metadata_toolkit
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'desc-metadata_toolkit', dsid: 'descMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//mods:recordContentSource[contains(text(), "Metadata ToolKit")]', mods: MODS_NS).present?
+  ng_xml.xpath('//mods:recordContentSource[contains(text(), "Metadata ToolKit")]', mods: MODS_NS).present?
 end

--- a/bin/reports/report-desc-mods_34_from_marc
+++ b/bin/reports/report-desc-mods_34_from_marc
@@ -5,6 +5,6 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'desc-mods_34_from_marc', dsid: 'descMetadata').run do |ng_xml|
-  ng_xml.root['version'] == '3.4' &&
-    ng_xml.root.xpath('mods:recordInfo/mods:recordIdentifier[starts-with(text(), "a")]', mods: MODS_NS).present?
+  ng_xml['version'] == '3.4' &&
+    ng_xml.xpath('mods:recordInfo/mods:recordIdentifier[starts-with(text(), "a")]', mods: MODS_NS).present?
 end

--- a/bin/reports/report-desc-multi_langterms
+++ b/bin/reports/report-desc-multi_langterms
@@ -6,6 +6,6 @@ require_relative '../../lib/report'
 
 # Records where <language> includes multiple instances of <languageTerm type="text"> or <languageTerm type="code"> (more than one code or term within same language element).
 Report.new(name: 'desc-multi_langterms', dsid: 'descMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//mods:language[count(mods:languageTerm[@type="text"]) > 1]', mods: MODS_NS).present? ||
-    ng_xml.root.xpath('//mods:language[count(mods:languageTerm[@type="code"]) > 1]', mods: MODS_NS).present?
+  ng_xml.xpath('//mods:language[count(mods:languageTerm[@type="text"]) > 1]', mods: MODS_NS).present? ||
+    ng_xml.xpath('//mods:language[count(mods:languageTerm[@type="code"]) > 1]', mods: MODS_NS).present?
 end

--- a/bin/reports/report-desc-note_types
+++ b/bin/reports/report-desc-note_types
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/unique_report'
 
 UniqueReport.new(name: 'desc-note_types', dsid: 'descMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//mods:note/@type', mods: MODS_NS).map(&:content)
+  ng_xml.xpath('//mods:note/@type', mods: MODS_NS).map(&:content)
 end

--- a/bin/reports/report-desc-parts
+++ b/bin/reports/report-desc-parts
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'desc-parts', dsid: 'descMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//mods:part', mods: MODS_NS).present?
+  ng_xml.xpath('//mods:part', mods: MODS_NS).present?
 end

--- a/bin/reports/report-desc-titles-translated
+++ b/bin/reports/report-desc-titles-translated
@@ -9,5 +9,5 @@ require_relative '../../lib/report'
 #   b) titleInfo has the attribute "transliteration" with any value.
 # Include titleInfo at any level of the hierarchy (inside subject and relatedItem for example).
 Report.new(name: 'desc-titles-translated', dsid: 'descMetadata').run do |ng_xml|
-  ng_xml.root.xpath('mods:titleInfo[@type="translated"]|mods:titleInfo[@transliteration]', mods: MODS_NS).any?
+  ng_xml.xpath('mods:titleInfo[@type="translated"]|mods:titleInfo[@transliteration]', mods: MODS_NS).any?
 end

--- a/bin/reports/report-identity-multi_catkeys
+++ b/bin/reports/report-identity-multi_catkeys
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'identity-multi_catkeys', dsid: 'identityMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//otherId[@name="catkey"]').map(&:text).uniq.length > 1
+  ng_xml.xpath('//otherId[@name="catkey"]').map(&:text).uniq.length > 1
 end

--- a/bin/reports/report-identity-other_ids
+++ b/bin/reports/report-identity-other_ids
@@ -7,5 +7,5 @@ require_relative '../../lib/report'
 Report.new(name: 'identity-other_ids', dsid: 'identityMetadata').run do |ng_xml|
   known_other_ids = %w[catkey barcode uuid shelfseq callseq label dissertationid previous_catkey symphony mdtoolkit].freeze
 
-  ng_xml.root.xpath('//otherId/@name').map(&:content).reject { |name| known_other_ids.include?(name) }.join(', ').presence
+  ng_xml.xpath('//otherId/@name').map(&:content).reject { |name| known_other_ids.include?(name) }.join(', ').presence
 end

--- a/bin/reports/report-identity-otherids_labels
+++ b/bin/reports/report-identity-otherids_labels
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'identity-otherids_labels', dsid: 'identityMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//otherId[@name="label"]').map(&:content).join(', ').presence
+  ng_xml.xpath('//otherId[@name="label"]').map(&:content).join(', ').presence
 end

--- a/bin/reports/report-identity-source_id
+++ b/bin/reports/report-identity-source_id
@@ -6,6 +6,6 @@ require_relative '../../lib/report'
 
 # Records where <otherId> has name="dissertationid" and also <sourceId> has source that's not "dissertation"
 Report.new(name: 'no-sourceid-dissid', dsid: 'identityMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//otherId[@name="dissertationid"]').present? &&
-    ng_xml.root.xpath('//sourceId[@source!="dissertation"]').present?
+  ng_xml.xpath('//otherId[@name="dissertationid"]').present? &&
+    ng_xml.xpath('//sourceId[@source!="dissertation"]').present?
 end

--- a/bin/reports/report-rels-apo_agreement_ids
+++ b/bin/reports/report-rels-apo_agreement_ids
@@ -9,7 +9,7 @@ Report.new(name: 'rels_apo_without_agreement_ids', dsid: 'RELS-EXT').run do |ng_
   hydra_ns = 'http://projecthydra.org/ns/relations#'
   fedora_ns = 'info:fedora/fedora-system:def/model#'
 
-  ng_xml.root.xpath(
+  ng_xml.xpath(
     '//fedora:hasModel[@rdf:resource="info:fedora/afmodel:Hydrus_AdminPolicyObject" ' \
     'or @rdf:resource="info:fedora/afmodel:Dor_AdminPolicyObject"] and not(//hydra:referencesAgreement)', hydra: hydra_ns, fedora: fedora_ns, rdf: rdf_ns
   )

--- a/bin/reports/report-rights-access_condition
+++ b/bin/reports/report-rights-access_condition
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'rights-access_condition', dsid: 'rightsMetadata').run do |ng_xml|
-  ng_xml.root.xpath('accessCondition').present?
+  ng_xml.xpath('accessCondition').present?
 end

--- a/bin/reports/report-rights-missing_use
+++ b/bin/reports/report-rights-missing_use
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'rights-missing_use', dsid: 'rightsMetadata').run do |ng_xml|
-  ng_xml.root.xpath('human | machine').present?
+  ng_xml.xpath('human | machine').present?
 end

--- a/bin/reports/report-role-groups
+++ b/bin/reports/report-role-groups
@@ -5,5 +5,5 @@ require_relative '../../config/environment'
 require_relative '../../lib/report'
 
 Report.new(name: 'role-group-without-role', dsid: 'roleMetadata').run do |ng_xml|
-  ng_xml.root.xpath('//roleMetadata/group').present?
+  ng_xml.xpath('//roleMetadata/group').present?
 end


### PR DESCRIPTION
## Why was this change made?

To remove redundancy.

## How was this change tested?

Ran a test report in sdr-deploy and it ran as expected, producing the same CSV results as before the change.

## Which documentation and/or configurations were updated?

None
