### PR TITLE
indicate which way version is mismatched

### DIFF
--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -180,7 +180,13 @@ module Cocina
 
       fedora_object.versionMetadata.increment_version
 
-      raise "Incremented version of #{fedora_object.current_version} is not expected version #{cocina_object.version}" unless version_match?
+      return if version_match?
+
+      if fedora_object.current_version.to_i > cocina_object.version
+        raise "Incremented version of #{fedora_object.current_version} is greater than expected version #{cocina_object.version} - it appears you are trying to update an old version."
+      end
+
+      raise "Incremented version of #{fedora_object.current_version} is less than the expected version #{cocina_object.version}"
     end
 
     def version_match?

--- a/spec/services/cocina/object_updater_spec.rb
+++ b/spec/services/cocina/object_updater_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Cocina::ObjectUpdater do
         end
       end
 
-      context 'when a version mismatch' do
+      context 'when a version mismatch (incremented less than expected)' do
         let(:cocina_attrs) do
           orig_cocina_attrs.tap do |attrs|
             attrs[:version] = 3
@@ -189,7 +189,23 @@ RSpec.describe Cocina::ObjectUpdater do
         end
 
         it 'raises' do
-          expect { update }.to raise_error('Incremented version of 2 is not expected version 3')
+          expect { update }.to raise_error('Incremented version of 2 is less than the expected version 3')
+        end
+      end
+
+      context 'when a version mismatch (incremented more than expected)' do
+        before do
+          allow(item).to receive(:current_version).and_return('4')
+        end
+
+        let(:cocina_attrs) do
+          orig_cocina_attrs.tap do |attrs|
+            attrs[:version] = 3
+          end
+        end
+
+        it 'raises' do
+          expect { update }.to raise_error('Incremented version of 4 is greater than expected version 3 - it appears you are trying to update an old version.')
         end
       end
     end
@@ -361,7 +377,7 @@ RSpec.describe Cocina::ObjectUpdater do
         end
       end
 
-      context 'when a version mismatch' do
+      context 'when a version mismatch (incremented less than expected)' do
         let(:cocina_attrs) do
           orig_cocina_attrs.tap do |attrs|
             attrs[:version] = 3
@@ -369,7 +385,7 @@ RSpec.describe Cocina::ObjectUpdater do
         end
 
         it 'raises' do
-          expect { update }.to raise_error('Incremented version of 2 is not expected version 3')
+          expect { update }.to raise_error('Incremented version of 2 is less than the expected version 3')
         end
       end
     end
@@ -718,7 +734,7 @@ RSpec.describe Cocina::ObjectUpdater do
         end
       end
 
-      context 'when a version mismatch' do
+      context 'when a version mismatch (incremented less than expected)' do
         let(:cocina_attrs) do
           orig_cocina_attrs.tap do |attrs|
             attrs[:version] = 3
@@ -726,7 +742,7 @@ RSpec.describe Cocina::ObjectUpdater do
         end
 
         it 'raises' do
-          expect { update }.to raise_error('Incremented version of 2 is not expected version 3')
+          expect { update }.to raise_error('Incremented version of 2 is less than the expected version 3')
         end
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3693 - provide better error message indicating which way the version mismatches (is that what you were thinking Jcoyne?)


## How was this change tested? 🤨

Added a new test


