### PR TITLE
Require cocina.json in BagVerifier

### DIFF
--- a/app/services/preserve/bag_verifier.rb
+++ b/app/services/preserve/bag_verifier.rb
@@ -12,6 +12,7 @@ module Preserve
       versionAdditions.xml
       versionInventory.xml
       data/metadata/versionMetadata.xml
+      data/metadata/cocina.json
     ].freeze
 
     # @param [Pathname] bag_dir the location of the bag to be verified

--- a/spec/services/preserve/bag_verifier_spec.rb
+++ b/spec/services/preserve/bag_verifier_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe Preserve::BagVerifier do
   let(:fixtures) { Pathname(File.dirname(__FILE__)).join('../../fixtures') }
 
+  # NOTE: BagVerifier#verify is exercised by spec/services/sdr_ingest_service_spec.rb
+
   describe '#verify_pathname' do
     subject(:verify_pathname) { instance.verify_pathname(path) }
 


### PR DESCRIPTION
## Why was this change made? 🤔

The BagVerifier should ensure that `cocina.json` is present.

## How was this change tested? 🤨

Unit tests.

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

closes #3496



