### PR TITLE
Archive versions

### DIFF
--- a/bin/archive-fedora
+++ b/bin/archive-fedora
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../config/environment'
+require_relative '../lib/fedora_archiver'
+
+options = { input: 'druids.txt', archive: 'archive' }
+
+parser = OptionParser.new do |option_parser|
+  option_parser.banner = 'Usage: bin/archive-fedora [options]'
+  option_parser.on('-iFILENAME', '--input FILENAME', String, 'File containing list of druids (instead of druids.txt).')
+  option_parser.on('-dDRUIDS', '--druids DRUIDS', Array, 'List of druids (instead of druids.txt).')
+  option_parser.on('-aDIRECTORY', '--archive DIRECTORY', String, 'Directory to write archived versions to (instead of archive).')
+  option_parser.on('-l', '--lenient', 'Log and ignore error messages from Fedora')
+  option_parser.on('-h', '--help', 'Displays help.') do
+    puts option_parser
+    exit
+  end
+end
+
+Rails.logger = ActiveSupport::Logger.new('archive-fedora.log')
+Rails.logger.formatter = proc do |severity, time, _, msg|
+  "#{time.strftime('%Y-%m-%d %H:%M:%S')} - #{severity} - #{msg}\n"
+end
+Rails.logger.datetime_format = '%Y-%m-%d %H:%M:%S'
+
+parser.parse!(into: options)
+druids = options[:druids] || File.read(options[:input]).split
+
+archiver = FedoraArchiver.new(
+  druids: druids,
+  archive_dir: options[:archive],
+  lenient: options[:lenient]
+)
+
+archiver.run

--- a/lib/fedora_archiver.rb
+++ b/lib/fedora_archiver.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'zlib'
+require 'ruby-progressbar'
+
+# Archive Fedora Objects as FOXML to a druid-tree
+class FedoraArchiver
+  include Rubydora::FedoraUrlHelpers
+
+  def initialize(druids:, archive_dir:, lenient:)
+    @druids = druids
+    @lenient = lenient
+    @archive_dir = Pathname.new archive_dir
+  end
+
+  def run
+    bar = ProgressBar.create(title: 'archiving', total: druids.length)
+    druids.map do |druid|
+      write_foxml(druid, archive_dir)
+      bar.increment
+    end
+  end
+
+  private
+
+  attr_reader :druids, :archive_dir, :lenient
+
+  def write_foxml(druid, archive_dir)
+    obj_file = archive_dir + "#{dtree(druid)}.xml.gz"
+    obj_dir = obj_file.dirname
+
+    if obj_file.file?
+      Rails.logger.info("#{druid} already found at #{obj_file}")
+      return
+    end
+
+    begin
+      content = fetch_foxml(druid)
+      if content
+        FileUtils.mkdir_p obj_dir
+        Zlib::GzipWriter.open(obj_file) do |gzip_file|
+          gzip_file.write(content)
+        end
+        Rails.logger.info("saved #{druid} as #{obj_file}")
+      end
+    rescue Faraday::TimeoutError
+      FileUtils.rm(obj_file) if obj_file.file?
+      msg = "timeout error when fetching #{druid}"
+      Rails.logger.error(msg)
+      raise msg unless lenient
+    rescue StandardError => e
+      FileUtils.rm(obj_file) if obj_file.file?
+      raise e
+    end
+  end
+
+  def fetch_foxml(druid)
+    resp = connection.get(export_object_url(druid, { context: 'archive' }))
+    if resp.status != 200
+      msg = "getting #{druid} returned #{resp.status}"
+      Rails.logger.error(msg)
+      return if lenient
+
+      raise msg
+    end
+    resp.body
+  end
+
+  def dtree(druid)
+    id = druid.delete_prefix('druid:')
+    "#{id[0..2]}/#{id[3..5]}/#{id}"
+  end
+
+  def connection
+    @connection ||= Faraday::Connection.new(
+      url: Settings.fedora_url,
+      ssl: {
+        client_cert: OpenSSL::X509::Certificate.new(File.read(Settings.ssl.cert_file)),
+        client_key: OpenSSL::PKey.read(File.read(Settings.ssl.key_file))
+      },
+      headers: { 'Accept' => 'text/xml' }
+    )
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'simplecov'
 SimpleCov.start :rails do
   add_filter '/spec/'
   add_filter '/lib/data_error_notifier.rb'
+  add_filter '/lib/fedora_archiver.rb'
   add_filter '/lib/fedora_cache.rb'
   add_filter '/lib/fedora_loader.rb'
   add_filter '/lib/report.rb'


### PR DESCRIPTION
## Why was this change made? 🤔

This command line utility can be used to download the FOXML archive files from a Fedora instance based on a list of druids.

## How was this change tested? 🤨

I tested against https://sul-dor-migrate.stanford.edu/fedora with 250,000 items. I wrote a [little program](https://gist.github.com/edsu/d0051fd6c89099af34621986f90b90ce) to analyze the log file that archive-fedora generates and it looks like for 4.3M items it will take 14 days, and generate 94 GB of data. The size seemed low to me, if the FOXML truly contains all versions of datastreams for the object?

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Closes #3102 

