### PR TITLE
Very optimistic locking

### DIFF
--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -6,6 +6,6 @@ class QueriesController < ApplicationController
 
   # Returns a list of collections this object is in.
   def collections
-    @collections = CocinaObjectStore.find_collections_for(@cocina_object)
+    @collections = CocinaObjectStore.find_collections_for(@cocina_object).map { |collection_object| Cocina::Models.without_metadata(collection_object) }
   end
 end

--- a/app/models/admin_policy.rb
+++ b/app/models/admin_policy.rb
@@ -2,9 +2,16 @@
 
 # Model for an AdminPolicy.
 class AdminPolicy < ApplicationRecord
+  self.locking_column = 'lock'
+
   # @return [Cocina::Models::AdminPolicy] Cocina Administrative Policy
   def to_cocina
-    Cocina::Models::AdminPolicy.new({
+    Cocina::Models::AdminPolicy.new(to_h)
+  end
+
+  # @return [Hash] Admin policy instance as a hash
+  def to_h
+    {
       cocinaVersion: cocina_version,
       type: Cocina::Models::ObjectType.admin_policy,
       externalIdentifier: external_identifier,
@@ -12,7 +19,7 @@ class AdminPolicy < ApplicationRecord
       version: version,
       administrative: administrative,
       description: description
-    }.compact)
+    }.compact
   end
 
   # @param [Cocina::Models::AdminPolicy] Cocina Administrative Policy

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -2,6 +2,8 @@
 
 # Model for a Collection.
 class Collection < ApplicationRecord
+  self.locking_column = 'lock'
+
   # @return [Cocina::Models::Collection] Cocina collection
   def to_cocina
     Cocina::Models::Collection.new(to_h)

--- a/app/models/dro.rb
+++ b/app/models/dro.rb
@@ -2,6 +2,8 @@
 
 # Model for a Digital Repository Object.
 class Dro < ApplicationRecord
+  self.locking_column = 'lock'
+
   # @return [Cocina::Models::DRO] Cocina Digital Repository Object
   def to_cocina
     Cocina::Models::DRO.new(to_h)

--- a/db/migrate/20220311015318_add_lock_version.rb
+++ b/db/migrate/20220311015318_add_lock_version.rb
@@ -1,0 +1,7 @@
+class AddLockVersion < ActiveRecord::Migration[5.2]
+  def change
+    add_column :dros, :lock, :integer
+    add_column :collections, :lock, :integer
+    add_column :admin_policies, :lock, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -35,7 +35,8 @@ CREATE TABLE public.admin_policies (
     administrative jsonb NOT NULL,
     description jsonb,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    lock integer
 );
 
 
@@ -150,7 +151,8 @@ CREATE TABLE public.collections (
     description jsonb NOT NULL,
     identification jsonb NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    lock integer
 );
 
 
@@ -191,7 +193,8 @@ CREATE TABLE public.dros (
     structural jsonb NOT NULL,
     geographic jsonb,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    lock integer
 );
 
 
@@ -583,6 +586,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220203155057'),
 ('20220307201030'),
 ('20220307201420'),
+('20220311015318'),
 ('20220329134023');
 
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -411,6 +411,12 @@ paths:
             text/plain:
               schema:
                 type: string
+        '412':
+          description: Provided ETag didn't match the previous version.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
       parameters:
         - name: object_id
           in: path
@@ -1107,8 +1113,25 @@ paths:
                 - $ref: '#/components/schemas/RequestCollection'
                 - $ref: '#/components/schemas/RequestAdminPolicy'
       responses:
-        '200':
+        '201':
           description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/DRO'
+                  - $ref: '#/components/schemas/Collection'
+                  - $ref: '#/components/schemas/AdminPolicy'
+          headers:
+            ETag:
+              schema:
+                type: string
+            Last-Modified:
+              schema:
+                type: string
+            X-Created-At:
+              schema:
+                type: string
         '400':
           description: Invalid DOR parameter
           content:
@@ -1184,6 +1207,23 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/DRO'
+                  - $ref: '#/components/schemas/Collection'
+                  - $ref: '#/components/schemas/AdminPolicy'
+          headers:
+            ETag:
+              schema:
+                type: string
+            Last-Modified:
+              schema:
+                type: string
+            X-Created-At:
+              schema:
+                type: string
         '400':
           description: Invalid DOR parameter
           content:
@@ -1223,12 +1263,17 @@ paths:
                   - $ref: '#/components/schemas/Collection'
                   - $ref: '#/components/schemas/AdminPolicy'
           headers:
+            ETag:
+              schema:
+                type: string
             Last-Modified:
               schema:
                 type: string
             X-Created-At:
               schema:
                 type: string
+        '304':
+          description: No change. The client provided an ETag that matches the current state of the item.                
         '422':
           description: Unprocessable Entity
           content:

--- a/spec/models/admin_policy_spec.rb
+++ b/spec/models/admin_policy_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe AdminPolicy do
       let(:admin_policy) { create(:admin_policy) }
 
       it 'returns a Cocina::Model::AdminPolicy' do
-        expect(admin_policy.to_cocina).to eq(minimal_cocina_admin_policy)
+        expect(admin_policy.to_cocina).to cocina_object_with(minimal_cocina_admin_policy)
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe AdminPolicy do
       let(:admin_policy) { create(:admin_policy, :with_admin_policy_description) }
 
       it 'returns a Cocina::Model::AdminPolicy' do
-        expect(admin_policy.to_cocina).to eq(cocina_admin_policy)
+        expect(admin_policy.to_cocina).to cocina_object_with(cocina_admin_policy)
       end
     end
   end

--- a/spec/models/dro_spec.rb
+++ b/spec/models/dro_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Dro do
       let(:source_id) { dro.identification['sourceId'] }
 
       it 'returns a Cocina::Model::DRO' do
-        expect(dro.to_cocina).to eq(minimal_cocina_dro)
+        expect(dro.to_cocina).to cocina_object_with(minimal_cocina_dro)
       end
     end
 
@@ -117,7 +117,7 @@ RSpec.describe Dro do
       let(:source_id) { dro.identification['sourceId'] }
 
       it 'returns a Cocina::Model::DRO' do
-        expect(dro.to_cocina).to eq(cocina_dro)
+        expect(dro.to_cocina).to cocina_object_with(cocina_dro)
       end
     end
   end

--- a/spec/requests/collections_for_object_spec.rb
+++ b/spec/requests/collections_for_object_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Get the object' do
   end
 
   let(:collection_records) { [create(:collection)] }
-  let(:collections) { collection_records.map(&:to_cocina) }
+  let(:collections) { collection_records.map(&:to_cocina).map { |cocina_object| Cocina::Models.without_metadata(cocina_object) } }
 
   let(:expected) do
     {

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -166,6 +166,9 @@ RSpec.describe 'Create object' do
                    parsed_body = JSON.parse(req.body).deep_symbolize_keys
                    expect(parsed_body[:cocina_object]).to eq(expected.to_h)
                  end).to have_been_made
+          expect(response.headers['Last-Modified']).to end_with 'GMT'
+          expect(response.headers['X-Created-At']).to end_with 'GMT'
+          expect(response.headers['ETag']).to match(%r{W/".+"})
         end
       end
 


### PR DESCRIPTION
## Why was this change made? 🤔
Prevent confusion over immutable cocina objects.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file system, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, integration tests in QA

