### PR TITLE
Add cache to prevent repeated lookup of APO

### DIFF
--- a/app/services/apply_admin_policy_defaults.rb
+++ b/app/services/apply_admin_policy_defaults.rb
@@ -117,11 +117,11 @@ class ApplyAdminPolicyDefaults
   end
 
   def default_access_from_apo
-    CocinaObjectStore
-      .find(@cocina_object.administrative.hasAdminPolicy)
-      .administrative
-      .accessTemplate
-      .to_h
-      .with_indifferent_access
+    @default_access_from_apo ||= CocinaObjectStore
+                                 .find(@cocina_object.administrative.hasAdminPolicy)
+                                 .administrative
+                                 .accessTemplate
+                                 .to_h
+                                 .with_indifferent_access
   end
 end


### PR DESCRIPTION


## Why was this change made? 🤔

Previously it would look up the APO once for each file in the object.
Fixes #3699

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file system, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



