### PR TITLE
Adds uniqueness constraint for sourceId for DROs and collections.

### DIFF
--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -218,6 +218,7 @@ class CocinaObjectStore
   # Persist a Cocina object with ActiveRecord.
   # @param [Cocina::Models::DRO,Cocina::Models::Collection,Cocina::Models::AdminPolicy] cocina_object
   # @return [Array] array consisting of created date and modified date
+  # @raise [Cocina::ValidationError] if externalIdentifier or sourceId not unique
   def cocina_to_ar_save(cocina_object)
     model_clazz = case cocina_object
                   when Cocina::Models::AdminPolicy
@@ -231,6 +232,8 @@ class CocinaObjectStore
                   end
     ar_cocina_object = model_clazz.upsert_cocina(cocina_object)
     [ar_cocina_object.created_at, ar_cocina_object.updated_at]
+  rescue ActiveRecord::RecordNotUnique
+    raise Cocina::ValidationError.new('ExternalIdentifier or sourceId is not unique.', status: :conflict)
   end
 
   # Find a Cocina object persisted by ActiveRecord.

--- a/app/validators/cocina/object_validator.rb
+++ b/app/validators/cocina/object_validator.rb
@@ -17,6 +17,7 @@ module Cocina
 
     # @raises [ValidationError] if not valid
     def validate
+      # This can be removed once Fedora migration is complete, as it will be performed by DB constraint.
       if request?
         validator = Cocina::UniqueSourceIdValidator.new(cocina_object)
         raise ValidationError.new(validator.error, status: :conflict) unless validator.valid?

--- a/db/migrate/20220307201030_add_unique_source_id_to_dros.rb
+++ b/db/migrate/20220307201030_add_unique_source_id_to_dros.rb
@@ -1,0 +1,5 @@
+class AddUniqueSourceIdToDros < ActiveRecord::Migration[5.2]
+  def change
+    Dro.connection.execute("CREATE UNIQUE INDEX dro_source_id_idx ON dros( (identification ->> 'sourceId') );")
+  end
+end

--- a/db/migrate/20220307201420_add_unique_source_id_to_collections.rb
+++ b/db/migrate/20220307201420_add_unique_source_id_to_collections.rb
@@ -1,0 +1,5 @@
+class AddUniqueSourceIdToCollections < ActiveRecord::Migration[5.2]
+  def change
+    Collection.connection.execute("CREATE UNIQUE INDEX collection_source_id_idx ON collections( (identification ->> 'sourceId') );")
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -457,6 +457,20 @@ ALTER TABLE ONLY public.tag_labels
 
 
 --
+-- Name: collection_source_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX collection_source_id_idx ON public.collections USING btree (((identification ->> 'sourceId'::text)));
+
+
+--
+-- Name: dro_source_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX dro_source_id_idx ON public.dros USING btree (((identification ->> 'sourceId'::text)));
+
+
+--
 -- Name: index_admin_policies_on_external_identifier; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -566,6 +580,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220131194025'),
 ('20220131194359'),
 ('20220131194912'),
-('20220203155057');
+('20220203155057'),
+('20220307201030'),
+('20220307201420');
 
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -89,4 +89,32 @@ RSpec.describe Collection do
       end
     end
   end
+
+  describe 'sourceId uniqueness' do
+    let(:cocina_object1) do
+      minimal_cocina_collection.new(identification: { sourceId: 'sul:PC0170_s3_USC_2010-10-09_141959_0031' })
+    end
+
+    context 'when sourceId is unique' do
+      let(:cocina_object2) do
+        minimal_cocina_collection.new(externalIdentifier: 'druid:dd645sg2172', identification: { sourceId: 'sul:PC0170_s3_USC_2010-10-09_141959_0032' })
+      end
+
+      it 'does not raise' do
+        described_class.upsert_cocina(cocina_object1)
+        described_class.upsert_cocina(cocina_object2)
+      end
+    end
+
+    context 'when sourceId is not unique' do
+      let(:cocina_object2) do
+        minimal_cocina_collection.new(externalIdentifier: 'druid:dd645sg2172', identification: { sourceId: 'sul:PC0170_s3_USC_2010-10-09_141959_0031' })
+      end
+
+      it 'raises' do
+        described_class.upsert_cocina(cocina_object1)
+        expect { described_class.upsert_cocina(cocina_object2) }.to raise_error(ActiveRecord::RecordNotUnique)
+      end
+    end
+  end
 end

--- a/spec/models/dro_spec.rb
+++ b/spec/models/dro_spec.rb
@@ -127,4 +127,32 @@ RSpec.describe Dro do
       end
     end
   end
+
+  describe 'sourceId uniqueness' do
+    let(:cocina_object1) do
+      minimal_cocina_dro.new(identification: { sourceId: 'sul:PC0170_s3_USC_2010-10-09_141959_0031' })
+    end
+
+    context 'when sourceId is unique' do
+      let(:cocina_object2) do
+        minimal_cocina_dro.new(externalIdentifier: 'druid:dd645sg2172', identification: { sourceId: 'sul:PC0170_s3_USC_2010-10-09_141959_0032' })
+      end
+
+      it 'does not raise' do
+        described_class.upsert_cocina(cocina_object1)
+        described_class.upsert_cocina(cocina_object2)
+      end
+    end
+
+    context 'when sourceId is not unique' do
+      let(:cocina_object2) do
+        minimal_cocina_dro.new(externalIdentifier: 'druid:dd645sg2172', identification: { sourceId: 'sul:PC0170_s3_USC_2010-10-09_141959_0031' })
+      end
+
+      it 'raises' do
+        described_class.upsert_cocina(cocina_object1)
+        expect { described_class.upsert_cocina(cocina_object2) }.to raise_error(ActiveRecord::RecordNotUnique)
+      end
+    end
+  end
 end

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -730,6 +730,32 @@ RSpec.describe CocinaObjectStore do
           expect(Collection.find_by(external_identifier: cocina_object.externalIdentifier)).not_to be_nil
         end
       end
+
+      context 'when sourceId is not unique' do
+        let(:cocina_object) do
+          Cocina::Models::Collection.new({
+                                           cocinaVersion: '0.0.1',
+                                           externalIdentifier: 'druid:hp308wm0436',
+                                           type: Cocina::Models::Vocab.collection,
+                                           label: 'Test Collection',
+                                           description: {
+                                             title: [{ value: 'Test Collection' }],
+                                             purl: 'https://purl.stanford.edu/hp308wm0436'
+                                           },
+                                           version: 1,
+                                           access: { access: 'world' },
+                                           identification: { sourceId: 'sul:PC0170_s3_USC_2010-10-09_141959_0031' }
+                                         })
+        end
+
+        before do
+          store.send(:cocina_to_ar_save, cocina_object.new(externalIdentifier: 'druid:dd645sg2172'))
+        end
+
+        it 'raises' do
+          expect { store.send(:cocina_to_ar_save, cocina_object) }.to raise_error(Cocina::ValidationError)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
closes #3665

## Why was this change made? 🤔
This approach is more reliable then querying Solr (since updating Solr involves a latency).


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file system, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

