### PR TITLE
Normalizes bookData to remove pageStart

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -42,6 +42,7 @@ module Cocina
         remove_empty_labels
         remove_provider_checksum
         remove_meaningless_attr_elements
+        remove_pagestart_attribute
         normalize_object_id_attribute(druid)
         normalize_reading_order(druid)
         normalize_attr_label
@@ -134,6 +135,10 @@ module Cocina
 
       def remove_provider_checksum
         ng_xml.xpath('//resource/file/provider_checksum').each(&:remove)
+      end
+
+      def remove_pagestart_attribute
+        ng_xml.xpath('//bookData/@pageStart').each(&:remove)
       end
 
       def normalize_reading_order(druid)

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -846,4 +846,30 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       )
     end
   end
+
+  context 'when bookData pageStart exists' do
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata objectId="druid:bb035tg0974" type="book">
+          <bookData readingOrder="rtl" pageStart="right"/>
+          <resource type="page"/>
+        </contentMetadata>
+      XML
+    end
+
+    before do
+      allow(AdministrativeTags).to receive(:content_type).and_return(['Book (rtl)'])
+    end
+
+    it 'removes pageStart' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <contentMetadata objectId="druid:bb035tg0974" type="book">
+            <bookData readingOrder="rtl"/>
+            <resource type="page"/>
+          </contentMetadata>
+        XML
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #3477, normalizing out pageStart from bookData.

## How was this change tested? 🤨
Added spec and rest of specs pass. Running `bin/validate-cocina-roundtrip -s 100000` on sdr-deploy: no change. 

Before
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99791 (99.873%)
  Different: 127 (0.127%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

After
```Status (n=100000; not using Missing for success/different/error stats):
  Success:   99791 (99.873%)
  Different: 127 (0.127%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



