### PR TITLE
[refactor] each notification aborts itself if rabbitMQ is not enabled

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -55,11 +55,9 @@ class MetadataController < ApplicationController
     cocina_object = Cocina::Mapper.build(@item)
 
     @item.save!
-    if Settings.rabbitmq.enabled
-      Notifications::ObjectUpdated.publish(model: cocina_object,
-                                           created_at: @item.create_date,
-                                           modified_at: @item.modified_date)
-    end
+    Notifications::ObjectUpdated.publish(model: cocina_object,
+                                         created_at: @item.create_date,
+                                         modified_at: @item.modified_date)
   rescue LegacyMetadataService::DatastreamValidationError => e
     json_api_error(status: :unprocessable_entity, message: e.detail, title: e.message)
   rescue Rubydora::FedoraInvalidRequest

--- a/app/controllers/mods_controller.rb
+++ b/app/controllers/mods_controller.rb
@@ -20,11 +20,9 @@ class ModsController < ApplicationController
 
     @item.save!
 
-    if Settings.rabbitmq.enabled
-      Notifications::ObjectUpdated.publish(model: cocina_object,
-                                           created_at: @item.create_date,
-                                           modified_at: @item.modified_date)
-    end
+    Notifications::ObjectUpdated.publish(model: cocina_object,
+                                         created_at: @item.create_date,
+                                         modified_at: @item.modified_date)
   rescue LegacyMetadataService::DatastreamValidationError => e
     json_api_error(status: :unprocessable_entity, message: e.detail, title: e.message)
   rescue Rubydora::FedoraInvalidRequest

--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -76,7 +76,7 @@ class CocinaObjectStore
     cocina_to_ar_save(updated_cocina_object) if Settings.enabled_features.postgres.update && ar_exists?(cocina_object.externalIdentifier)
 
     # Broadcast this update action to a topic
-    Notifications::ObjectUpdated.publish(model: updated_cocina_object, created_at: created_at, modified_at: modified_at) if Settings.rabbitmq.enabled
+    Notifications::ObjectUpdated.publish(model: updated_cocina_object, created_at: created_at, modified_at: modified_at)
     updated_cocina_object
   end
 
@@ -116,7 +116,7 @@ class CocinaObjectStore
 
     ar_destroy(druid) if Settings.enabled_features.postgres.destroy && ar_exists?(druid)
 
-    Notifications::ObjectDeleted.publish(model: cocina_object, deleted_at: Time.zone.now) if Settings.rabbitmq.enabled
+    Notifications::ObjectDeleted.publish(model: cocina_object, deleted_at: Time.zone.now)
   end
 
   # This is only public for ObjectCreator use.

--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -87,7 +87,7 @@ class CocinaObjectStore
     cocina_object = fedora_create(cocina_request_object, assign_doi: assign_doi)
 
     # Broadcast this to a topic
-    Notifications::ObjectCreated.publish(model: cocina_object, created_at: Time.zone.now, modified_at: Time.zone.now) if Settings.rabbitmq.enabled
+    Notifications::ObjectCreated.publish(model: cocina_object, created_at: Time.zone.now, modified_at: Time.zone.now)
     cocina_object
   end
 

--- a/app/services/embargo_release_service.rb
+++ b/app/services/embargo_release_service.rb
@@ -58,7 +58,7 @@ class EmbargoReleaseService
     VersionService.close(cocina_object, { description: 'embargo released', significance: 'admin' }, event_factory: EventFactory)
 
     # Broadcast this action to a topic
-    Notifications::EmbargoLifted.publish(model: cocina_object) if Settings.rabbitmq.enabled
+    Notifications::EmbargoLifted.publish(model: cocina_object)
   rescue StandardError => e
     Rails.logger.error("!!! Unable to release embargo for: #{druid}\n#{e.inspect}\n#{e.backtrace.join("\n")}")
     Honeybadger.notify "Unable to release embargo for: #{druid}", backtrace: e.backtrace

--- a/app/services/notifications/embargo_lifted.rb
+++ b/app/services/notifications/embargo_lifted.rb
@@ -5,6 +5,8 @@ module Notifications
   # The primary use case here is that h2 needs to log a message when this happens
   class EmbargoLifted
     def self.publish(model:)
+      return unless Settings.rabbitmq.enabled
+
       Rails.logger.debug "Publishing Rabbitmq Message for embargo #{model.externalIdentifier}"
       new(model: model, channel: RabbitChannel.instance).publish
       Rails.logger.debug "Published Rabbitmq Message for embargo #{model.externalIdentifier}"

--- a/app/services/notifications/object_created.rb
+++ b/app/services/notifications/object_created.rb
@@ -5,6 +5,8 @@ module Notifications
   # The primary use case here is that the requestor may want to know what druid was assigned to the request.
   class ObjectCreated
     def self.publish(model:, created_at:, modified_at:)
+      return unless Settings.rabbitmq.enabled
+
       # Skipping APOs because they don't (yet) have a partOfProject assertion.
       return if model.is_a? Cocina::Models::AdminPolicy
 

--- a/app/services/notifications/object_deleted.rb
+++ b/app/services/notifications/object_deleted.rb
@@ -5,6 +5,8 @@ module Notifications
   # The primary use case here is that an index may need to be updated (dor-indexing-app)
   class ObjectDeleted
     def self.publish(model:, deleted_at:)
+      return unless Settings.rabbitmq.enabled
+
       Rails.logger.debug "Publishing Rabbitmq Message for deleting #{model.externalIdentifier}"
       new(model: model, deleted_at: deleted_at, channel: RabbitChannel.instance).publish
       Rails.logger.debug "Published Rabbitmq Message for deleting #{model.externalIdentifier}"

--- a/app/services/notifications/object_updated.rb
+++ b/app/services/notifications/object_updated.rb
@@ -5,6 +5,8 @@ module Notifications
   # The primary use case here is that an index may need to be updated (dor-indexing-app)
   class ObjectUpdated
     def self.publish(model:, created_at:, modified_at:)
+      return unless Settings.rabbitmq.enabled
+
       Rails.logger.debug "Publishing Rabbitmq Message for updating #{model.externalIdentifier}"
       new(model: model, created_at: created_at, modified_at: modified_at, channel: RabbitChannel.instance).publish
       Rails.logger.debug "Published Rabbitmq Message for updating #{model.externalIdentifier}"

--- a/spec/requests/legacy_metadata_update_spec.rb
+++ b/spec/requests/legacy_metadata_update_spec.rb
@@ -107,7 +107,6 @@ RSpec.describe 'Update the legacy (datastream) metadata' do
     allow(Dor).to receive(:find).and_return(item)
     allow(LegacyMetadataService).to receive(:update_datastream_if_newer)
     allow(Notifications::ObjectUpdated).to receive(:publish)
-    allow(Settings.rabbitmq).to receive(:enabled).and_return(true)
     allow(Cocina::Mapper).to receive(:build).and_return(instance_double(Cocina::Models::DRO))
   end
 

--- a/spec/requests/mods_update_spec.rb
+++ b/spec/requests/mods_update_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe 'Update MODS' do
     allow(Dor).to receive(:find).and_return(object)
     allow(object).to receive(:save!)
     allow(Notifications::ObjectUpdated).to receive(:publish)
-    allow(Settings.rabbitmq).to receive(:enabled).and_return(true)
   end
 
   context 'with valid xml' do

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe CocinaObjectStore do
         let(:updated_cocina_object) { instance_double(Cocina::Models::DRO) }
 
         before do
-          allow(Settings.rabbitmq).to receive(:enabled).and_return(true)
           allow(Notifications::ObjectUpdated).to receive(:publish)
           allow(Dor).to receive(:find).and_return(item)
           allow(Cocina::ObjectUpdater).to receive(:run).and_return(updated_cocina_object)
@@ -122,7 +121,6 @@ RSpec.describe CocinaObjectStore do
       let(:created_cocina_object) { instance_double(Cocina::Models::DRO) }
 
       before do
-        allow(Settings.rabbitmq).to receive(:enabled).and_return(true)
         allow(Notifications::ObjectCreated).to receive(:publish)
         allow(Cocina::ObjectCreator).to receive(:create).and_return(created_cocina_object)
       end
@@ -140,7 +138,6 @@ RSpec.describe CocinaObjectStore do
         let(:fedora_object) { instance_double(Dor::Item, destroy: nil) }
 
         before do
-          allow(Settings.rabbitmq).to receive(:enabled).and_return(true)
           allow(Dor).to receive(:find).and_return(fedora_object)
           allow(Notifications::ObjectDeleted).to receive(:publish)
           allow(described_class).to receive(:find).and_return(cocina_object)

--- a/spec/services/embargo_release_service_spec.rb
+++ b/spec/services/embargo_release_service_spec.rb
@@ -249,7 +249,6 @@ RSpec.describe EmbargoReleaseService do
       context 'when it is openable' do
         before do
           allow(Notifications::EmbargoLifted).to receive(:publish)
-          allow(Settings.rabbitmq).to receive(:enabled).and_return(true)
         end
 
         it 'is successful' do

--- a/spec/services/notifications/embargo_lifted_spec.rb
+++ b/spec/services/notifications/embargo_lifted_spec.rb
@@ -13,41 +13,62 @@ RSpec.describe Notifications::EmbargoLifted do
   let(:channel) { instance_double(Notifications::RabbitChannel, topic: topic) }
   let(:topic) { instance_double(Bunny::Exchange, publish: true) }
 
-  before do
-    allow(Notifications::RabbitChannel).to receive(:instance).and_return(channel)
-  end
-
-  context 'when called with a DRO' do
-    let(:model) do
-      instance_double(Cocina::Models::DRO,
-                      externalIdentifier: 'druid:123', administrative: administrative, to_h: data)
-    end
-
-    it 'is successful' do
-      publish
-      expect(topic).to have_received(:publish).with('{"model":{"data":"455"}}', routing_key: 'h2')
-    end
-  end
-
-  context 'when called with an AdminPolicy' do
-    let(:model) do
-      Cocina::Models::AdminPolicy.new(externalIdentifier: 'druid:bc123dg9393',
-                                      administrative: {
-                                        hasAdminPolicy: 'druid:gg123vx9393',
-                                        hasAgreement: 'druid:bb008zm4587'
-                                      },
-                                      version: 1,
-                                      label: 'just an apo',
-                                      type: Cocina::Models::Vocab.admin_policy)
-    end
-
+  context 'when RabbitMQ is enabled' do
     before do
-      allow(model).to receive(:to_h).and_return(data)
+      allow(Notifications::RabbitChannel).to receive(:instance).and_return(channel)
+      allow(Settings.rabbitmq).to receive(:enabled).and_return(true)
     end
 
-    it 'is successful' do
-      publish
-      expect(topic).to have_received(:publish).with('{"model":{"data":"455"}}', routing_key: 'SDR')
+    context 'when called with a DRO' do
+      let(:model) do
+        instance_double(Cocina::Models::DRO,
+                        externalIdentifier: 'druid:123', administrative: administrative, to_h: data)
+      end
+
+      it 'is successful' do
+        publish
+        expect(topic).to have_received(:publish).with('{"model":{"data":"455"}}', routing_key: 'h2')
+      end
+    end
+
+    context 'when called with an AdminPolicy' do
+      let(:model) do
+        Cocina::Models::AdminPolicy.new(externalIdentifier: 'druid:bc123dg9393',
+                                        administrative: {
+                                          hasAdminPolicy: 'druid:gg123vx9393',
+                                          hasAgreement: 'druid:bb008zm4587'
+                                        },
+                                        version: 1,
+                                        label: 'just an apo',
+                                        type: Cocina::Models::Vocab.admin_policy)
+      end
+
+      before do
+        allow(model).to receive(:to_h).and_return(data)
+      end
+
+      it 'is successful' do
+        publish
+        expect(topic).to have_received(:publish).with('{"model":{"data":"455"}}', routing_key: 'SDR')
+      end
+    end
+  end
+
+  context 'when RabbitMQ is disabled' do
+    before do
+      allow(Settings.rabbitmq).to receive(:enabled).and_return(false)
+    end
+
+    context 'when called with a DRO' do
+      let(:model) do
+        instance_double(Cocina::Models::DRO,
+                        externalIdentifier: 'druid:123', administrative: administrative, to_h: data)
+      end
+
+      it 'does not receive a message' do
+        publish
+        expect(topic).not_to have_received(:publish).with('{"model":{"data":"455"}}', routing_key: 'h2')
+      end
     end
   end
 end

--- a/spec/services/notifications/object_created_spec.rb
+++ b/spec/services/notifications/object_created_spec.rb
@@ -16,37 +16,58 @@ RSpec.describe Notifications::ObjectCreated do
   let(:channel) { instance_double(Notifications::RabbitChannel, topic: topic) }
   let(:topic) { instance_double(Bunny::Exchange, publish: true) }
 
-  before do
-    allow(Notifications::RabbitChannel).to receive(:instance).and_return(channel)
+  context 'when RabbitMQ is enabled' do
+    before do
+      allow(Notifications::RabbitChannel).to receive(:instance).and_return(channel)
+      allow(Settings.rabbitmq).to receive(:enabled).and_return(true)
+    end
+
+    context 'when called with a DRO' do
+      let(:model) do
+        instance_double(Cocina::Models::DRO,
+                        externalIdentifier: 'druid:123', administrative: administrative, to_h: data)
+      end
+
+      it 'is successful' do
+        publish
+        expect(topic).to have_received(:publish).with(message, routing_key: 'h2')
+      end
+    end
+
+    context 'when called with an AdminPolicy' do
+      let(:model) do
+        Cocina::Models::AdminPolicy.new(externalIdentifier: 'druid:bc123dg9393',
+                                        administrative: {
+                                          hasAdminPolicy: 'druid:gg123vx9393',
+                                          hasAgreement: 'druid:bb008zm4587'
+                                        },
+                                        version: 1,
+                                        label: 'just an apo',
+                                        type: Cocina::Models::Vocab.admin_policy)
+      end
+
+      it 'is successful' do
+        publish
+        expect(topic).not_to have_received(:publish)
+      end
+    end
   end
 
-  context 'when called with a DRO' do
-    let(:model) do
-      instance_double(Cocina::Models::DRO,
-                      externalIdentifier: 'druid:123', administrative: administrative, to_h: data)
+  context 'when RabbitMQ is disabled' do
+    before do
+      allow(Settings.rabbitmq).to receive(:enabled).and_return(false)
     end
 
-    it 'is successful' do
-      publish
-      expect(topic).to have_received(:publish).with(message, routing_key: 'h2')
-    end
-  end
+    context 'when called with a DRO' do
+      let(:model) do
+        instance_double(Cocina::Models::DRO,
+                        externalIdentifier: 'druid:123', administrative: administrative, to_h: data)
+      end
 
-  context 'when called with an AdminPolicy' do
-    let(:model) do
-      Cocina::Models::AdminPolicy.new(externalIdentifier: 'druid:bc123dg9393',
-                                      administrative: {
-                                        hasAdminPolicy: 'druid:gg123vx9393',
-                                        hasAgreement: 'druid:bb008zm4587'
-                                      },
-                                      version: 1,
-                                      label: 'just an apo',
-                                      type: Cocina::Models::Vocab.admin_policy)
-    end
-
-    it 'is successful' do
-      publish
-      expect(topic).not_to have_received(:publish)
+      it 'does not receive a message' do
+        publish
+        expect(topic).not_to have_received(:publish).with(message, routing_key: 'h2')
+      end
     end
   end
 end

--- a/spec/services/notifications/object_deleted_spec.rb
+++ b/spec/services/notifications/object_deleted_spec.rb
@@ -14,28 +14,49 @@ RSpec.describe Notifications::ObjectDeleted do
   let(:topic) { instance_double(Bunny::Exchange, publish: true) }
   let(:message) { "{\"druid\":\"druid:123\",\"deleted_at\":\"#{deleted_at.to_datetime.httpdate}\"}" }
 
-  before do
-    allow(Notifications::RabbitChannel).to receive(:instance).and_return(channel)
-  end
-
-  context 'when called with a DRO' do
-    let(:model) do
-      instance_double(Cocina::Models::DRO,
-                      externalIdentifier: 'druid:123', administrative: administrative)
+  context 'when RabbitMQ is enabled' do
+    before do
+      allow(Notifications::RabbitChannel).to receive(:instance).and_return(channel)
+      allow(Settings.rabbitmq).to receive(:enabled).and_return(true)
     end
 
-    it 'is successful' do
-      publish
-      expect(topic).to have_received(:publish).with(message, routing_key: 'h2')
+    context 'when called with a DRO' do
+      let(:model) do
+        instance_double(Cocina::Models::DRO,
+                        externalIdentifier: 'druid:123', administrative: administrative)
+      end
+
+      it 'is successful' do
+        publish
+        expect(topic).to have_received(:publish).with(message, routing_key: 'h2')
+      end
+    end
+
+    context 'when called with an AdminPolicy' do
+      let(:model) { instance_double(Cocina::Models::AdminPolicy, externalIdentifier: 'druid:123', is_a?: true) }
+
+      it 'is successful' do
+        publish
+        expect(topic).to have_received(:publish).with(message, routing_key: 'SDR')
+      end
     end
   end
 
-  context 'when called with an AdminPolicy' do
-    let(:model) { instance_double(Cocina::Models::AdminPolicy, externalIdentifier: 'druid:123', is_a?: true) }
+  context 'when RabbitMQ is disabled' do
+    before do
+      allow(Settings.rabbitmq).to receive(:enabled).and_return(false)
+    end
 
-    it 'is successful' do
-      publish
-      expect(topic).to have_received(:publish).with(message, routing_key: 'SDR')
+    context 'when called with a DRO' do
+      let(:model) do
+        instance_double(Cocina::Models::DRO,
+                        externalIdentifier: 'druid:123', administrative: administrative)
+      end
+
+      it 'does not receive a message' do
+        publish
+        expect(topic).not_to have_received(:publish).with(message, routing_key: 'h2')
+      end
     end
   end
 end

--- a/spec/services/notifications/object_updated_spec.rb
+++ b/spec/services/notifications/object_updated_spec.rb
@@ -16,41 +16,62 @@ RSpec.describe Notifications::ObjectUpdated do
   let(:topic) { instance_double(Bunny::Exchange, publish: true) }
   let(:message) { "{\"model\":{\"data\":\"455\"},\"created_at\":\"#{created_at.to_datetime.httpdate}\",\"modified_at\":\"#{modified_at.to_datetime.httpdate}\"}" }
 
-  before do
-    allow(Notifications::RabbitChannel).to receive(:instance).and_return(channel)
-  end
-
-  context 'when called with a DRO' do
-    let(:model) do
-      instance_double(Cocina::Models::DRO,
-                      externalIdentifier: 'druid:123', administrative: administrative, to_h: data)
-    end
-
-    it 'is successful' do
-      publish
-      expect(topic).to have_received(:publish).with(message, routing_key: 'h2')
-    end
-  end
-
-  context 'when called with an AdminPolicy' do
-    let(:model) do
-      Cocina::Models::AdminPolicy.new(externalIdentifier: 'druid:bc123dg9393',
-                                      administrative: {
-                                        hasAdminPolicy: 'druid:gg123vx9393',
-                                        hasAgreement: 'druid:bb008zm4587'
-                                      },
-                                      version: 1,
-                                      label: 'just an apo',
-                                      type: Cocina::Models::Vocab.admin_policy)
-    end
-
+  context 'when RabbitMQ is enabled' do
     before do
-      allow(model).to receive(:to_h).and_return(data)
+      allow(Notifications::RabbitChannel).to receive(:instance).and_return(channel)
+      allow(Settings.rabbitmq).to receive(:enabled).and_return(true)
     end
 
-    it 'is successful' do
-      publish
-      expect(topic).to have_received(:publish).with(message, routing_key: 'SDR')
+    context 'when called with a DRO' do
+      let(:model) do
+        instance_double(Cocina::Models::DRO,
+                        externalIdentifier: 'druid:123', administrative: administrative, to_h: data)
+      end
+
+      it 'is successful' do
+        publish
+        expect(topic).to have_received(:publish).with(message, routing_key: 'h2')
+      end
+    end
+
+    context 'when called with an AdminPolicy' do
+      let(:model) do
+        Cocina::Models::AdminPolicy.new(externalIdentifier: 'druid:bc123dg9393',
+                                        administrative: {
+                                          hasAdminPolicy: 'druid:gg123vx9393',
+                                          hasAgreement: 'druid:bb008zm4587'
+                                        },
+                                        version: 1,
+                                        label: 'just an apo',
+                                        type: Cocina::Models::Vocab.admin_policy)
+      end
+
+      before do
+        allow(model).to receive(:to_h).and_return(data)
+      end
+
+      it 'is successful' do
+        publish
+        expect(topic).to have_received(:publish).with(message, routing_key: 'SDR')
+      end
+    end
+  end
+
+  context 'when RabbitMQ is disabled' do
+    before do
+      allow(Settings.rabbitmq).to receive(:enabled).and_return(false)
+    end
+
+    context 'when called with a DRO' do
+      let(:model) do
+        instance_double(Cocina::Models::DRO,
+                        externalIdentifier: 'druid:123', administrative: administrative, to_h: data)
+      end
+
+      it 'does not receive a message' do
+        publish
+        expect(topic).not_to have_received(:publish).with(message, routing_key: 'h2')
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3507 - make the notifications responsible for checking if rabbitMQ is enabled instead of the caller


## How was this change tested? 🤨

Added new tests

NOTE: The diffs in the specs are less substantial than they appear.  The existing tests were moved into a new context of "RabbitMQ enabled", with mocking of that setting to true.  Then a new context block was added mocking RabbitMQ to disabled to verify the messages are not sent.




