### PR TITLE
Allow collection and item use statements to be blanked

### DIFF
--- a/app/services/cocina/to_fedora/collection_access.rb
+++ b/app/services/cocina/to_fedora/collection_access.rb
@@ -20,9 +20,11 @@ module Cocina
         return if access.nil?
 
         AccessGenerator.generate(root: collection.rightsMetadata.ng_xml.root, access: access)
-        collection.rightsMetadata.copyright = access.copyright if access.copyright
-        collection.rightsMetadata.use_statement = access.useAndReproductionStatement if access.useAndReproductionStatement
-        License.update(collection.rightsMetadata, access.license) if access.license
+        collection.rightsMetadata.copyright = access.copyright
+        # now remove any empty copyright elements
+        collection.rightsMetadata.ng_xml.root.xpath('//copyright[count(*) = 0]').each(&:remove)
+        collection.rightsMetadata.use_statement = access.useAndReproductionStatement
+        License.update(collection.rightsMetadata, access.license)
         collection.rightsMetadata.ng_xml_will_change!
       end
 

--- a/app/services/cocina/to_fedora/dro_access.rb
+++ b/app/services/cocina/to_fedora/dro_access.rb
@@ -35,7 +35,7 @@ module Cocina
         item.rightsMetadata.copyright = access.copyright
         # now remove any empty copyright elements
         item.rightsMetadata.ng_xml.root.xpath('//copyright[count(*) = 0]').each(&:remove)
-        item.rightsMetadata.use_statement = access.useAndReproductionStatement if access.useAndReproductionStatement
+        item.rightsMetadata.use_statement = access.useAndReproductionStatement
         License.update(item.rightsMetadata, access.license)
         item.rightsMetadata.ng_xml_will_change!
       end

--- a/spec/services/cocina/to_fedora/collection_access_spec.rb
+++ b/spec/services/cocina/to_fedora/collection_access_spec.rb
@@ -29,16 +29,6 @@ RSpec.describe Cocina::ToFedora::CollectionAccess do
               <world/>
             </machine>
           </access>
-          <use>
-            <human type="useAndReproduction"/>
-            <human type="creativeCommons"/>
-            <machine type="creativeCommons" uri=""/>
-            <human type="openDataCommons"/>
-            <machine type="openDataCommons" uri=""/>
-          </use>
-          <copyright>
-            <human/>
-          </copyright>
         </rightsMetadata>
       XML
     end
@@ -92,12 +82,57 @@ RSpec.describe Cocina::ToFedora::CollectionAccess do
             </machine>
           </access>
           <use>
-            <human type="useAndReproduction"/>
             <license>https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode</license>
+          </use>
+        </rightsMetadata>
+      XML
+    end
+  end
+
+  context 'with an existing use statement' do
+    let(:access) do
+      Cocina::Models::CollectionAccess.new
+    end
+
+    before do
+      collection.rightsMetadata.content = <<~XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction">A Really Cool Use Statement</human>
           </use>
           <copyright>
             <human/>
           </copyright>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'builds the xml, blanking the existing license' do
+      apply
+      expect(collection.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
+        <?xml version="1.0"?>
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
         </rightsMetadata>
       XML
     end

--- a/spec/services/cocina/to_fedora/dro_access_spec.rb
+++ b/spec/services/cocina/to_fedora/dro_access_spec.rb
@@ -167,4 +167,52 @@ RSpec.describe Cocina::ToFedora::DROAccess do
       XML
     end
   end
+
+  context 'when clearing an existing use statement' do
+    let(:item) do
+      Dor::Item.new
+    end
+    let(:access) do
+      Cocina::Models::DROAccess.new
+    end
+
+    before do
+      item.rightsMetadata.content = <<~XML
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <use>
+            <human type="useAndReproduction">New Use Statement</human>
+          </use>
+          <copyright/>
+        </rightsMetadata>
+      XML
+    end
+
+    it 'clears out the license' do
+      apply
+      expect(item.rightsMetadata.ng_xml).to be_equivalent_to <<-XML
+        <rightsMetadata>
+          <access type="discover">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+          <access type="read">
+            <machine>
+              <none/>
+            </machine>
+          </access>
+        </rightsMetadata>
+      XML
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes https://github.com/sul-dlss/argo/issues/3200

While the issue this closes is only about DROs, I figure we are going to run into the same problem with collections eventually, so bring parity to the access approaches of DROs and collections.


## How was this change tested? 🤨

CI, and in QA (approved by @andrewjbtw)
