### PR TITLE
administrativeMetadata/registration/collection - normalize out default attribute

### DIFF
--- a/app/services/cocina/normalizers/admin_normalizer.rb
+++ b/app/services/cocina/normalizers/admin_normalizer.rb
@@ -24,6 +24,7 @@ module Cocina
         remove_assembly_node
         remove_accessioning_node
         remove_empty_registration_and_dissemination
+        remove_registration_collection_default_attr
         remove_object_id_attr
         regenerate_ng_xml(ng_xml.to_xml)
       end
@@ -63,6 +64,10 @@ module Cocina
         ng_xml.xpath('/administrativeMetadata/registration[not(node())]').each(&:remove)
         ng_xml.xpath('/administrativeMetadata/dissemination/workflow[@id=""]').each { |node| node.parent.remove }
         ng_xml.xpath('/administrativeMetadata/dissemination[not(node())]').each(&:remove)
+      end
+
+      def remove_registration_collection_default_attr
+        ng_xml.xpath('/administrativeMetadata/registration/collection/@default').each(&:remove)
       end
 
       def remove_object_id_attr

--- a/spec/services/cocina/normalizers/admin_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/admin_normalizer_spec.rb
@@ -196,6 +196,33 @@ RSpec.describe Cocina::Normalizers::AdminNormalizer do
     end
   end
 
+  describe '#remove_registration_collection_default_attr' do
+    #  adapted from bj961cc4982
+    let(:original_xml) do
+      <<~XML
+        <administrativeMetadata>
+          <registration>
+            <collection default="yes" id="druid:md481fb4654"/>
+            <workflow id="registrationWF"/>
+          </registration>
+        </administrativeMetadata>
+      XML
+    end
+
+    it 'removes default attribute from registration collection element' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <administrativeMetadata>
+            <registration>
+              <collection id="druid:md481fb4654"/>
+              <workflow id="registrationWF"/>
+            </registration>
+          </administrativeMetadata>
+        XML
+      )
+    end
+  end
+
   describe '#remove_object_id_attr' do
     let(:original_xml) do
       <<~XML


### PR DESCRIPTION
## Why was this change made?

Closes #3354

There are 6 APOs that have a `default` attribute on the registration collection element and it should be normalized out

```xml
<administrativeMetadata objectId="druid:bj961cc4982">
  <registration>
    <collection default="yes" id="druid:md481fb4654"/>
    <workflow id="registrationWF"/>
  </registration>
</administrativeMetadata>
```

BONUS:  I was able to refactor `admin_normalizer` to remove a method and to remove a redundant spec.

## How was this change tested?

unit test added, and testing against all APOs:

`$ bin/validate-cocina-roundtrip -i tmp/druid-lists/druids.apos.txt -f -n


### THIS branch (after):

```
Status (n=1270; not using Missing for success/different/error stats):
  Success:   1180 (92.913%)
  Different: 80 (6.299%)
  Mapping error:     10 (0.787%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     0 (0.0%)
  Bad cache:     0 (0.0%)
```

### MAIN branch (before):

```
Status (n=1270; not using Missing for success/different/error stats):
  Success:   1174 (92.441%)
  Different: 86 (6.772%)
  Mapping error:     10 (0.787%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     0 (0.0%)
  Bad cache:     0 (0.0%)
```
## Which documentation and/or configurations were updated?



