### PR TITLE
Normalizes missing access for embargo metadata.

### DIFF
--- a/app/services/cocina/normalizers/embargo_normalizer.rb
+++ b/app/services/cocina/normalizers/embargo_normalizer.rb
@@ -27,6 +27,7 @@ module Cocina
       def normalize
         return ng_xml.to_xml if normalize_released?
 
+        normalize_missing_discover
         normalize_twentypct
         normalize_empty
 
@@ -69,6 +70,19 @@ module Cocina
 
         ng_xml.root.remove
         true
+      end
+
+      def normalize_missing_discover
+        release_access_nodes = ng_xml.xpath('//releaseAccess[access[@type="read"]/machine/world][not(access[@type="discover"]/machine/world)]')
+
+        release_access_nodes.each do |release_access_node|
+          access_node = Nokogiri::XML::Node.new('access', ng_xml)
+          access_node[:type] = 'discover'
+          machine_node = Nokogiri::XML::Node.new('machine', ng_xml)
+          machine_node << Nokogiri::XML::Node.new('world', ng_xml)
+          access_node << machine_node
+          release_access_node << access_node
+        end
       end
     end
   end

--- a/spec/services/cocina/normalizers/embargo_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/embargo_normalizer_spec.rb
@@ -201,4 +201,46 @@ RSpec.describe Cocina::Normalizers::EmbargoNormalizer do
       )
     end
   end
+
+  context 'when missing access type=discover' do
+    # From druid:bm722zk9642
+    let(:original_xml) do
+      <<~XML
+        <embargoMetadata>
+          <status>embargoed</status>
+          <releaseDate>2022-06-08T07:00:00Z</releaseDate>
+          <releaseAccess>
+            <access type="read">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+          </releaseAccess>
+        </embargoMetadata>
+      XML
+    end
+
+    it 'adds missing access' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+            <embargoMetadata>
+            <status>embargoed</status>
+            <releaseDate>2022-06-08T07:00:00Z</releaseDate>
+            <releaseAccess>
+              <access type="read">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+              <access type="discover">
+                <machine>
+                  <world/>
+                </machine>
+              </access>
+            </releaseAccess>
+          </embargoMetadata>#{'        '}
+        XML
+      )
+    end
+  end
 end


### PR DESCRIPTION
closes #3396

## Why was this change made?
Normalization.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



