### PR TITLE
Renames DatastreamExtractor to PreservationMetadataExtractor.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -111,7 +111,7 @@ RSpec/ContextWording:
 RSpec/ExpectInHook:
   Exclude:
     - 'spec/dor/update_marc_record_service_spec.rb'
-    - 'spec/services/datastream_extractor_spec.rb'
+    - 'spec/services/preservation_metadata_extractor_spec.rb'
     - 'spec/services/publish/metadata_transfer_service_spec.rb'
     - 'spec/services/publish/public_desc_metadata_service_spec.rb'
     - 'spec/services/sdr_ingest_service_spec.rb'
@@ -128,7 +128,7 @@ RSpec/InstanceVariable:
 RSpec/MessageSpies:
   Exclude:
     - 'spec/dor/update_marc_record_service_spec.rb'
-    - 'spec/services/datastream_extractor_spec.rb'
+    - 'spec/services/preservation_metadata_extractor_spec.rb'
     - 'spec/services/digital_stacks_service_spec.rb'
     - 'spec/services/publish/public_desc_metadata_service_spec.rb'
     - 'spec/services/sdr_ingest_service_spec.rb'
@@ -161,7 +161,7 @@ RSpec/ScatteredSetup:
 # Offense count: 7
 RSpec/StubbedMock:
   Exclude:
-    - 'spec/services/datastream_extractor_spec.rb'
+    - 'spec/services/preservation_metadata_extractor_spec.rb'
     - 'spec/services/publish/public_desc_metadata_service_spec.rb'
     - 'spec/services/sdr_ingest_service_spec.rb'
     - 'spec/services/version_service_spec.rb'

--- a/app/services/preservation_metadata_extractor.rb
+++ b/app/services/preservation_metadata_extractor.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-# This writes the contents of datastreams to the workspace metadata directory
-class DatastreamExtractor
+# This writes the object metadata files to the workspace metadata directory
+class PreservationMetadataExtractor
   # @param [Dor::Item] item The representation of the digital object
   # @param [DruidTools::Druid] workspace The representation of the item's work area
   # @return [Pathname] Pull all the datastreams specified in the configuration file
   #   into the workspace's metadata directory, overwriting existing file if present
-  def self.extract_datastreams(item:, workspace:)
+  def self.extract(item:, workspace:)
     new(item: item, workspace: workspace).extract_datastreams
   end
 

--- a/app/services/sdr_ingest_service.rb
+++ b/app/services/sdr_ingest_service.rb
@@ -15,7 +15,7 @@ class SdrIngestService
     workspace = DruidTools::Druid.new(druid, Settings.sdr.local_workspace_root)
     signature_catalog = signature_catalog_from_preservation(druid)
     new_version_id = signature_catalog.version_id + 1
-    metadata_dir = DatastreamExtractor.extract_datastreams(item: dor_item, workspace: workspace)
+    metadata_dir = PreservationMetadataExtractor.extract(item: dor_item, workspace: workspace)
     verify_version_metadata(metadata_dir, new_version_id)
     version_inventory = Preserve::FileInventoryBuilder.build(metadata_dir: metadata_dir,
                                                              druid: druid,

--- a/spec/services/preservation_metadata_extractor_spec.rb
+++ b/spec/services/preservation_metadata_extractor_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe DatastreamExtractor do
+RSpec.describe PreservationMetadataExtractor do
   let(:workspace) { instance_double(DruidTools::Druid, path: 'foo') }
   let(:druid) { 'druid:nc893zj8956' }
   let(:item) { instance_double(Dor::Item, pid: druid) }

--- a/spec/services/sdr_ingest_service_spec.rb
+++ b/spec/services/sdr_ingest_service_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe SdrIngestService do
 
     before do
       allow(Preservation::Client.objects).to receive(:signature_catalog).and_return(fixture_sig_cat_obj)
-      expect(DatastreamExtractor).to receive(:extract_datastreams).with(item: dor_item, workspace: an_instance_of(DruidTools::Druid)).and_return(metadata_dir)
+      expect(PreservationMetadataExtractor).to receive(:extract).with(item: dor_item, workspace: an_instance_of(DruidTools::Druid)).and_return(metadata_dir)
     end
 
     specify 'with content changes' do


### PR DESCRIPTION
## Why was this change made? 🤔
For forthcoming work, the role of this class will be changing to go beyond datastream extraction, so pre-emptively renaming.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



