### PR TITLE
Export the identityMetadata/objecType to public XML

### DIFF
--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -80,6 +80,8 @@ module Publish
 
     SYMPHONY = 'symphony'
 
+    # catkeys are used by PURL
+    # objectType is used by purl-fetcher
     def public_identity_metadata
       catkeys = Array(public_cocina.identification&.catalogLinks).filter_map { |link| link.catalogRecordId if link.catalog == SYMPHONY }
       nodes = catkeys.map { |catkey| "  <otherId name=\"catkey\">#{catkey}</otherId>" }
@@ -87,6 +89,7 @@ module Publish
       Nokogiri::XML(
         <<~XML
           <identityMetadata>
+            <objectType>#{public_cocina.collection? ? 'collection' : 'item'}</objectType>
           #{nodes.join("\n")}
           </identityMetadata>
         XML

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -129,7 +129,9 @@ RSpec.describe 'Display metadata' do
       expect(response.body).to be_equivalent_to <<~XML
         <?xml version="1.0" encoding="UTF-8"?>
         <publicObject id="druid:mk420bs7601" published="#{now.utc.xmlschema}" publishVersion="dor-services/#{Dor::VERSION}">
-          <identityMetadata/>
+          <identityMetadata>
+            <objectType>item</objectType>
+          </identityMetadata>
           <rightsMetadata>
             <access type="discover">
               <machine>

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -218,7 +218,12 @@ RSpec.describe Publish::PublicXmlService do
       end
 
       it 'has identityMetadata with catkeys' do
-        expected = '<identityMetadata><otherId name="catkey">129483625</otherId></identityMetadata>'
+        expected = <<~XML
+          <identityMetadata>
+            <objectType>item</objectType>
+            <otherId name="catkey">129483625</otherId>
+          </identityMetadata>
+        XML
         expect(ng_xml.at_xpath('/publicObject/identityMetadata').to_xml).to be_equivalent_to expected
       end
 


### PR DESCRIPTION
## Why was this change made?

purl-fetcher uses this to index they type: https://github.com/sul-dlss/purl-fetcher/blob/cc003ceaf67a90bbf549b1b4bd55706ddc0cc0c5/app/services/purl_parser.rb#L55-L57


## How was this change tested?

Unit test added

## Which documentation and/or configurations were updated?



