### PR TITLE
Apply APO defaults, not merge.

### DIFF
--- a/app/services/apply_admin_policy_defaults.rb
+++ b/app/services/apply_admin_policy_defaults.rb
@@ -67,7 +67,8 @@ class ApplyAdminPolicyDefaults
 
   def updated_cocina_object
     access_updated = @cocina_object.new(
-      access: @cocina_object.access.new(access_properties_for(type: cocina_type))
+      # Note that this is a replace, not a merge.
+      access: access_properties_for(type: cocina_type)
     )
     return access_updated unless access_updated.dro? && access_updated.structural&.contains&.any?
 

--- a/spec/services/apply_admin_policy_defaults_spec.rb
+++ b/spec/services/apply_admin_policy_defaults_spec.rb
@@ -17,13 +17,14 @@ RSpec.describe ApplyAdminPolicyDefaults do
       version: 1,
       type: Cocina::Models::Vocab.object,
       label: 'Dummy DRO',
-      access: {},
+      access: access_props,
       administrative: { hasAdminPolicy: apo_druid }
     )
   end
   let(:workflow_state) { 'Registered' }
   let(:workflow_client) { instance_double(Dor::Workflow::Client, status: status_client) }
   let(:status_client) { instance_double(Dor::Workflow::Client::Status, display_simplified: workflow_state) }
+  let(:access_props) { {} }
 
   before do
     allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
@@ -138,10 +139,28 @@ RSpec.describe ApplyAdminPolicyDefaults do
     end
 
     context 'with a DRO that lack structural metadata' do
-      it 'copies APO defaultAccess to item access' do
-        expect(CocinaObjectStore).to have_received(:save)
-          .once
-          .with(cocina_object_with(access: default_access))
+      context 'with dark access' do
+        it 'copies APO defaultAccess to item access' do
+          expect(CocinaObjectStore).to have_received(:save)
+            .once
+            .with(cocina_object_with(access: default_access))
+        end
+      end
+
+      context 'with location-based access' do
+        let(:access_props) do
+          {
+            access: 'location-based',
+            download: 'location-based',
+            readLocation: 'spec'
+          }
+        end
+
+        it 'copies APO defaultAccess to item access' do
+          expect(CocinaObjectStore).to have_received(:save)
+            .once
+            .with(cocina_object_with(access: default_access))
+        end
       end
     end
 
@@ -276,7 +295,8 @@ RSpec.describe ApplyAdminPolicyDefaults do
                 },
                 access: {
                   access: 'stanford',
-                  download: 'stanford'
+                  download: 'location-based',
+                  readLocation: 'spec'
                 },
                 hasMessageDigests: []
               }


### PR DESCRIPTION
closes #3648

## Why was this change made? 🤔
Access rights were getting merged instead of applied, leading to erroneous rights.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file system, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

