### PR TITLE
make sourceid query match previous version

### DIFF
--- a/app/validators/cocina/unique_source_id_validator.rb
+++ b/app/validators/cocina/unique_source_id_validator.rb
@@ -35,7 +35,7 @@ module Cocina
     end
 
     def lookup_duplicate
-      solr_response = SolrService.get("identifier_tesim:\"#{@cocina_dro.identification.sourceId}\"", rows: 100, fl: 'id')
+      solr_response = SolrService.get("{!term f=identifier_ssim}#{@cocina_dro.identification.sourceId}", rows: 100, fl: 'id', defType: 'lucene')
 
       return if solr_response['response']['numFound'].zero?
 


### PR DESCRIPTION
## Why was this change made? 🤔

Follow on from #3653, taking into account https://github.com/sul-dlss/dor-services-app/pull/3653#discussion_r818230404 

Make solr query to find duplicate sourceIDs match what we used before
(see https://github.com/sul-dlss/dor-services/blob/main/lib/dor/services/search_service.rb#L29-L43)

## How was this change tested? 🤨

Existing tests


