### PR TITLE
Stop using Dor::PidUtils.

### DIFF
--- a/app/models/dor/update_marc_record_service.rb
+++ b/app/models/dor/update_marc_record_service.rb
@@ -15,7 +15,7 @@ module Dor
 
     def initialize(cocina_object, thumbnail_service:)
       @cocina_object = cocina_object
-      @druid_id = Dor::PidUtils.remove_druid_prefix(cocina_object.externalIdentifier)
+      @druid_id = cocina_object.externalIdentifier.delete_prefix('druid:')
       @access = cocina_object.access if cocina_object.respond_to?(:access)
       @thumbnail_service = thumbnail_service
     end

--- a/app/services/thumbnail_service.rb
+++ b/app/services/thumbnail_service.rb
@@ -20,7 +20,7 @@ class ThumbnailService
       file_set.structural.contains.each do |file|
         next unless file.hasMimeType.include?(MIME_TYPE)
 
-        return "#{Dor::PidUtils.remove_druid_prefix(object.externalIdentifier)}/#{file.filename}"
+        return "#{object.externalIdentifier.delete_prefix('druid:')}/#{file.filename}"
       end
     end
 

--- a/spec/dor/update_marc_record_service_spec.rb
+++ b/spec/dor/update_marc_record_service_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
   let(:apo_druid) { 'druid:pp000pp0000' }
   let(:druid) { 'druid:bc123dg9393' }
+  let(:bare_druid) { druid.delete_prefix('druid:') }
   let(:collection_druid) { 'druid:cc111cc1111' }
   let(:dro_object_label) { 'A generic label' }
   let(:collection_label) { 'Collection label' }
@@ -17,7 +18,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
   let(:descriptive_metadata_basic) do
     {
       title: [{ value: 'Constituent label & A Special character' }],
-      purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+      purl: "https://purl.stanford.edu/#{bare_druid}"
     }
   end
   let(:identity_metadata_basic) do
@@ -792,7 +793,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
               ]
             }
           ],
-          purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+          purl: "https://purl.stanford.edu/#{bare_druid}"
         }
       end
       let(:cocina_object) do
@@ -833,7 +834,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
               ]
             }
           ],
-          purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+          purl: "https://purl.stanford.edu/#{bare_druid}"
         }
       end
       let(:cocina_object) do
@@ -874,7 +875,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
               ]
             }
           ],
-          purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}",
+          purl: "https://purl.stanford.edu/#{bare_druid}",
           note: [
             {
               value: '123',
@@ -926,7 +927,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
               ]
             }
           ],
-          purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+          purl: "https://purl.stanford.edu/#{bare_druid}"
         }
       end
       let(:cocina_object) do
@@ -981,7 +982,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
               ]
             }
           ],
-          purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+          purl: "https://purl.stanford.edu/#{bare_druid}"
         }
       end
       let(:cocina_object) do
@@ -1036,7 +1037,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
               ]
             }
           ],
-          purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+          purl: "https://purl.stanford.edu/#{bare_druid}"
         }
       end
       let(:cocina_object) do

--- a/spec/requests/mods_update_spec.rb
+++ b/spec/requests/mods_update_spec.rb
@@ -4,11 +4,12 @@ require 'rails_helper'
 
 RSpec.describe 'Update MODS' do
   let(:druid) { 'druid:mk420bs7601' }
+  let(:bare_druid) { druid.delete_prefix('druid:') }
   let(:apo_druid) { 'druid:dd999df4567' }
   let(:description) do
     {
       title: [{ value: 'Dummy Title' }],
-      purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+      purl: "https://purl.stanford.edu/#{bare_druid}"
     }
   end
   let(:object) do
@@ -65,7 +66,7 @@ RSpec.describe 'Update MODS' do
                               version: 1,
                               description: {
                                 title: [{ value: 'Hello' }],
-                                purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+                                purl: "https://purl.stanford.edu/#{bare_druid}"
                               },
                               identification: { sourceId: 'sul:50807230' },
                               access: {},

--- a/spec/requests/update_marc_record_spec.rb
+++ b/spec/requests/update_marc_record_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Update MARC record' do
                             version: 1,
                             description: {
                               title: [{ value: 'Constituent label &amp; A Special character' }],
-                              purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+                              purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
                             },
                             identification: {},
                             access: {},

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Publish::PublicXmlService do
   let(:description) do
     {
       title: [{ value: 'Constituent label &amp; A Special character' }],
-      purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+      purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
     }
   end
   let(:structural) do

--- a/spec/services/thumbnail_service_spec.rb
+++ b/spec/services/thumbnail_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ThumbnailService do
   let(:description) do
     {
       title: [{ value: 'Constituent label &amp; A Special character' }],
-      purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+      purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
     }
   end
 


### PR DESCRIPTION
closes #3638

## Why was this change made? 🤔
Reduce use of dor-services gem.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file system, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



