### PR TITLE
report for contentMetadata/resource/file[@size='']

### DIFF
--- a/bin/reports/report-content-missing-file-size
+++ b/bin/reports/report-content-missing-file-size
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+Report.new(name: 'content-missing-file-size', dsid: 'contentMetadata').run do |ng_xml|
+  ng_xml.xpath('/contentMetadata/resource/file[@size=""]').present?
+end


### PR DESCRIPTION
## Why was this change made?

add a report to help us decide how to deal with #3443

## How was this change tested?

run on ETDs and it came back with the single known ETD with this problem.

## Which documentation and/or configurations were updated?



