### PR TITLE
Create the missing bookData node as the first child when normalizing

### DIFF
--- a/app/services/cocina/from_fedora/viewing_direction_helper.rb
+++ b/app/services/cocina/from_fedora/viewing_direction_helper.rb
@@ -13,7 +13,7 @@ module Cocina
         'Manuscript (ltr)' => 'left-to-right'
       }.freeze
 
-      def self.viewing_direction(druid:, content_ng_xml:)
+      def self.viewing_direction(druid:, content_ng_xml:, use_tags: true)
         reading_direction = content_ng_xml.xpath('//bookData/@readingOrder').first&.value
         # See https://consul.stanford.edu/pages/viewpage.action?spaceKey=chimera&title=DOR+content+types%2C+resource+types+and+interpretive+metadata
         case reading_direction
@@ -22,10 +22,12 @@ module Cocina
         when 'rtl'
           'right-to-left'
         else
-          # Fallback to using tags.  Some books don't have bookData nodes in contentMetadata XML.
-          # When we migrate from Fedora 3, we don't need to look this up from AdministrativeTags
-          content_type = AdministrativeTags.content_type(pid: druid).first
-          VIEWING_DIRECTION_FOR_CONTENT_TYPE[content_type]
+          if use_tags
+            # Fallback to using tags.  Some books don't have bookData nodes in contentMetadata XML.
+            # When we migrate from Fedora 3, we don't need to look this up from AdministrativeTags
+            content_type = AdministrativeTags.content_type(pid: druid).first
+            VIEWING_DIRECTION_FOR_CONTENT_TYPE[content_type]
+          end
         end
       end
     end

--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -43,6 +43,7 @@ module Cocina
         remove_provider_checksum
         remove_meaningless_attr_elements
         remove_pagestart_attribute
+        remove_bookdata
         normalize_object_id_attribute(druid)
         normalize_reading_order(druid)
         normalize_attr_label
@@ -163,6 +164,13 @@ module Cocina
 
       def remove_pagestart_attribute
         ng_xml.xpath('//bookData/@pageStart').each(&:remove)
+      end
+
+      # Only book and image content are permitted to have bookData
+      def remove_bookdata
+        return if %w[book image].include?(ng_xml.root['type'])
+
+        ng_xml.xpath('//bookData').each(&:remove)
       end
 
       def normalize_reading_order(druid)

--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -179,7 +179,7 @@ module Cocina
 
         book_data_node = Nokogiri::XML::Node.new('bookData', ng_xml)
         book_data_node['readingOrder'] = fedora_reading_direction
-        ng_xml.root << book_data_node
+        ng_xml.root.prepend_child(book_data_node)
       end
 
       def normalize_attr_label

--- a/spec/services/cocina/from_fedora/dro_structural_spec.rb
+++ b/spec/services/cocina/from_fedora/dro_structural_spec.rb
@@ -245,9 +245,10 @@ RSpec.describe Cocina::FromFedora::DroStructural do
     subject { structural[:hasMemberOrders].first[:viewingDirection] }
 
     let(:book_data) { "<bookData readingOrder=\"#{reading_direction}\" />" }
+    let(:content_type) { 'book' }
     let(:xml) do
       <<~XML
-        <contentMetadata type="book" id="druid:hx013yf6680">
+        <contentMetadata type="#{content_type}" id="druid:hx013yf6680">
           #{book_data}
           <resource id="bb000sc2803_1" sequence="1" type="page">
             <file id="aar_19990525_0001.jp2" preserve="yes" shelve="no" publish="no" size="6765428" mimetype="image/jp2">
@@ -274,40 +275,58 @@ RSpec.describe Cocina::FromFedora::DroStructural do
 
     context "when bookData doesn't exist" do
       before do
-        allow(AdministrativeTags).to receive(:content_type).with(pid: item.id).and_return(content_type)
+        allow(AdministrativeTags).to receive(:content_type).with(pid: item.id).and_return(content_type_tag)
       end
 
       let(:book_data) { nil }
 
-      context "when content type is ['Book (rtl)']" do
-        let(:content_type) { ['Book (rtl)'] }
+      context "when content type tag is ['Book (rtl)']" do
+        let(:content_type_tag) { ['Book (rtl)'] }
 
         it { is_expected.to eq 'right-to-left' }
       end
 
-      context "when content type is ['Book (flipbook, ltr)']" do
-        let(:content_type) { ['Book (flipbook, ltr)'] }
+      context "when content type tag is ['Book (flipbook, ltr)']" do
+        let(:content_type_tag) { ['Book (flipbook, ltr)'] }
 
         it { is_expected.to eq 'left-to-right' }
       end
 
-      context "when content type is ['Book (flipbook, rtl)']" do
-        let(:content_type) { ['Book (flipbook, rtl)'] }
+      context "when content type tag is ['Book (flipbook, rtl)']" do
+        let(:content_type_tag) { ['Book (flipbook, rtl)'] }
 
         it { is_expected.to eq 'right-to-left' }
       end
 
-      context "when content type is ['Manuscript (flipbook, ltr)']" do
-        let(:content_type) { ['Manuscript (flipbook, ltr)'] }
+      context "when content type tag is ['Manuscript (flipbook, ltr)']" do
+        let(:content_type_tag) { ['Manuscript (flipbook, ltr)'] }
 
         it { is_expected.to eq 'left-to-right' }
       end
 
-      context "when content type is ['Manuscript (ltr)']" do
-        let(:content_type) { ['Manuscript (ltr)'] }
+      context "when content type tag is ['Manuscript (ltr)']" do
+        let(:content_type_tag) { ['Manuscript (ltr)'] }
 
         it { is_expected.to eq 'left-to-right' }
       end
+
+      context 'when content type is image' do
+        let(:content_type) { 'image' }
+        let(:content_type_tag) { [] }
+        let(:type) { Cocina::Models::Vocab.image }
+
+        it "doesn't have hasMemberOrders" do
+          expect(structural[:hasMemberOrders]).to be_nil
+        end
+      end
+    end
+
+    context 'when content type is image' do
+      let(:content_type) { 'image' }
+      let(:type) { Cocina::Models::Vocab.image }
+      let(:reading_direction) { 'rtl' }
+
+      it { is_expected.to eq 'right-to-left' }
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔
This prevents diffs from showing up in the round trip testing.
Fixes #3563



## How was this change tested? 🤨
Before:
```
Status (n=25000; not using Missing for success/different/error stats):
  Success:   24785 (99.863%)
  Different: 34 (0.137%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     6 (0.024%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     175 (0.7%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

After:
```
Status (n=25000; not using Missing for success/different/error stats):
  Success:   24785 (99.863%)
  Different: 34 (0.137%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     6 (0.024%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     175 (0.7%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



