### PR TITLE
Deploy qa to load balancer

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-server 'dor-services-qa.stanford.edu', user: 'dor_services', roles: %w(web app scheduler)
-server 'dor-services-worker-qa-a.stanford.edu', user: 'dor_services', roles: %w(app worker)
+server 'dor-services-app-qa-a.stanford.edu', user: 'dor_services', roles: %w(web app)
+server 'dor-services-app-qa-b.stanford.edu', user: 'dor_services', roles: %w(web app)
+server 'dor-services-worker-qa-a.stanford.edu', user: 'dor_services', roles: %w(app worker scheduler)
 
 Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
## Why was this change made? 🤔

To deploy the latest code behind the load balancer

## How was this change tested? 🤨

I verified capistrano could deploy to the nodes.


