### PR TITLE
Rewrite rights metadata in public xml to use Cocina

### DIFF
--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -33,7 +33,6 @@ module Publish
 
       thumb = @thumbnail_service.thumb
       pub.add_child(Nokogiri("<thumb>#{thumb}</thumb>").root) unless thumb.nil?
-
       new_pub = Nokogiri::XML(pub.to_xml, &:noblanks)
       new_pub.encoding = 'UTF-8'
       new_pub.to_xml
@@ -64,7 +63,7 @@ module Publish
     end
 
     def public_rights_metadata
-      @public_rights_metadata ||= RightsMetadata.new(public_cocina).create
+      @public_rights_metadata ||= RightsMetadata.new(public_cocina, release_date).create
     end
 
     def release_date

--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -22,7 +22,7 @@ module Publish
       pub['publishVersion'] = "dor-services/#{Dor::VERSION}"
       pub.add_child(public_identity_metadata.root) # add in modified identityMetadata datastream
       pub.add_child(public_content_metadata.root) if public_content_metadata.xpath('//resource').any?
-      pub.add_child(public_rights_metadata.root)
+      pub.add_child(public_rights_metadata)
       pub.add_child(public_relationships.root)
       desc_md_xml = Publish::PublicDescMetadataService.new(public_cocina).ng_xml(include_access_conditions: false)
       pub.add_child(DublinCoreService.new(desc_md_xml).ng_xml.root)
@@ -64,7 +64,7 @@ module Publish
     end
 
     def public_rights_metadata
-      @public_rights_metadata ||= RightsMetadata.new(fedora_object.rightsMetadata.ng_xml, release_date: release_date).create
+      @public_rights_metadata ||= RightsMetadata.new(public_cocina).create
     end
 
     def release_date

--- a/app/services/publish/rights_metadata.rb
+++ b/app/services/publish/rights_metadata.rb
@@ -2,200 +2,48 @@
 
 module Publish
   # Exports the rightsMetadata XML that is sent to purl.stanford.edu
-  # rubocop:disable Metrics/ClassLength
   class RightsMetadata
-    attr_reader :cocina_object
+    attr_reader :cocina_object, :release_date
 
     # @param [Cocina::Models::DRO, Cocina::Models::Collection] public_cocina a cocina object stripped of non-public data
-    def initialize(cocina_object)
+    def initialize(cocina_object, release_date)
       @cocina_object = cocina_object
+      @release_date = release_date
     end
 
     # @return [Nokogiri::Xml] the original xml with the legacy style rights added so that the description can be displayed.
     def create
-      return create_collection_xml if cocina_object.collection?
+      structural = cocina_object.structural || nil if cocina_object.respond_to?(:structural)
+      cocina_access = Nokogiri::XML(Cocina::ToFedora::AccessGenerator.generate(root: Nokogiri::XML('<rightsMetadata/>').root,
+                                                                               access: cocina_object.access,
+                                                                               structural: structural))
+      add_release_date(cocina_access) if release_date
+      add_use_statement(cocina_access) if cocina_object.access.useAndReproductionStatement
+      add_copyright_statement(cocina_access) if cocina_object.access.copyright
 
-      create_dro_xml
+      cocina_access.root
     end
 
     private
 
-    def create_collection_xml
-      <<~XML
-        <rightsMetadata>
-          <access type="discover">
-            <machine>
-              <#{collection_access} />
-            </machine>
-          </access>
-          <access type="read">
-            <machine>
-              <#{collection_access} />
-            </machine>
-          </access>
-          #{use}
-          #{copyright}
-        </rightsMetadata>
-      XML
+    def add_release_date(cocina_access)
+      read_machine_node = cocina_access.xpath('/rightsMetadata/access[@type="read"]/machine').first
+      date_node = read_machine_node.xpath('./embargoReleaseDate').first || read_machine_node.add_child('<embargoReleaseDate />').first
+      date_node.content = release_date
     end
 
-    def collection_access
-      cocina_object.access.access == 'dark' ? 'none' : cocina_object.access.access
+    def add_use_statement(cocina_access)
+      use_node = cocina_access.root.add_child('<use />').first
+      use_human_node = use_node.add_child('<human type="useAndReproduction" />').first
+      use_human_node.content = cocina_object.access.useAndReproductionStatement
+      use_license_node = use_node.add_child('<license />').first
+      use_license_node.content = cocina_object.access.license
     end
 
-    def create_dro_xml
-      <<~XML
-        <rightsMetadata>
-          #{discover}
-          #{read(cocina_object.access)}
-          #{read_world_no_download}
-          #{read_content}
-          #{use}
-          #{copyright}
-        </rightsMetadata>
-      XML
-    end
-
-    def discover
-      <<~XML
-        <access type="discover">
-          <machine>
-            <#{access} />
-          </machine>
-        </access>
-      XML
-    end
-
-    def access
-      return 'none' if %w[dark none].include?(cocina_object.access.access)
-
-      'world'
-    end
-
-    def read(object_access)
-      return read_location(object_access) if location_based?(object_access)
-
-      <<~XML
-        <access type="read">
-          <machine>
-            #{download(object_access)}
-            #{release_date}
-          </machine>
-        </access>
-        #{read_location(object_access) if object_access.download == 'location-based'}
-      XML
-    end
-
-    def read_file(object_access, filename)
-      <<~XML
-        <access type="read">
-          <file>#{filename}</file>
-          #{file_download(object_access)}
-          #{file_location(object_access) if object_access.download == 'location-based'}
-        </access>
-      XML
-    end
-
-    def location_based?(object_access)
-      return true if object_access.access == 'location-based'
-      return true if [object_access.access, object_access.download] == %w[world location-based]
-
-      false
-    end
-
-    def read_location(object_access)
-      <<~XML
-        <access type="read">
-          <machine>
-            #{read_location_based(object_access)}
-          </machine>
-        </access>
-      XML
-    end
-
-    def read_location_based(object_access)
-      rule = 'rule="no-download"' if object_access.download == 'none'
-      "<location #{rule}>#{object_access.readLocation}</location>" if object_access.readLocation
-    end
-
-    def read_world_no_download
-      return unless cocina_object.access.access == 'world'
-      return unless %w[stanford location-based].include? cocina_object.access.download
-
-      '<access type="read"><machine><world rule="no-download" /></machine></access>'
-    end
-
-    def read_content
-      return unless cocina_object.structural
-
-      access_nodes = []
-      cocina_object.structural.contains.each do |file_set|
-        next unless file_set.structural
-
-        file_set.structural.contains.each do |file|
-          access_nodes.push(read_file(file.access, file.filename))
-        end
-      end
-
-      access_nodes.join("\n")
-    end
-
-    def file_download(object_access)
-      <<~XML
-        <machine>
-          #{download(object_access)}
-        </machine>
-      XML
-    end
-
-    def file_location(object_access)
-      <<~XML
-        <machine>
-          #{read_location_based(object_access)}
-        </machine>
-      XML
-    end
-
-    def download(object_access)
-      return cdl if object_access.controlledDigitalLending
-      return '<group>stanford</group>' if object_access.download == 'stanford'
-      return '<group rule="no-download">stanford</group>' if object_access.access == 'stanford' && object_access.download != 'stanford'
-      return '<world rule="no-download" />' if object_access.access == 'world' && object_access.download != 'world'
-
-      "<#{object_access.download} />"
-    end
-
-    def cdl
-      '<cdl><group rule="no-download">stanford</group></cdl>'
-    end
-
-    def release_date
-      return unless cocina_object.access.embargo
-
-      "<embargoReleaseDate>#{cocina_object.access.embargo.releaseDate.utc.iso8601}</embargoReleaseDate>"
-    end
-
-    def use
-      return unless use_statement || license
-
-      "<use>#{use_statement}#{license}</use>"
-    end
-
-    def use_statement
-      "<human type=\"useAndReproduction\">#{cocina_object.access.useAndReproductionStatement}</human>" if cocina_object.access.useAndReproductionStatement
-    end
-
-    def license
-      "<license>#{cocina_object.access.license}</license>" if cocina_object.access.license
-    end
-
-    def copyright
-      "<copyright>#{copyright_statement}</copyright>" if copyright_statement
-    end
-
-    def copyright_statement
-      "<human>#{cocina_object.access.copyright}</human>" if cocina_object.access.copyright
+    def add_copyright_statement(cocina_access)
+      copyright_node = cocina_access.root.add_child('<copyright />').first
+      use_human_node = copyright_node.add_child('<human />').first
+      use_human_node.content = cocina_object.access.copyright
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/app/services/publish/rights_metadata.rb
+++ b/app/services/publish/rights_metadata.rb
@@ -134,29 +134,25 @@ module Publish
     end
 
     def use
+      return unless use_statement || license
+
       "<use>#{use_statement}#{license}</use>"
     end
 
     def use_statement
-      return '<human type="useAndReproduction" />' unless cocina_object.access.useAndReproductionStatement
-
-      "<human type=\"useAndReproduction\">#{cocina_object.access.useAndReproductionStatement}</human>"
+      "<human type=\"useAndReproduction\">#{cocina_object.access.useAndReproductionStatement}</human>" if cocina_object.access.useAndReproductionStatement
     end
 
     def license
-      return '<license />' unless cocina_object.access.license
-
-      "<license>#{cocina_object.access.license}</license>"
+      "<license>#{cocina_object.access.license}</license>" if cocina_object.access.license
     end
 
     def copyright
-      "<copyright>#{copyright_statement}</copyright>"
+      "<copyright>#{copyright_statement}</copyright>" if copyright_statement
     end
 
     def copyright_statement
-      return '<human />' unless cocina_object.access.copyright
-
-      "<human>#{cocina_object.access.copyright}</human>"
+      "<human>#{cocina_object.access.copyright}</human>" if cocina_object.access.copyright
     end
   end
 end

--- a/app/services/publish/rights_metadata.rb
+++ b/app/services/publish/rights_metadata.rb
@@ -3,29 +3,160 @@
 module Publish
   # Exports the rightsMetadata XML that is sent to purl.stanford.edu
   class RightsMetadata
-    attr_reader :original, :release_date
+    attr_reader :cocina_object
 
-    # @param [Nokogiri::XML] original
-    # @param [String] release_date the embargo release date if one is set, otherwise send nil.
-    def initialize(original, release_date:)
-      @original = original
-      @release_date = release_date
+    # @param [Cocina::Models::DRO, Cocina::Models::Collection] public_cocina a cocina object stripped of non-public data
+    def initialize(cocina_object)
+      @cocina_object = cocina_object
     end
 
     # @return [Nokogiri::Xml] the original xml with the legacy style rights added so that the description can be displayed.
     def create
-      add_release_date
-      original.clone
+      return create_collection_xml if cocina_object.collection?
+
+      create_dro_xml
     end
 
     private
 
-    def add_release_date
-      return unless release_date
+    def create_collection_xml
+      <<~XML
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <#{collection_access} />
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <#{collection_access} />
+            </machine>
+          </access>
+          #{use}
+          #{copyright}
+        </rightsMetadata>
+      XML
+    end
 
-      read_machine_node = original.xpath('/rightsMetadata/access[@type="read"]/machine').first
-      date_node = read_machine_node.xpath('./embargoReleaseDate').first || read_machine_node.add_child('<embargoReleaseDate />').first
-      date_node.content = release_date
+    def collection_access
+      cocina_object.access.access == 'dark' ? 'none' : cocina_object.access.access
+    end
+
+    def create_dro_xml
+      <<~XML
+        <rightsMetadata>
+          #{discover}
+          #{read}
+          #{read_location}
+          #{read_world_no_download}
+          #{use}
+          #{copyright}
+        </rightsMetadata>
+      XML
+    end
+
+    def discover
+      <<~XML
+        <access type="discover">
+          <machine>
+            <#{access} />
+          </machine>
+        </access>
+      XML
+    end
+
+    def access
+      return 'none' if %w[dark none].include?(cocina_object.access.access)
+
+      'world'
+    end
+
+    def read
+      return if location_based?
+
+      <<~XML
+        <access type="read">
+          <machine>
+            #{download}
+            #{release_date}
+          </machine>
+        </access>
+      XML
+    end
+
+    def location_based?
+      return true if cocina_object.access.access == 'location-based'
+      return true if [cocina_object.access.access, cocina_object.access.download] == %w[world location-based]
+
+      false
+    end
+
+    def read_location
+      return unless [cocina_object.access.access, cocina_object.access.download].include? 'location-based'
+
+      <<~XML
+        <access type="read">
+          <machine>
+            #{read_location_based}
+          </machine>
+        </access>
+      XML
+    end
+
+    def read_location_based
+      rule = 'rule="no-download"' if cocina_object.access.download == 'none'
+      "<location #{rule}>#{cocina_object.access.readLocation}</location>" if cocina_object.access.readLocation
+    end
+
+    def read_world_no_download
+      return unless cocina_object.access.access == 'world'
+      return unless %w[stanford location-based].include? cocina_object.access.download
+
+      '<access type="read"><machine><world rule="no-download" /></machine></access>'
+    end
+
+    def download
+      return cdl if cocina_object.access.controlledDigitalLending
+      return '<group>stanford</group>' if cocina_object.access.download == 'stanford'
+      return '<group rule="no-download">stanford</stanford>' if cocina_object.access.access == 'stanford' && cocina_object.access.download != 'stanford'
+
+      "<#{cocina_object.access.download} />"
+    end
+
+    def cdl
+      '<cdl><group rule="no-download">stanford</group></cdl>'
+    end
+
+    def release_date
+      return unless cocina_object.access.embargo
+
+      "<embargoReleaseDate>#{cocina_object.access.embargo.releaseDate.utc.iso8601}</embargoReleaseDate>"
+    end
+
+    def use
+      "<use>#{use_statement}#{license}</use>"
+    end
+
+    def use_statement
+      return '<human type="useAndReproduction" />' unless cocina_object.access.useAndReproductionStatement
+
+      "<human type=\"useAndReproduction\">#{cocina_object.access.useAndReproductionStatement}</human>"
+    end
+
+    def license
+      return '<license />' unless cocina_object.access.license
+
+      "<license>#{cocina_object.access.license}</license>"
+    end
+
+    def copyright
+      "<copyright>#{copyright_statement}</copyright>"
+    end
+
+    def copyright_statement
+      return '<human />' unless cocina_object.access.copyright
+
+      "<human>#{cocina_object.access.copyright}</human>"
     end
   end
 end

--- a/bin/reports/report-rights-discover-world
+++ b/bin/reports/report-rights-discover-world
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+Report.new(name: 'rights-discover-world', dsid: 'rightsMetadata').run do |ng_xml|
+  ng_xml.xpath('//access[@type = "discover"]/machine/world').nil?
+end

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -154,10 +154,7 @@ RSpec.describe 'Display metadata' do
             </access>
             <use>
               <human type="useAndReproduction"/>
-              <human type="creativeCommons"/>
-              <machine type="creativeCommons" uri=""/>
-              <human type="openDataCommons"/>
-              <machine type="openDataCommons" uri=""/>
+              <license />
             </use>
             <copyright>
               <human/>

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -152,13 +152,6 @@ RSpec.describe 'Display metadata' do
                 <none/>
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
           #{relationships_xml}
           <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -60,25 +60,6 @@ RSpec.describe Publish::PublicXmlService do
 
     let(:ng_xml) { Nokogiri::XML(xml) }
 
-    let(:rights) do
-      <<~XML
-        <rightsMetadata objectId="druid:bc123df4567">
-          <copyright>
-            <human>(c) Copyright 2010 by Sebastian Jeremias Osterfeld</human>
-          </copyright>
-          <access type="read">
-            <machine>
-              <group>stanford:stanford</group>
-            </machine>
-          </access>
-          <use>
-            <machine type="creativeCommons">by-sa</machine>
-            <human type="creativeCommons">CC Attribution Share Alike license</human>
-          </use>
-        </rightsMetadata>
-      XML
-    end
-
     before do
       mods = <<-EOXML
         <mods:mods xmlns:mods="http://www.loc.gov/mods/v3"
@@ -126,8 +107,10 @@ RSpec.describe Publish::PublicXmlService do
                                 description: description,
                                 identification: {},
                                 access: {
+                                  access: 'world',
+                                  download: 'world',
                                   embargo: {
-                                    releaseDate: DateTime.parse('2050-05-31')
+                                    releaseDate: '2021-10-08T00:00:00Z'
                                   }
                                 },
                                 administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
@@ -138,7 +121,7 @@ RSpec.describe Publish::PublicXmlService do
       end
 
       it 'adds embargo to the rights' do
-        expect(result).to eq '2050-05-31T00:00:00Z'
+        expect(result).to eq '2021-10-08T00:00:00Z'
       end
     end
 

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe Publish::PublicXmlService do
       allow(VirtualObject).to receive(:for).and_return([{ id: 'druid:hj097bm8879' }])
       item.contentMetadata.content = '<contentMetadata/>'
       item.descMetadata.content    = mods
-      item.rightsMetadata.content  = rights
       allow_any_instance_of(Publish::PublicDescMetadataService).to receive(:ng_xml).and_return(Nokogiri::XML(mods)) # calls Item.find and not needed in general tests
       allow(OpenURI).to receive(:open_uri).with('https://purl-test.stanford.edu/bc123df4567.xml').and_return('<xml/>')
       WebMock.disable_net_connect!

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -124,6 +124,31 @@ RSpec.describe Publish::PublicXmlService do
       end
     end
 
+    context 'with an problematic location code' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {
+                                  access: 'location-based',
+                                  download: 'location-based',
+                                  readLocation: 'm&m'
+                                },
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+
+      let(:result) do
+        ng_xml.at_xpath('/publicObject/rightsMetadata/access[@type="read"]/machine/location').text
+      end
+
+      it 'does not munge the location code' do
+        expect(result).to eq 'm&m'
+      end
+    end
+
     context 'produces xml with' do
       let(:cocina_object) do
         Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',

--- a/spec/services/publish/rights_metadata_spec.rb
+++ b/spec/services/publish/rights_metadata_spec.rb
@@ -42,13 +42,6 @@ RSpec.describe Publish::RightsMetadata do
                 <none />
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
         XML
       end
@@ -86,13 +79,6 @@ RSpec.describe Publish::RightsMetadata do
                 <world />
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
         XML
       end
@@ -177,13 +163,6 @@ RSpec.describe Publish::RightsMetadata do
                 <none />
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
         XML
       end
@@ -231,13 +210,6 @@ RSpec.describe Publish::RightsMetadata do
                 <world rule="no-download" />
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
         XML
       end
@@ -276,13 +248,6 @@ RSpec.describe Publish::RightsMetadata do
                 <location>art</location>
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
         XML
       end
@@ -321,13 +286,6 @@ RSpec.describe Publish::RightsMetadata do
                 <location rule="no-download">art</location>
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
         XML
       end
@@ -371,13 +329,6 @@ RSpec.describe Publish::RightsMetadata do
                 <group rule="no-download">stanford</group>
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
         XML
       end
@@ -421,13 +372,6 @@ RSpec.describe Publish::RightsMetadata do
                 <world rule="no-download" />
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
         XML
       end
@@ -464,13 +408,6 @@ RSpec.describe Publish::RightsMetadata do
                 <none />
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
         XML
       end
@@ -510,13 +447,6 @@ RSpec.describe Publish::RightsMetadata do
                 </cdl>
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
         XML
       end
@@ -554,13 +484,6 @@ RSpec.describe Publish::RightsMetadata do
                 <group rule="no-download">stanford</group>
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
         XML
       end
@@ -602,13 +525,6 @@ RSpec.describe Publish::RightsMetadata do
                 <world rule="no-download" />
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
         XML
       end
@@ -645,13 +561,6 @@ RSpec.describe Publish::RightsMetadata do
                 <group>stanford</group>
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
         XML
       end
@@ -688,13 +597,6 @@ RSpec.describe Publish::RightsMetadata do
                 <world />
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
         XML
       end
@@ -731,13 +633,6 @@ RSpec.describe Publish::RightsMetadata do
                 <none />
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction"/>
-              <license />
-            </use>
-            <copyright>
-              <human/>
-            </copyright>
           </rightsMetadata>
         XML
       end

--- a/spec/services/publish/rights_metadata_spec.rb
+++ b/spec/services/publish/rights_metadata_spec.rb
@@ -2,16 +2,215 @@
 
 require 'rails_helper'
 
+# rights objects for testing can be found at:
+# https://argo-stage.stanford.edu/catalog?f%5Bnonhydrus_collection_title_ssim%5D%5B%5D=rights+examples
 RSpec.describe Publish::RightsMetadata do
-  subject(:service) { described_class.new(Nokogiri::XML(original), release_date: release_date) }
-
-  let(:release_date) { nil }
+  subject(:service) { described_class.new(cocina_object) }
 
   describe '#create' do
     subject(:result) { service.create }
 
+    let(:description) do
+      {
+        title: [{ value: 'Constituent label &amp; A Special character' }],
+        purl: 'https://purl.stanford.edu/bc123df4567'
+      }
+    end
+
+    context 'when an object has an empty access node' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {},
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <none />
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <none />
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction"/>
+              <license />
+            </use>
+            <copyright>
+              <human/>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'outputs dark rights metadata' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when an object is world' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {
+                                  access: 'world',
+                                  download: 'world'
+                                },
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world />
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world />
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction"/>
+              <license />
+            </use>
+            <copyright>
+              <human/>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'adds discover world and read world' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when an object is world and includes use and copyright statements' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {
+                                  access: 'world',
+                                  download: 'world',
+                                  useAndReproductionStatement: 'Temporary use statement',
+                                  copyright: 'Temporary copyright',
+                                  license: 'https://creativecommons.org/licenses/by/4.0/legalcode'
+                                },
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world />
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world />
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction">Temporary use statement</human
+              <license>https://creativecommons.org/licenses/by/4.0/legalcode</license>
+            </use>
+            <copyright>
+              <human>Temporary copyright</human>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'adds discover world and read world with use and license' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when an object is dark' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {
+                                  access: 'dark',
+                                  download: 'none'
+                                },
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <none />
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <none />
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction"/>
+              <license />
+            </use>
+            <copyright>
+              <human/>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'adds discover none and read none' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
     context 'when an embargo date is provided' do
-      let(:release_date) { '2020-02-26T00:00:00Z' }
+      let(:release_date) { '2020-02-26T00:00:00+00:00' }
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {
+                                  access: 'world',
+                                  download: 'stanford',
+                                  embargo: {
+                                    releaseDate: release_date
+                                  }
+                                },
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
 
       let(:expected) do
         <<~XML
@@ -27,73 +226,524 @@ RSpec.describe Publish::RightsMetadata do
                 <embargoReleaseDate>2020-02-26T00:00:00Z</embargoReleaseDate>
               </machine>
             </access>
+            <access type="read">
+              <machine>
+                <world rule="no-download" />
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction"/>
+              <license />
+            </use>
+            <copyright>
+              <human/>
+            </copyright>
           </rightsMetadata>
         XML
       end
 
-      context 'without an existing embargoReleaseDate node' do
-        let(:original) do
-          <<~XML
-            <rightsMetadata>
-              <access type="discover">
-                <machine>
-                  <world />
-                </machine>
-              </access>
-              <access type="read">
-                <machine>
-                  <group>stanford</group>
-                </machine>
-              </access>
-            </rightsMetadata>
-          XML
-        end
-
-        it 'adds the embargo release date' do
-          expect(result).to be_equivalent_to(expected)
-        end
-      end
-
-      context 'with an existing embargoReleaseDate node' do
-        let(:original) do
-          <<~XML
-            <rightsMetadata>
-              <access type="discover">
-                <machine>
-                  <world />
-                </machine>
-              </access>
-              <access type="read">
-                <machine>
-                  <embargoReleaseDate>2025-11-11T00:00:00Z</embargoReleaseDate>
-                  <group>stanford</group>
-                </machine>
-              </access>
-            </rightsMetadata>
-          XML
-        end
-
-        it 'adds the embargo release date' do
-          expect(result).to be_equivalent_to(expected)
-        end
+      it 'adds the embargo release date' do
+        expect(result).to be_equivalent_to(expected)
       end
     end
 
-    context 'when no license node is present' do
-      let(:original) do
+    context 'when read access is location based' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {
+                                  access: 'location-based',
+                                  download: 'location-based',
+                                  readLocation: 'art'
+                                },
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+
+      let(:expected) do
         <<~XML
           <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world />
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <location>art</location>
+              </machine>
+            </access>
             <use>
-               <human type="openDataCommons">Open Data Commons Attribution License 1.0</human>
-               <machine type="openDataCommons" uri="https://opendatacommons.org/licenses/by/1-0/">odc-by</machine>
-               <human type="useAndReproduction">Whatever makes you happy</human>
+              <human type="useAndReproduction"/>
+              <license />
             </use>
+            <copyright>
+              <human/>
+            </copyright>
           </rightsMetadata>
         XML
       end
 
-      it 'returns the original value' do
-        expect(result).to be_equivalent_to(original)
+      it 'includes the location based access node' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when read access is location based and no download' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {
+                                  access: 'location-based',
+                                  download: 'none',
+                                  readLocation: 'art'
+                                },
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world />
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <location rule="no-download">art</location>
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction"/>
+              <license />
+            </use>
+            <copyright>
+              <human/>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'adds the embargo release date' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when object is location based and stanford no download' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {
+                                  access: 'stanford',
+                                  download: 'location-based',
+                                  readLocation: 'art'
+                                },
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world />
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <location>art</location>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <group rule="no-download">stanford</group>
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction"/>
+              <license />
+            </use>
+            <copyright>
+              <human/>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'outputs read blocks for stanford and the location' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when object is location based and world no download' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {
+                                  access: 'world',
+                                  download: 'location-based',
+                                  readLocation: 'art'
+                                },
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world />
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <location>art</location>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world rule="no-download" />
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction"/>
+              <license />
+            </use>
+            <copyright>
+              <human/>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'outputs read blocks for world and the location' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when an object is citation only' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {
+                                  access: 'citation-only',
+                                  download: 'none'
+                                },
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world />
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <none />
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction"/>
+              <license />
+            </use>
+            <copyright>
+              <human/>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'returns the appropriate rights metadata xml' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when an object is controlled digital lending' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {
+                                  access: 'stanford',
+                                  download: 'none',
+                                  controlledDigitalLending: true
+                                },
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <cdl>
+                  <group rule="no-download">stanford</group>
+                </cdl>
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction"/>
+              <license />
+            </use>
+            <copyright>
+              <human/>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'returns the appropriate rights metadata xml' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when an object is stanford no-download' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {
+                                  access: 'stanford',
+                                  download: 'none',
+                                  controlledDigitalLending: false
+                                },
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <group rule="no-download">stanford</group>
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction"/>
+              <license />
+            </use>
+            <copyright>
+              <human/>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'returns the appropriate rights metadata xml' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when an object is world no-download' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {
+                                  access: 'world',
+                                  download: 'stanford'
+                                },
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <group>stanford</group>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world rule="no-download" />
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction"/>
+              <license />
+            </use>
+            <copyright>
+              <human/>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'returns the appropriate rights metadata xml' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when an object is stanford stanford' do
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {
+                                  access: 'stanford',
+                                  download: 'stanford'
+                                },
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <group>stanford</group>
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction"/>
+              <license />
+            </use>
+            <copyright>
+              <human/>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'returns the appropriate rights metadata xml' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when a collection is world' do
+      let(:cocina_object) do
+        Cocina::Models::Collection.new(externalIdentifier: 'druid:bc123df4567',
+                                       type: Cocina::Models::Vocab.collection,
+                                       label: 'A generic label',
+                                       version: 1,
+                                       description: description,
+                                       identification: {},
+                                       access: {
+                                         access: 'world'
+                                       },
+                                       administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world />
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world />
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction"/>
+              <license />
+            </use>
+            <copyright>
+              <human/>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'adds discover world and read world' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when a collection is dark' do
+      let(:cocina_object) do
+        Cocina::Models::Collection.new(externalIdentifier: 'druid:bc123df4567',
+                                       type: Cocina::Models::Vocab.collection,
+                                       label: 'A generic label',
+                                       version: 1,
+                                       description: description,
+                                       identification: {},
+                                       access: {
+                                         access: 'dark'
+                                       },
+                                       administrative: { hasAdminPolicy: 'druid:pp000pp0000' })
+      end
+
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <none />
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <none />
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction"/>
+              <license />
+            </use>
+            <copyright>
+              <human/>
+            </copyright>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'adds discover none and read none' do
+        expect(result).to be_equivalent_to(expected)
       end
     end
   end

--- a/spec/services/publish/rights_metadata_spec.rb
+++ b/spec/services/publish/rights_metadata_spec.rb
@@ -710,11 +710,87 @@ RSpec.describe Publish::RightsMetadata do
               <machine>
                 <location>art</location>
               </machine>
+              <machine>
+                <group rule="no-download">stanford</group>
+              </machine>
+            </access>
+          </rightsMetadata>
+        XML
+      end
+
+      it 'outputs read blocks for stanford and the location' do
+        expect(result).to be_equivalent_to(expected)
+      end
+    end
+
+    context 'when object is world but the file is location based and world no download' do
+      let(:structural) do
+        {
+          contains: [{
+            type: 'http://cocina.sul.stanford.edu/models/resources/file.jsonld',
+            externalIdentifier: 'http://cocina.sul.stanford.edu/fileSet/wf816pb3072/8043b03b-9ec3-44e9-8a93-00be030a5f65',
+            label: 'Image 1',
+            version: 7,
+            structural: {
+              contains: [{
+                type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
+                externalIdentifier: 'http://cocina.sul.stanford.edu/file/wf816pb3072/8043b03b-9ec3-44e9-8a93-00be030a5f65/placeholder.jp2',
+                label: 'placeholder.jp2',
+                filename: 'placeholder.jp2',
+                size: 111_541_144,
+                version: 7,
+                hasMimeType: 'image/jp2',
+                hasMessageDigests: [],
+                access: {
+                  access: 'world',
+                  download: 'location-based',
+                  readLocation: 'art'
+                },
+                administrative: {
+                  publish: true,
+                  sdrPreserve: false,
+                  shelve: true
+                }
+              }]
+            }
+          }]
+        }
+      end
+      let(:cocina_object) do
+        Cocina::Models::DRO.new(externalIdentifier: 'druid:bc123df4567',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'A generic label',
+                                version: 1,
+                                description: description,
+                                identification: {},
+                                access: {
+                                  access: 'world',
+                                  download: 'world'
+                                },
+                                administrative: { hasAdminPolicy: 'druid:pp000pp0000' },
+                                structural: structural)
+      end
+
+      let(:expected) do
+        <<~XML
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world />
+              </machine>
             </access>
             <access type="read">
               <file>placeholder.jp2</file>
               <machine>
-                <group rule="no-download">stanford</group>
+                <location>art</location>
+              </machine>
+              <machine>
+                <world rule="no-download" />
               </machine>
             </access>
           </rightsMetadata>

--- a/spec/services/publish/rights_metadata_spec.rb
+++ b/spec/services/publish/rights_metadata_spec.rb
@@ -5,11 +5,12 @@ require 'rails_helper'
 # rights objects for testing can be found at:
 # https://argo-stage.stanford.edu/catalog?f%5Bnonhydrus_collection_title_ssim%5D%5B%5D=rights+examples
 RSpec.describe Publish::RightsMetadata do
-  subject(:service) { described_class.new(cocina_object) }
+  subject(:service) { described_class.new(cocina_object, release_date) }
 
   describe '#create' do
     subject(:result) { service.create }
 
+    let(:release_date) { nil }
     let(:description) do
       {
         title: [{ value: 'Constituent label &amp; A Special character' }],
@@ -34,12 +35,12 @@ RSpec.describe Publish::RightsMetadata do
           <rightsMetadata>
             <access type="discover">
               <machine>
-                <none />
+                <none/>
               </machine>
             </access>
             <access type="read">
               <machine>
-                <none />
+                <none/>
               </machine>
             </access>
           </rightsMetadata>
@@ -47,7 +48,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'outputs dark rights metadata' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -84,7 +85,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'adds discover world and read world' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -119,10 +120,7 @@ RSpec.describe Publish::RightsMetadata do
                 <world />
               </machine>
             </access>
-            <use>
-              <human type="useAndReproduction">Temporary use statement</human
-              <license>https://creativecommons.org/licenses/by/4.0/legalcode</license>
-            </use>
+            <use><human type="useAndReproduction">Temporary use statement</human<license>https://creativecommons.org/licenses/by/4.0/legalcode</license></use>
             <copyright>
               <human>Temporary copyright</human>
             </copyright>
@@ -131,7 +129,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'adds discover world and read world with use and license' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(Nokogiri::XML(expected).to_xml)
       end
     end
 
@@ -168,7 +166,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'adds discover none and read none' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -202,12 +200,12 @@ RSpec.describe Publish::RightsMetadata do
             <access type="read">
               <machine>
                 <group>stanford</group>
-                <embargoReleaseDate>2020-02-26T00:00:00Z</embargoReleaseDate>
               </machine>
             </access>
             <access type="read">
               <machine>
                 <world rule="no-download" />
+                <embargoReleaseDate>2020-02-26T00:00:00+00:00</embargoReleaseDate>
               </machine>
             </access>
           </rightsMetadata>
@@ -215,7 +213,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'adds the embargo release date' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -253,7 +251,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'includes the location based access node' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -291,7 +289,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'adds the embargo release date' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -334,7 +332,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'outputs read blocks for stanford and the location' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -377,7 +375,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'outputs read blocks for world and the location' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -413,7 +411,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'returns the appropriate rights metadata xml' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -452,7 +450,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'returns the appropriate rights metadata xml' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -489,7 +487,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'returns the appropriate rights metadata xml' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -530,7 +528,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'returns the appropriate rights metadata xml' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -566,7 +564,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'returns the appropriate rights metadata xml' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -640,7 +638,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'returns the appropriate rights metadata xml' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -719,7 +717,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'outputs read blocks for stanford and the location' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -744,7 +742,7 @@ RSpec.describe Publish::RightsMetadata do
                 access: {
                   access: 'world',
                   download: 'location-based',
-                  readLocation: 'art'
+                  readLocation: 'm&m'
                 },
                 administrative: {
                   publish: true,
@@ -787,7 +785,7 @@ RSpec.describe Publish::RightsMetadata do
             <access type="read">
               <file>placeholder.jp2</file>
               <machine>
-                <location>art</location>
+                <location>m&amp;m</location>
               </machine>
               <machine>
                 <world rule="no-download" />
@@ -798,7 +796,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'outputs read blocks for stanford and the location' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -834,7 +832,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'adds discover world and read world' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
 
@@ -870,7 +868,7 @@ RSpec.describe Publish::RightsMetadata do
       end
 
       it 'adds discover none and read none' do
-        expect(result).to be_equivalent_to(expected)
+        expect(result.to_xml).to be_equivalent_to(expected)
       end
     end
   end


### PR DESCRIPTION
Hold for testing by Andrew

## Why was this change made? 🤔

Fixes #3330

This adds a lot of rights combinations based on https://argo-stage.stanford.edu/catalog?f%5Bnonhydrus_collection_title_ssim%5D%5B%5D=rights+examples for testing and builds the `rightsMetadata` XML for PublicXml.

Prior to this the only change to the rights metadata datastream in public xml was to add an embargo release date, so this change is relatively significant in that now it has to build the XML.

## How was this change tested? 🤨

Updated unit tests.

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

As this touches integration tests should probably be run.


