### PR TITLE
remove contact nodes from adminMetadata

### DIFF
--- a/app/services/cocina/normalizers/admin_normalizer.rb
+++ b/app/services/cocina/normalizers/admin_normalizer.rb
@@ -26,6 +26,7 @@ module Cocina
         remove_empty_registration_and_dissemination
         remove_registration_collection_default_attr
         remove_object_id_attr
+        remove_contacts
         regenerate_ng_xml(ng_xml.to_xml)
       end
 
@@ -72,6 +73,10 @@ module Cocina
 
       def remove_object_id_attr
         ng_xml.xpath('/administrativeMetadata/@objectId').each(&:remove)
+      end
+
+      def remove_contacts
+        ng_xml.xpath('/administrativeMetadata/contact').each(&:remove)
       end
     end
   end

--- a/spec/services/cocina/normalizers/admin_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/admin_normalizer_spec.rb
@@ -246,4 +246,39 @@ RSpec.describe Cocina::Normalizers::AdminNormalizer do
       )
     end
   end
+
+  describe '#remove_contacts' do
+    #  adapted from bm077td6448
+    let(:original_xml) do
+      <<~XML
+        <administrativeMetadata>
+          <contact type="user">
+            <id type="sunetid">awesomeguitardude</id>
+            <name>Eddie Van Halen</name>
+            <email>evanhalen@stanford.edu</email>
+            <organization>Stanford University Libraries</organization>
+          </contact>
+          <registration>
+            <collection default="yes" id="druid:dx969tv9730"/>
+            <workflow id="registrationWF"/>
+            <collection id="druid:pr871vx0830"/>
+          </registration>
+         </administrativeMetadata>
+      XML
+    end
+
+    it 'removes contact nodes' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <administrativeMetadata>
+            <registration>
+              <collection id="druid:dx969tv9730"/>
+              <workflow id="registrationWF"/>
+              <collection id="druid:pr871vx0830"/>
+            </registration>
+          </administrativeMetadata>
+        XML
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3471 - remove contacts when normalizing adminMetadata

## How was this change tested? 🤨

- Added new test
- validate-cocina-roundtrip results (shown in comments below, no change)