### PR TITLE
Extract from ObjectCreator/ObjectUpdater to CocinaObjectStore.

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -7,9 +7,9 @@ module Cocina
   class ObjectCreator
     # @raises SymphonyReader::ResponseError if symphony connection failed
     def self.create(cocina_object, druid:, event_factory: EventFactory, persister: ActiveFedoraPersister, assign_doi: false, cocina_object_store: CocinaObjectStore.new)
-      _fedora_object, cocina_object = new(cocina_object_store: cocina_object_store).create(cocina_object, druid: druid, event_factory: event_factory, persister: persister,
+      fedora_object, _cocina_object = new(cocina_object_store: cocina_object_store).create(cocina_object, druid: druid, event_factory: event_factory, persister: persister,
                                                                                                           assign_doi: assign_doi)
-      cocina_object
+      fedora_object
     end
 
     def self.trial_create(cocina_object, notifier:, cocina_object_store:)
@@ -110,8 +110,6 @@ module Cocina
                 catkey: catkey_for(cocina_item)).tap do |fedora_item|
         add_description(fedora_item, cocina_item, trial: trial)
 
-        add_dro_tags(druid, cocina_item) unless trial
-
         Cocina::ToFedora::DROAccess.apply(fedora_item, cocina_item.access, cocina_item.structural) if cocina_item.access || cocina_item.structural
 
         fedora_item.contentMetadata.content = Cocina::ToFedora::ContentMetadataGenerator.generate(druid: druid, type: cocina_item.type, structural: cocina_item.structural,
@@ -141,7 +139,6 @@ module Cocina
                           source_id: cocina_collection.identification&.sourceId,
                           catkey: catkey_for(cocina_collection)).tap do |fedora_collection|
         add_description(fedora_collection, cocina_collection, trial: trial)
-        add_collection_tags(druid, cocina_collection) unless trial
         Cocina::ToFedora::CollectionAccess.apply(fedora_collection, cocina_collection.access) if cocina_collection.access
         Cocina::ToFedora::Identity.initialize_identity(fedora_collection)
         Cocina::ToFedora::Identity.apply_catalog_links(fedora_collection, catalog_links: cocina_collection.identification&.catalogLinks)
@@ -173,20 +170,6 @@ module Cocina
         fedora_object.descMetadata.mods_title = cocina_object.label
         Cocina::ToFedora::Identity.apply_label(fedora_object, label: cocina_object.label)
       end
-    end
-
-    def add_dro_tags(pid, cocina_object)
-      tags = []
-      process_tag = ToFedora::ProcessTag.map(cocina_object.type, cocina_object.structural&.hasMemberOrders&.first&.viewingDirection)
-      tags << process_tag if process_tag
-      tags << "Project : #{cocina_object.administrative.partOfProject}" if cocina_object.administrative.partOfProject
-      AdministrativeTags.create(pid: pid, tags: tags) if tags.any?
-    end
-
-    def add_collection_tags(pid, cocina_object)
-      return unless cocina_object.administrative.partOfProject
-
-      AdministrativeTags.create(pid: pid, tags: ["Project : #{cocina_object.administrative.partOfProject}"])
     end
 
     def validate(cocina_object)

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -9,6 +9,8 @@ module Cocina
     def self.create(cocina_object, druid:, persister: ActiveFedoraPersister, assign_doi: false, cocina_object_store: CocinaObjectStore.new)
       fedora_object, _cocina_object = new(cocina_object_store: cocina_object_store).create(cocina_object, druid: druid, persister: persister,
                                                                                                           assign_doi: assign_doi)
+
+      # Return Fedora object so that CocinaObjectStore can perform late mapping.
       fedora_object
     end
 

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -466,10 +466,6 @@ RSpec.describe 'Update object' do
             params: data,
             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
       expect(response.status).to eq(400)
-      expect(EventFactory).to have_received(:create)
-        .with(druid: other_druid,
-              data: hash_including(:request, success: false, error: "Identifier on the query and in the body don't match"),
-              event_type: 'update')
     end
   end
 

--- a/spec/services/cocina/object_creator_spec.rb
+++ b/spec/services/cocina/object_creator_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Cocina::ObjectCreator do
     allow(RefreshMetadataAction).to receive(:run) do |args|
       args[:fedora_object].descMetadata.mods_title = 'foo'
     end
-    allow(SynchronousIndexer).to receive(:reindex_remotely)
     allow(Settings.datacite).to receive(:prefix).and_return('10.25740')
   end
 
@@ -286,37 +285,6 @@ RSpec.describe Cocina::ObjectCreator do
       it 'keeps DOI' do
         expect(result[1].identification.doi).to eq '10.25740/bb010dx6027'
       end
-    end
-  end
-
-  context 'when postgres create is enabled' do
-    let(:params) do
-      {
-        'type' => 'http://cocina.sul.stanford.edu/models/object.jsonld',
-        'label' => 'label value',
-        'access' => {},
-        'version' => 1,
-        'structural' => {},
-        'administrative' => {
-          'hasAdminPolicy' => apo
-        },
-        'identification' => {
-          'sourceId' => 'donot:care'
-        }
-      }
-    end
-
-    let(:cocina_object_store) { instance_double(CocinaObjectStore, cocina_to_ar_save: nil) }
-
-    before do
-      allow(Settings.enabled_features.postgres).to receive(:create).and_return(true)
-      allow(CocinaObjectStore).to receive(:new).and_return(cocina_object_store)
-    end
-
-    it 'saves to postgres' do
-      result
-
-      expect(cocina_object_store).to have_received(:cocina_to_ar_save).with(instance_of(Cocina::Models::DRO))
     end
   end
 

--- a/spec/services/cocina/object_creator_spec.rb
+++ b/spec/services/cocina/object_creator_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe Cocina::ObjectCreator do
   subject(:result) { described_class.create(request, druid: druid, persister: persister, assign_doi: assign_doi) }
 
+  let(:created_cocina_object) { Cocina::Mapper.build(result) }
+
   let(:apo) { 'druid:bz845pv2292' }
   let(:minimal_cocina_admin_policy) do
     Cocina::Models::AdminPolicy.new({
@@ -52,7 +54,7 @@ RSpec.describe Cocina::ObjectCreator do
       end
 
       it 'title is set to result of RefreshMetadataAction when there is a catalogLink' do
-        expect(result.description.title.first.value).to eq 'foo'
+        expect(created_cocina_object.description.title.first.value).to eq 'foo'
       end
     end
 
@@ -74,7 +76,7 @@ RSpec.describe Cocina::ObjectCreator do
       end
 
       it 'title is set to label' do
-        expect(result.description.title.first.value).to eq 'label value'
+        expect(created_cocina_object.description.title.first.value).to eq 'label value'
       end
     end
 
@@ -152,36 +154,36 @@ RSpec.describe Cocina::ObjectCreator do
       end
 
       it 'title is set to value passed in' do
-        expect(result.description.title.first.value).to eq 'more desc mappings'
+        expect(created_cocina_object.description.title.first.value).to eq 'more desc mappings'
       end
 
       it 'contributors are set' do
-        expect(result.description.contributor.first.type).to eq 'person'
-        expect(result.description.contributor.first.name.first.value).to eq 'Miss Piggy'
-        expect(result.description.contributor.first.role.first.value).to eq 'Creator'
-        expect(result.description.contributor.last.type).to eq 'organization'
-        expect(result.description.contributor.last.name.first.value).to eq 'funder.example.org'
-        expect(result.description.contributor.last.role.first.value).to eq 'Funder'
+        expect(created_cocina_object.description.contributor.first.type).to eq 'person'
+        expect(created_cocina_object.description.contributor.first.name.first.value).to eq 'Miss Piggy'
+        expect(created_cocina_object.description.contributor.first.role.first.value).to eq 'Creator'
+        expect(created_cocina_object.description.contributor.last.type).to eq 'organization'
+        expect(created_cocina_object.description.contributor.last.name.first.value).to eq 'funder.example.org'
+        expect(created_cocina_object.description.contributor.last.role.first.value).to eq 'Funder'
       end
 
       it 'subjects are set' do
-        expect(result.description.subject.first.type).to eq 'topic'
-        expect(result.description.subject.first.value).to eq 'I am a keyword'
+        expect(created_cocina_object.description.subject.first.type).to eq 'topic'
+        expect(created_cocina_object.description.subject.first.value).to eq 'I am a keyword'
       end
 
       it 'abstract (note of type abstract) is set' do
-        summary_note = result.description.note.find { |note| note.type == 'abstract' }
+        summary_note = created_cocina_object.description.note.find { |note| note.type == 'abstract' }
         expect(summary_note.value).to eq 'I am an abstract'
       end
 
       it 'contact (note of type contact) is set' do
-        contact_note = result.description.note.find { |note| note.type == 'email' }
+        contact_note = created_cocina_object.description.note.find { |note| note.type == 'email' }
         expect(contact_note.value).to eq 'marypoppins@umbrellas.org'
         expect(contact_note.displayLabel).to eq 'Contact'
       end
 
       it 'preferred citation is set with the link placeholder replaced' do
-        contact_note = result.description.note.find { |note| note.type == 'preferred citation' }
+        contact_note = created_cocina_object.description.note.find { |note| note.type == 'preferred citation' }
         expect(contact_note.value).to eq 'Zappa, F. (2013) https://purl.stanford.edu/mb046vj7485'
       end
     end
@@ -206,7 +208,7 @@ RSpec.describe Cocina::ObjectCreator do
       end
 
       it 'creates dark access' do
-        expect(result.access.access).to eq 'dark'
+        expect(created_cocina_object.access.access).to eq 'dark'
       end
     end
 
@@ -227,7 +229,7 @@ RSpec.describe Cocina::ObjectCreator do
       end
 
       it 'creates an agreement' do
-        expect(result.type).to eq Cocina::Models::Vocab.agreement
+        expect(created_cocina_object.type).to eq Cocina::Models::Vocab.agreement
       end
     end
 
@@ -253,7 +255,7 @@ RSpec.describe Cocina::ObjectCreator do
       end
 
       it 'adds DOI' do
-        expect(result.identification.doi).to eq '10.25740/mb046vj7485'
+        expect(created_cocina_object.identification.doi).to eq '10.25740/mb046vj7485'
       end
     end
 
@@ -353,11 +355,11 @@ RSpec.describe Cocina::ObjectCreator do
       end
 
       it 'collection title is set to params title' do
-        expect(result.description.title.first.value).to eq 'collection title'
+        expect(created_cocina_object.description.title.first.value).to eq 'collection title'
       end
 
       it 'collection abstract (note of type abstract) is set' do
-        summary_note = result.description.note.find { |note| note.type == 'abstract' }
+        summary_note = created_cocina_object.description.note.find { |note| note.type == 'abstract' }
         expect(summary_note.value).to eq 'I am an abstract'
       end
     end
@@ -393,7 +395,7 @@ RSpec.describe Cocina::ObjectCreator do
     end
 
     it 'geoMetadata content is set' do
-      expect(result.geographic.iso19139).to eq geo_xml
+      expect(created_cocina_object.geographic.iso19139).to eq geo_xml
     end
   end
 end

--- a/spec/services/cocina/object_updater_spec.rb
+++ b/spec/services/cocina/object_updater_spec.rb
@@ -452,62 +452,6 @@ RSpec.describe Cocina::ObjectUpdater do
       end
     end
 
-    context 'when updating administrative' do
-      before do
-        allow(item).to receive(:admin_policy_object_id=)
-        allow(AdministrativeTags).to receive(:create)
-      end
-
-      context 'when administrative has changed' do
-        let(:cocina_attrs) do
-          orig_cocina_attrs.tap do |attrs|
-            attrs[:administrative] = {
-              hasAdminPolicy: 'druid:ff000df4567',
-              partOfProject: 'Google Books'
-            }
-          end
-        end
-
-        context 'when creating a new project tag' do
-          it 'updates administrative' do
-            update
-            expect(item).to have_received(:admin_policy_object_id=).with('druid:ff000df4567')
-            expect(AdministrativeTags).to have_received(:create)
-          end
-        end
-
-        context 'when multiple project tags already exists' do
-          before do
-            allow(AdministrativeTags).to receive(:for).and_return(['Project : Phoenix', 'Project : Google Books'])
-          end
-
-          it 'updates administrative' do
-            expect { update }.to raise_error(/Too many tags for prefix/)
-          end
-        end
-
-        context 'when creating a new project tag with an existing project subtag' do
-          before do
-            allow(AdministrativeTags).to receive(:for).and_return(['Project : Google Books : Special'])
-          end
-
-          it 'updates administrative' do
-            update
-            expect(item).to have_received(:admin_policy_object_id=).with('druid:ff000df4567')
-            expect(AdministrativeTags).to have_received(:create)
-          end
-        end
-      end
-
-      context 'when administrative has not changed' do
-        it 'does not update administrative' do
-          update
-          expect(item).not_to have_received(:admin_policy_object_id=)
-          expect(AdministrativeTags).not_to have_received(:create)
-        end
-      end
-    end
-
     context 'when updating identification' do
       before do
         allow(item).to receive(:source_id=)
@@ -586,7 +530,6 @@ RSpec.describe Cocina::ObjectUpdater do
           instance_double(Dor::RightsMetadataDS, ng_xml_will_change!: nil)
         )
         allow(content_metadata).to receive(:contentType=)
-        allow(AdministrativeTags).to receive(:create)
         allow(content_metadata).to receive(:ng_xml)
         allow(Cocina::ToFedora::DROAccess).to receive(:apply)
       end
@@ -606,7 +549,6 @@ RSpec.describe Cocina::ObjectUpdater do
           expect(item).to have_received(:collection_ids=)
           expect(content_metadata).to have_received(:contentType=)
           expect(content_metadata).not_to have_received(:ng_xml)
-          expect(AdministrativeTags).to have_received(:create)
           expect(Cocina::ToFedora::DROAccess).to have_received(:apply)
         end
       end
@@ -616,7 +558,6 @@ RSpec.describe Cocina::ObjectUpdater do
           update
           expect(item).not_to have_received(:collection_ids=)
           expect(content_metadata).not_to have_received(:contentType=)
-          expect(AdministrativeTags).not_to have_received(:create)
           expect(Cocina::ToFedora::DROAccess).not_to have_received(:apply)
         end
       end
@@ -631,7 +572,6 @@ RSpec.describe Cocina::ObjectUpdater do
         allow(content_metadata).to receive(:content=)
         allow(content_metadata).to receive(:contentType=)
         allow(content_metadata).to receive(:ng_xml)
-        allow(AdministrativeTags).to receive(:create)
         allow(Cocina::ToFedora::DROAccess).to receive(:apply)
       end
 
@@ -676,7 +616,6 @@ RSpec.describe Cocina::ObjectUpdater do
         expect(content_metadata).to have_received(:content=)
         expect(content_metadata).not_to have_received(:contentType=)
         expect(content_metadata).not_to have_received(:ng_xml)
-        expect(AdministrativeTags).to have_received(:create)
         expect(Cocina::ToFedora::DROAccess).to have_received(:apply)
       end
     end

--- a/spec/services/cocina/object_updater_spec.rb
+++ b/spec/services/cocina/object_updater_spec.rb
@@ -7,7 +7,7 @@ require 'rails_helper'
 RSpec.describe Cocina::ObjectUpdater do
   include Dry::Monads[:result]
 
-  subject(:update) { described_class.run(item, cocina_object, event_factory: event_factory, trial: trial) }
+  subject(:update) { described_class.run(item, cocina_object, trial: trial) }
 
   # For the existing item.
   let(:orig_cocina_object) do
@@ -21,8 +21,6 @@ RSpec.describe Cocina::ObjectUpdater do
 
   let(:cocina_attrs) { orig_cocina_attrs }
 
-  let(:event_factory) { class_double(EventFactory) }
-
   let(:trial) { false }
 
   let(:version_metadata) { instance_double(Dor::VersionMetadataDS, increment_version: nil) }
@@ -32,7 +30,6 @@ RSpec.describe Cocina::ObjectUpdater do
     allow(Cocina::ApoExistenceValidator).to receive(:new).and_return(instance_double(Cocina::ApoExistenceValidator, valid?: true))
     allow(Settings.enabled_features).to receive(:update_descriptive).and_return(true)
     allow(AdministrativeTags).to receive(:for).and_return([])
-    allow(event_factory).to receive(:create)
   end
 
   context 'when an admin policy' do
@@ -783,7 +780,6 @@ RSpec.describe Cocina::ObjectUpdater do
     it 'updates but does not save' do
       update
       expect(item).not_to have_received(:save!)
-      expect(event_factory).not_to have_received(:create)
       expect(AdministrativeTags).not_to have_received(:create)
 
       expect(item).to have_received(:admin_policy_object_id=)


### PR DESCRIPTION
closes #3512

## Why was this change made? 🤔
Move non-Fedora specific code out of ObjectCreator and ObjectUpdater.

I implemented 3 tickets in a single PR so that I only had to run integration tests once.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Ran integration tests in QA.


