### PR TITLE
Move creating description from label to CocinaObjectStore

### DIFF
--- a/app/services/cocina/object_creator.rb
+++ b/app/services/cocina/object_creator.rb
@@ -139,8 +139,6 @@ module Cocina
       if cocina_object.description
         fedora_object.descMetadata.content = Cocina::ToFedora::Descriptive.transform(cocina_object.description, fedora_object.pid).to_xml
         fedora_object.descMetadata.content_will_change!
-      else
-        fedora_object.descMetadata.mods_title = cocina_object.label
       end
       Cocina::ToFedora::Identity.apply_label(fedora_object, label: cocina_object.label)
     end

--- a/spec/services/cocina/object_creator_spec.rb
+++ b/spec/services/cocina/object_creator_spec.rb
@@ -32,29 +32,6 @@ RSpec.describe Cocina::ObjectCreator do
   end
 
   context 'when Cocina::Models::DRO is received' do
-    context 'when no description is supplied (no title, but label)' do
-      let(:params) do
-        {
-          'type' => 'http://cocina.sul.stanford.edu/models/object.jsonld',
-          'externalIdentifier' => druid,
-          'label' => 'label value',
-          'access' => {},
-          'version' => 1,
-          'structural' => {},
-          'administrative' => {
-            'hasAdminPolicy' => apo
-          },
-          'identification' => {
-            'sourceId' => 'donot:care'
-          }
-        }
-      end
-
-      it 'title is set to label' do
-        expect(created_cocina_object.description.title.first.value).to eq 'label value'
-      end
-    end
-
     context 'when description is supplied' do
       let(:params) do
         {
@@ -161,7 +138,7 @@ RSpec.describe Cocina::ObjectCreator do
         {
           'type' => 'http://cocina.sul.stanford.edu/models/media.jsonld',
           'externalIdentifier' => druid,
-          'label' => ':auto',
+          'label' => 'Rockhounding Utah',
           'access' => { 'access' => 'dark', 'download' => 'none' },
           'version' => 1,
           'structural' => {},
@@ -172,6 +149,10 @@ RSpec.describe Cocina::ObjectCreator do
           'identification' => {
             'sourceId' => 'sul:8.559351',
             'catalogLinks' => [{ 'catalog' => 'symphony', 'catalogRecordId' => '10121797' }]
+          },
+          'description' => {
+            'title' => [{ 'value' => 'Rockhounding Utah' }],
+            'purl' => Purl.for(druid: druid)
           }
         }
       end
@@ -194,6 +175,10 @@ RSpec.describe Cocina::ObjectCreator do
           },
           'identification' => {
             'sourceId' => 'identifier:1'
+          },
+          'description' => {
+            'title' => [{ 'value' => 'My Agreement' }],
+            'purl' => Purl.for(druid: druid)
           }
         }
       end
@@ -211,7 +196,7 @@ RSpec.describe Cocina::ObjectCreator do
         {
           'type' => 'http://cocina.sul.stanford.edu/models/object.jsonld',
           'externalIdentifier' => druid,
-          'label' => ':auto',
+          'label' => 'Mountain Biking Utah',
           'access' => {},
           'version' => 1,
           'structural' => {},
@@ -223,6 +208,10 @@ RSpec.describe Cocina::ObjectCreator do
             'sourceId' => 'sul:8.559351',
             'catalogLinks' => [{ 'catalog' => 'symphony', 'catalogRecordId' => '10121797' }],
             'doi' => '10.25740/bb010dx6027'
+          },
+          'description' => {
+            'title' => [{ 'value' => 'Mountain Biking Utah' }],
+            'purl' => Purl.for(druid: druid)
           }
         }
       end

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -216,8 +216,11 @@ RSpec.describe CocinaObjectStore do
 
     describe '#create' do
       let(:cocina_object_store) { described_class.new }
-      let(:requested_cocina_object) { instance_double(Cocina::Models::RequestDRO, admin_policy?: false, identification: request_identification, to_h: cocina_hash) }
+      let(:requested_cocina_object) do
+        instance_double(Cocina::Models::RequestDRO, admin_policy?: false, identification: request_identification, to_h: cocina_hash, description: request_description)
+      end
       let(:request_identification) { instance_double(Cocina::Models::RequestIdentification, catalogLinks: catalog_links) }
+      let(:request_description) { instance_double(Cocina::Models::RequestDescription) }
       let(:catalog_links) { [] }
       let(:cocina_hash) { {} }
 
@@ -345,6 +348,20 @@ RSpec.describe CocinaObjectStore do
                                                                    purl: 'https://purl.stanford.edu/bc123df4567'
                                                                  }
                                                                })
+        end
+      end
+
+      context 'when there is no description' do
+        let(:request_description) { nil }
+
+        before do
+          allow(requested_cocina_object).to receive(:new).and_return(requested_cocina_object)
+          allow(requested_cocina_object).to receive(:label).and_return('Roadside Geology of Utah')
+        end
+
+        it 'adds a description from label' do
+          expect(cocina_object_store.create(requested_cocina_object)).to be created_cocina_object
+          expect(requested_cocina_object).to have_received(:new).with(description: { title: [{ value: 'Roadside Geology of Utah' }] })
         end
       end
 


### PR DESCRIPTION
closes #3625

## Why was this change made? 🤔
This action is required regardless of datastore.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file system, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

