### PR TITLE
Decouple mods_controller from ActiveFedora

### DIFF
--- a/app/controllers/mods_controller.rb
+++ b/app/controllers/mods_controller.rb
@@ -2,30 +2,15 @@
 
 # A controller for the MODS data on an object
 class ModsController < ApplicationController
-  before_action :load_item
+  before_action :load_cocina_object
 
   def show
-    render xml: @item.descMetadata.content
+    render xml: Cocina::ToFedora::Descriptive.transform(@cocina_object.description, @cocina_object.externalIdentifier).to_xml
   end
 
   def update
-    LegacyMetadataService.update_datastream_if_newer(item: @item,
-                                                     datastream_name: 'descMetadata',
-                                                     updated: Time.zone.now,
-                                                     content: request.body.read,
-                                                     event_factory: EventFactory)
-
-    # Mapping before save to guard against invalid cocina objects.
-    cocina_object = Cocina::Mapper.build(@item)
-
-    @item.save!
-
-    Notifications::ObjectUpdated.publish(model: cocina_object,
-                                         created_at: @item.create_date,
-                                         modified_at: @item.modified_date)
-  rescue LegacyMetadataService::DatastreamValidationError => e
-    json_api_error(status: :unprocessable_entity, message: e.detail, title: e.message)
-  rescue Rubydora::FedoraInvalidRequest
-    json_api_error(status: :service_unavailable, message: 'Invalid Fedora request possibly due to concurrent requests')
+    props = Cocina::FromFedora::Descriptive.props(mods: Nokogiri::XML(request.body.read), druid: @cocina_object.externalIdentifier)
+    updated_cocina_object = @cocina_object.new(description: props)
+    CocinaObjectStore.save(updated_cocina_object)
   end
 end

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -53,10 +53,13 @@ RSpec.describe 'Display metadata' do
           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
       expect(response.body).to be_equivalent_to <<~XML
-        <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.7" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
           <titleInfo>
             <title>Hello</title>
           </titleInfo>
+          <location>
+            <url usage="primary display">https://purl.stanford.edu/mk420bs7601</url>\n
+          </location>
         </mods>
       XML
     end

--- a/spec/requests/mods_update_spec.rb
+++ b/spec/requests/mods_update_spec.rb
@@ -3,11 +3,39 @@
 require 'rails_helper'
 
 RSpec.describe 'Update MODS' do
+  let(:druid) { 'druid:mk420bs7601' }
+  let(:apo_druid) { 'druid:dd999df4567' }
+  let(:description) do
+    {
+      title: [{ value: 'Dummy Title' }],
+      purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+    }
+  end
   let(:object) do
     Dor::Item.new(pid: 'druid:mk420bs7601',
                   label: 'Hey',
                   source_id: 'foo:bar',
                   admin_policy_object_id: 'druid:dd999df4567')
+  end
+  let(:cocina_object) do
+    Cocina::Models::DRO.new(externalIdentifier: druid,
+                            type: Cocina::Models::Vocab.object,
+                            label: 'A new map of Africa',
+                            version: 1,
+                            description: description,
+                            identification: { sourceId: 'sul:50807230' },
+                            access: {},
+                            administrative: { hasAdminPolicy: apo_druid })
+  end
+  let(:cocina_apo_object) do
+    Cocina::Models::AdminPolicy.new(externalIdentifier: apo_druid,
+                                    administrative: {
+                                      hasAdminPolicy: 'druid:gg123vx9393',
+                                      hasAgreement: 'druid:bb008zm4587'
+                                    },
+                                    version: 1,
+                                    label: 'just an apo',
+                                    type: Cocina::Models::Vocab.admin_policy)
   end
 
   let(:xml) do
@@ -24,18 +52,32 @@ RSpec.describe 'Update MODS' do
     object.descMetadata.title_info.main_title = 'Goodbye'
     allow(Dor).to receive(:find).and_return(object)
     allow(object).to receive(:save!)
-    allow(Notifications::ObjectUpdated).to receive(:publish)
+    allow(CocinaObjectStore).to receive(:find).with(apo_druid).and_return(cocina_apo_object)
+    allow(CocinaObjectStore).to receive(:find).with(druid).and_return(cocina_object)
+    allow(CocinaObjectStore).to receive(:save)
   end
 
   context 'with valid xml' do
+    let(:new_cocina_object) do
+      Cocina::Models::DRO.new(externalIdentifier: druid,
+                              type: Cocina::Models::Vocab.object,
+                              label: 'A new map of Africa',
+                              version: 1,
+                              description: {
+                                title: [{ value: 'Hello' }],
+                                purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+                              },
+                              identification: { sourceId: 'sul:50807230' },
+                              access: {},
+                              administrative: { hasAdminPolicy: apo_druid })
+    end
+
     it 'updates the source MODS xml' do
       put '/v1/objects/druid:mk420bs7601/metadata/mods',
           params: xml,
           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to have_http_status(:no_content)
-      expect(object.descMetadata.title_info.main_title).to eq ['Hello']
-      expect(object.descMetadata.title_info.main_title).to eq ['Hello']
-      expect(Notifications::ObjectUpdated).to have_received(:publish)
+      expect(CocinaObjectStore).to have_received(:save).with(new_cocina_object)
     end
   end
 
@@ -48,27 +90,11 @@ RSpec.describe 'Update MODS' do
       XML
     end
 
-    it 'returns an error' do
+    it 'saves the original cocina object' do
       put '/v1/objects/druid:mk420bs7601/metadata/mods',
           params: xml,
           headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response).to have_http_status(:unprocessable_entity)
-    end
-  end
-
-  context 'when invalid cocina' do
-    before do
-      allow(Cocina::Mapper).to receive(:build).and_raise(Cocina::Mapper::UnexpectedBuildError, ' #/components/schemas/DRO missing required parameters')
-    end
-
-    it 'returns error' do
-      put '/v1/objects/druid:mk420bs7601/metadata/mods',
-          params: xml,
-          headers: { 'Authorization' => "Bearer #{jwt}" }
-
-      expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to match(/Unexpected Cocina::Mapper.build error/)
-      expect(object).not_to have_received(:save!)
+      expect(response).to have_http_status(:no_content)
     end
   end
 end

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -501,15 +501,19 @@ RSpec.describe 'Update object' do
   end
 
   context 'when title changes' do
-    before do
-      item.descMetadata.title_info.main_title = 'Not the title'
+    let(:description) do
+      {
+        title: [{ value: 'Not a title' }],
+        purl: 'https://purl.stanford.edu/gg777gg7777'
+      }
     end
 
-    it 'raises 422' do
+    it 'returns the updated object' do
       patch "/v1/objects/#{druid}",
             params: data,
             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-      expect(response.status).to eq(422)
+      expect(response.status).to eq(200)
+      expect(response.body).to include('Not a title')
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3529 by refactoring mods_controller#update for the CocinaObjectStore.
Fixes #3528 by refactoring mods_controller#show to use a cocina object

## How was this change tested? 🤨

Updated tests

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



