### PR TITLE
Ignore identifiers when roundtrip validating.

### DIFF
--- a/spec/validators/cocina/description_roundtrip_validator_spec.rb
+++ b/spec/validators/cocina/description_roundtrip_validator_spec.rb
@@ -110,6 +110,21 @@ RSpec.describe Cocina::DescriptionRoundtripValidator do
         expect(result.success?).to be true
       end
     end
+
+    context 'when has an identifier type that does not roundtrip' do
+      let(:cocina_object) do
+        new_cocina_hash = cocina_hash.dup
+        new_cocina_hash[:description][:identifier] = [{
+          value: 'GM 132. Amadeus.',
+          type: 'music publisher'
+        }]
+        Cocina::Models::DRO.new(new_cocina_hash)
+      end
+
+      it 'returns success (ignoring identifier)' do
+        expect(result.success?).to be true
+      end
+    end
   end
 
   describe '.valid_from_fedora?' do


### PR DESCRIPTION
## Why was this change made? 🤔
Roundtrip validation was causing refresh metadata to mistakingly fail.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file system, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

