### PR TITLE
Fix the message returned on a source ID conflict

### DIFF
--- a/app/validators/cocina/unique_source_id_validator.rb
+++ b/app/validators/cocina/unique_source_id_validator.rb
@@ -14,6 +14,7 @@ module Cocina
     def valid?
       return true unless meets_preconditions?
 
+      # This message is pattern matched by sdr-api to parse out a druid.
       @error = "An object (#{duplicate_druid}) with the source ID '#{cocina_dro.identification.sourceId}' has already been registered." if duplicate_druid
 
       @error.nil?
@@ -39,7 +40,7 @@ module Cocina
 
       return if solr_response['response']['numFound'].zero?
 
-      solr_response['response']['docs'].map { |doc| doc['id'] }
+      solr_response['response']['docs'].first['id']
     end
 
     def meets_preconditions?

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe 'Create object' do
              params: data,
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
         expect(response).to have_http_status(:conflict)
-        expect(response.body).to match(/druid:abc123/)
+        expect(response.body).to match(/\(druid:abc123\)/)
       end
     end
 


### PR DESCRIPTION
Previously it was inspecting a single element array, but now it just shows the single conflicting druid

## Why was this change made? 🤔

Fixes https://github.com/sul-dlss/sdr-api/issues/415

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



