### PR TITLE
add report-content-imagedata-not-num

### DIFF
--- a/bin/reports/report-content-imagedata-not-num
+++ b/bin/reports/report-content-imagedata-not-num
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+Report.new(name: 'content-missing-imagedata-non-num', dsid: 'contentMetadata').run do |ng_xml|
+  not_svg = '@mimetype!="image/svg+xml"'
+
+  width = ng_xml.xpath("/contentMetadata/resource/file[#{not_svg}]/imageData/@width").presence&.first&.content
+  height = ng_xml.xpath("/contentMetadata/resource/file[#{not_svg}]/imageData/@height").presence&.first&.content
+
+  # we are interested in the ones that cannot be parsed as a Integer value
+  Integer(width) if width.present?
+  Integer(height) if height.present?
+  false
+rescue (ArgumentError)
+  # we are interested in the ones that cannot be parsed as a Integer value
+  true
+end


### PR DESCRIPTION
## Why was this change made? 🤔

To look beyond the tea leaves into the actual data, I presume.

Closes #3540 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

I ran the code in this report against some contentMetadata in the rails console.



