### PR TITLE
Decouple MetadataTransferService from RightsMetadataDS

### DIFF
--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -48,8 +48,7 @@ module Publish
     end
 
     def world_discoverable?
-      rights = item.rightsMetadata.ng_xml.clone.remove_namespaces!
-      rights.at_xpath("//rightsMetadata/access[@type='discover']/machine/world")
+      ['world', 'citation-only'].include? cocina_object.access.access
     end
 
     # Create a file inside the content directory under the stacks.local_document_cache_root

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -173,12 +173,6 @@ RSpec.describe Publish::MetadataTransferService do
           expect(Publish::PublicXmlService).to have_received(:new).with(item, public_cocina: Cocina::Models::DRO, released_for: release_tags, thumbnail_service: thumbnail_service)
           expect(Publish::PublicDescMetadataService).to have_received(:new).with(Cocina::Models::DRO)
         end
-
-        it 'even when rightsMetadata uses xml namespaces' do
-          item.rightsMetadata.content = %q(<rightsMetadata xmlns="http://hydra-collab.stanford.edu/schemas/rightsMetadata/v1">
-            <access type='discover'><machine><world/></machine></access></rightsMetadata>)
-          service.publish
-        end
       end
 
       context 'with a collection object' do


### PR DESCRIPTION
## Why was this change made? 🤔

Get rid of ActiveFedora.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



