### PR TITLE
Restore fetching 856 sort from note as well as title

### DIFF
--- a/app/models/dor/update_marc_record_service.rb
+++ b/app/models/dor/update_marc_record_service.rb
@@ -180,12 +180,14 @@ module Dor
 
       part_label = part_parts.filter_map(&:value).join(parts_delimiter(part_parts))
 
-      part_sort = title_info.structuredValue.select { |part| 'date/sequential designation'.include? part.type }
-
       str = ''
       str += "|xlabel:#{part_label}" unless part_label.empty?
-      str += "|xsort:#{part_sort.first.value}" unless part_sort.empty?
 
+      part_sort_from_title = title_info.structuredValue.find { |part| 'date/sequential designation'.include? part.type }
+      part_sort_from_note = @cocina_object.description.note.find { |note| 'date/sequential designation'.include? note.type }
+      return str unless part_sort_from_title || part_sort_from_note
+
+      str += "|xsort:#{[part_sort_from_note, part_sort_from_title].flatten.compact.first.value}"
       str
     end
 

--- a/spec/dor/update_marc_record_service_spec.rb
+++ b/spec/dor/update_marc_record_service_spec.rb
@@ -870,15 +870,18 @@ RSpec.describe Dor::UpdateMarcRecordService do
                 {
                   value: '2011',
                   type: 'part number'
-                },
-                {
-                  value: '123',
-                  type: 'date/sequential designation'
                 }
               ]
             }
           ],
-          purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+          purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}",
+          note: [
+            {
+              value: '123',
+              type: 'date/sequential designation'
+            }
+          ]
+
         }
       end
       let(:cocina_object) do


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3641 by restoring the selection of part sort from description.note (as well as title parts)

## How was this change tested? 🤨

Fixed a bad test that suggested it was testing part sort from note, but was really title.

⚡ ⚠ If this change has cross service impact, including data writes to shared file system, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



