### PR TITLE
Stop using ActiveFedora::Base.internal_uri

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -5,7 +5,7 @@ class MembersController < ApplicationController
   # Return the published members of this collection
   def index
     solr_params = {
-      q: "is_member_of_collection_ssim:\"#{ActiveFedora::Base.internal_uri(params[:object_id])}\" published_dttsim:[* TO *]",
+      q: "is_member_of_collection_ssim:\"info:fedora/#{params[:object_id]}\" published_dttsim:[* TO *]",
       wt: :json,
       fl: 'id,objectType_ssim',
       rows: 100_000_000

--- a/spec/requests/members_for_collection_spec.rb
+++ b/spec/requests/members_for_collection_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Get the members' do
   let(:solr_params) do
     {
       fl: 'id,objectType_ssim',
-      q: "is_member_of_collection_ssim:\"#{ActiveFedora::Base.internal_uri(druid)}\" published_dttsim:[* TO *]",
+      q: "is_member_of_collection_ssim:\"info:fedora/#{druid}\" published_dttsim:[* TO *]",
       rows: 100_000_000,
       wt: :json
     }


### PR DESCRIPTION


## Why was this change made? 🤔
This helps us decouple from ActiveFedora


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file system, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



