### PR TITLE
[HOLD] normalize blank file directives to no

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -6,6 +6,7 @@ module Cocina
     # when round-tripping.
     class ContentMetadataNormalizer
       include Cocina::Normalizers::Base
+      FILE_DIRECTIVES = %i[publish preserve shelve].freeze
 
       # @param [String] druid
       # @param [Nokogiri::Document] content_ng_xml content metadata XML to be normalized
@@ -47,6 +48,7 @@ module Cocina
         normalize_empty_xml
         normalize_content_file_type
         normalize_image_data
+        normalize_blank_file_directives
 
         regenerate_ng_xml(ng_xml.to_s)
       end
@@ -160,6 +162,12 @@ module Cocina
             attr_node.parent << label_node
           end
           attr_node.remove
+        end
+      end
+
+      def normalize_blank_file_directives
+        FILE_DIRECTIVES.each do |directive|
+          ng_xml.root.xpath("//file[@#{directive} = '']").each { |file| file[directive] = 'no' }
         end
       end
 

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -42,6 +42,41 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
     end
   end
 
+  context 'when normalizing blank file directives' do
+    # adapted from ft113wv9260 and ns538tk9778
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata type="file" objectId="druid:ft113wv9260">
+          <resource id="ft113wv9260_1" type="file" objectId="druid:ft113wv9260">
+            <file mimetype="image/tiff" preserve="" format="" size="456" shelve="" publish="no" id="ft113wv9260_00_0001.tif">
+              <imageData width="4865" height="4933"/>
+            </file>
+            <file mimetype="image/tiff" preserve="yes" format="" size="123" shelve="yes" publish="" id="ft113wv9260_00_0002.tif">
+              <imageData width="4865" height="4933"/>
+          </file>
+        </contentMetadata>
+      XML
+    end
+
+    let(:expected_xml) do
+      <<~XML
+        <contentMetadata type="file" objectId="druid:ft113wv9260">
+          <resource type="file">
+            <file mimetype="image/tiff" preserve="no" size="456" shelve="no" publish="no" id="ft113wv9260_00_0001.tif">
+              <imageData width="4865" height="4933"/>
+            </file>
+            <file mimetype="image/tiff" preserve="yes" size="123" shelve="yes" publish="no" id="ft113wv9260_00_0002.tif">
+              <imageData width="4865" height="4933"/>
+          </file>
+        </contentMetadata>
+      XML
+    end
+
+    it 'normalizes blank file directive attributes to no' do
+      expect(normalized_ng_xml).to be_equivalent_to(expected_xml)
+    end
+  end
+
   context 'when normalizing labels' do
     # adapted from dm559qb5551 and fm402pc0937
     let(:original_xml) do


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3473 - normalize blank file directives (publish/preserve/shelve) to no

HOLD pending roundtrip validation testing

## How was this change tested? 🤨

1. Added a new test
2. Running roundtrip validations, results in comment below