### PR TITLE
add report for /contentMetadata/resource/file checksum attributes

### DIFF
--- a/bin/reports/report-content-checksum-attribs
+++ b/bin/reports/report-content-checksum-attribs
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+Report.new(name: 'content-checksum-attribs', dsid: 'contentMetadata').run do |ng_xml|
+  ng_xml.xpath('/contentMetadata/resource/file/@md5').present? || ng_xml.xpath('/contentMetadata/resource/file/@sha1').present?
+end


### PR DESCRIPTION
## Why was this change made?

as part of #3444 determine if there is more than one record with /contentMetadata/resource/file with @md5 or @sha1

## How was this change tested?

ran the report locally on ETDs and it found the one ETD with this condition.

## Which documentation and/or configurations were updated?



