### PR TITLE
Decouple moving collections into public descriptive from ActiveFedora

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -2,17 +2,17 @@
 
 # A controller to display derived metadata about an object
 class MetadataController < ApplicationController
-  before_action :load_item, :load_cocina_object
-  before_action :load_cocina_object, only: [:public_xml]
+  before_action :load_item
+  before_action :load_cocina_object, only: %i[dublin_core descriptive public_xml]
 
   def dublin_core
-    desc_md_xml = Publish::PublicDescMetadataService.new(@item).ng_xml(include_access_conditions: false)
+    desc_md_xml = Publish::PublicDescMetadataService.new(@item, @cocina_object).ng_xml(include_access_conditions: false)
     service = Publish::DublinCoreService.new(desc_md_xml)
     render xml: service
   end
 
   def descriptive
-    service = Publish::PublicDescMetadataService.new(@item)
+    service = Publish::PublicDescMetadataService.new(@item, @cocina_object)
     render xml: service
   end
 

--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -6,9 +6,6 @@ class QueriesController < ApplicationController
 
   # Returns a list of collections this object is in.
   def collections
-    # isMemberOf may be nil, in which case we want to return an empty array
-    @collections = Array(@cocina_object.structural.isMemberOf).map do |collection_id|
-      CocinaObjectStore.find(collection_id)
-    end
+    @collections = CocinaObjectStore.find_collections_for(@cocina_object)
   end
 end

--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -80,7 +80,7 @@ module Cocina
             if node['nameTitleGroup']
               structured_name(node: node, display_types: display_types)
             else
-              attrs = TitleBuilder.build(title_info_element: node, notifier: notifier)
+              attrs = Descriptive::TitleBuilder.build(title_info_element: node, notifier: notifier)
               attrs.present? ? attrs.merge(common_attributes(node, display_types: display_types)) : nil
             end
           end

--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -43,6 +43,17 @@ class CocinaObjectStore
     new.destroy(druid)
   end
 
+  # @param [Cocina::Models::DRO] cocina_item
+  # @param [Boolean] swallow_exceptions (false) should this return a list even if some members aren't found?
+  def self.find_collections_for(cocina_item, swallow_exceptions: false)
+    # isMemberOf may be nil, in which case we want to return an empty array
+    Array(cocina_item.structural.isMemberOf).filter_map do |collection_id|
+      find(collection_id)
+    rescue CocinaObjectNotFoundError
+      raise unless swallow_exceptions
+    end
+  end
+
   def find(druid)
     fedora_to_cocina_find(druid)
   end

--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -38,7 +38,7 @@ module Publish
                                                    thumbnail_service: @thumbnail_service)
       transfer_to_document_store(public_cocina.to_json, 'cocina.json')
       transfer_to_document_store(public_nokogiri.to_xml, 'public')
-      transfer_to_document_store(PublicDescMetadataService.new(item).to_xml, 'mods')
+      transfer_to_document_store(PublicDescMetadataService.new(item, public_cocina).to_xml, 'mods')
     end
 
     # Clear out the document cache for this item

--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -28,9 +28,9 @@ module Publish
       pub.add_child(public_content_metadata.root) if public_content_metadata.xpath('//resource').any?
       pub.add_child(public_rights_metadata.root)
       pub.add_child(public_relationships.root)
-      desc_md_xml = Publish::PublicDescMetadataService.new(object).ng_xml(include_access_conditions: false)
+      desc_md_xml = Publish::PublicDescMetadataService.new(object, public_cocina).ng_xml(include_access_conditions: false)
       pub.add_child(DublinCoreService.new(desc_md_xml).ng_xml.root)
-      pub.add_child(PublicDescMetadataService.new(object).ng_xml.root)
+      pub.add_child(PublicDescMetadataService.new(object, public_cocina).ng_xml.root)
       pub.add_child(release_xml.root) unless release_xml.xpath('//release').children.empty? # If there are no release_tags, this prevents an empty <releaseData/> from being added
       # Note we cannot base this on if an individual object has release tags or not, because the collection may cause one to be generated for an item,
       # so we need to calculate it and then look at the final result.

--- a/app/services/title_builder.rb
+++ b/app/services/title_builder.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+# Copied from dor_indexing_app
+class TitleBuilder # rubocop:disable Metrics/ClassLength
+  # @param [Array<Cocina::Models::Title>] titles
+  # @param [Symbol] strategy ":first" is the strategy for how to choose a name if primary and display name is not found
+  # @return [String] the title value for Solr
+  def self.build(titles, strategy: :first, add_punctuation: true)
+    new(strategy: strategy, add_punctuation: add_punctuation).build(titles)
+  end
+
+  def initialize(strategy:, add_punctuation:)
+    @strategy = strategy
+    @add_punctuation = add_punctuation
+  end
+
+  def build(titles)
+    cocina_title = primary_title(titles) || untyped_title(titles) || other_title(titles)
+
+    if strategy == :first
+      build_title(cocina_title)
+    else
+      cocina_title.map { |one| build_title(one) }
+    end
+  end
+
+  private
+
+  attr_reader :strategy
+
+  def add_punctuation?
+    @add_punctuation
+  end
+
+  # This handles 'main title', 'uniform' or 'translated'
+  def other_title(titles)
+    if strategy == :first
+      titles.first
+    else
+      titles
+    end
+  end
+
+  def build_title(cocina_title)
+    result = if cocina_title.value
+               cocina_title.value
+             elsif cocina_title.structuredValue.present?
+               title_from_structured_values(cocina_title.structuredValue, non_sorting_char_count(cocina_title))
+             elsif cocina_title.parallelValue.present?
+               return build(cocina_title.parallelValue)
+             end
+    remove_trailing_punctuation(result.strip) if result.present?
+  end
+
+  # rubocop:disable Metrics/BlockLength
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
+  # @param [Array<Cocina::Models::StructuredValue>] structured_values - the individual pieces of a structuredValue to be combined
+  # @param [Integer] the length of the non_sorting_characters
+  # @return [String] the title value from combining the pieces of the structured_values according to type and order of occurrence,
+  #   with desired punctuation per specs
+  def title_from_structured_values(structured_values, non_sorting_char_count)
+    structured_title = ''
+    part_name_number = ''
+    # combine pieces of the cocina structuredValue into a single title
+    structured_values.each do |structured_value|
+      # There can be a structuredValue inside a structuredValue.  For example,
+      #   a uniform title where both the name and the title have internal StructuredValue
+      return title_from_structured_values(structured_value.structuredValue, non_sorting_char_count) if structured_value.structuredValue.present?
+
+      value = structured_value.value&.strip
+      next unless value
+
+      # additional types:  name, uniform ...
+      case structured_value.type&.downcase
+      when 'nonsorting characters'
+        non_sort_value = value&.size == non_sorting_char_count ? value : "#{value} "
+        structured_title = if structured_title.present?
+                             "#{structured_title}#{non_sort_value}"
+                           else
+                             non_sort_value
+                           end
+      when 'part name', 'part number'
+        if part_name_number.blank?
+          part_name_number = part_name_number(structured_values)
+          structured_title = if !add_punctuation?
+                               [structured_title, part_name_number].join(' ')
+                             elsif structured_title.present?
+                               "#{structured_title.sub(/[ .,]*$/, '')}. #{part_name_number}. "
+                             else
+                               "#{part_name_number}. "
+                             end
+        end
+      when 'main title', 'title'
+        structured_title = "#{structured_title}#{value}"
+      when 'subtitle'
+        # subtitle is preceded by space colon space, unless it is at the beginning of the title string
+        structured_title = if !add_punctuation?
+                             [structured_title, value].join(' ')
+                           elsif structured_title.present?
+                             "#{structured_title.sub(/[. :]+$/, '')} : #{value.sub(/^:/, '').strip}"
+                           else
+                             structured_title = value.sub(/^:/, '').strip
+                           end
+      end
+    end
+    structured_title
+  end
+  # rubocop:enable Metrics/BlockLength
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
+
+  def remove_trailing_punctuation(title)
+    title.sub(%r{[ .,;:/\\]+$}, '')
+  end
+
+  # @param [Array<Cocina::Models::Title>] titles
+  # @return [Cocina::Models::Title, nil] title that has status=primary
+  def primary_title(titles)
+    primary_title = titles.find do |title|
+      title.status == 'primary'
+    end
+    return primary_title if primary_title.present?
+
+    # NOTE: structuredValues would only have status primary assigned as a sibling, not as an attribute
+
+    titles.find do |title|
+      title.parallelValue&.find do |parallel_title|
+        parallel_title.status == 'primary'
+      end
+    end
+  end
+
+  # @param [Array<Cocina::Models::Title>] titles
+  # @return [Cocina::Models::Title, nil] first title that has no type attribute
+  def untyped_title(titles)
+    method = strategy == :first ? :find : :select
+    titles.public_send(method) do |title|
+      if title.parallelValue.present?
+        untyped_title(title.parallelValue)
+      else
+        title.type.nil? || title.type == 'title'
+      end
+    end
+  end
+
+  def non_sorting_char_count(title)
+    non_sort_note = title.note&.find { |note| note.type&.downcase == 'nonsorting character count' }
+    return 0 unless non_sort_note
+
+    non_sort_note.value.to_i
+  end
+
+  # combine part name and part number:
+  #   respect order of occurrence
+  #   separated from each other by comma space
+  def part_name_number(structured_values)
+    title_from_part = ''
+    structured_values.each do |structured_value|
+      case structured_value.type&.downcase
+      when 'part name', 'part number'
+        value = structured_value.value&.strip
+        next unless value
+
+        title_from_part = append_part_to_title(title_from_part, value)
+
+      end
+    end
+    title_from_part
+  end
+
+  def append_part_to_title(title_from_part, value)
+    if !add_punctuation?
+      [title_from_part, value].select(&:presence).join(' ')
+    elsif title_from_part.strip.present?
+      "#{title_from_part.sub(/[ .,]*$/, '')}, #{value}"
+    else
+      value
+    end
+  end
+end

--- a/spec/services/publish/dublin_core_service_spec.rb
+++ b/spec/services/publish/dublin_core_service_spec.rb
@@ -6,7 +6,22 @@ RSpec.describe Publish::DublinCoreService do
   subject(:service) { described_class.new(desc_md_xml) }
 
   let(:item) { instantiate_fixture('druid:bc123df4567', Dor::Item) }
-  let(:desc_md_xml) { Publish::PublicDescMetadataService.new(item).ng_xml(include_access_conditions: false) }
+  let(:cocina_object) do
+    Cocina::Models.build({
+                           'type' => Cocina::Models::Vocab.object,
+                           'label' => 'test',
+                           'externalIdentifier' => 'druid:bc123df4567',
+                           'access' => {},
+                           'version' => 1,
+                           'structural' => {},
+                           'administrative' => {
+                             'hasAdminPolicy' => 'druid:bz845pv2292'
+                           },
+                           'description' => { title: [{ value: 'stuff' }], purl: 'https://purl.stanford.edu/bc123df4567' },
+                           'identification' => {}
+                         })
+  end
+  let(:desc_md_xml) { Publish::PublicDescMetadataService.new(item, cocina_object).ng_xml(include_access_conditions: false) }
   let(:solr_client) { instance_double(RSolr::Client, get: solr_response) }
   let(:solr_response) { { 'response' => { 'docs' => virtual_object_solr_docs } } }
   let(:virtual_object_solr_docs) { [] }

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Publish::MetadataTransferService do
           item.rightsMetadata.content = "<rightsMetadata><access type='discover'><machine><world/></machine></access></rightsMetadata>"
           service.publish
           expect(Publish::PublicXmlService).to have_received(:new).with(item, public_cocina: Cocina::Models::DRO, released_for: release_tags, thumbnail_service: thumbnail_service)
-          expect(Publish::PublicDescMetadataService).to have_received(:new).with(item)
+          expect(Publish::PublicDescMetadataService).to have_received(:new).with(item, Cocina::Models::DRO)
         end
 
         it 'even when rightsMetadata uses xml namespaces' do

--- a/spec/services/title_builder_spec.rb
+++ b/spec/services/title_builder_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TitleBuilder do
+  subject { described_class.build(cocina_titles) }
+
+  # lots more specs in spec/indexers/descriptive_metadata/title_spec
+
+  # from a spreadsheet upload integration test
+  #   https://argo-stage.stanford.edu/view/sk561pf3505
+  let(:cocina_titles) do
+    [
+      # Yes, there can be a structuredValue inside a StructuredValue.  For example,
+      # a uniform title where both the name and the title have internal StructuredValue
+      Cocina::Models::Title.new(
+        structuredValue: [
+          {
+            structuredValue: [
+              {
+                value: 'ti1:nonSort',
+                type: 'nonsorting characters'
+              },
+              {
+                value: 'brisk junket',
+                type: 'main title'
+              },
+              {
+                value: 'ti1:subTitle',
+                type: 'subtitle'
+              },
+              {
+                value: 'ti1:partNumber',
+                type: 'part number'
+              },
+              {
+                value: 'ti1:partName',
+                type: 'part name'
+              }
+            ]
+          }
+        ]
+      )
+    ]
+  end
+
+  it { is_expected.to eq 'ti1:nonSort brisk junket : ti1:subTitle. ti1:partNumber, ti1:partName' }
+end


### PR DESCRIPTION


## Why was this change made? 🤔

Ref #3098

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



