### PR TITLE
Use ContentMetadataGenerator to output contentMetadata XML for pres

### DIFF
--- a/app/services/preservation_metadata_extractor.rb
+++ b/app/services/preservation_metadata_extractor.rb
@@ -69,6 +69,7 @@ class PreservationMetadataExtractor
     ds = (ds_name == :relationshipMetadata ? 'RELS-EXT' : ds_name.to_s)
     return workflow_xml if ds_name == :workflows
     return version_xml(item) if ds_name == :versionMetadata
+    return content_xml if ds_name == :contentMetadata
     return item.datastreams[ds].content if item.datastreams.key?(ds) && !item.datastreams[ds].new?
 
     raise "required datastream #{ds_name} for #{item.pid} not found in DOR" if required
@@ -84,6 +85,10 @@ class PreservationMetadataExtractor
     VersionMigrationService.migrate(item)
 
     ObjectVersion.version_xml(cocina_object.externalIdentifier)
+  end
+
+  def content_xml
+    Cocina::ToFedora::ContentMetadataGenerator.generate(druid: cocina_object.externalIdentifier, structural: cocina_object.structural, type: cocina_object.type)
   end
 
   def extract_cocina

--- a/spec/services/preservation_metadata_extractor_spec.rb
+++ b/spec/services/preservation_metadata_extractor_spec.rb
@@ -102,6 +102,70 @@ RSpec.describe PreservationMetadataExtractor do
       it { is_expected.to be_equivalent_to expected_xml }
     end
 
+    context 'when datastream is contentMetadata' do
+      let(:ds_name) { :contentMetadata }
+      let(:structural) do
+        {
+          contains: [{
+            type: Cocina::Models::Vocab::Resources.image,
+            externalIdentifier: 'wt183gy6220',
+            label: 'Image 1',
+            version: 1,
+            structural: {
+              contains: [{
+                type: Cocina::Models::Vocab.file,
+                externalIdentifier: 'wt183gy6220_1',
+                label: 'Image 1',
+                filename: 'wt183gy6220_00_0001.jp2',
+                hasMimeType: 'image/jp2',
+                size: 3_182_927,
+                version: 1,
+                access: {},
+                administrative: {
+                  publish: false,
+                  sdrPreserve: false,
+                  shelve: false
+                },
+                hasMessageDigests: []
+              }]
+            }
+          }]
+        }
+      end
+      let(:cocina_object) do
+        Cocina::Models::DRO.new({
+                                  cocinaVersion: '0.0.1',
+                                  externalIdentifier: druid,
+                                  type: Cocina::Models::Vocab.book,
+                                  label: 'Test DRO',
+                                  version: 1,
+                                  access: { access: 'world', download: 'world' },
+                                  administrative: { hasAdminPolicy: 'druid:hy787xj5878' },
+                                  structural: structural
+                                })
+      end
+
+      let(:fileset_id) { 'http://cocina.sul.stanford.edu/fileSet/3f231c45-5af9-4530-bea9-f99982e394fb' }
+      let(:expected_xml) do
+        <<~XML
+          <contentMetadata objectId="druid:nc893zj8956" type="book">\n
+            <resource id="http://cocina.sul.stanford.edu/fileSet/3f231c45-5af9-4530-bea9-f99982e394fb" sequence="1" type="image">\n
+              <label>Image 1</label>\n
+              <file id="wt183gy6220_00_0001.jp2" mimetype="image/jp2" size="3182927" publish="no" shelve="no" preserve="no"/>\n
+            </resource>\n
+          </contentMetadata>
+        XML
+      end
+
+      before do
+        allow(Cocina::IdGenerator).to receive(:generate_or_existing_fileset_id).and_return(fileset_id)
+      end
+
+      it 'returns the correct datastream xml' do
+        expect(datastream_content).to be_equivalent_to expected_xml
+      end
+    end
+
     context 'when datastream is empty or missing' do
       let(:ds_name) { :dummy }
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3466 by calling `Cocina::ToFedora::ContentMetadataGenerator` in order to write content metadata for preservation instead of writing the fedora based datastream.

## How was this change tested? 🤨

Updated unit test.

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



