### PR TITLE
[HOLD] Fixes logic for applying default object rights.

### DIFF
--- a/app/services/access_merge_service.rb
+++ b/app/services/access_merge_service.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Determines access by merging provided access with default access.
+class AccessMergeService
+  # @param [Cocina::Models::RequestDRO,Cocina::Models::RequestCollection] cocina_object for which to determine access.
+  # @param [Cocina::Models::AdminPolicy] apo_object admin policy for the cocina_object
+  # @return [Cocina::Models::DROAccess]
+  def self.merge(cocina_object, apo_object)
+    new(cocina_object, apo_object).merge
+  end
+
+  def initialize(cocina_object, apo_object)
+    @cocina_object = cocina_object
+    @apo_object = apo_object
+  end
+
+  def merge
+    # Admin policy may not have default access.
+    if default_access.nil?
+      # access is optional on a request, so may be nil.
+      return cocina_object.access || access_class.new
+    end
+
+    props = cocina_object.access&.to_h || {}
+
+    # Note for below: For cocina, an omitted value will not have a key in the hash.
+
+    # Add rights (access, cdl, download, readLocation) if not present.
+    props.merge!(rights) unless props.key?(:access)
+
+    # Add others
+    props[:copyright] = default_access.copyright unless props.key?(:copyright)
+    props[:useAndReproductionStatement] = default_access.useAndReproductionStatement unless props.key?(:useAndReproductionStatement)
+    props[:license] = default_access.license unless props.key?(:license)
+
+    access_class.new(props.compact)
+  end
+
+  private
+
+  attr_reader :cocina_object, :apo_object
+
+  def default_access
+    @default_access ||= apo_object.administrative.defaultAccess
+  end
+
+  def rights
+    cocina_object.collection? ? collection_rights : dro_rights
+  end
+
+  def collection_rights
+    {
+      access: default_access.access == 'dark' ? 'dark' : 'world'
+    }
+  end
+
+  def dro_rights
+    default_access.to_h.slice(:access, :controlledDigitalLending, :download, :readLocation)
+  end
+
+  def access_class
+    cocina_object.collection? ? Cocina::Models::CollectionAccess : Cocina::Models::DROAccess
+  end
+end

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Create object' do
         {
           "cocinaVersion":"0.0.1",
           "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
-          "label":"#{label}","version":1,"access":{},
+          "label":"#{label}","version":1,"access":{"access":"world"},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567"},
           "description":{"title":[{"value":"#{title}"}]},
           "identification":#{identification.to_json}}
@@ -126,7 +126,7 @@ RSpec.describe 'Create object' do
         {
           "cocinaVersion":"0.0.1",
           "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
-          "label":"#{label}","version":1,"access":{},
+          "label":"#{label}","version":1,"access":{"access":"world"},
           "administrative":{"releaseTags":[],"hasAdminPolicy":"druid:dd999df4567","partOfProject":"Hydrus"},
           "identification":{"sourceId":"hydrus:collection-456"},
           "description":{"title":[{"value":"#{title}"}]}
@@ -152,7 +152,7 @@ RSpec.describe 'Create object' do
           "type":"http://cocina.sul.stanford.edu/models/collection.jsonld",
           "label":"#{label}",
           "version":1,
-          "access":{},
+          "access":{"access":"world"},
           "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
           "description":{
             "title":[{"value":"#{title}"}],

--- a/spec/services/access_merge_service_spec.rb
+++ b/spec/services/access_merge_service_spec.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccessMergeService do
+  let(:merged_access) { described_class.merge(cocina_object, apo_object) }
+
+  let(:apo_object) { instance_double(Cocina::Models::AdminPolicy, administrative: apo_administrative) }
+  let(:apo_administrative) { instance_double(Cocina::Models::AdminPolicyAdministrative, defaultAccess: default_access) }
+
+  context 'when a RequestDRO' do
+    let(:cocina_object) { instance_double(Cocina::Models::RequestDRO, access: access, collection?: false) }
+
+    context 'when no access but APO has access' do
+      let(:access) { nil }
+
+      let(:default_access) do
+        Cocina::Models::AdminPolicyDefaultAccess.new(
+          access: 'location-based',
+          download: 'none',
+          readLocation: 'spec'
+        )
+      end
+
+      it 'uses APO access' do
+        expect(merged_access).to eq(Cocina::Models::DROAccess.new(
+                                      access: 'location-based',
+                                      download: 'none',
+                                      readLocation: 'spec'
+                                    ))
+      end
+    end
+
+    context 'when no access and APO has no access' do
+      let(:access) { nil }
+
+      let(:default_access) { nil }
+
+      it 'uses default access (dark)' do
+        expect(merged_access).to eq(Cocina::Models::DROAccess.new)
+      end
+    end
+
+    context 'when access already has rights' do
+      let(:access) do
+        Cocina::Models::DROAccess.new(
+          access: 'stanford',
+          download: 'none',
+          controlledDigitalLending: true
+        )
+      end
+
+      let(:default_access) do
+        Cocina::Models::AdminPolicyDefaultAccess.new(
+          access: 'location-based',
+          download: 'none',
+          readLocation: 'spec'
+        )
+      end
+
+      it 'retains rights' do
+        expect(merged_access).to eq(access)
+      end
+    end
+
+    context 'when access has copyright, useAndReproductionStatement, license' do
+      let(:access) do
+        Cocina::Models::DROAccess.new(
+          access: 'world',
+          download: 'world',
+          copyright: 'dro copyright',
+          useAndReproductionStatement: 'dro use and reproduction statement',
+          license: 'https://www.gnu.org/licenses/agpl.txt'
+        )
+      end
+
+      let(:default_access) do
+        Cocina::Models::AdminPolicyDefaultAccess.new(
+          access: 'dark',
+          download: 'none',
+          copyright: 'apo copyright',
+          useAndReproductionStatement: 'apo use and reproduction statement',
+          license: 'https://www.apache.org/licenses/LICENSE-2.0'
+        )
+      end
+
+      it 'retains' do
+        expect(merged_access).to eq(access)
+      end
+    end
+
+    context 'when access does not have copyright, useAndReproductionStatement, license' do
+      let(:access) do
+        Cocina::Models::DROAccess.new(
+          access: 'world',
+          download: 'world'
+        )
+      end
+
+      let(:default_access) do
+        Cocina::Models::AdminPolicyDefaultAccess.new(
+          access: 'location-based',
+          download: 'none',
+          readLocation: 'spec',
+          copyright: 'apo copyright',
+          useAndReproductionStatement: 'apo use and reproduction statement',
+          license: 'https://www.apache.org/licenses/LICENSE-2.0'
+        )
+      end
+
+      it 'inherits' do
+        expect(merged_access).to eq(Cocina::Models::DROAccess.new(
+                                      access: 'world',
+                                      download: 'world',
+                                      copyright: 'apo copyright',
+                                      useAndReproductionStatement: 'apo use and reproduction statement',
+                                      license: 'https://www.apache.org/licenses/LICENSE-2.0'
+                                    ))
+      end
+    end
+  end
+
+  context 'when a RequestCollection' do
+    let(:cocina_object) { instance_double(Cocina::Models::RequestCollection, access: access, collection?: true) }
+
+    context 'when no access but APO has dark access' do
+      let(:access) { nil }
+
+      let(:default_access) do
+        Cocina::Models::AdminPolicyDefaultAccess.new(
+          access: 'dark',
+          download: 'none',
+          readLocation: 'spec'
+        )
+      end
+
+      it 'uses APO access' do
+        expect(merged_access).to eq(Cocina::Models::CollectionAccess.new(
+                                      access: 'dark'
+                                    ))
+      end
+    end
+
+    context 'when no access but APO has non-dark access' do
+      let(:access) { nil }
+
+      let(:default_access) do
+        Cocina::Models::AdminPolicyDefaultAccess.new(
+          access: 'stanford',
+          download: 'none',
+          readLocation: 'spec'
+        )
+      end
+
+      it 'uses world access' do
+        expect(merged_access).to eq(Cocina::Models::CollectionAccess.new(
+                                      access: 'world'
+                                    ))
+      end
+    end
+
+    context 'when no access and APO has no access' do
+      let(:access) { nil }
+
+      let(:default_access) { nil }
+
+      it 'uses default access (dark)' do
+        expect(merged_access).to eq(Cocina::Models::CollectionAccess.new)
+      end
+    end
+
+    context 'when access already has rights' do
+      let(:access) do
+        Cocina::Models::CollectionAccess.new(
+          access: 'world'
+        )
+      end
+
+      let(:default_access) do
+        Cocina::Models::AdminPolicyDefaultAccess.new(
+          access: 'dark'
+        )
+      end
+
+      it 'retains rights' do
+        expect(merged_access).to eq(access)
+      end
+    end
+
+    context 'when access has copyright, useAndReproductionStatement, license' do
+      let(:access) do
+        Cocina::Models::CollectionAccess.new(
+          access: 'world',
+          copyright: 'collection copyright',
+          useAndReproductionStatement: 'collection use and reproduction statement',
+          license: 'https://www.gnu.org/licenses/agpl.txt'
+        )
+      end
+
+      let(:default_access) do
+        Cocina::Models::AdminPolicyDefaultAccess.new(
+          access: 'location-based',
+          download: 'none',
+          readLocation: 'spec',
+          copyright: 'apo copyright',
+          useAndReproductionStatement: 'apo use and reproduction statement',
+          license: 'https://www.apache.org/licenses/LICENSE-2.0'
+        )
+      end
+
+      it 'retains' do
+        expect(merged_access).to eq(access)
+      end
+    end
+
+    context 'when access does not have copyright, useAndReproductionStatement, license' do
+      let(:access) do
+        Cocina::Models::CollectionAccess.new(
+          access: 'dark'
+        )
+      end
+
+      let(:default_access) do
+        Cocina::Models::AdminPolicyDefaultAccess.new(
+          access: 'location-based',
+          download: 'none',
+          readLocation: 'spec',
+          copyright: 'apo copyright',
+          useAndReproductionStatement: 'apo use and reproduction statement',
+          license: 'https://www.apache.org/licenses/LICENSE-2.0'
+        )
+      end
+
+      it 'inherits' do
+        expect(merged_access).to eq(Cocina::Models::CollectionAccess.new(
+                                      access: 'dark',
+                                      copyright: 'apo copyright',
+                                      useAndReproductionStatement: 'apo use and reproduction statement',
+                                      license: 'https://www.apache.org/licenses/LICENSE-2.0'
+                                    ))
+      end
+    end
+  end
+end

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe CocinaObjectStore do
       before do
         allow(Notifications::ObjectCreated).to receive(:publish)
         allow(Cocina::ObjectCreator).to receive(:create).and_return(item)
-        allow(cocina_object_store).to receive(:default_access_for).and_return(requested_cocina_object)
+        allow(cocina_object_store).to receive(:merge_access_for).and_return(requested_cocina_object)
         allow(cocina_object_store).to receive(:add_tags_for_create)
         allow(Dor::SuriService).to receive(:mint_id).and_return(druid)
         allow(Cocina::Mapper).to receive(:build).and_return(created_cocina_object)
@@ -180,7 +180,7 @@ RSpec.describe CocinaObjectStore do
         expect(Cocina::ObjectCreator).to have_received(:create).with(requested_cocina_object, druid: druid, assign_doi: true)
         expect(Notifications::ObjectCreated).to have_received(:publish).with(model: created_cocina_object, created_at: kind_of(Time), modified_at: kind_of(Time))
         expect(Cocina::ObjectValidator).to have_received(:validate).with(requested_cocina_object)
-        expect(cocina_object_store).to have_received(:default_access_for).with(requested_cocina_object)
+        expect(cocina_object_store).to have_received(:merge_access_for).with(requested_cocina_object)
         expect(cocina_object_store).to have_received(:add_tags_for_create).with(druid, requested_cocina_object)
         expect(Cocina::Mapper).to have_received(:build).with(item)
         expect(SynchronousIndexer).to have_received(:reindex_remotely).with(druid)


### PR DESCRIPTION
closes https://github.com/sul-dlss/google-books/issues/753

## Why was this change made? 🤔
The previous logic was causing APO default object rights to trump collection/DRO provided rights.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

