### PR TITLE
admin_metadata: normalize out cruft

### DIFF
--- a/app/services/cocina/normalizers/admin_normalizer.rb
+++ b/app/services/cocina/normalizers/admin_normalizer.rb
@@ -19,6 +19,10 @@ module Cocina
 
       def normalize
         remove_desc_metadata_format_mods
+        remove_desc_metadata_source
+        remove_relationships
+        remove_assembly_node
+        remove_accessioning_node
         remove_empty_registration_and_dissemination
         remove_empty_dissemination_workflow
         remove_object_id_attr
@@ -32,6 +36,24 @@ module Cocina
       # removes nodes like this: <descMetadata><format>MODS</format><descMetadata>
       def remove_desc_metadata_format_mods
         ng_xml.xpath('/administrativeMetadata/descMetadata/format[text()="MODS"]').each { |node| node.parent.remove }
+      end
+
+      # removes nodes like this: <descMetadata><source>whatevs</source><descMetadata>
+      def remove_desc_metadata_source
+        ng_xml.xpath('/administrativeMetadata/descMetadata/source').each { |node| node.parent.remove }
+      end
+
+      # we get this info from RELS-EXT
+      def remove_relationships
+        ng_xml.xpath('/administrativeMetadata/relationships').each(&:remove)
+      end
+
+      def remove_assembly_node
+        ng_xml.xpath('/administrativeMetadata/assembly').each(&:remove)
+      end
+
+      def remove_accessioning_node
+        ng_xml.xpath('/administrativeMetadata/accessioning').each(&:remove)
       end
 
       # removes empty nodes like this: <registration/> or <dissemination/> or <dissemination><workflow id="" /></dissemination>

--- a/spec/services/cocina/mapping/administrative/apo_administrative_spec.rb
+++ b/spec/services/cocina/mapping/administrative/apo_administrative_spec.rb
@@ -716,4 +716,222 @@ RSpec.describe 'APO administrative mappings' do
       end
     end
   end
+
+  context 'with objectId, descMetadata and relationships' do
+    # ff628mq8354
+    it_behaves_like 'valid APO mappings' do
+      let(:admin_metadata_xml) do
+        <<~XML
+          <administrativeMetadata objectId="druid:ff628mq8354">
+            <descMetadata>
+              <source>Symphony</source>
+            </descMetadata>
+            <relationships xmlns:fedora-rel="info:fedora/fedora-system:def/relations-external#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <fedora-rel:isMemberOf rdf:resource="info:fedora/druid:rt210jg0056"/>
+              <fedora-rel:isMemberOfCollection rdf:resource="info:fedora/druid:rt210jg0056"/>
+            </relationships>
+            <registration>
+              <workflow id="registrationWF"/>
+              <collection id="druid:rt210jg0056"/>
+            </registration>
+            <descMetadata>
+              <format>MODS</format>
+            </descMetadata>
+          </administrativeMetadata>
+        XML
+      end
+      let(:roundtrip_admin_metadata_xml) do
+        <<~XML
+          <administrativeMetadata>
+            <registration>
+              <workflow id="registrationWF"/>
+              <collection id="druid:rt210jg0056"/>
+            </registration>
+          </administrativeMetadata>
+        XML
+      end
+      let(:default_object_rights_xml) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <none/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <none/>
+              </machine>
+            </access>
+            <use>
+              <license>https://creativecommons.org/licenses/by-nc/3.0/legalcode</license>
+              <human type="useAndReproduction">Use at will.</human>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+      let(:role_metadata_xml) do
+        <<~XML
+          <roleMetadata>
+            <role type="dor-apo-manager">
+              <group>
+                <identifier type="workgroup">sdr:developer</identifier>
+              </group>
+              <group>
+                <identifier type="workgroup">sdr:psm-staff</identifier>
+              </group>
+            </role>
+          </roleMetadata>
+        XML
+      end
+      let(:agreement_druid) { 'druid:dd327qr3670' }
+      let(:cocina) do
+        {
+          defaultAccess: {
+            access: 'dark',
+            download: 'none',
+            license: 'https://creativecommons.org/licenses/by-nc/3.0/legalcode',
+            useAndReproductionStatement: 'Use at will.'
+          },
+          registrationWorkflow: [
+            'registrationWF'
+          ],
+          collectionsForRegistration: [
+            'druid:rt210jg0056'
+          ],
+          hasAdminPolicy: ur_apo_druid,
+          hasAgreement: agreement_druid,
+          roles: [
+            {
+              name: 'dor-apo-manager',
+              members: [
+                {
+                  type: 'workgroup',
+                  identifier: 'sdr:developer'
+                },
+                {
+                  type: 'workgroup',
+                  identifier: 'sdr:psm-staff'
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
+  end
+
+  context 'with assembly and accessioning, objectId and relationships' do
+    # cb081vd1895
+    it_behaves_like 'valid APO mappings' do
+      let(:admin_metadata_xml) do
+        <<~XML
+          <administrativeMetadata objectId="druid:cb081vd1895">
+            <descMetadata>
+              <format>MODS</format>
+            </descMetadata>
+            <relationships xmlns:fedora-rel="info:fedora/fedora-system:def/relations-external#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <fedora-rel:isMemberOf rdf:resource="info:fedora/druid:kh020kr4702"/>
+              <fedora-rel:isMemberOfCollection rdf:resource="info:fedora/druid:kh020kr4702"/>
+            </relationships>
+            <registration>
+              <workflow id="registrationWF"/>
+            </registration>
+            <assembly>
+              <workflow id="assemblyWF"/>
+            </assembly>
+            <accessioning>
+              <workflow id="accessionWF"/>
+            </accessioning>
+          </administrativeMetadata>
+        XML
+      end
+      let(:roundtrip_admin_metadata_xml) do
+        <<~XML
+          <administrativeMetadata>
+            <registration>
+              <workflow id="registrationWF"/>
+            </registration>
+          </administrativeMetadata>
+        XML
+      end
+      let(:default_object_rights_xml) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <none/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <none/>
+              </machine>
+            </access>
+            <use>
+              <license>https://creativecommons.org/licenses/by-nc/3.0/legalcode</license>
+            </use>
+          </rightsMetadata>
+        XML
+      end
+      let(:role_metadata_xml) do
+        <<~XML
+          <roleMetadata objectId="druid:cb081vd1895">
+            <role type="dor-apo-manager">
+              <group>
+                <identifier type="workgroup">sdr:developer</identifier>
+              </group>
+              <group>
+                <identifier type="workgroup">sdr:metadata-staff</identifier>
+              </group>
+            </role>
+          </roleMetadata>
+        XML
+      end
+      let(:roundtrip_role_metadata_xml) do
+        <<~XML
+          <roleMetadata>
+            <role type="dor-apo-manager">
+              <group>
+                <identifier type="workgroup">sdr:developer</identifier>
+              </group>
+              <group>
+                <identifier type="workgroup">sdr:metadata-staff</identifier>
+              </group>
+            </role>
+          </roleMetadata>
+        XML
+      end
+      let(:agreement_druid) { 'druid:dd327qr3670' }
+      let(:cocina) do
+        {
+          defaultAccess: {
+            access: 'dark',
+            download: 'none',
+            license: 'https://creativecommons.org/licenses/by-nc/3.0/legalcode'
+          },
+          registrationWorkflow: [
+            'registrationWF'
+          ],
+          hasAdminPolicy: ur_apo_druid,
+          hasAgreement: agreement_druid,
+          roles: [
+            {
+              name: 'dor-apo-manager',
+              members: [
+                {
+                  type: 'workgroup',
+                  identifier: 'sdr:developer'
+                },
+                {
+                  type: 'workgroup',
+                  identifier: 'sdr:metadata-staff'
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
+  end
 end

--- a/spec/services/cocina/normalizers/admin_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/admin_normalizer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Cocina::Normalizers::AdminNormalizer do
   let(:normalized_ng_xml) { described_class.normalize(admin_ng_xml: Nokogiri::XML(original_xml)) }
 
-  context 'when #normalize_desc_metadata_nodes' do
+  describe '#remove_desc_metadata_format_mods' do
     let(:original_xml) do
       <<~XML
         <administrativeMetadata>
@@ -24,7 +24,7 @@ RSpec.describe Cocina::Normalizers::AdminNormalizer do
       XML
     end
 
-    it 'removes unncessary descMetadata node' do
+    it 'removes descMetadata node with format of MODS' do
       expect(normalized_ng_xml).to be_equivalent_to(
         <<~XML
           <administrativeMetadata>
@@ -41,7 +41,124 @@ RSpec.describe Cocina::Normalizers::AdminNormalizer do
     end
   end
 
-  context 'when #normalize_empty_registration_and_dissemination' do
+  describe '#remove_desc_metadata_source' do
+    let(:original_xml) do
+      <<~XML
+        <administrativeMetadata>
+          <descMetadata>
+            <source>Symphony</source>
+          </descMetadata>
+          <registration>
+            <workflow id="registrationWF"/>
+            <collection id="druid:rt210jg0056"/>
+          </registration>
+        </administrativeMetadata>
+      XML
+    end
+
+    it 'removes descMetadata node with source child' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <administrativeMetadata>
+            <registration>
+              <workflow id="registrationWF"/>
+              <collection id="druid:rt210jg0056"/>
+            </registration>
+          </administrativeMetadata>
+        XML
+      )
+    end
+  end
+
+  describe '#remove_relationships' do
+    let(:original_xml) do
+      <<~XML
+        <administrativeMetadata>
+          <relationships xmlns:fedora-rel="info:fedora/fedora-system:def/relations-external#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <fedora-rel:isMemberOf rdf:resource="info:fedora/druid:rt210jg0056"/>
+            <fedora-rel:isMemberOfCollection rdf:resource="info:fedora/druid:rt210jg0056"/>
+          </relationships>
+          <registration>
+            <workflow id="registrationWF"/>
+            <collection id="druid:rt210jg0056"/>
+          </registration>
+        </administrativeMetadata>
+      XML
+    end
+
+    it 'removes relationships node' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <administrativeMetadata>
+            <registration>
+              <workflow id="registrationWF"/>
+              <collection id="druid:rt210jg0056"/>
+            </registration>
+          </administrativeMetadata>
+        XML
+      )
+    end
+  end
+
+  describe '#remove_assembly_node' do
+    let(:original_xml) do
+      <<~XML
+        <administrativeMetadata>
+          <registration>
+            <workflow id="registrationWF"/>
+            <collection id="druid:rt210jg0056"/>
+          </registration>
+          <assembly>
+            <workflow id="assemblyWF"/>
+          </assembly>
+        </administrativeMetadata>
+      XML
+    end
+
+    it 'removes assembly node' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <administrativeMetadata>
+            <registration>
+              <workflow id="registrationWF"/>
+              <collection id="druid:rt210jg0056"/>
+            </registration>
+          </administrativeMetadata>
+        XML
+      )
+    end
+  end
+
+  describe '#remove_accessioning_node' do
+    let(:original_xml) do
+      <<~XML
+        <administrativeMetadata>
+          <registration>
+            <workflow id="registrationWF"/>
+            <collection id="druid:rt210jg0056"/>
+          </registration>
+          <accessioning>
+            <workflow id="accessionWF"/>
+          </accessioning>
+        </administrativeMetadata>
+      XML
+    end
+
+    it 'removes accessioning node' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <administrativeMetadata>
+            <registration>
+              <workflow id="registrationWF"/>
+              <collection id="druid:rt210jg0056"/>
+            </registration>
+          </administrativeMetadata>
+        XML
+      )
+    end
+  end
+
+  describe '#remove_empty_registration_and_dissemination' do
     #  adapted from bb329pr4129
     let(:original_xml) do
       <<~XML
@@ -79,7 +196,7 @@ RSpec.describe Cocina::Normalizers::AdminNormalizer do
     end
   end
 
-  context 'when #normalize_empty_dissemination_workflow' do
+  describe '#remove_empty_dissemination_workflow' do
     let(:original_xml) do
       <<~XML
         <administrativeMetadata>
@@ -99,7 +216,7 @@ RSpec.describe Cocina::Normalizers::AdminNormalizer do
     end
   end
 
-  context 'when #normalize_object_id' do
+  describe '#remove_object_id_attr' do
     let(:original_xml) do
       <<~XML
         <administrativeMetadata objectId="druid:cg616xd9084">
@@ -110,7 +227,7 @@ RSpec.describe Cocina::Normalizers::AdminNormalizer do
       XML
     end
 
-    it 'removes dissemination nodes' do
+    it 'removes objectId attribute' do
       expect(normalized_ng_xml).to be_equivalent_to(
         <<~XML
           <administrativeMetadata>


### PR DESCRIPTION
## Why was this change made?

Closes #3322
Related to #3359, which is already closed.

Four separate pieces are removed from adminMetadata.xml;  all four of these only apply to APO objects
- `<relationships>`
- `<assembly>`
- `<accessioning>`
- `<descriptiveMetadata>` with a `<source>` child.

## How was this change tested?

unit tests, roundtrip unit test,  and run actual roundtrips against APOs, and mixed object types.

`$ bin/validate-cocina-roundtrip -i druids.apos.txt -f -n`

### THIS branch (after)

[expect SMALL "Different" numbers in this section]

**APOs only:**

```
Status (n=1264; not using Missing for success/different/error stats):
  Success:   1192 (94.304%)
  Different: 72 (5.696%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     0 (0.0%)
  Bad cache:     0 (0.0%)
```

**100,000 records, all flavors**

```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99898 (99.98%)
  Different: 6 (0.006%)
  Mapping error:     14 (0.014%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```


### MAIN branch (before)

[expect BIGGER "Different" numbers below]

**APOs only:**

```
Status (n=1264; not using Missing for success/different/error stats):
  Success:   1161 (91.851%)
  Different: 103 (8.149%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     0 (0.0%)
  Bad cache:     0 (0.0%)
```

**100,000 records, all flavors**

```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99896 (99.978%)
  Different: 8 (0.008%)
  Mapping error:     14 (0.014%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```


## Which documentation and/or configurations were updated?



