### PR TITLE
Remove duplicate source ids from original xml

### DIFF
--- a/app/services/cocina/normalizers/identity_normalizer.rb
+++ b/app/services/cocina/normalizers/identity_normalizer.rb
@@ -43,6 +43,7 @@ module Cocina
         add_missing_sourceid_from_otherid_dissertationid
         normalize_source_id_whitespace
         normalize_label_whitespace
+        remove_duplicate_source_id
 
         regenerate_ng_xml(ng_xml.to_xml)
       end
@@ -63,6 +64,10 @@ module Cocina
           source_node['source'] = source_node['source']&.strip
           source_node.content = source_node.content&.strip
         end
+      end
+
+      def remove_duplicate_source_id
+        ng_xml.xpath('//sourceId[@source="sul"][position()>1]').each(&:remove)
       end
 
       # we don't care about uuids

--- a/app/services/cocina/normalizers/identity_normalizer.rb
+++ b/app/services/cocina/normalizers/identity_normalizer.rb
@@ -67,7 +67,14 @@ module Cocina
       end
 
       def remove_duplicate_source_id
-        ng_xml.xpath('//sourceId[@source="sul"][position()>1]').each(&:remove)
+        nodes = []
+        ng_xml.xpath('//sourceId').each do |node|
+          nodes.each do |node1|
+            node.remove if EquivalentXml.equivalent?(node1, node)
+            next
+          end
+          nodes << node
+        end
       end
 
       # we don't care about uuids

--- a/app/services/cocina/normalizers/identity_normalizer.rb
+++ b/app/services/cocina/normalizers/identity_normalizer.rb
@@ -69,11 +69,11 @@ module Cocina
       def remove_duplicate_source_id
         nodes = []
         ng_xml.xpath('//sourceId').each do |node|
-          nodes.each do |node1|
-            node.remove if EquivalentXml.equivalent?(node1, node)
-            next
+          if nodes.include? node.to_xml
+            node.remove
+          else
+            nodes << node.to_xml
           end
-          nodes << node
         end
       end
 

--- a/spec/services/cocina/normalizers/identity_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/identity_normalizer_spec.rb
@@ -54,6 +54,29 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
     end
   end
 
+  context 'when #remove_duplicate_source_id' do
+    let(:original_xml) do
+      <<~XML
+        <identityMetadata>
+          <sourceId source="sul">M0443_S2_D-K_B9_F33_011</sourceId>
+          <sourceId source="sul">M0443_S2_D-K_B9_F33_011</sourceId>
+        </identityMetadata>
+      XML
+    end
+
+    it 'removes the duplicate' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <identityMetadata>
+            <sourceId source="sul">M0443_S2_D-K_B9_F33_011</sourceId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>Some cool object label</objectLabel>
+          </identityMetadata>
+        XML
+      )
+    end
+  end
+
   describe '#add_missing_sourceid_from_otherid_dissertationid' do
     context 'when there is an existing sourceId' do
       let(:original_xml) do


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3401 

Equal round trip runs

```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99896 (99.978%)
  Different: 6 (0.006%)
  Mapping error:     16 (0.016%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)

```

After:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99896 (99.978%)
  Different: 6 (0.006%)
  Mapping error:     16 (0.016%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
```

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run integration tests*** and/or test in [stage|qa] environment, in addition to specs. ⚡

