### PR TITLE
Switch roundtrip validation failure HTTP status to unprocessable_entity

### DIFF
--- a/app/validators/cocina/roundtrip_validation_error.rb
+++ b/app/validators/cocina/roundtrip_validation_error.rb
@@ -4,7 +4,7 @@ module Cocina
   # Raised when a roundtrip validation fails
   class RoundtripValidationError < ValidationError
     def initialize(message)
-      super(message, status: :conflict)
+      super(message, status: :unprocessable_entity)
     end
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -1122,7 +1122,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '409':
-          description: Object with that sourceId already exists or roundtrip validation failed
+          description: Object with that sourceId already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Roundtrip validation has failed
           content:
             application/json:
               schema:
@@ -1187,7 +1193,13 @@ paths:
         '404':
           description: Object not found in DOR
         '409':
-          description: Object with that sourceId already exists or roundtrip validation failed
+          description: Object with that sourceId already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '412':
+          description: Roundtrip validation has failed
           content:
             application/json:
               schema:

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'Create object' do
         post '/v1/objects',
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.status).to eq(409)
+        expect(response).to have_http_status(:conflict)
         expect(response.body).to match(/druid:abc123/)
       end
     end
@@ -287,7 +287,7 @@ RSpec.describe 'Create object' do
           post '/v1/objects',
                params: data,
                headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-          expect(response.status).to eq(409)
+          expect(response).to have_http_status(:unprocessable_entity)
           expect(Honeybadger).to have_received(:notify)
         end
       end

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe 'Update object' do
         patch "/v1/objects/#{druid}",
               params: data,
               headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-        expect(response.status).to eq(409)
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(item).not_to have_received(:save!)
         expect(Honeybadger).to have_received(:notify)
       end


### PR DESCRIPTION

## Why was this change made? 🤔
This allows SDR-API to not have to parse the conflict error differently for different types of errors. See https://github.com/sul-dlss/sdr-api/issues/415.

Furthermore 412 is a better fit, as there is no value the user could change to bring it out of this conflict state.  Finally, UnexpectedBuildError already uses 412, and this makes the RoundtripValidationError consistent with that.



## How was this change tested? 🤨
Test suite.
