### PR TITLE
Fix non-sorting with extra spaces.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/title_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/title_builder.rb
@@ -78,7 +78,7 @@ module Cocina
           if %w[title titleInfo].include?(tag)
             title.delete_suffix(',')
           elsif tag == 'nonSort'
-            title.delete_suffix(' ')
+            title.sub(/ +$/, '')
           else
             title
           end

--- a/app/services/cocina/to_fedora/descriptive/title.rb
+++ b/app/services/cocina/to_fedora/descriptive/title.rb
@@ -130,9 +130,24 @@ module Cocina
 
             title_parts_without_names.each do |title_part|
               title_type = tag_name_for(title_part)
-              xml.public_send(title_type, title_part.value) if title_part.note.blank?
+              title_value = title_value_for(title_part, title_type, title)
+              xml.public_send(title_type, title_value) if title_part.note.blank?
             end
           end
+        end
+
+        def title_value_for(title_part, title_type, title)
+          return title_part.value unless title_type == 'nonSort'
+
+          non_sorting_size = [non_sorting_char_count_for(title) - (title_part.value&.size || 0), 0].max
+          "#{title_part.value}#{' ' * non_sorting_size}"
+        end
+
+        def non_sorting_char_count_for(title)
+          non_sort_note = title.note&.find { |note| note.type&.downcase == 'nonsorting character count' }
+          return 0 unless non_sort_note
+
+          non_sort_note.value.to_i
         end
 
         # Flatten the structuredValues into a simple list.

--- a/app/services/title_builder.rb
+++ b/app/services/title_builder.rb
@@ -74,7 +74,8 @@ class TitleBuilder # rubocop:disable Metrics/ClassLength
       # additional types:  name, uniform ...
       case structured_value.type&.downcase
       when 'nonsorting characters'
-        non_sort_value = value&.size == non_sorting_char_count ? value : "#{value} "
+        non_sorting_size = [non_sorting_char_count - (value&.size || 0), 0].max
+        non_sort_value = "#{value}#{' ' * non_sorting_size}"
         structured_title = if structured_title.present?
                              "#{structured_title}#{non_sort_value}"
                            else

--- a/spec/services/cocina/mapping/descriptive/mods/title_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/title_info_spec.rb
@@ -1303,4 +1303,42 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
       end
     end
   end
+
+  describe 'Title with non-sorting characters with extra spaces' do
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <titleInfo usage="primary">
+            <nonSort>The  </nonSort>
+            <title>means to prosperity</title>
+          </titleInfo>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          title: [
+            {
+              structuredValue: [
+                {
+                  value: 'The',
+                  type: 'nonsorting characters'
+                }, {
+                  value: 'means to prosperity',
+                  type: 'main title'
+                }
+              ],
+              note: [
+                {
+                  value: '5',
+                  type: 'nonsorting character count'
+                }
+              ],
+              status: 'primary'
+            }
+          ]
+        }
+      end
+    end
+  end
 end

--- a/spec/services/title_builder_spec.rb
+++ b/spec/services/title_builder_spec.rb
@@ -7,42 +7,72 @@ RSpec.describe TitleBuilder do
 
   # lots more specs in spec/indexers/descriptive_metadata/title_spec
 
-  # from a spreadsheet upload integration test
-  #   https://argo-stage.stanford.edu/view/sk561pf3505
-  let(:cocina_titles) do
-    [
-      # Yes, there can be a structuredValue inside a StructuredValue.  For example,
-      # a uniform title where both the name and the title have internal StructuredValue
-      Cocina::Models::Title.new(
-        structuredValue: [
+  context 'when structuredValue in structuredValue' do
+    # from a spreadsheet upload integration test
+    #   https://argo-stage.stanford.edu/view/sk561pf3505
+    let(:cocina_titles) do
+      [
+        # Yes, there can be a structuredValue inside a StructuredValue.  For example,
+        # a uniform title where both the name and the title have internal StructuredValue
+        Cocina::Models::Title.new(
+          structuredValue: [
+            {
+              structuredValue: [
+                {
+                  value: 'ti1:nonSort',
+                  type: 'nonsorting characters'
+                },
+                {
+                  value: 'brisk junket',
+                  type: 'main title'
+                },
+                {
+                  value: 'ti1:subTitle',
+                  type: 'subtitle'
+                },
+                {
+                  value: 'ti1:partNumber',
+                  type: 'part number'
+                },
+                {
+                  value: 'ti1:partName',
+                  type: 'part name'
+                }
+              ]
+            }
+          ]
+        )
+      ]
+    end
+
+    it { is_expected.to eq 'ti1:nonSortbrisk junket : ti1:subTitle. ti1:partNumber, ti1:partName' }
+  end
+
+  context 'when multiple nonsorting characters' do
+    let(:cocina_titles) do
+      [
+        Cocina::Models::Title.new(
           {
             structuredValue: [
               {
-                value: 'ti1:nonSort',
+                value: 'The',
                 type: 'nonsorting characters'
-              },
-              {
-                value: 'brisk junket',
+              }, {
+                value: 'means to prosperity',
                 type: 'main title'
-              },
+              }
+            ],
+            note: [
               {
-                value: 'ti1:subTitle',
-                type: 'subtitle'
-              },
-              {
-                value: 'ti1:partNumber',
-                type: 'part number'
-              },
-              {
-                value: 'ti1:partName',
-                type: 'part name'
+                value: '5',
+                type: 'nonsorting character count'
               }
             ]
           }
-        ]
-      )
-    ]
-  end
+        )
+      ]
+    end
 
-  it { is_expected.to eq 'ti1:nonSort brisk junket : ti1:subTitle. ti1:partNumber, ti1:partName' }
+    it { is_expected.to eq 'The  means to prosperity' }
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Mapping logic for non-sorting characters assumed that there could be only one trailing space. However, a case appeared in integration testing in which there was multiple trailing spaces.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file system, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

```
Before:
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99798 (99.88%)
  Different: 120 (0.12%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)

After:
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99798 (99.88%)
  Different: 120 (0.12%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

