### PR TITLE
Handle Hydrus APOs with no descriptive metadata.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive.rb
+++ b/app/services/cocina/from_fedora/descriptive.rb
@@ -27,6 +27,8 @@ module Cocina
       # @return [Hash] a hash that can be mapped to a cocina descriptive model
       # @raises [Cocina::Mapper::InvalidDescMetadata] if some assumption about descMetadata is violated
       def props
+        return nil if ng_xml.root.nil?
+
         check_altrepgroups
         check_version
         DescriptiveBuilder.build(title_builder: title_builder,

--- a/app/services/cocina/normalizers/mods_normalizer.rb
+++ b/app/services/cocina/normalizers/mods_normalizer.rb
@@ -32,8 +32,8 @@ module Cocina
       end
 
       def initialize(mods_ng_xml:, druid:, label: nil)
-        @ng_xml = mods_ng_xml.dup
-        @ng_xml.encoding = 'UTF-8' if @ng_xml.respond_to?(:encoding=) # sometimes it's a String (?)
+        @ng_xml = mods_ng_xml.root ? mods_ng_xml.dup : blank_ng_xml
+        @ng_xml.encoding = 'UTF-8'
         @druid = druid
         @label = label
       end
@@ -360,6 +360,16 @@ module Cocina
           related_item_node.delete('lang')
           related_item_node.delete('script')
         end
+      end
+
+      def blank_ng_xml
+        Nokogiri::XML(<<~XML
+          <mods xmlns="http://www.loc.gov/mods/v3"#{' '}
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"#{' '}
+            version="3.6"#{' '}
+            xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd" />
+        XML
+                     )
       end
     end
   end

--- a/spec/services/cocina/normalizers/mods/title_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/mods/title_normalizer_spec.rb
@@ -51,6 +51,24 @@ RSpec.describe Cocina::Normalizers::Mods::TitleNormalizer do
     end
   end
 
+  context 'when normalizing Hydrus title with no root' do
+    let(:label) { 'Hydrus' }
+
+    let(:mods_ng_xml) do
+      Nokogiri::XML('')
+    end
+
+    it 'adds Hydrus titleInfo' do
+      expect(normalized_ng_xml).to be_equivalent_to <<~XML
+        <mods #{MODS_ATTRIBUTES}>
+          <titleInfo>
+            <title>Hydrus</title>
+          </titleInfo>
+        </mods>
+      XML
+    end
+  end
+
   context 'when normalizing titles with type' do
     let(:mods_ng_xml) do
       Nokogiri::XML <<~XML

--- a/spec/support/mods_mapping_spec_helper.rb
+++ b/spec/support/mods_mapping_spec_helper.rb
@@ -160,7 +160,10 @@ RSpec.shared_examples 'MODS cocina mapping' do
       # the starting MODS is normalized to address discrepancies found against MODS roundtripped to data store (Fedora)
       #  and back, per Arcadia's specifications.  E.g., removal of empty nodes and attributes; addition of eventType to
       #  originInfo nodes.
-      normalized_rt_mods_xml = Cocina::Normalizers::ModsNormalizer.normalize(mods_ng_xml: roundtrip_mods_xml, druid: local_druid, label: label).to_xml if defined?(roundtrip_mods)
+      if defined?(roundtrip_mods)
+        normalized_rt_mods_xml = Cocina::Normalizers::ModsNormalizer.normalize(mods_ng_xml: Nokogiri::XML(roundtrip_mods_xml), druid: local_druid,
+                                                                               label: label).to_xml
+      end
       expect(re_roundtrip_mods_xml).to be_equivalent_to normalized_rt_mods_xml if defined?(roundtrip_mods)
     end
   end
@@ -274,7 +277,7 @@ RSpec.shared_examples 'cocina MODS mapping' do
 
     it 'roundtrip cocina Description maps to expected MODS, normalized' do
       # the roundtrip cocina is, effectively, the cocina for the normalized MODS - the MODS is normalized before it gets to cocina
-      normalized_mods_xml = Cocina::Normalizers::ModsNormalizer.normalize(mods_ng_xml: mods_xml, druid: local_druid, label: label).to_xml if defined?(roundtrip_cocina)
+      normalized_mods_xml = Cocina::Normalizers::ModsNormalizer.normalize(mods_ng_xml: Nokogiri::XML(mods_xml), druid: local_druid, label: label).to_xml if defined?(roundtrip_cocina)
       expect(roundtrip_mods_xml).to be_equivalent_to normalized_mods_xml if defined?(roundtrip_cocina)
     end
 


### PR DESCRIPTION
closes #3553

## Why was this change made? 🤔
Avoid normalizer error.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Before:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99795 (99.877%)
  Different: 123 (0.123%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

After:
```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99795 (99.877%)
  Different: 123 (0.123%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

This was also tested locally with some know problems.

