### PR TITLE
Extracts validation from ObjectCreator and ObjectUpdater.

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -43,10 +43,7 @@ class ObjectsController < ApplicationController
     return json_api_error(status: :service_unavailable, message: 'Registration is temporarily disabled') unless Settings.enabled_features.registration
 
     model_request = Cocina::Models.build_request(params.except(:action, :controller, :assign_doi).to_unsafe_h)
-    cocina_object = Cocina::ObjectCreator.create(model_request, assign_doi: params[:assign_doi])
-
-    # Broadcast this to a topic
-    Notifications::ObjectCreated.publish(model: cocina_object, created_at: Time.zone.now, modified_at: Time.zone.now) if Settings.rabbitmq.enabled
+    cocina_object = CocinaObjectStore.create(model_request, assign_doi: params[:assign_doi])
 
     render status: :created, location: object_path(cocina_object.externalIdentifier), json: cocina_object
   rescue SymphonyReader::ResponseError => e

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -157,13 +157,7 @@ module Cocina
 
     # rubocop:disable Style/GuardClause
     def validate
-      validator = ValidateDarkService.new(cocina_object)
-      raise ValidationError, validator.error unless validator.valid?
-
       raise ValidationError, "Identifier on the query and in the body don't match" if fedora_object.pid != cocina_object.externalIdentifier
-
-      validator = ApoExistenceValidator.new(cocina_object)
-      raise ValidationError, validator.error unless validator.valid?
 
       raise NotImplemented, 'Updating descriptive metadata not supported' if !update_descriptive? && client_attempted_metadata_update?
 

--- a/spec/services/cocina/object_creator_spec.rb
+++ b/spec/services/cocina/object_creator_spec.rb
@@ -210,36 +210,6 @@ RSpec.describe Cocina::ObjectCreator do
       end
     end
 
-    context "when the collection doesn't exist" do
-      before do
-        allow(Dor).to receive(:find).and_raise(ActiveFedora::ObjectNotFoundError)
-        allow(CocinaObjectStore).to receive(:find).and_raise(CocinaObjectStore::CocinaObjectNotFoundError)
-      end
-
-      let(:params) do
-        {
-          'type' => 'http://cocina.sul.stanford.edu/models/media.jsonld',
-          'label' => ':auto',
-          'access' => { 'access' => 'world', 'download' => 'world' },
-          'version' => 1,
-          'administrative' => {
-            'hasAdminPolicy' => apo
-          },
-          'structural' => {
-            'isMemberOf' => ['druid:bk024qs1809']
-          },
-          'identification' => {
-            'sourceId' => 'sul:8.559351',
-            'catalogLinks' => [{ 'catalog' => 'symphony', 'catalogRecordId' => '10121797' }]
-          }
-        }
-      end
-
-      it 'raises an error' do
-        expect { result }.to raise_error Cocina::ValidationError
-      end
-    end
-
     context 'when the type is agreement' do
       let(:params) do
         {

--- a/spec/validators/cocina/object_validator_spec.rb
+++ b/spec/validators/cocina/object_validator_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::ObjectValidator do
+  let(:unique_source_id_validator) { instance_double(Cocina::UniqueSourceIdValidator, valid?: true) }
+  let(:validate_dark_service) { instance_double(Cocina::ValidateDarkService, valid?: true) }
+  let(:apo_existence_validator) { instance_double(Cocina::ApoExistenceValidator, valid?: true) }
+  let(:collection_existence_validator) { instance_double(Cocina::CollectionExistenceValidator, valid?: true) }
+
+  before do
+    allow(Cocina::UniqueSourceIdValidator).to receive(:new).and_return(unique_source_id_validator)
+    allow(Cocina::ValidateDarkService).to receive(:new).and_return(validate_dark_service)
+    allow(Cocina::ApoExistenceValidator).to receive(:new).and_return(apo_existence_validator)
+    allow(Cocina::CollectionExistenceValidator).to receive(:new).and_return(collection_existence_validator)
+  end
+
+  context 'when a request DRO' do
+    let(:cocina_object) { instance_double(Cocina::Models::RequestDRO, dro?: true) }
+
+    it 'validates' do
+      described_class.validate(cocina_object)
+
+      expect(unique_source_id_validator).to have_received(:valid?)
+      expect(validate_dark_service).to have_received(:valid?)
+      expect(apo_existence_validator).to have_received(:valid?)
+      expect(collection_existence_validator).to have_received(:valid?)
+    end
+  end
+
+  context 'when a DRO' do
+    let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: true, externalIdentifier: nil) }
+
+    it 'validates' do
+      described_class.validate(cocina_object)
+
+      expect(unique_source_id_validator).not_to have_received(:valid?)
+      expect(validate_dark_service).to have_received(:valid?)
+      expect(apo_existence_validator).to have_received(:valid?)
+      expect(collection_existence_validator).to have_received(:valid?)
+    end
+  end
+
+  context 'when a Collection' do
+    let(:cocina_object) { instance_double(Cocina::Models::Collection, dro?: false, externalIdentifier: nil) }
+
+    it 'validates' do
+      described_class.validate(cocina_object)
+
+      expect(unique_source_id_validator).not_to have_received(:valid?)
+      expect(validate_dark_service).to have_received(:valid?)
+      expect(apo_existence_validator).to have_received(:valid?)
+      expect(collection_existence_validator).not_to have_received(:valid?)
+    end
+  end
+end


### PR DESCRIPTION
closes #3497

## Why was this change made? 🤔
Allow validation will need to be performed regardless of whether persisting to Fedora or PG.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

