### PR TITLE
Export the identity metadata to the public metadata xml

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -18,7 +18,10 @@ class MetadataController < ApplicationController
 
   def public_xml
     release_tags = ReleaseTags.for(cocina_object: @cocina_object)
-    service = Publish::PublicXmlService.new(@item, released_for: release_tags, thumbnail_service: ThumbnailService.new(@cocina_object))
+    public_cocina = Publish::PublicCocinaService.create(@cocina_object)
+    service = Publish::PublicXmlService.new(@item, public_cocina: public_cocina,
+                                                   released_for: release_tags,
+                                                   thumbnail_service: ThumbnailService.new(@cocina_object))
     render xml: service
   end
 

--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -33,8 +33,11 @@ module Publish
     # @raise [Dor::DataError]
     def transfer_metadata(release_tags)
       public_cocina = PublicCocinaService.create(cocina_object)
+      public_nokogiri = PublicXmlService.new(item, public_cocina: public_cocina,
+                                                   released_for: release_tags,
+                                                   thumbnail_service: @thumbnail_service)
       transfer_to_document_store(public_cocina.to_json, 'cocina.json')
-      transfer_to_document_store(PublicXmlService.new(item, released_for: release_tags, thumbnail_service: @thumbnail_service).to_xml, 'public')
+      transfer_to_document_store(public_nokogiri.to_xml, 'public')
       transfer_to_document_store(PublicDescMetadataService.new(item).to_xml, 'mods')
     end
 

--- a/app/services/publish/public_cocina_service.rb
+++ b/app/services/publish/public_cocina_service.rb
@@ -17,8 +17,6 @@ module Publish
     def build
       return cocina unless cocina.dro?
 
-      build_structural
-
       cocina.new(structural: build_structural,
                  administrative: build_administrative)
     end
@@ -33,6 +31,8 @@ module Publish
     end
 
     def build_structural
+      return unless cocina.structural
+
       file_sets = Array(cocina.structural.contains)
       new_file_sets = file_sets.filter_map do |fs|
         files = fs.structural.contains.select { |file| file.administrative.publish }

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe Publish::MetadataTransferService do
         it 'identityMetadta, contentMetadata, rightsMetadata, generated dublin core, and public xml' do
           item.rightsMetadata.content = "<rightsMetadata><access type='discover'><machine><world/></machine></access></rightsMetadata>"
           service.publish
-          expect(Publish::PublicXmlService).to have_received(:new).with(item, released_for: release_tags, thumbnail_service: thumbnail_service)
+          expect(Publish::PublicXmlService).to have_received(:new).with(item, public_cocina: Cocina::Models::DRO, released_for: release_tags, thumbnail_service: thumbnail_service)
           expect(Publish::PublicDescMetadataService).to have_received(:new).with(item)
         end
 

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -3,8 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe Publish::PublicXmlService do
-  subject(:service) { described_class.new(item, released_for: release_tags, thumbnail_service: thumbnail_service) }
+  subject(:service) do
+    described_class.new(item,
+                        public_cocina: public_cocina,
+                        released_for: release_tags,
+                        thumbnail_service: thumbnail_service)
+  end
 
+  let(:public_cocina) { Publish::PublicCocinaService.create(cocina_object) }
   let(:release_tags) { {} }
 
   let(:druid) { 'druid:bc123df4567' }
@@ -179,7 +185,12 @@ RSpec.describe Publish::PublicXmlService do
                                 label: 'A generic label',
                                 version: 1,
                                 description: description,
-                                identification: {},
+                                identification: {
+                                  catalogLinks: [
+                                    { catalog: 'previous symphony', catalogRecordId: '9001001001' },
+                                    { catalog: 'symphony', catalogRecordId: '129483625' }
+                                  ]
+                                },
                                 access: {},
                                 administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
                                 structural: structural)
@@ -206,8 +217,9 @@ RSpec.describe Publish::PublicXmlService do
         expect(ng_xml.at_xpath('/publicObject/@publishVersion').value).to eq("dor-services/#{Dor::VERSION}")
       end
 
-      it 'identityMetadata' do
-        expect(ng_xml.at_xpath('/publicObject/identityMetadata')).to be
+      it 'has identityMetadata with catkeys' do
+        expected = '<identityMetadata><otherId name="catkey">129483625</otherId></identityMetadata>'
+        expect(ng_xml.at_xpath('/publicObject/identityMetadata').to_xml).to be_equivalent_to expected
       end
 
       it 'no contentMetadata element' do


### PR DESCRIPTION

## Why was this change made?
Fixes #3328

The only property from identityMetadata that is used by purl is the catkey:
https://github.com/search?q=identityMetadata+repo%3Asul-dlss%2Fpurl+path%3Aapp&type=Code



## How was this change tested?



## Which documentation and/or configurations were updated?



