### PR TITLE
Push the ActiveFedora dependency out of the interface for Preservatio…

### DIFF
--- a/app/jobs/preserve_job.rb
+++ b/app/jobs/preserve_job.rb
@@ -18,12 +18,11 @@ class PreserveJob < ApplicationJob
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
   def perform(druid:, background_job_result:)
     background_job_result.processing!
-
-    item = Dor.find(druid)
-    SdrIngestService.transfer(item) # This might raise a StandardError which will be handled by the retry above.
+    cocina_object = CocinaObjectStore.find(druid)
+    SdrIngestService.transfer(cocina_object) # This might raise a StandardError which will be handled by the retry above.
 
     StartPreservationWorkflowJob.perform_later(druid: druid,
-                                               version: item.current_version,
+                                               version: cocina_object.version,
                                                background_job_result: background_job_result)
   end
 end

--- a/spec/jobs/preserve_job_spec.rb
+++ b/spec/jobs/preserve_job_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe PreserveJob, type: :job do
 
   let(:druid) { 'druid:mk420bs7601' }
   let(:result) { create(:background_job_result) }
-  let(:item) { instance_double(Dor::Item, current_version: '7') }
+  let(:cocina) { instance_double(Cocina::Models::DRO, version: 7) }
 
   before do
-    allow(Dor).to receive(:find).with(druid).and_return(item)
+    allow(CocinaObjectStore).to receive(:find).with(druid).and_return(cocina)
     allow(result).to receive(:processing!)
     allow(Honeybadger).to receive(:notify)
     allow(Honeybadger).to receive(:context)
@@ -30,7 +30,7 @@ RSpec.describe PreserveJob, type: :job do
     end
 
     it 'invokes the SdrIngestService' do
-      expect(SdrIngestService).to have_received(:transfer).with(item).once
+      expect(SdrIngestService).to have_received(:transfer).with(cocina).once
     end
 
     it 'marks the job as complete' do
@@ -51,7 +51,7 @@ RSpec.describe PreserveJob, type: :job do
         described_class.perform_now(druid: druid, background_job_result: result)
       end
       expect(result).to have_received(:processing!).once
-      expect(SdrIngestService).to have_received(:transfer).with(item).exactly(5).times
+      expect(SdrIngestService).to have_received(:transfer).with(cocina).exactly(5).times
       expect(LogFailureJob).to have_received(:perform_later)
         .with(druid: druid,
               background_job_result: result,

--- a/spec/services/preservation_metadata_extractor_spec.rb
+++ b/spec/services/preservation_metadata_extractor_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PreservationMetadataExtractor do
   let(:workspace) { instance_double(DruidTools::Druid, path: 'foo') }
   let(:druid) { 'druid:nc893zj8956' }
   let(:item) { instance_double(Dor::Item, pid: druid) }
-  let(:instance) { described_class.new(item: item, workspace: workspace, cocina_object: cocina_object) }
+  let(:instance) { described_class.new(workspace: workspace, cocina_object: cocina_object) }
   let(:cocina_object) do
     Cocina::Models::DRO.new({
                               cocinaVersion: '0.0.1',
@@ -17,6 +17,10 @@ RSpec.describe PreservationMetadataExtractor do
                               access: { access: 'world', download: 'world' },
                               administrative: { hasAdminPolicy: 'druid:hy787xj5878' }
                             })
+  end
+
+  before do
+    allow(Dor).to receive(:find).and_return(item)
   end
 
   describe '.extract' do
@@ -37,27 +41,27 @@ RSpec.describe PreservationMetadataExtractor do
 
     it 'extracts the metadata' do
       extract
-      expect(instance).to have_received(:datastream_content).with(:administrativeMetadata, false)
-      expect(instance).to have_received(:datastream_content).with(:contentMetadata, false)
-      expect(instance).to have_received(:datastream_content).with(:defaultObjectRights, false)
-      expect(instance).to have_received(:datastream_content).with(:descMetadata, true).once
-      expect(instance).to have_received(:datastream_content).with(:events, false)
-      expect(instance).to have_received(:datastream_content).with(:geoMetadata, false)
-      expect(instance).to have_received(:datastream_content).with(:embargoMetadata, false)
-      expect(instance).to have_received(:datastream_content).with(:identityMetadata, true)
-      expect(instance).to have_received(:datastream_content).with(:provenanceMetadata, false)
-      expect(instance).to have_received(:datastream_content).with(:relationshipMetadata, true)
-      expect(instance).to have_received(:datastream_content).with(:roleMetadata, false)
-      expect(instance).to have_received(:datastream_content).with(:sourceMetadata, false)
-      expect(instance).to have_received(:datastream_content).with(:rightsMetadata, false)
-      expect(instance).to have_received(:datastream_content).with(:versionMetadata, true)
-      expect(instance).to have_received(:datastream_content).with(:workflows, false)
+      expect(instance).to have_received(:datastream_content).with(item, :administrativeMetadata, false)
+      expect(instance).to have_received(:datastream_content).with(item, :contentMetadata, false)
+      expect(instance).to have_received(:datastream_content).with(item, :defaultObjectRights, false)
+      expect(instance).to have_received(:datastream_content).with(item, :descMetadata, true).once
+      expect(instance).to have_received(:datastream_content).with(item, :events, false)
+      expect(instance).to have_received(:datastream_content).with(item, :geoMetadata, false)
+      expect(instance).to have_received(:datastream_content).with(item, :embargoMetadata, false)
+      expect(instance).to have_received(:datastream_content).with(item, :identityMetadata, true)
+      expect(instance).to have_received(:datastream_content).with(item, :provenanceMetadata, false)
+      expect(instance).to have_received(:datastream_content).with(item, :relationshipMetadata, true)
+      expect(instance).to have_received(:datastream_content).with(item, :roleMetadata, false)
+      expect(instance).to have_received(:datastream_content).with(item, :sourceMetadata, false)
+      expect(instance).to have_received(:datastream_content).with(item, :rightsMetadata, false)
+      expect(instance).to have_received(:datastream_content).with(item, :versionMetadata, true)
+      expect(instance).to have_received(:datastream_content).with(item, :workflows, false)
       expect(instance).to have_received(:extract_cocina)
     end
   end
 
   describe '#datastream_content' do
-    subject(:datastream_content) { instance.send(:datastream_content, ds_name, required) }
+    subject(:datastream_content) { instance.send(:datastream_content, item, ds_name, required) }
 
     let(:ds_name) { :myMetadata }
     let(:datastream) { instance_double(Dor::ContentMetadataDS) }


### PR DESCRIPTION
…nMetadataExtractor

## Why was this change made? 🤔
Fixes #3178
Decoupling from ActiveFedora.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



