### PR TITLE
Remove trailing whitespace from catkeys and previous_catkeys.

### DIFF
--- a/app/services/cocina/normalizers/identity_normalizer.rb
+++ b/app/services/cocina/normalizers/identity_normalizer.rb
@@ -36,6 +36,7 @@ module Cocina
         normalize_out_release_tags
         normalize_out_otherid_labels
         normalize_out_apo_hydrus_source_id
+        normalize_catkey_trailing_space
 
         add_missing_object_creator
         add_missing_object_label
@@ -200,6 +201,11 @@ module Cocina
         diss_id_node.node_name = 'sourceId'
         diss_id_node['source'] = diss_id_node['name']
         diss_id_node.delete('name')
+      end
+
+      def normalize_catkey_trailing_space
+        ng_xml.root.xpath('//otherId[@name="catkey" or @name="previous_catkey"]')
+              .each { |node| node.content = node.content.chomp(' ') }
       end
     end
     # rubocop:enable Metrics/ClassLength

--- a/spec/services/cocina/normalizers/identity_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/identity_normalizer_spec.rb
@@ -805,5 +805,35 @@ RSpec.describe Cocina::Normalizers::IdentityNormalizer do
         )
       end
     end
+
+    describe '#normalize_catkey_trailing_space' do
+      let(:original_xml) do
+        <<~XML
+          <identityMetadata>
+            <otherId name="catkey">666</otherId>
+            <otherId name="catkey">667 </otherId>
+            <otherId name="previous_catkey">668</otherId>
+            <otherId name="catkey">669 </otherId>
+            <objectCreator>DOR</objectCreator>
+            <objectLabel>Label</objectLabel>
+          </identityMetadata>
+        XML
+      end
+
+      it 'removes trailing space' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+              <identityMetadata>
+              <otherId name="catkey">666</otherId>
+              <otherId name="catkey">667</otherId>
+              <otherId name="previous_catkey">668</otherId>
+              <otherId name="catkey">669</otherId>
+              <objectCreator>DOR</objectCreator>
+              <objectLabel>Label</objectLabel>
+            </identityMetadata>
+          XML
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
closes #3558

## Why was this change made? 🤔
Roundtrippin'


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, local with druids mentioned in ticket, sdr-deploy

Before:
```
Status (n=50000; not using Missing for success/different/error stats):
  Success:   49895 (99.86%)
  Different: 70 (0.14%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     35 (0.07%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

After:
```
Status (n=50000; not using Missing for success/different/error stats):
  Success:   49895 (99.86%)
  Different: 70 (0.14%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     35 (0.07%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```
