### PR TITLE
[Refactor] Move version metadata generation to ObjectVersion.

### DIFF
--- a/app/models/object_version.rb
+++ b/app/models/object_version.rb
@@ -81,4 +81,20 @@ class ObjectVersion < ApplicationRecord
   def self.current_version(druid)
     ObjectVersion.where(druid: druid).order(version: :desc).first
   end
+
+  # @param [String] druid
+  # @return [String] xml representation of version metadata
+  def self.version_xml(druid)
+    object_versions = ObjectVersion.where(druid: druid).order(:version)
+
+    Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
+      xml.versionMetadata({ objectId: druid }) do
+        object_versions.each do |object_version|
+          xml.version({ versionId: object_version.version, tag: object_version.tag }.compact) do
+            xml.description(object_version.description) if object_version.description
+          end
+        end
+      end
+    end.to_xml
+  end
 end

--- a/app/services/datastream_extractor.rb
+++ b/app/services/datastream_extractor.rb
@@ -76,16 +76,6 @@ class DatastreamExtractor
     # This can be removed after migration.
     VersionMigrationService.migrate(item)
 
-    object_versions = ObjectVersion.where(druid: item.pid).order(:version)
-
-    Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
-      xml.versionMetadata({ objectId: item.pid }) do
-        object_versions.each do |object_version|
-          xml.version({ versionId: object_version.version, tag: object_version.tag }.compact) do
-            xml.description(object_version.description) if object_version.description
-          end
-        end
-      end
-    end.to_xml
+    ObjectVersion.version_xml(item.pid)
   end
 end

--- a/spec/models/object_version_spec.rb
+++ b/spec/models/object_version_spec.rb
@@ -178,4 +178,29 @@ RSpec.describe ObjectVersion, type: :model do
       end
     end
   end
+
+  describe '#version_xml' do
+    let(:expected_xml) do
+      <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+          <versionMetadata objectId="#{druid}">
+            <version versionId="1" tag="1.0.0">
+              <description>
+                Initial version
+              </description>
+            </version>
+            <version versionId="2"/>
+          </versionMetadata>
+      XML
+    end
+
+    before do
+      described_class.create(druid: druid, version: 1, tag: '1.0.0', description: 'Initial version')
+      described_class.create(druid: druid, version: 2)
+    end
+
+    it 'returns xml' do
+      expect(described_class.version_xml(druid)).to be_equivalent_to(expected_xml)
+    end
+  end
 end

--- a/spec/services/datastream_extractor_spec.rb
+++ b/spec/services/datastream_extractor_spec.rb
@@ -75,24 +75,11 @@ RSpec.describe DatastreamExtractor do
     context 'when datastream is versionMetadata' do
       let(:ds_name) { :versionMetadata }
 
-      let(:expected_xml) do
-        <<~XML
-          <?xml version="1.0" encoding="UTF-8"?>
-            <versionMetadata objectId="druid:nc893zj8956">
-              <version versionId="1" tag="1.0.0">
-                <description>
-                  Initial version
-                </description>
-              </version>
-              <version versionId="2"/>
-            </versionMetadata>
-        XML
-      end
+      let(:expected_xml) { '<versionMetadata />' }
 
       before do
         allow(VersionMigrationService).to receive(:migrate)
-        ObjectVersion.create(druid: druid, version: 1, tag: '1.0.0', description: 'Initial version')
-        ObjectVersion.create(druid: druid, version: 2)
+        allow(ObjectVersion).to receive(:version_xml).and_return(expected_xml)
       end
 
       it { is_expected.to be_equivalent_to expected_xml }


### PR DESCRIPTION
## Why was this change made?
Refactor suggested by @jcoyne 


## How was this change tested?



## Which documentation and/or configurations were updated?



