### PR TITLE
Rewrite RefreshMetadataAction for Cocina objects

### DIFF
--- a/app/controllers/metadata_refresh_controller.rb
+++ b/app/controllers/metadata_refresh_controller.rb
@@ -2,18 +2,18 @@
 
 # Gets the catkey or barcode from identityMetadata and returns the catalog info
 class MetadataRefreshController < ApplicationController
+  before_action :load_cocina_object
+
   rescue_from(SymphonyReader::ResponseError) do |e|
     render status: :internal_server_error, plain: e.message
   end
 
   def refresh
-    @item = Dor.find(params[:id])
-    status = RefreshMetadataAction.run(identifiers: identifiers,
-                                       fedora_object: @item)
-    return render status: :unprocessable_entity, plain: "#{@item.pid} had no resolvable identifiers: #{identifiers.inspect}" unless status
-    return render status: :internal_server_error, plain: "#{@item.pid} descMetadata missing required fields (<title>)" if missing_required_fields?
+    updated_cocina_object = RefreshMetadataAction.run(identifiers: identifiers,
+                                                      cocina_object: @cocina_object)
+    return render status: :unprocessable_entity, plain: "#{@cocina_object.externalIdentifier} had no resolvable identifiers: #{identifiers.inspect}" unless updated_cocina_object
 
-    @item.save!
+    CocinaObjectStore.save(updated_cocina_object)
   rescue SymphonyReader::NotFound => e
     json_api_error(status: :bad_request, title: 'Catkey not found in Symphony', message: e.message)
   end
@@ -21,10 +21,10 @@ class MetadataRefreshController < ApplicationController
   private
 
   def identifiers
-    @identifiers ||= @item.identityMetadata.otherId.collect(&:to_s)
-  end
+    return [] unless @cocina_object.identification&.catalogLinks
 
-  def missing_required_fields?
-    @item.descMetadata.mods_title.blank?
+    @identifiers ||= @cocina_object.identification.catalogLinks.filter_map { |clink| "catkey:#{clink.catalogRecordId}" if clink.catalog == 'symphony' }.tap do |id|
+      id << "barcode:#{@cocina_object.identification.barcode}" if @cocina_object.identification.barcode
+    end
   end
 end

--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -138,13 +138,13 @@ module Cocina
     end
 
     # @param [Dor::[Item|Collection|APO]] fedora_object
-    # @param [Cocina:Models::Request[DOR|Collection|xxx]] cocina_object
+    # @param [Cocina:Models::Request[DRO|Collection|xxx]] cocina_object
     # @param [Boolean] trial
     # @raises SymphonyReader::ResponseError if symphony connection failed
     def add_description(fedora_object, cocina_object, trial:)
       # Synch from symphony if a catkey is present
       if fedora_object.catkey && !trial
-        RefreshMetadataAction.run(identifiers: ["catkey:#{fedora_object.catkey}"], fedora_object: fedora_object)
+        LegacyRefreshMetadataAction.run(identifiers: ["catkey:#{fedora_object.catkey}"], fedora_object: fedora_object)
         label = MetadataService.label_from_mods(fedora_object.descMetadata.ng_xml)
         fedora_object.objectLabel = label
         Cocina::ToFedora::Identity.apply_label(fedora_object, label: label)

--- a/app/services/legacy_refresh_metadata_action.rb
+++ b/app/services/legacy_refresh_metadata_action.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Look into identityMetadata for compliant ids and use them to fetch
+# descriptive metadata from Symphony.  Put the fetched value in the descMetadata
+class LegacyRefreshMetadataAction
+  # @return [NilClass,Object] returns nil if there was no resolvable metadata id.
+  # @raises SymphonyReader::ResponseError
+  def self.run(identifiers:, fedora_object:)
+    new(identifiers: identifiers, fedora_object: fedora_object).run
+  end
+
+  # @param [Array<String>] identifiers the set of identifiers that might be resolvable
+  # @param [Dor::Abstract] fedora_object to refresh
+  def initialize(identifiers:, fedora_object:)
+    @identifiers = identifiers
+    @fedora_object = fedora_object
+    @datastream = fedora_object.descMetadata
+  end
+
+  # Returns nil if it didn't retrieve anything
+  # @raises SymphonyReader::ResponseError
+  def run
+    content = fetch_datastream
+    return nil if content.nil?
+
+    datastream.dsLabel = 'Descriptive Metadata'
+    datastream.ng_xml = Nokogiri::XML(content)
+    datastream.ng_xml.normalize_text!
+    datastream.content = datastream.ng_xml.to_xml
+
+    validate
+
+    datastream
+  end
+
+  private
+
+  attr_reader :identifiers, :datastream, :fedora_object
+
+  # @raises SymphonyReader::ResponseError
+  def fetch_datastream
+    metadata_id = MetadataService.resolvable(identifiers).first
+    metadata_id.nil? ? nil : MetadataService.fetch(metadata_id.to_s)
+  end
+
+  def validate
+    return unless Settings.enabled_features.validate_descriptive_roundtrip.refresh
+
+    result = Cocina::DescriptionRoundtripValidator.valid_from_fedora?(fedora_object)
+    Honeybadger.notify('DescMetadata did not successfully roundtrip after metadata refresh.') if result.failure?
+  end
+end

--- a/bin/refresh-metadata
+++ b/bin/refresh-metadata
@@ -23,7 +23,7 @@ druids.each_with_index do |druid, index|
   puts "#{druid} (#{index + 1})\n"
   object = Dor.find(druid)
   orig_xml = object.descMetadata.ng_xml.canonicalize
-  status = RefreshMetadataAction.run(identifiers: object.identityMetadata.otherId.collect(&:to_s), fedora_object: object)
+  status = LegacyRefreshMetadataAction.run(identifiers: object.identityMetadata.otherId.collect(&:to_s), fedora_object: object)
   if status
     if orig_xml == object.descMetadata.ng_xml.canonicalize
       puts 'No change'

--- a/spec/requests/metadata_refresh_spec.rb
+++ b/spec/requests/metadata_refresh_spec.rb
@@ -3,69 +3,115 @@
 require 'rails_helper'
 
 RSpec.describe 'Refresh metadata' do
-  let(:object) { Dor::Item.new(pid: 'druid:1234') }
+  let(:druid) { 'druid:bc753qt7345' }
+  let(:object) { Dor::Item.new(pid: druid) }
+  let(:apo_druid) { 'druid:pp000pp0000' }
+  let(:description) do
+    {
+      title: [{ value: 'However am I going to be' }],
+      purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+    }
+  end
+  let(:identification) do
+    {
+      catalogLinks: [{
+        catalog: 'symphony',
+        catalogRecordId: '10121797'
+      }]
+    }
+  end
+  let(:cocina_object) do
+    Cocina::Models::DRO.new(externalIdentifier: druid,
+                            type: Cocina::Models::Vocab.object,
+                            label: 'A new map of Africa',
+                            version: 1,
+                            description: description,
+                            identification: identification,
+                            access: {},
+                            administrative: { hasAdminPolicy: apo_druid })
+  end
+  let(:updated_cocina_object) do
+    Cocina::Models::DRO.new(externalIdentifier: druid,
+                            type: Cocina::Models::Vocab.object,
+                            label: 'A new map of Africa',
+                            version: 1,
+                            description: {
+                              title: [{ value: 'Paying for College' }],
+                              purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+                            },
+                            identification: identification,
+                            access: {},
+                            administrative: { hasAdminPolicy: apo_druid })
+  end
+  let(:cocina_apo_object) do
+    Cocina::Models::AdminPolicy.new(externalIdentifier: apo_druid,
+                                    administrative: {
+                                      hasAdminPolicy: 'druid:gg123vx9393',
+                                      hasAgreement: 'druid:bb008zm4587'
+                                    },
+                                    version: 1,
+                                    label: 'just an apo',
+                                    type: Cocina::Models::Vocab.admin_policy)
+  end
+
+  let(:mods) do
+    <<~XML
+      <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.7">
+        <titleInfo>
+          <title>Paying for College</title>
+        </titleInfo>
+      </mods>
+    XML
+  end
 
   before do
     allow(Dor).to receive(:find).and_return(object)
-    allow(object).to receive(:save)
+    allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
+    allow(CocinaObjectStore).to receive(:find).with(apo_druid).and_return(cocina_apo_object)
+    allow(CocinaObjectStore).to receive(:save).and_return(updated_cocina_object)
   end
 
   context 'when happy path' do
     before do
-      object.descMetadata.mods_title = ['one title']
-      object.identityMetadata.otherId = ['catkey:123']
-      allow(RefreshMetadataAction).to receive(:run).and_return('<xml />')
+      allow(MetadataService).to receive(:fetch).and_return(mods)
     end
 
     it 'updates the metadata and saves the changes' do
       post '/v1/objects/druid:mk420bs7601/refresh_metadata',
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
-      expect(RefreshMetadataAction).to have_received(:run)
-        .with(fedora_object: object, identifiers: [':catkey:123'])
-      expect(object).to have_received(:save)
+      expect(CocinaObjectStore).to have_received(:save).with(updated_cocina_object)
     end
   end
 
-  context "when the item doesn't have metadata ids" do
-    before do
-      object.identityMetadata.otherId = ['uuid:1234']
-      allow(RefreshMetadataAction).to receive(:run).and_return(nil)
+  context 'when the cocina object only has a barcode' do
+    let(:identification) do
+      {
+        barcode: '36105216275185'
+      }
     end
 
-    it 'raises an error' do
+    before do
+      allow(MetadataService).to receive(:fetch).and_return(mods)
+    end
+
+    it 'updates the metadata and saves the changes' do
       post '/v1/objects/druid:mk420bs7601/refresh_metadata',
            headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to eq 'druid:1234 had no resolvable identifiers: [":uuid:1234"]'
-      expect(RefreshMetadataAction).to have_received(:run)
-        .with(fedora_object: object, identifiers: [':uuid:1234'])
-      expect(object).not_to have_received(:save)
-    end
-  end
-
-  context "when the item doesn't get a title" do
-    before do
-      object.identityMetadata.otherId = ['catkey:123']
-      allow(RefreshMetadataAction).to receive(:run).and_return('<xml />')
-    end
-
-    it 'raises an error' do
-      post '/v1/objects/druid:mk420bs7601/refresh_metadata',
-           headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response.status).to eq(500)
-      expect(response.body).to eq('druid:1234 descMetadata missing required fields (<title>)')
-      expect(RefreshMetadataAction).to have_received(:run)
-        .with(fedora_object: object, identifiers: [':catkey:123'])
-      expect(object).not_to have_received(:save)
+      expect(response).to be_successful
+      expect(CocinaObjectStore).to have_received(:save).with(updated_cocina_object)
     end
   end
 
   describe 'errors in response from Symphony' do
     let(:marc_url) { Settings.catalog.symphony.base_url + Settings.catalog.symphony.marcxml_path }
-
-    before do
-      allow(object.identityMetadata).to receive(:otherId).and_return(['catkey:666'])
+    let(:identification) do
+      {
+        catalogLinks: [{
+          catalog: 'symphony',
+          catalogRecordId: '666'
+        }]
+      }
     end
 
     context 'when incomplete response' do

--- a/spec/services/cocina/object_creator_spec.rb
+++ b/spec/services/cocina/object_creator_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Cocina::ObjectCreator do
     allow(Dor::SearchService).to receive(:query_by_id).and_return([])
     allow(Dor).to receive(:find).with(apo).and_return(Dor::AdminPolicyObject.new)
     allow(CocinaObjectStore).to receive(:find).with('druid:bz845pv2292').and_return(minimal_cocina_admin_policy)
-    allow(RefreshMetadataAction).to receive(:run) do |args|
+    allow(LegacyRefreshMetadataAction).to receive(:run) do |args|
       args[:fedora_object].descMetadata.mods_title = 'foo'
     end
     allow(Settings.datacite).to receive(:prefix).and_return('10.25740')

--- a/spec/services/legacy_refresh_metadata_action_spec.rb
+++ b/spec/services/legacy_refresh_metadata_action_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LegacyRefreshMetadataAction do
+  include Dry::Monads[:result]
+
+  subject(:refresh) { described_class.run(identifiers: ['catkey:123'], fedora_object: item) }
+
+  let(:item) { Dor::Item.new(pid: 'druid:bc753qt7345') }
+
+  let(:mods) do
+    <<~XML
+      <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.7">
+        <titleInfo>
+          <title>Paying for College</title>
+        </titleInfo>
+      </mods>
+    XML
+  end
+
+  before do
+    allow(MetadataService).to receive(:fetch).and_return(mods)
+    allow(Honeybadger).to receive(:notify)
+  end
+
+  it 'gets the data and puts it in descMetadata' do
+    expect(refresh).not_to be_nil
+    expect(item.descMetadata.ng_xml).to be_equivalent_to Nokogiri::XML(mods)
+    expect(Honeybadger).not_to have_received(:notify)
+  end
+
+  context 'when validation fails' do
+    before do
+      allow(Cocina::DescriptionRoundtripValidator).to receive(:valid_from_fedora?).and_return(Failure())
+    end
+
+    it 'gets the data and puts it in descMetadata and Honeybadger notifies' do
+      expect(refresh).not_to be_nil
+      expect(item.descMetadata.ng_xml).to be_equivalent_to Nokogiri::XML(mods)
+      expect(Honeybadger).to have_received(:notify)
+    end
+  end
+end

--- a/spec/services/refresh_metadata_action_spec.rb
+++ b/spec/services/refresh_metadata_action_spec.rb
@@ -5,9 +5,39 @@ require 'rails_helper'
 RSpec.describe RefreshMetadataAction do
   include Dry::Monads[:result]
 
-  subject(:refresh) { described_class.run(identifiers: ['catkey:123'], fedora_object: item) }
+  subject(:refresh) { described_class.run(identifiers: ['catkey:123'], cocina_object: cocina_object) }
 
-  let(:item) { Dor::Item.new(pid: 'druid:bc753qt7345') }
+  let(:druid) { 'druid:bc753qt7345' }
+  let(:apo_druid) { 'druid:pp000pp0000' }
+  let(:description) do
+    {
+      title: [{ value: 'However am I going to be' }],
+      purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+    }
+  end
+  let(:cocina_object) do
+    Cocina::Models::DRO.new(externalIdentifier: druid,
+                            type: Cocina::Models::Vocab.object,
+                            label: 'A new map of Africa',
+                            version: 1,
+                            description: description,
+                            identification: {},
+                            access: {},
+                            administrative: { hasAdminPolicy: apo_druid })
+  end
+  let(:updated_cocina_object) do
+    Cocina::Models::DRO.new(externalIdentifier: druid,
+                            type: Cocina::Models::Vocab.object,
+                            label: 'A new map of Africa',
+                            version: 1,
+                            description: {
+                              title: [{ value: 'Paying for College' }],
+                              purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+                            },
+                            identification: {},
+                            access: {},
+                            administrative: { hasAdminPolicy: apo_druid })
+  end
 
   let(:mods) do
     <<~XML
@@ -24,21 +54,38 @@ RSpec.describe RefreshMetadataAction do
     allow(Honeybadger).to receive(:notify)
   end
 
-  it 'gets the data and puts it in descMetadata' do
-    expect(refresh).not_to be_nil
-    expect(item.descMetadata.ng_xml).to be_equivalent_to Nokogiri::XML(mods)
+  it 'gets the data and updates the cocina object' do
+    expect(refresh).to eq(updated_cocina_object)
     expect(Honeybadger).not_to have_received(:notify)
   end
 
-  context 'when validation fails' do
+  context 'when fetch_metadata fails' do
     before do
-      allow(Cocina::DescriptionRoundtripValidator).to receive(:valid_from_fedora?).and_return(Failure())
+      allow(MetadataService).to receive(:fetch).and_raise(SymphonyReader::ResponseError)
     end
 
     it 'gets the data and puts it in descMetadata and Honeybadger notifies' do
-      expect(refresh).not_to be_nil
-      expect(item.descMetadata.ng_xml).to be_equivalent_to Nokogiri::XML(mods)
-      expect(Honeybadger).to have_received(:notify)
+      expect { refresh }.to raise_error(SymphonyReader::ResponseError)
+    end
+  end
+
+  context 'when fetch_metadata returns nil' do
+    before do
+      allow(MetadataService).to receive(:fetch).and_return(nil)
+    end
+
+    it 'returns a Dry::Monads::Result::Failure object' do
+      expect(refresh).to be_a(Dry::Monads::Result::Failure)
+    end
+  end
+
+  context 'when Descriptive.props returns nil' do
+    before do
+      allow(Cocina::FromFedora::Descriptive).to receive(:props).and_return(nil)
+    end
+
+    it 'returns a Dry::Monads::Result::Failure object' do
+      expect(refresh).to be_a(Dry::Monads::Result::Failure)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3169 - rewrites RefreshMetadataAction to use cocina objects, Moves existing RefreshMetadataAction into LegacyRefreshMetadataAction for object creation where Draft cocina objects do not have the required externalIdentifier yet.


## How was this change tested? 🤨

Updated unit tests.

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



