### PR TITLE
Tweaks ordering of content metadata normalizers.

### DIFF
--- a/app/services/cocina/normalizers/content_metadata_normalizer.rb
+++ b/app/services/cocina/normalizers/content_metadata_normalizer.rb
@@ -35,7 +35,6 @@ module Cocina
         remove_external_resource_id
         remove_external_image_data
         remove_external_resource_type
-        remove_external_type
         remove_resource_sequence_attribute
         remove_location
         remove_file_format_and_data_type_attributes
@@ -60,6 +59,7 @@ module Cocina
         normalize_image_data_to_integers
         normalize_file_directives
         normalize_relationship
+        remove_external_type # Near bottom, as other normalizers use type.
         normalize_empty_resources
 
         regenerate_ng_xml(ng_xml.to_s)

--- a/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/content_metadata_normalizer_spec.rb
@@ -279,6 +279,34 @@ RSpec.describe Cocina::Normalizers::ContentMetadataNormalizer do
       end
     end
 
+    context 'when a virtual object image and reading order already exists' do
+      let(:original_xml) do
+        <<~XML
+          <contentMetadata objectId="druid:bb035tg0974" type="image">
+            <bookData readingOrder="rtl"/>
+            <resource id="dv137rh0690_1" sequence="1" type="image">
+              <externalFile fileId="24-jan-1.jp2" mimetype="image/jp2" objectId="druid:sf548ym8677"/>
+              <relationship objectId="druid:sf548ym8677" type="alsoAvailableAs"/>
+            </resource>
+          </contentMetadata>
+        XML
+      end
+
+      it 'does nothing' do
+        expect(normalized_ng_xml).to be_equivalent_to(<<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <contentMetadata objectId="druid:bb035tg0974">
+            <bookData readingOrder="rtl"/>
+            <resource>
+              <externalFile fileId="24-jan-1.jp2" mimetype="image/jp2" objectId="druid:sf548ym8677"/>
+              <relationship objectId="druid:sf548ym8677" type="alsoAvailableAs"/>
+            </resource>
+          </contentMetadata>
+        XML
+                                                     )
+      end
+    end
+
     context 'when reading order already exists' do
       let(:original_xml) do
         <<~XML


### PR DESCRIPTION
## Why was this change made? 🤔
Reading order was getting dropped in normalization for virtual objects.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file system, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

Before:
```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9980 (99.88%)
  Different: 12 (0.12%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     8 (0.08%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

After:
```
Status (n=10000; not using Missing for success/different/error stats):
  Success:   9980 (99.88%)
  Different: 12 (0.12%)
  Mapping error:     0 (0.0%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     8 (0.08%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

Also tested with 2 known problematic objects.