### PR TITLE
Improve archive-fedora progressbar

### DIFF
--- a/bin/archive-fedora
+++ b/bin/archive-fedora
@@ -3,6 +3,7 @@
 
 require_relative '../config/environment'
 require_relative '../lib/fedora_archiver'
+require 'tty-progressbar'
 
 options = { input: 'druids.txt', archive: 'archive' }
 
@@ -27,10 +28,18 @@ Rails.logger.datetime_format = '%Y-%m-%d %H:%M:%S'
 parser.parse!(into: options)
 druids = options[:druids] || File.read(options[:input]).split
 
+bar = TTY::ProgressBar.new(
+  'Archiving [:bar] (:percent (:current/:total), rate: :rate/s, :elapsed total, ETA: :eta_time)',
+  bar_format: :burger,
+  total: druids.length
+)
+
 archiver = FedoraArchiver.new(
   druids: druids,
   archive_dir: options[:archive],
   lenient: options[:lenient]
 )
 
-archiver.run
+archiver.run do
+  bar.advance
+end

--- a/lib/fedora_archiver.rb
+++ b/lib/fedora_archiver.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'zlib'
-require 'ruby-progressbar'
 
 # Archive Fedora Objects as FOXML to a druid-tree
 class FedoraArchiver
@@ -14,10 +13,9 @@ class FedoraArchiver
   end
 
   def run
-    bar = ProgressBar.create(title: 'archiving', total: druids.length)
     druids.map do |druid|
       write_foxml(druid, archive_dir)
-      bar.increment
+      yield druid
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

It would be useful to see a projection of how long the archive process might take in addition to the progress bar.

## How was this change tested? 🤨

I tested against https://sul-dor-migrate.stanford.edu/fedora with a few thousand druids.

⚡ ⚠ If this change has cross service impact, including data writes to shared file system, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



