### PR TITLE
Include the objectLabel in the public xml

### DIFF
--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -82,6 +82,7 @@ module Publish
 
     # catkeys are used by PURL
     # objectType is used by purl-fetcher
+    # objectLabel is used by https://github.com/sul-dlss/searchworks_traject_indexer/blob/b5ed9906a5a0130eca5e68fbb0e8633bdbe6ffd6/lib/sdr_stuff.rb#L54
     def public_identity_metadata
       catkeys = Array(public_cocina.identification&.catalogLinks).filter_map { |link| link.catalogRecordId if link.catalog == SYMPHONY }
       nodes = catkeys.map { |catkey| "  <otherId name=\"catkey\">#{catkey}</otherId>" }
@@ -90,6 +91,7 @@ module Publish
         <<~XML
           <identityMetadata>
             <objectType>#{public_cocina.collection? ? 'collection' : 'item'}</objectType>
+            <objectLabel>#{public_cocina.label}</objectLabel>
           #{nodes.join("\n")}
           </identityMetadata>
         XML

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -137,6 +137,7 @@ RSpec.describe 'Display metadata' do
         <publicObject id="druid:mk420bs7601" published="#{now.utc.xmlschema}" publishVersion="dor-services/#{Dor::VERSION}">
           <identityMetadata>
             <objectType>item</objectType>
+            <objectLabel>A generic label</objectLabel>
           </identityMetadata>
           <rightsMetadata>
             <access type="discover">

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -221,6 +221,7 @@ RSpec.describe Publish::PublicXmlService do
         expected = <<~XML
           <identityMetadata>
             <objectType>item</objectType>
+            <objectLabel>A generic label</objectLabel>
             <otherId name="catkey">129483625</otherId>
           </identityMetadata>
         XML


### PR DESCRIPTION


## Why was this change made? 🤔
This value is used by the searchworks indexer for collection titles.
See https://github.com/sul-dlss/searchworks_traject_indexer/blob/master/lib/sdr_stuff.rb#L54


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



