### PR TITLE
refactor: use cocina_object instead of item in validators

### DIFF
--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -5,17 +5,17 @@
 class PublishJob < ApplicationJob
   queue_as :default
 
-  # @param [String] druid the identifier of the item to be published
+  # @param [String] druid the identifier of the fedora_item to be published
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
   # @param [String] workflow Which workflow should this be reported to?
   def perform(druid:, background_job_result:, workflow:)
     background_job_result.processing!
     workflow_process = workflow == 'releaseWF' ? 'release-publish' : 'publish'
     begin
-      item = Dor.find(druid)
+      fedora_item = Dor.find(druid)
 
       # Disabling validation until pre-assembly and WAS handle this correctly.
-      # validator = validator_for?(item)
+      # validator = validator_for?(fedora_item)
       # unless validator.valid?
       # Honeybadger.notify("Not all files for '#{druid}' have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}")
       # return LogFailureJob.perform_later(druid: druid,
@@ -26,7 +26,7 @@ class PublishJob < ApplicationJob
       #                                                         detail: "Not all files have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}" }] })
       # end
 
-      Publish::MetadataTransferService.publish(item)
+      Publish::MetadataTransferService.publish(fedora_item)
       EventFactory.create(druid: druid, event_type: 'publishing_complete', data: { background_job_result_id: background_job_result.id })
     rescue Dor::DataError => e
       return LogFailureJob.perform_later(druid: druid,
@@ -42,8 +42,8 @@ class PublishJob < ApplicationJob
                                 workflow_process: workflow_process)
   end
 
-  def validator_for?(item)
-    model = Cocina::Mapper.build(item)
+  def validator_for?(fedora_item)
+    model = Cocina::Mapper.build(fedora_item)
     Cocina::ValidateDarkService.new(model)
   end
 end

--- a/app/jobs/shelve_job.rb
+++ b/app/jobs/shelve_job.rb
@@ -4,7 +4,7 @@
 class ShelveJob < ApplicationJob
   queue_as :default
 
-  # @param [String] druid the identifier of the item to be published
+  # @param [String] druid the identifier of the object to be shelved
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
   def perform(druid:, background_job_result:)
     background_job_result.processing!
@@ -13,15 +13,15 @@ class ShelveJob < ApplicationJob
       cocina_object = CocinaObjectStore.find(druid)
 
       # Disabling validation until pre-assembly and WAS handle this correctly.
-      # validator = validator_for?(item)
+      # validator = validator_for?(cocina_object)
       # unless validator.valid?
-      # Honeybadger.notify("Not all files for '#{druid}' have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}")
+      # Honeybadger.notify("Not all files for '#{druid}' have dark access and/or are unshelved when dro access is dark: #{validator.invalid_filenames}")
       # return LogFailureJob.perform_later(druid: druid,
       #                                    background_job_result: background_job_result,
       #                                    workflow: 'accessionWF',
       #                                    workflow_process: 'shelve',
       #                                    output: { errors: [{ title: 'Access mismatch',
-      #                                                         detail: "Not all files have dark access and/or are unshelved when item access is dark: #{validator.invalid_filenames}" }] })
+      #                                                         detail: "Not all files have dark access and/or are unshelved when dro access is dark: #{validator.invalid_filenames}" }] })
       # end
 
       ShelvingService.shelve(cocina_object)
@@ -44,8 +44,8 @@ class ShelveJob < ApplicationJob
                                 workflow_process: 'shelve')
   end
 
-  def validator_for?(item)
-    model = Cocina::Mapper.build(item)
+  def validator_for?(cocina_object)
+    model = Cocina::Mapper.build(cocina_object)
     Cocina::ValidateDarkService.new(model)
   end
 end

--- a/app/validators/cocina/apo_existence_validator.rb
+++ b/app/validators/cocina/apo_existence_validator.rb
@@ -3,8 +3,8 @@
 module Cocina
   # Validates that the administrative.hasAdminPolicy property references an AdminPolicyObject
   class ApoExistenceValidator
-    def initialize(item)
-      @apo_id = item.administrative.hasAdminPolicy
+    def initialize(cocina_object)
+      @apo_id = cocina_object.administrative.hasAdminPolicy
     end
 
     attr_reader :error

--- a/app/validators/cocina/collection_existence_validator.rb
+++ b/app/validators/cocina/collection_existence_validator.rb
@@ -3,8 +3,8 @@
 module Cocina
   # Validates that the structural.isMemberOf property references Collections
   class CollectionExistenceValidator
-    def initialize(item)
-      @collection_ids = Array.wrap(item.structural&.isMemberOf)
+    def initialize(cocina_object)
+      @collection_ids = Array.wrap(cocina_object.structural&.isMemberOf)
     end
 
     attr_reader :error

--- a/app/validators/cocina/unique_source_id_validator.rb
+++ b/app/validators/cocina/unique_source_id_validator.rb
@@ -3,9 +3,9 @@
 module Cocina
   # Validates that the sourceId attribute for a new DRO has not been used before
   class UniqueSourceIdValidator
-    # @param [#dro?] item to be validated
-    def initialize(item)
-      @item = item
+    # @param [#dro?] cocina_dro to be validated
+    def initialize(cocina_dro)
+      @cocina_dro = cocina_dro
     end
 
     attr_reader :error
@@ -14,14 +14,14 @@ module Cocina
     def valid?
       return true unless meets_preconditions?
 
-      @error = "An object (#{duplicate_druid}) with the source ID '#{item.identification.sourceId}' has already been registered." if duplicate_druid
+      @error = "An object (#{duplicate_druid}) with the source ID '#{cocina_dro.identification.sourceId}' has already been registered." if duplicate_druid
 
       @error.nil?
     end
 
     private
 
-    attr_reader :item
+    attr_reader :cocina_dro
 
     def duplicate_druid
       unless @already_ran
@@ -35,11 +35,11 @@ module Cocina
     end
 
     def lookup_duplicate
-      Dor::SearchService.query_by_id(item.identification.sourceId).first
+      Dor::SearchService.query_by_id(cocina_dro.identification.sourceId).first
     end
 
     def meets_preconditions?
-      item.dro?
+      cocina_dro.dro?
     end
   end
 end

--- a/app/validators/cocina/validate_dark_service.rb
+++ b/app/validators/cocina/validate_dark_service.rb
@@ -3,9 +3,9 @@
 module Cocina
   # Validates that shelve and publish file attributes are set to false for dark DRO objects.
   class ValidateDarkService
-    # @param [#dro?] item to be validated
-    def initialize(item)
-      @item = item
+    # @param [#dro?] cocina_object to be validated
+    def initialize(cocina_object)
+      @cocina_object = cocina_object
     end
 
     attr_reader :error
@@ -14,17 +14,17 @@ module Cocina
     def valid?
       return true unless meets_preconditions?
 
-      @error = "Not all files have dark access and/or are unshelved when item access is dark: #{invalid_filenames}" unless invalid_files.empty?
+      @error = "Not all files have dark access and/or are unshelved when object access is dark: #{invalid_filenames}" unless invalid_files.empty?
 
       @error.nil?
     end
 
     private
 
-    attr_reader :item
+    attr_reader :cocina_object
 
     def meets_preconditions?
-      item.dro? && item.access&.access == 'dark'
+      cocina_object.dro? && cocina_object.access&.access == 'dark'
     end
 
     def invalid_files
@@ -52,9 +52,9 @@ module Cocina
 
     def files
       [].tap do |files|
-        next if item&.structural&.contains.nil?
+        next if cocina_object&.structural&.contains.nil?
 
-        item.structural.contains.each do |fileset|
+        cocina_object.structural.contains.each do |fileset|
           next if fileset&.structural&.contains.nil?
 
           fileset.structural.contains.each do |file|

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -551,7 +551,7 @@ RSpec.describe 'Create object' do
           expect(response.status).to eq 400
           expect(response.body).to eq '{"errors":[' \
                                       '{"status":"400","title":"Bad Request",' \
-                                      '"detail":"Not all files have dark access and/or are unshelved when item access is dark: ' \
+                                      '"detail":"Not all files have dark access and/or are unshelved when object access is dark: ' \
                                       '[\\"00001.jp2\\", \\"00002.jp2\\"]"}]}'
         end
       end

--- a/spec/validators/cocina/validate_dark_service_spec.rb
+++ b/spec/validators/cocina/validate_dark_service_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Cocina::ValidateDarkService do
     context 'when not a WARC' do
       it 'is not valid' do
         expect(validator.valid?).to be false
-        expect(validator.error).to eq 'Not all files have dark access and/or are unshelved when item access is dark: ["page1.txt"]'
+        expect(validator.error).to eq 'Not all files have dark access and/or are unshelved when object access is dark: ["page1.txt"]'
       end
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

confusing variable names leads to confusion. 

Closes #3506    @justinlittman  is this what the ticket meant?

## How was this change tested? 🤨

unit tests

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

nope.

