### PR TITLE
Use the project admin tag for routing update messages

### DIFF
--- a/app/services/notifications/object_updated.rb
+++ b/app/services/notifications/object_updated.rb
@@ -38,7 +38,7 @@ module Notifications
 
     # Using the project as a routing key because listeners may only care about their projects.
     def routing_key
-      model.is_a?(Cocina::Models::AdminPolicy) ? 'SDR' : model.administrative.partOfProject
+      model.is_a?(Cocina::Models::AdminPolicy) ? 'SDR' : AdministrativeTags.project(identifier: model.externalIdentifier).first
     end
   end
 end

--- a/spec/services/notifications/object_updated_spec.rb
+++ b/spec/services/notifications/object_updated_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe Notifications::ObjectUpdated do
   let(:data) { { data: '455' } }
   let(:created_at) { '04 Feb 2022' }
   let(:modified_at) { '04 Feb 2022' }
-  let(:administrative) do
-    instance_double(Cocina::Models::RequestAdministrative, partOfProject: 'h2')
-  end
-
   let(:channel) { instance_double(Notifications::RabbitChannel, topic: topic) }
   let(:topic) { instance_double(Bunny::Exchange, publish: true) }
   let(:message) { "{\"model\":{\"data\":\"455\"},\"created_at\":\"#{created_at.to_datetime.httpdate}\",\"modified_at\":\"#{modified_at.to_datetime.httpdate}\"}" }
@@ -25,12 +21,17 @@ RSpec.describe Notifications::ObjectUpdated do
     context 'when called with a DRO' do
       let(:model) do
         instance_double(Cocina::Models::DRO,
-                        externalIdentifier: 'druid:123', administrative: administrative, to_h: data)
+                        externalIdentifier: 'druid:123', to_h: data)
+      end
+
+      before do
+        allow(AdministrativeTags).to receive(:project).and_return(['h2'])
       end
 
       it 'is successful' do
         publish
         expect(topic).to have_received(:publish).with(message, routing_key: 'h2')
+        expect(AdministrativeTags).to have_received(:project).with(identifier: 'druid:123')
       end
     end
 
@@ -66,12 +67,12 @@ RSpec.describe Notifications::ObjectUpdated do
     context 'when called with a DRO' do
       let(:model) do
         instance_double(Cocina::Models::DRO,
-                        externalIdentifier: 'druid:123', administrative: administrative, to_h: data)
+                        externalIdentifier: 'druid:123', to_h: data)
       end
 
       it 'does not receive a message' do
         publish
-        expect(topic).not_to have_received(:publish).with(message, routing_key: 'h2')
+        expect(topic).not_to have_received(:publish)
       end
     end
   end


### PR DESCRIPTION

## Why was this change made? 🤔

This was part of the update to cocina-models 0.68.0

## How was this change tested? 🤨

CI and running integration tests in QA


