### PR TITLE
[HOLD] normalize non-integer imagedata

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -50,8 +50,9 @@ module Cocina
         downcase_checksum_type
         normalize_empty_xml
         missing_type_attribute_assigned_file
-        normalize_image_data
+        remove_empty_image_data
         remove_duplicate_image_data
+        normalize_image_data_to_integers
         normalize_blank_file_directives
         normalize_relationship
 
@@ -99,10 +100,17 @@ module Cocina
 
       # remove empty width and height attributes from imageData, e.g. <imageData width="" height=""/>
       # then remove any totally empty imageData nodes, e.g. <imageData/>
-      def normalize_image_data
+      def remove_empty_image_data
         ng_xml.xpath('//imageData[@height=""]').each { |node| node.remove_attribute('height') }
         ng_xml.xpath('//imageData[@width=""]').each { |node| node.remove_attribute('width') }
         ng_xml.xpath('//imageData[not(text())][not(@*)]').each(&:remove)
+      end
+
+      # convert any imageData to integers and ditch any units <imageData width="27.544308mm" height="29.510118mm"/>
+      # goes to <imageData width="27" height="29"/>
+      def normalize_image_data_to_integers
+        ng_xml.xpath('//imageData[not(@height="")]').each { |node| node['height'] = node['height'].to_i if node['height'] }
+        ng_xml.xpath('//imageData[not(@width="")]').each { |node| node['width'] = node['width'].to_i if node['width'] }
       end
 
       def remove_duplicate_image_data

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -110,7 +110,7 @@ module Cocina
                 catkey: catkey_for(cocina_item)).tap do |fedora_item|
         add_description(fedora_item, cocina_item, trial: trial)
 
-        add_dro_tags(druid, cocina_item)
+        add_dro_tags(druid, cocina_item) unless trial
 
         Cocina::ToFedora::DROAccess.apply(fedora_item, cocina_item.access, cocina_item.structural) if cocina_item.access || cocina_item.structural
 

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       end
     end
 
-    context 'when normalizing imageData' do
+    context 'when removing blank imageData' do
       # adapted from druid:bb101rd7954
       let(:original_xml) do
         <<~XML
@@ -412,6 +412,37 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
                 <file id="Thumbs3.db" mimetype="image/vnd.fpx" size="17408" preserve="yes" publish="no" shelve="no">
                   <checksum type="md5">99c8d3026749b6103f20c911ea102339</checksum>
                   <checksum type="sha1">f73a49b173c741b540170a4f3aa64b87988d4db7</checksum>
+                </file>
+              </resource>
+            </contentMetadata>
+          XML
+        )
+      end
+    end
+
+    context 'when normalizing non-integer imageData' do
+      # adapted from druid:ft996xy0052
+      let(:original_xml) do
+        <<~XML
+          <contentMetadata objectId="druid:ft996xy0052" type="image">
+            <resource type="image">
+              <label>Image 1</label>
+              <file id="test.jpg" mimetype="image/jpg" size="100" preserve="yes" publish="no" shelve="no">
+                <imageData width="27.544308mm" height="29.510118mm"/>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      end
+
+      it 'converts imagedata to integers and removes units' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <contentMetadata objectId="druid:ft996xy0052" type="image">
+              <resource type="image">
+                <label>Image 1</label>
+                <file id="test.jpg" mimetype="image/jpg" size="100" preserve="yes" publish="no" shelve="no">
+                  <imageData width="27" height="29"/>
                 </file>
               </resource>
             </contentMetadata>


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3541 - normalize non-integer imagedata to be integers and strip units

Note: changed some existing method names to be more clear 

HOLD Pending validate cocina tests

## How was this change tested? 🤨

- New unit test
- validate cocina roundtrip