### PR TITLE
Normalizing virtual object relationship type.

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -52,6 +52,7 @@ module Cocina
         missing_type_attribute_assigned_file
         normalize_image_data
         normalize_blank_file_directives
+        normalize_relationship
 
         regenerate_ng_xml(ng_xml.to_s)
       end
@@ -205,6 +206,12 @@ module Cocina
 
       def remove_external_resource_id
         ng_xml.xpath('//externalFile/@resourceId').each(&:remove)
+      end
+
+      def normalize_relationship
+        ng_xml.root.xpath('//relationship[not(@type)]').each do |node|
+          node['type'] = 'alsoAvailableAs'
+        end
       end
     end
   end

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -872,4 +872,30 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       )
     end
   end
+
+  context 'when normalizing contentMetadata virtual object relationship with missing type' do
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata type="file" objectId="druid:bb035tg0974">
+          <resource sequence="1" id="bb035tg0974_1" type="file">
+            <externalFile objectId="druid:fn851rw5684" resourceId="fn851rw5684_1" fileId="PC0170_s3_Oregon_State_2008-08-28_154120_0001.jp2" mimetype="image/jp2"/>
+            <relationship objectId="druid:fn851rw5684"/>
+          </resource>
+        </contentMetadata>
+      XML
+    end
+
+    it 'adds a type' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <contentMetadata type="file" objectId="druid:bb035tg0974">
+            <resource type="file">
+              <externalFile objectId="druid:fn851rw5684" fileId="PC0170_s3_Oregon_State_2008-08-28_154120_0001.jp2" mimetype="image/jp2"/>
+              <relationship objectId="druid:fn851rw5684" type="alsoAvailableAs"/>
+            </resource>
+          </contentMetadata>
+        XML
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #3409 to normalize contentMetadata relationship node in virtual objects.

## How was this change tested? 🤨
Added spec and specs pass. `bin/validate-cocina-roundtrip -s 100000` on sdr-deploy has no change:
Before:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99791 (99.873%)
  Different: 127 (0.127%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```
After
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99791 (99.873%)
  Different: 127 (0.127%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



