### PR TITLE
add report-content-file-directives-blank

### DIFF
--- a/bin/reports/report-content-file-directives-blank
+++ b/bin/reports/report-content-file-directives-blank
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+Report.new(name: 'content-file-directives-blank', dsid: 'contentMetadata').run do |ng_xml|
+  ng_xml.xpath('/contentMetadata/resource[file]/file[@preserve="" and @shelve="" and @publish=""]').present?
+end


### PR DESCRIPTION
## Why was this change made? 🤔

To find data to match certain criteria, presumably to be examined and decisions to be made.

Closes #3533

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Ran code in rails console with hoked up contentMetadata.

