### PR TITLE
Decouple ObjectsController#show from ActiveFedora

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -2,8 +2,7 @@
 
 # rubocop:disable Metrics/ClassLength
 class ObjectsController < ApplicationController
-  before_action :load_cocina_object, only: %i[show update_doi_metadata update_marc_record notify_goobi accession destroy]
-  before_action :load_item, only: %i[show]
+  before_action :load_cocina_object, only: %i[update_doi_metadata update_marc_record notify_goobi accession destroy]
 
   # No longer be necessary when remove Fedora.
   rescue_from(Cocina::ObjectUpdater::NotImplemented) do |e|
@@ -72,8 +71,9 @@ class ObjectsController < ApplicationController
   end
 
   def show
-    headers['Last-Modified'] = @item.modified_date.to_datetime.httpdate
-    headers['X-Created-At'] = @item.create_date.to_datetime.httpdate
+    (@cocina_object, created_at, modified_at) = CocinaObjectStore.find_with_timestamps(params[:id])
+    headers['X-Created-At'] = created_at.httpdate
+    headers['Last-Modified'] = modified_at.httpdate
     render json: @cocina_object
   end
 

--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -22,6 +22,16 @@ class CocinaObjectStore
     new.find(druid)
   end
 
+  # Retrieves a Cocina object from the datastore and supplies the timestamps
+  # @param [String] druid
+  # @return [Array] a tuple consisting of cocina_object, created date and updated date
+  # @raise [SolrConnectionError] raised when cannot connect to Solr. This error will no longer be raised when Fedora is removed.
+  # @raise [Cocina::Mapper::UnexpectedBuildError] raised when an mapping error occurs. This error will no longer be raised when Fedora is removed.
+  # @raise [CocinaObjectNotFoundError] raised when the requested Cocina object is not found.
+  def self.find_with_timestamps(druid)
+    new.find_with_timestamps(druid)
+  end
+
   # Determine if an object exists in the datastore.
   # @param [String] druid
   # @return [boolean] true if object exists
@@ -74,6 +84,11 @@ class CocinaObjectStore
   end
 
   def find(druid)
+    fedora_to_cocina_find(druid).first
+  end
+
+  # @return [Array] a tuple consisting of cocina object, created date and modified date
+  def find_with_timestamps(druid)
     fedora_to_cocina_find(druid)
   end
 
@@ -160,9 +175,10 @@ class CocinaObjectStore
 
   # In later steps in the migration, the *fedora* methods will be replaced by the *ar* methods.
 
+  # @return [Array] a tuple consisting of cocina object, created date and modified date
   def fedora_to_cocina_find(druid)
     fedora_object = fedora_find(druid)
-    Cocina::Mapper.build(fedora_object)
+    [Cocina::Mapper.build(fedora_object), fedora_object.create_date.to_datetime, fedora_object.modified_date.to_datetime]
   end
 
   def cocina_to_fedora_save(cocina_object)

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -42,6 +42,31 @@ RSpec.describe CocinaObjectStore do
       end
     end
 
+    describe '#find_with_timestamps' do
+      context 'when DRO is found' do
+        before do
+          allow(Dor).to receive(:find).and_return(item)
+          allow(Cocina::Mapper).to receive(:build).and_return(cocina_object)
+        end
+
+        it 'returns Cocina object adn the timestamps' do
+          expect(described_class.find_with_timestamps(druid)).to eq [cocina_object, date, date]
+          expect(Dor).to have_received(:find).with(druid)
+          expect(Cocina::Mapper).to have_received(:build).with(item)
+        end
+      end
+
+      context 'when DRO is not found' do
+        before do
+          allow(Dor).to receive(:find).and_raise(ActiveFedora::ObjectNotFoundError)
+        end
+
+        it 'returns Cocina object' do
+          expect { described_class.find_with_timestamps(druid) }.to raise_error(CocinaObjectStore::CocinaObjectNotFoundError)
+        end
+      end
+    end
+
     describe '#exists?' do
       context 'when DRO is found' do
         before do


### PR DESCRIPTION
## Why was this change made? 🤔
We're trying to get rid of the ActiveFedora dependency.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



