### PR TITLE
Adds migration audit script.

### DIFF
--- a/bin/migrate-audit
+++ b/bin/migrate-audit
@@ -1,0 +1,81 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Audits migration by determining if all druids are in the database.
+
+require_relative '../config/environment'
+require_relative '../lib/fedora_migrator'
+require 'optparse'
+require 'parallel'
+require 'tty-progressbar'
+
+options = { druids: [], input: 'druids.txt', processes: 4 }
+parser = OptionParser.new do |option_parser|
+  option_parser.banner = 'Usage: bin/migrate-audit [options]'
+
+  option_parser.on('-sSAMPLE', '--sample SAMPLE', Integer, 'Sample size, otherwise all druids.')
+  option_parser.on('-pPROCESSES', '--processes PROCESSES', Integer, "Number of processes. Default is #{options[:processes]}.")
+  option_parser.on('-dDRUIDS', '--druids DRUIDS', Array, 'List of druids (instead of druids.txt).')
+  option_parser.on('-iFILENAME', '--input FILENAME', String, 'File containing list of druids (instead of druids.txt).')
+  option_parser.on('-h', '--help', 'Displays help.') do
+    puts option_parser
+    exit
+  end
+end
+
+parser.parse!(into: options)
+
+druids ||= if options[:druids].empty?
+             file_druids = File.read(options[:input]).split
+             if options[:sample]
+               file_druids.take(options[:sample])
+             else
+               file_druids
+             end
+           else
+             options[:druids]
+           end
+
+def on_finish(druid, result, progress_bar, file)
+  progress_bar.advance(druid: druid)
+  file.write("#{druid}=#{result ? 'exists' : 'missing'}\n")
+end
+
+# how many druids to process as a single advance unit of the progress bar
+def num_for_progress_advance(count)
+  return 1 if count < 100
+
+  count / 100
+end
+
+def tty_progress_bar(count)
+  TTY::ProgressBar.new(
+    'Migrating fedora objects to postgres [:bar] (:percent (:current/:total), rate: :rate/s, mean rate: :mean_rate/s, :elapsed total, ETA: :eta_time)',
+    bar_format: :crate,
+    advance: num_for_progress_advance(count),
+    total: count
+  )
+end
+
+# rubocop:disable Rails/TimeZone
+# empirically proven to work, while a couple other approaches did not
+results_file_name = "migration-audit-#{Time.now.strftime('%Y-%m-%dT%H:%M:%S')}.txt"
+# rubocop:enable Rails/TimeZone
+
+results = []
+File.open("log/migration_results/#{results_file_name}", 'w') do |file|
+  progress_bar = tty_progress_bar(druids.size)
+  progress_bar.start
+  results = Parallel.map(druids,
+                         in_processes: options[:processes],
+                         finish: ->(druid, _, result) { on_finish(druid, result, progress_bar, file) }) do |druid|
+    cocina_object_store = CocinaObjectStore.new
+    cocina_object_store.ar_exists?(druid)
+  end
+end
+
+puts "Provided druids: #{druids.size}"
+found = results.count { |result| result }
+puts "Found: #{found}"
+missing = results.count(&:!)
+puts "Missing: #{missing}"


### PR DESCRIPTION
closes #3712

## Why was this change made? 🤔
Per @andrewjbtw allow verifying that all objects were migration from Fedora to PG.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

On DSA migrate:
```
[dor_services@dor-services-migrate current]$ RAILS_ENV=production bin/migrate-audit -i ~/druids.20220219.txt -s 250000
Provided druids: 250000
Found: 246283
Missing: 3717
```

