### PR TITLE
Virtual object normalization

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -271,7 +271,7 @@ module Cocina
       end
 
       def normalize_relationship
-        ng_xml.root.xpath('//relationship[not(@type)]').each do |node|
+        ng_xml.root.xpath('//relationship[not(@type="alsoAvailableAs")]').each do |node|
           node['type'] = 'alsoAvailableAs'
         end
       end

--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -34,6 +34,7 @@ module Cocina
         remove_resource_data_attribute
         remove_external_resource_id
         remove_external_image_data
+        remove_external_resource_type
         remove_resource_sequence_attribute
         remove_location
         remove_file_format_and_data_type_attributes
@@ -68,6 +69,7 @@ module Cocina
         remove_resource_id_attribute
         remove_external_resource_id
         remove_external_image_data
+        remove_external_resource_type
         remove_resource_sequence_attribute
 
         regenerate_ng_xml(ng_xml.to_s)
@@ -256,6 +258,10 @@ module Cocina
       def remove_external_image_data
         ng_xml.root.xpath('//externalFile/imageData').each(&:remove)
         ng_xml.root.xpath('//externalFile/preceding-sibling::label').each(&:remove)
+      end
+
+      def remove_external_resource_type
+        ng_xml.root.xpath('//resource[externalFile]/@type').each(&:remove)
       end
 
       def normalize_relationship

--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -35,6 +35,7 @@ module Cocina
         remove_external_resource_id
         remove_external_image_data
         remove_external_resource_type
+        remove_external_type
         remove_resource_sequence_attribute
         remove_location
         remove_file_format_and_data_type_attributes
@@ -70,6 +71,7 @@ module Cocina
         remove_external_resource_id
         remove_external_image_data
         remove_external_resource_type
+        remove_external_type
         remove_resource_sequence_attribute
 
         regenerate_ng_xml(ng_xml.to_s)
@@ -244,7 +246,7 @@ module Cocina
 
       # set the type attribute on the contentMetadata node when it's missing
       def missing_type_attribute_assigned_file
-        ng_xml.xpath('//contentMetadata[not(@type)]').each do |node|
+        ng_xml.xpath('//contentMetadata[not(@type)][not(//externalFile)]').each do |node|
           node['type'] = 'file'
         end
       end
@@ -262,6 +264,10 @@ module Cocina
 
       def remove_external_resource_type
         ng_xml.root.xpath('//resource[externalFile]/@type').each(&:remove)
+      end
+
+      def remove_external_type
+        ng_xml.xpath('//contentMetadata[//externalFile]/@type').each(&:remove)
       end
 
       def normalize_relationship

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -975,7 +975,7 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
   context 'when normalizing contentMetadata virtual object relationship with missing type' do
     let(:original_xml) do
       <<~XML
-        <contentMetadata type="file" objectId="druid:bb035tg0974">
+        <contentMetadata objectId="druid:bb035tg0974">
           <resource sequence="1" id="bb035tg0974_1">
             <externalFile objectId="druid:fn851rw5684" resourceId="fn851rw5684_1" fileId="PC0170_s3_Oregon_State_2008-08-28_154120_0001.jp2" mimetype="image/jp2"/>
             <relationship objectId="druid:fn851rw5684"/>
@@ -987,7 +987,7 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
     it 'adds a type' do
       expect(normalized_ng_xml).to be_equivalent_to(
         <<~XML
-          <contentMetadata type="file" objectId="druid:bb035tg0974">
+          <contentMetadata objectId="druid:bb035tg0974">
             <resource>
               <externalFile objectId="druid:fn851rw5684" fileId="PC0170_s3_Oregon_State_2008-08-28_154120_0001.jp2" mimetype="image/jp2"/>
               <relationship objectId="druid:fn851rw5684" type="alsoAvailableAs"/>
@@ -1001,7 +1001,7 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
   context 'when normalizing virtual object resource type' do
     let(:original_xml) do
       <<~XML
-        <contentMetadata type="file" objectId="druid:bb035tg0974">
+        <contentMetadata objectId="druid:bb035tg0974">
           <resource type="image">
             <externalFile fileId="PC0170_s3_San_Jose_State_2009-09-19_100544_0001.jp2" mimetype="image/jp2" objectId="druid:mq130hw5269"/>
             <relationship objectId="druid:mq130hw5269" type="alsoAvailableAs"/>
@@ -1013,12 +1013,38 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
     it 'removes type' do
       expect(normalized_ng_xml).to be_equivalent_to(
         <<~XML
-        <contentMetadata type="file" objectId="druid:bb035tg0974">
+          <contentMetadata objectId="druid:bb035tg0974">
+            <resource>
+              <externalFile fileId="PC0170_s3_San_Jose_State_2009-09-19_100544_0001.jp2" mimetype="image/jp2" objectId="druid:mq130hw5269"/>
+              <relationship objectId="druid:mq130hw5269" type="alsoAvailableAs"/>
+            </resource>
+          </contentMetadata>
+        XML
+      )
+    end
+  end
+
+  context 'when normalizing virtual object type' do
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata type="image" objectId="druid:bb035tg0974">
           <resource>
             <externalFile fileId="PC0170_s3_San_Jose_State_2009-09-19_100544_0001.jp2" mimetype="image/jp2" objectId="druid:mq130hw5269"/>
             <relationship objectId="druid:mq130hw5269" type="alsoAvailableAs"/>
           </resource>
         </contentMetadata>
+      XML
+    end
+
+    it 'removes type' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <contentMetadata objectId="druid:bb035tg0974">
+            <resource>
+              <externalFile fileId="PC0170_s3_San_Jose_State_2009-09-19_100544_0001.jp2" mimetype="image/jp2" objectId="druid:mq130hw5269"/>
+              <relationship objectId="druid:mq130hw5269" type="alsoAvailableAs"/>
+            </resource>
+          </contentMetadata>
         XML
       )
     end

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -976,7 +976,7 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
     let(:original_xml) do
       <<~XML
         <contentMetadata type="file" objectId="druid:bb035tg0974">
-          <resource sequence="1" id="bb035tg0974_1" type="file">
+          <resource sequence="1" id="bb035tg0974_1">
             <externalFile objectId="druid:fn851rw5684" resourceId="fn851rw5684_1" fileId="PC0170_s3_Oregon_State_2008-08-28_154120_0001.jp2" mimetype="image/jp2"/>
             <relationship objectId="druid:fn851rw5684"/>
           </resource>
@@ -988,11 +988,37 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       expect(normalized_ng_xml).to be_equivalent_to(
         <<~XML
           <contentMetadata type="file" objectId="druid:bb035tg0974">
-            <resource type="file">
+            <resource>
               <externalFile objectId="druid:fn851rw5684" fileId="PC0170_s3_Oregon_State_2008-08-28_154120_0001.jp2" mimetype="image/jp2"/>
               <relationship objectId="druid:fn851rw5684" type="alsoAvailableAs"/>
             </resource>
           </contentMetadata>
+        XML
+      )
+    end
+  end
+
+  context 'when normalizing virtual object resource type' do
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata type="file" objectId="druid:bb035tg0974">
+          <resource type="image">
+            <externalFile fileId="PC0170_s3_San_Jose_State_2009-09-19_100544_0001.jp2" mimetype="image/jp2" objectId="druid:mq130hw5269"/>
+            <relationship objectId="druid:mq130hw5269" type="alsoAvailableAs"/>
+          </resource>
+        </contentMetadata>
+      XML
+    end
+
+    it 'removes type' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+        <contentMetadata type="file" objectId="druid:bb035tg0974">
+          <resource>
+            <externalFile fileId="PC0170_s3_San_Jose_State_2009-09-19_100544_0001.jp2" mimetype="image/jp2" objectId="druid:mq130hw5269"/>
+            <relationship objectId="druid:mq130hw5269" type="alsoAvailableAs"/>
+          </resource>
+        </contentMetadata>
         XML
       )
     end

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -998,6 +998,32 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
     end
   end
 
+  context 'when normalizing contentMetadata virtual object relationship with wrong type' do
+    let(:original_xml) do
+      <<~XML
+        <contentMetadata objectId="druid:bb035tg0974">
+          <resource sequence="1" id="bb035tg0974_1">
+            <externalFile objectId="druid:fn851rw5684" resourceId="fn851rw5684_1" fileId="PC0170_s3_Oregon_State_2008-08-28_154120_0001.jp2" mimetype="image/jp2"/>
+            <relationship objectId="druid:fn851rw5684" type="image"/>
+          </resource>
+        </contentMetadata>
+      XML
+    end
+
+    it 'corrects type' do
+      expect(normalized_ng_xml).to be_equivalent_to(
+        <<~XML
+          <contentMetadata objectId="druid:bb035tg0974">
+            <resource>
+              <externalFile objectId="druid:fn851rw5684" fileId="PC0170_s3_Oregon_State_2008-08-28_154120_0001.jp2" mimetype="image/jp2"/>
+              <relationship objectId="druid:fn851rw5684" type="alsoAvailableAs"/>
+            </resource>
+          </contentMetadata>
+        XML
+      )
+    end
+  end
+
   context 'when normalizing virtual object resource type' do
     let(:original_xml) do
       <<~XML


### PR DESCRIPTION
## Why was this change made? 🤔
Deal with messy virtual objects.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file system, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

Before:
```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9979 (99.87%)
  Different: 13 (0.13%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     8 (0.08%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)

Virtual objects:
Status (n=4674; not using Missing for success/different/error stats):
  Success:   4611 (98.652%)
  Different: 63 (1.348%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     0 (0.0%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

After:
```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9980 (99.88%)
  Different: 12 (0.12%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     8 (0.08%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)

Virtual objects:
Status (n=4674; not using Missing for success/different/error stats):
  Success:   4631 (99.08%)
  Different: 43 (0.92%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     0 (0.0%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

