### PR TITLE
write report for invalid agreement objects

### DIFF
--- a/bin/reports/report-invalid-agreement
+++ b/bin/reports/report-invalid-agreement
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+# see https://github.com/sul-dlss/dor-services-app/issues/3469, find agreements missing needed fedora-model:hasModel declaration
+Report.new(name: 'invalid-agreement-relsext', dsid: 'RELS-EXT').run do |ng_xml|
+  rdf_ns = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+  hydra_ns = 'http://projecthydra.org/ns/relations#'
+  fedora_ns = 'info:fedora/fedora-system:def/model#'
+
+  ng_xml.xpath(
+    '//fedora:hasModel[@rdf:resource="info:fedora/afmodel:Dor_Agreement"]',
+    hydra: hydra_ns, fedora: fedora_ns, rdf: rdf_ns
+  ).blank?
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Report for invalid agreement objects (re: action for #3469)

## How was this change tested? 🤨

Ran report on just agreement objects.  Results below:

```
 ./bin/reports/report-invalid-agreement -f -i druids.agreements.txt
```

```
druid,apo,catkey,message
druid:dg278wx3858,,,
druid:dt823rz5296,,,
druid:ft372rz1240,,,
druid:gm695yd8142,,,
druid:hq927rk2991,,,
druid:mk868xs8150,,,
druid:mw295sx0691,,,
druid:pq564qy0793,,,
druid:py754rs4479,,,
druid:rd901vy3935,,,
druid:rp956gh8463,,,
druid:sb526wm1291,,,
druid:sh907mq5434,,,
druid:sj243xv3654,,,
druid:sp446mf1465,,,
druid:sq935ky5956,,,
druid:td469vd5422,,,
druid:tk248ff9846,,,
druid:tm368gc3870,,,
druid:vs363xg0079,,,
druid:vz378kx9883,,,
druid:xg091rg0886,,,
druid:xm864kq4041,,,
druid:yy885bd8557,,,
druid:zf455ms5258,,,
druid:zh724bv4125,,,
druid:zp985cv0241,,,
```
