### PR TITLE
Extracting druid minting from ObjectCreator

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -4,13 +4,16 @@ module Cocina
   # Given a Cocina model, create an ActiveFedora model.
   class ObjectCreator
     # @raises SymphonyReader::ResponseError if symphony connection failed
-    def self.create(cocina_object, event_factory: EventFactory, persister: ActiveFedoraPersister, assign_doi: false, cocina_object_store: CocinaObjectStore.new)
-      _fedora_object, cocina_object = new(cocina_object_store: cocina_object_store).create(cocina_object, event_factory: event_factory, persister: persister, assign_doi: assign_doi)
+    # rubocop:disable Metrics/ParameterLists
+    def self.create(cocina_object, druid:, event_factory: EventFactory, persister: ActiveFedoraPersister, assign_doi: false, cocina_object_store: CocinaObjectStore.new)
+      _fedora_object, cocina_object = new(cocina_object_store: cocina_object_store).create(cocina_object, druid: druid, event_factory: event_factory, persister: persister,
+                                                                                                          assign_doi: assign_doi)
       cocina_object
     end
+    # rubocop:enable Metrics/ParameterLists
 
     def self.trial_create(cocina_object, notifier:, cocina_object_store:)
-      new(cocina_object_store: cocina_object_store).create(cocina_object, event_factory: nil, persister: nil, trial: true, notifier: notifier)
+      new(cocina_object_store: cocina_object_store).create(cocina_object, druid: cocina_object.externalIdentifier, event_factory: nil, persister: nil, trial: true, notifier: notifier)
     end
 
     def initialize(cocina_object_store: CocinaObjectStore.new)
@@ -18,12 +21,13 @@ module Cocina
     end
 
     # @param [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAdminPolicy] cocina_object
+    # @param [String] druid
     # @raises SymphonyReader::ResponseError if symphony connection failed
     # rubocop:disable Metrics/ParameterLists
-    def create(cocina_object, event_factory:, persister:, trial: false, notifier: nil, assign_doi: false)
+    def create(cocina_object, druid:, event_factory:, persister:, trial: false, notifier: nil, assign_doi: false)
       validate(cocina_object) unless trial
 
-      fedora_object = create_from_model(cocina_object, trial: trial, assign_doi: assign_doi)
+      fedora_object = create_from_model(cocina_object, druid: druid, trial: trial, assign_doi: assign_doi)
 
       # This will rebuild the cocina model from fedora, which shows we are only returning persisted data
       roundtrip_cocina_object = Mapper.build(fedora_object, notifier: notifier)
@@ -53,26 +57,28 @@ module Cocina
 
     # @param [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAdminPolicy,
     #   Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy] cocina_object
+    # @param [String] druid
+    # @param [Boolean] trial
     # @return [Dor::Abstract] a persisted ActiveFedora model
     # @raises SymphonyReader::ResponseError if symphony connection failed
-    def create_from_model(cocina_object, trial:, assign_doi:)
+    def create_from_model(cocina_object, druid:, trial:, assign_doi:)
       case cocina_object
       when Cocina::Models::RequestAdminPolicy, Cocina::Models::AdminPolicy
-        create_apo(cocina_object, trial: trial)
+        create_apo(cocina_object, druid: druid, trial: trial)
       when Cocina::Models::RequestDRO, Cocina::Models::DRO
-        create_dro(cocina_object, trial: trial, assign_doi: assign_doi)
+        create_dro(cocina_object, druid: druid, trial: trial, assign_doi: assign_doi)
       when Cocina::Models::RequestCollection, Cocina::Models::Collection
-        create_collection(cocina_object, trial: trial)
+        create_collection(cocina_object, druid: druid, trial: trial)
       else
         raise "unsupported type #{cocina_object.type}"
       end
     end
 
     # @param [Cocina::Models::RequestAdminPolicy,Cocina::Models::AdminPolicy] cocina_admin_policy
+    # @param [String] druid
     # @return [Dor::AdminPolicyObject] a persisted APO model
-    def create_apo(cocina_admin_policy, trial:)
-      pid = trial ? cocina_admin_policy.externalIdentifier : Dor::SuriService.mint_id
-      Dor::AdminPolicyObject.new(pid: pid,
+    def create_apo(cocina_admin_policy, druid:, trial:)
+      Dor::AdminPolicyObject.new(pid: druid,
                                  admin_policy_object_id: cocina_admin_policy.administrative.hasAdminPolicy,
                                  agreement_object_id: cocina_admin_policy.administrative.hasAgreement,
                                  # source_id: cocina_admin_policy.identification.sourceId,
@@ -87,32 +93,33 @@ module Cocina
     end
 
     # @param [Cocina::Models::RequestDRO,Cocina::Models::DRO] cocina_item
+    # @param [String] druid
+    # @param [Boolean] trial
     # @param [Boolean] assign_doi if true, a DOI is added to the model
     # @return [Dor::Item] a persisted Item model
     # @raises SymphonyReader::ResponseError if symphony connection failed
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
-    def create_dro(cocina_item, trial:, assign_doi:)
-      pid = trial ? cocina_item.externalIdentifier : Dor::SuriService.mint_id
+    def create_dro(cocina_item, druid:, trial:, assign_doi:)
       klass = cocina_item.type == Cocina::Models::Vocab.agreement ? Dor::Agreement : Dor::Item
-      klass.new(pid: pid,
+      klass.new(pid: druid,
                 admin_policy_object_id: cocina_item.administrative.hasAdminPolicy,
                 source_id: cocina_item.identification.sourceId,
                 collection_ids: Array.wrap(cocina_item.structural&.isMemberOf).compact,
                 catkey: catkey_for(cocina_item)).tap do |fedora_item|
         add_description(fedora_item, cocina_item, trial: trial)
 
-        add_dro_tags(pid, cocina_item) unless trial
+        add_dro_tags(druid, cocina_item)
 
         Cocina::ToFedora::DROAccess.apply(fedora_item, cocina_item.access, cocina_item.structural) if cocina_item.access || cocina_item.structural
 
-        fedora_item.contentMetadata.content = Cocina::ToFedora::ContentMetadataGenerator.generate(druid: pid, type: cocina_item.type, structural: cocina_item.structural,
+        fedora_item.contentMetadata.content = Cocina::ToFedora::ContentMetadataGenerator.generate(druid: druid, type: cocina_item.type, structural: cocina_item.structural,
                                                                                                   cocina_object_store: cocina_object_store)
         identity = Cocina::ToFedora::Identity.new(fedora_item)
         identity.initialize_identity
         identity.apply_release_tags(cocina_item.administrative&.releaseTags)
-        identity.apply_doi(Doi.for(druid: pid)) if assign_doi
+        identity.apply_doi(Doi.for(druid: druid)) if assign_doi
         identity.apply_doi(cocina_item.identification.doi) if trial && cocina_item.identification&.doi
         identity.apply_catalog_links(cocina_item.identification&.catalogLinks)
 
@@ -125,15 +132,16 @@ module Cocina
     # rubocop:enable Metrics/PerceivedComplexity
 
     # @param [Cocina::Models::RequestCollection,Cocina::Models::Collection] cocina_collection
+    # @param [String] druid
+    # @param [Boolean] trial
     # @return [Dor::Collection] a persisted Collection model
-    def create_collection(cocina_collection, trial:)
-      pid = trial ? cocina_collection.externalIdentifier : Dor::SuriService.mint_id
-      Dor::Collection.new(pid: pid,
+    def create_collection(cocina_collection, druid:, trial:)
+      Dor::Collection.new(pid: druid,
                           admin_policy_object_id: cocina_collection.administrative.hasAdminPolicy,
                           source_id: cocina_collection.identification&.sourceId,
                           catkey: catkey_for(cocina_collection)).tap do |fedora_collection|
         add_description(fedora_collection, cocina_collection, trial: trial)
-        add_collection_tags(pid, cocina_collection) unless trial
+        add_collection_tags(druid, cocina_collection) unless trial
         Cocina::ToFedora::CollectionAccess.apply(fedora_collection, cocina_collection.access) if cocina_collection.access
         Cocina::ToFedora::Identity.initialize_identity(fedora_collection)
         Cocina::ToFedora::Identity.apply_catalog_links(fedora_collection, catalog_links: cocina_collection.identification&.catalogLinks)
@@ -147,6 +155,7 @@ module Cocina
 
     # @param [Dor::[Item|Collection|APO]] fedora_object
     # @param [Cocina:Models::Request[DOR|Collection|xxx]] cocina_object
+    # @param [Boolean] trial
     # @raises SymphonyReader::ResponseError if symphony connection failed
     def add_description(fedora_object, cocina_object, trial:)
       # Synch from symphony if a catkey is present

--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -57,7 +57,7 @@ class CocinaObjectStore
 
   # @param [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAdminPolicy] cocina_object
   # @param [boolean] assign_doi
-  # @rturn [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]
+  # @return [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]
   # @raises [SymphonyReader::ResponseError] if symphony connection failed
   # @raise [Cocina::ValidationError] raised when validation of the Cocina object fails.
   def self.create(cocina_request_object, assign_doi: false)
@@ -85,8 +85,8 @@ class CocinaObjectStore
     ensure_ur_admin_policy_exists(cocina_request_object)
     validate(cocina_request_object)
     updated_cocina_request_object = default_access_for(cocina_request_object)
-
-    cocina_object = fedora_create(updated_cocina_request_object, assign_doi: assign_doi)
+    druid = Dor::SuriService.mint_id
+    cocina_object = fedora_create(updated_cocina_request_object, druid: druid, assign_doi: assign_doi)
 
     # Broadcast this to a topic
     Notifications::ObjectCreated.publish(model: cocina_object, created_at: Time.zone.now, modified_at: Time.zone.now)
@@ -168,11 +168,12 @@ class CocinaObjectStore
   end
 
   # @param [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection,Cocina::Models::RequestAdminPolicy] cocina_object
+  # @param [String] druid
   # @param [boolean] assign_doi
   # @rturn [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy]
   # @raises SymphonyReader::ResponseError if symphony connection failed
-  def fedora_create(cocina_request_object, assign_doi: false)
-    Cocina::ObjectCreator.create(cocina_request_object, assign_doi: assign_doi)
+  def fedora_create(cocina_request_object, druid:, assign_doi: false)
+    Cocina::ObjectCreator.create(cocina_request_object, druid: druid, assign_doi: assign_doi)
   end
 
   # The *ar* methods are private. In later steps in the migration, the *ar* methods will be invoked by the

--- a/spec/services/cocina/object_creator_spec.rb
+++ b/spec/services/cocina/object_creator_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::ObjectCreator do
-  subject(:result) { described_class.create(request, persister: persister, assign_doi: assign_doi) }
+  subject(:result) { described_class.create(request, druid: druid, persister: persister, assign_doi: assign_doi) }
 
   let(:apo) { 'druid:bz845pv2292' }
   let(:minimal_cocina_admin_policy) do
@@ -18,13 +18,13 @@ RSpec.describe Cocina::ObjectCreator do
   end
   let(:persister) { class_double(Cocina::ActiveFedoraPersister, store: nil) }
   let(:request) { Cocina::Models.build_request(params) }
+  let(:druid) { 'druid:mb046vj7485' }
   let(:assign_doi) { false }
 
   before do
     allow(Dor::SearchService).to receive(:query_by_id).and_return([])
     allow(Dor).to receive(:find).with(apo).and_return(Dor::AdminPolicyObject.new)
     allow(CocinaObjectStore).to receive(:find).with('druid:bz845pv2292').and_return(minimal_cocina_admin_policy)
-    allow(Dor::SuriService).to receive(:mint_id).and_return('druid:mb046vj7485')
     allow(RefreshMetadataAction).to receive(:run) do |args|
       args[:fedora_object].descMetadata.mods_title = 'foo'
     end

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -125,11 +125,12 @@ RSpec.describe CocinaObjectStore do
         allow(Notifications::ObjectCreated).to receive(:publish)
         allow(Cocina::ObjectCreator).to receive(:create).and_return(created_cocina_object)
         allow(cocina_object_store).to receive(:default_access_for).and_return(requested_cocina_object)
+        allow(Dor::SuriService).to receive(:mint_id).and_return(druid)
       end
 
       it 'maps and saves to Fedora' do
         expect(cocina_object_store.create(requested_cocina_object, assign_doi: true)).to be created_cocina_object
-        expect(Cocina::ObjectCreator).to have_received(:create).with(requested_cocina_object, assign_doi: true)
+        expect(Cocina::ObjectCreator).to have_received(:create).with(requested_cocina_object, druid: druid, assign_doi: true)
         expect(Notifications::ObjectCreated).to have_received(:publish).with(model: created_cocina_object, created_at: kind_of(Time), modified_at: kind_of(Time))
         expect(Cocina::ObjectValidator).to have_received(:validate).with(requested_cocina_object)
         expect(cocina_object_store).to have_received(:default_access_for).with(requested_cocina_object)


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #3511 to move druid minting from ObjectCreator to CocinaObjectStore.

## How was this change tested? 🤨
Specs pass (made two changes, however).

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



