### PR TITLE
public_desc_metadata_service: fix bug for APOs

### DIFF
--- a/app/services/publish/public_desc_metadata_service.rb
+++ b/app/services/publish/public_desc_metadata_service.rb
@@ -102,7 +102,7 @@ module Publish
     # For use in published mods and mods-to-DC conversion.
     # @return [Void]
     def add_collection_reference!
-      return if cocina_object.collection? || cocina_object.structural&.isMemberOf.blank?
+      return if cocina_object.collection? || cocina_object.admin_policy? || cocina_object.structural&.isMemberOf.blank?
 
       collections = CocinaObjectStore.find_collections_for(cocina_object, swallow_exceptions: true)
 

--- a/spec/services/publish/public_desc_metadata_service_spec.rb
+++ b/spec/services/publish/public_desc_metadata_service_spec.rb
@@ -117,6 +117,28 @@ RSpec.describe Publish::PublicDescMetadataService do
         doc
       end
     end
+
+    context 'when the object is an apo' do
+      subject(:doc) { service.ng_xml(include_access_conditions: false) }
+
+      let(:cocina_object) do
+        Cocina::Models.build({
+                               'type' => Cocina::Models::Vocab.admin_policy,
+                               'label' => 'test',
+                               'externalIdentifier' => 'druid:bb666cc7777',
+                               'version' => 1,
+                               'administrative' => {
+                                 'hasAdminPolicy' => 'druid:ss666tt7777',
+                                 'hasAgreement' => 'druid:ff666kk6666'
+                               },
+                               'description' => description
+                             })
+      end
+
+      it 'has no errors' do
+        doc
+      end
+    end
   end
 
   describe '#to_xml' do


### PR DESCRIPTION
## Why was this change made? 🤔

To address https://app.honeybadger.io/projects/50568/faults/84175043, which happened in prod with an APO.  (not sure why we need public_desc_metadata for an APO.)

QUESTION:  do we need to put in some guards for Agreement objects also?   

QUESTION:  how do we find other places where a cocina object of unknown type is being queried for`structural` or `access` info?   as they don't all have it.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



