### PR TITLE
map previous catkeys for collections

### DIFF
--- a/app/services/cocina/from_fedora/collection.rb
+++ b/app/services/cocina/from_fedora/collection.rb
@@ -16,7 +16,6 @@ module Cocina
         @notifier = notifier
       end
 
-      # rubocop:disable Metrics/AbcSize
       def props
         {
           externalIdentifier: fedora_collection.pid,
@@ -30,11 +29,9 @@ module Cocina
           description = FromFedora::Descriptive.props(title_builder: title_builder, mods: fedora_collection.descMetadata.ng_xml, druid: fedora_collection.pid, notifier: notifier)
           props[:description] = description unless description.nil?
           identification = FromFedora::Identification.props(fedora_collection)
-          identification[:catalogLinks] = [{ catalog: 'symphony', catalogRecordId: fedora_collection.catkey }] if fedora_collection.catkey
           props[:identification] = identification unless identification.empty?
         end
       end
-      # rubocop:enable Metrics/AbcSize
 
       private
 

--- a/app/services/cocina/from_fedora/identification.rb
+++ b/app/services/cocina/from_fedora/identification.rb
@@ -58,7 +58,7 @@ module Cocina
         results = []
         fedora_object.identityMetadata.ng_xml.xpath('//otherId[@name="catkey" or @name="previous_catkey"]').each do |clink|
           catalog = clink['name'] == 'catkey' ? 'symphony' : 'previous symphony'
-          results << { catalog: catalog, catalogRecordId: clink.text } if clink.text.present?
+          results << { catalog: catalog, catalogRecordId: clink.text.strip } if clink.text.present?
         end
         results.uniq { |clink| "#{clink[:catalog]}::#{clink[:catalogRecordId]}" }.presence
       end

--- a/spec/services/cocina/mapper_spec.rb
+++ b/spec/services/cocina/mapper_spec.rb
@@ -303,6 +303,7 @@ RSpec.describe Cocina::Mapper do
           <objectLabel>Stanford University map collection, 1853-1997</objectLabel>
           <objectType>collection</objectType>
           <otherId name="catkey">4366577</otherId>
+          <otherId name="previous_catkey">12345 </otherId>
           <otherId name="uuid">3a69d380-d615-11e3-96be-0050569b3c3c</otherId>
           <tag>Remediated By : 5.8.2</tag>
           <release to="Searchworks" what="self" when="2016-11-16T22:45:36Z" who="blalbrit">true</release>
@@ -331,6 +332,12 @@ RSpec.describe Cocina::Mapper do
       expect(cocina_model).to be_kind_of Cocina::Models::Collection
       expect(cocina_model.administrative.hasAdminPolicy).to eq 'druid:sc012gz0974'
       expect(cocina_model.administrative.releaseTags.size).to eq 13
+    end
+
+    it 'maps both the current and previous catkeys and strips extra spaces' do
+      expect(cocina_model.identification.catalogLinks.size).to eq 2
+      expect(cocina_model.identification.catalogLinks[0].catalogRecordId).to eq '4366577'
+      expect(cocina_model.identification.catalogLinks[1].catalogRecordId).to eq '12345'
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3470 - previous catkeys for collections should be mapped (also strip extra spaces when mapping catkeys)

(Assuming this is what we want, and not what was coded before).

## How was this change tested? 🤨

Added a new test (and verified it fails without change and passes with).




