### PR TITLE
omit imageData for SVG

### DIFF
--- a/app/services/cocina/from_fedora/file_sets.rb
+++ b/app/services/cocina/from_fedora/file_sets.rb
@@ -95,7 +95,7 @@ module Cocina
           }.tap do |attrs|
             # Files from Goobi don't have mimetype until they hit exif-collect in the assemblyWF
             attrs[:hasMimeType] = node['mimetype'] if node['mimetype'].present?
-            attrs[:presentation] = { height: height, width: width } if height && width
+            attrs[:presentation] = { height: height, width: width } if height && width && attrs[:hasMimeType] != 'image/svg+xml'
             attrs[:use] = use if use
           end
         end

--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -50,6 +50,7 @@ module Cocina
         downcase_checksum_type
         normalize_empty_xml
         missing_type_attribute_assigned_file
+        remove_svg_image_data
         remove_empty_image_data
         remove_duplicate_image_data
         normalize_image_data_to_integers
@@ -97,6 +98,12 @@ module Cocina
 
       def remove_location
         ng_xml.xpath('//location[@type="url"]').each(&:remove)
+      end
+
+      def remove_svg_image_data
+        ng_xml.xpath('//file[@mimetype="image/svg+xml"]').each do |file_node|
+          file_node.xpath('./imageData').each(&:remove)
+        end
       end
 
       # remove empty width and height attributes from imageData, e.g. <imageData width="" height=""/>

--- a/bin/validate-cocina-roundtrip
+++ b/bin/validate-cocina-roundtrip
@@ -285,6 +285,19 @@ else
   druids = options[:druids]
 end
 
+def branch_name
+  `git rev-parse --abbrev-ref HEAD`.strip
+end
+
+def short_commit_hash
+  `git rev-parse --short HEAD`.strip
+end
+
+def now_str
+  DateTime.now.utc.iso8601.to_s
+end
+
+puts "Running against: branch_name=#{branch_name} / short_commit_hash=#{short_commit_hash} (starting at: #{now_str})"
 results = Parallel.map(druids, progress: 'Testing') do |druid|
   validate_druid(druid, loader, no_content: options[:no_content], no_desc: options[:no_descriptive], create: !options[:update])
 rescue StandardError

--- a/spec/services/cocina/from_fedora/dro_structural_spec.rb
+++ b/spec/services/cocina/from_fedora/dro_structural_spec.rb
@@ -241,6 +241,37 @@ RSpec.describe Cocina::FromFedora::DroStructural do
     end
   end
 
+  context 'with imageData' do
+    subject { structural[:contains].first[:structural][:contains].first[:presentation] }
+
+    let(:xml) do
+      <<~XML
+        <contentMetadata objectId="ft996xy0052" type="file">
+          <resource id="ft996xy0052_3" sequence="3" type="file">
+            <label>File 3</label>
+            <file id="12220080_labyrinth_trace.svg" preserve="yes" shelve="yes" publish="yes" size="13543" mimetype="#{mime_type}">
+              <checksum type="md5">f4d7c7316e50b026d922e7450b1ec11a</checksum>
+              <checksum type="sha1">09ad00510e0acd8882c202a19ef5f1a9111ae19f</checksum>
+              <imageData width="27" height="29"/>
+            </file>
+          </resource>
+        </contentMetadata>
+      XML
+    end
+
+    context 'when image is svg' do
+      let(:mime_type) { 'image/svg+xml' }
+
+      it { is_expected.to be nil }
+    end
+
+    context 'when image is not svg' do
+      let(:mime_type) { 'image' }
+
+      it { is_expected.to eq({ height: 29, width: 27 }) }
+    end
+  end
+
   context 'with bookData' do
     subject { structural[:hasMemberOrders].first[:viewingDirection] }
 

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -481,6 +481,34 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       end
     end
 
+    context 'when normalizing svg imageData' do
+      let(:original_xml) do
+        <<~XML
+          <contentMetadata objectId="druid:ft996xy0052" type="image">
+            <resource type="image">
+              <label>Image 1</label>
+              <file id="12220080_labyrinth_trace.svg" preserve="yes" shelve="yes" publish="yes" size="13543" mimetype="image/svg+xml">
+                <imageData width="27" height="29"/>
+              </file>
+            </resource>
+          </contentMetadata>
+        XML
+      end
+
+      it 'removes the imageData element' do
+        expect(normalized_ng_xml).to be_equivalent_to(
+          <<~XML
+            <contentMetadata objectId="druid:ft996xy0052" type="image">
+              <resource type="image">
+                <label>Image 1</label>
+                <file id="12220080_labyrinth_trace.svg" preserve="yes" shelve="yes" publish="yes" size="13543" mimetype="image/svg+xml" />
+              </resource>
+            </contentMetadata>
+          XML
+        )
+      end
+    end
+
     context 'when normalizing format' do
       let(:original_xml) do
         <<~XML


### PR DESCRIPTION
## Why was this change made? 🤔

closes #3542 

per that ticket, when `<file mimetype="image/svg+xml">`:
* `<imageData>` should not be mapped to presentation
* `<imageData>` should be removed in normalization.

i also threw on a commit for printing branch info and time of run in `validate-cocina-roundtrip`, which i find helpful when doing roundtrip testing, happy to lop that off if people find it unnecessary.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

- [x] unit tests
- [x] sdr-deploy `validate-cocina-roundtrip`