### PR TITLE
add report for /contentMetadata/resource/file/videoData

### DIFF
--- a/bin/reports/report-content-video-data
+++ b/bin/reports/report-content-video-data
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+Report.new(name: 'content-file-video-data', dsid: 'contentMetadata').run do |ng_xml|
+  ng_xml.xpath('/contentMetadata/resource/file/videoData').present?
+end


### PR DESCRIPTION
## Why was this change made?

As part of #3445, determine if there is more than one record with /contentMetadata/resource/file/videoData

## How was this change tested?

ran it locally on a record known to have this condition.

## Which documentation and/or configurations were updated?



