### PR TITLE
Reports for contentMetadata resource of type preview

### DIFF
--- a/bin/reports/report-content-resource-preview-not-geodata
+++ b/bin/reports/report-content-resource-preview-not-geodata
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+Report.new(name: 'content-resource-type-preview-not-geodata', dsid: 'contentMetadata').run do |ng_xml|
+  # there is a resource with type=preview and there is NOT a geoData element in the contentMetadata
+  ng_xml.xpath('/contentMetadata[not(resource/file/geoData)]/resource/@type="preview"')
+end

--- a/bin/reports/report-content-resource-preview-yes-geodata
+++ b/bin/reports/report-content-resource-preview-yes-geodata
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+Report.new(name: 'content-resource-type-preview-yes-geodata', dsid: 'contentMetadata').run do |ng_xml|
+  # there is a resource with type=preview and there is a geoData element in the contentMetadata
+  ng_xml.xpath('/contentMetadata[resource/file/geoData]/resource/@type="preview"')
+end


### PR DESCRIPTION
## Why was this change made? 🤔

These reports were requested by Andrew, presumably to gain an understanding of what contentMetadata resources are of type "preview" and how it is used (captured in the ticket)

Part of #3467 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



