### PR TITLE
[Hold] Update uniform title mappings

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/name_builder.rb
+++ b/app/services/cocina/from_fedora/descriptive/name_builder.rb
@@ -51,6 +51,7 @@ module Cocina
           }.compact.merge(common_lang_script(name_node))
 
           name_attrs = name_attrs.merge(common_name(name_node, name_attrs[:name]))
+          name_attrs[:appliesTo] = [{ value: matching_title_value(name_node) }] if name_node['nameTitleGroup'].present? && name_node['altRepGroup'].present?
           name_parts = build_name_parts(name_node)
           notifier.warn('Missing name/namePart element') if name_parts.all?(&:empty?)
           name_parts.each { |name_part| name_attrs = name_part.merge(name_attrs) }
@@ -82,6 +83,13 @@ module Cocina
             roles = build_roles(name_node)
             attrs[:role] = roles unless name.nil?
           end.compact
+        end
+
+        def matching_title_value(name_node)
+          desired_name_title_group = name_node['nameTitleGroup']
+          xpath_expression = "//mods:titleInfo[@nameTitleGroup='#{desired_name_title_group}']"
+          matching_title_elements = name_node.xpath(xpath_expression, mods: DESC_METADATA_NS)
+          matching_title_elements.first&.content&.strip
         end
 
         def common_lang_script(name_node)

--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -77,7 +77,7 @@ module Cocina
 
         def simple_or_structured(node_set, display_types: true)
           node_set.filter_map do |node|
-            if node['nameTitleGroup']
+            if node['primary']
               structured_name(node: node, display_types: display_types)
             else
               attrs = Descriptive::TitleBuilder.build(title_info_element: node, notifier: notifier)

--- a/app/services/cocina/normalizers/mods/name_normalizer.rb
+++ b/app/services/cocina/normalizers/mods/name_normalizer.rb
@@ -22,6 +22,7 @@ module Cocina
           normalize_role_term
           normalize_role # must be after normalize_role_term
           normalize_name
+          normalize_corporate_needing_primary
           normalize_dupes
           normalize_type
           normalize_name_part_type
@@ -72,6 +73,17 @@ module Cocina
           ng_xml.xpath('//mods:name[@xlink:href and mods:*]', mods: ModsNormalizer::MODS_NS, xlink: ModsNormalizer::XLINK_NS).each do |node|
             node['valueURI'] = node.remove_attribute('href').value
           end
+        end
+
+        # assign usage="primary" to a single corporate name with nameTitleGroup if there is no other "primary" usage designation
+        def normalize_corporate_needing_primary
+          existing_primary_name = ng_xml.root.xpath('//mods:mods/mods:name[@usage="primary"]', mods: ModsNormalizer::MODS_NS)
+          return if existing_primary_name.present?
+
+          name_title_group_names = ng_xml.root.xpath('//mods:mods/mods:name[@nameTitleGroup][@type="corporate"]', mods: ModsNormalizer::MODS_NS)
+          return unless name_title_group_names.size == 1
+
+          name_title_group_names.first['usage'] = 'primary'
         end
 
         def normalize_dupes

--- a/app/services/cocina/to_fedora/descriptive/contributor.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor.rb
@@ -9,6 +9,7 @@ module Cocina
         NAME_TYPE = Cocina::FromFedora::Descriptive::Contributor::ROLES.invert.merge('event' => 'corporate').freeze
         NAME_PART = FromFedora::Descriptive::Contributor::NAME_PART.invert.freeze
 
+        # NOTE: contributors in nameTitleGroups are output as part of Title.
         # @params [Nokogiri::XML::Builder] xml
         # @params [Array<Cocina::Models::Contributor>] contributors
         # @params [Array<Cocina::Models::Title>] titles
@@ -24,9 +25,10 @@ module Cocina
           @id_generator = id_generator
         end
 
+        # NOTE: contributors in nameTitleGroups are output as part of Title.
         def write
           Array(contributors)
-            .reject { |contributor| NameTitleGroup.part_of_nametitlegroup?(contributor: contributor, titles: titles) }
+            .reject { |contributor| NameTitleGroup.in_name_title_group?(contributor: contributor, titles: titles) }
             .each { |contributor| ContributorWriter.write(xml: xml, contributor: contributor, id_generator: id_generator) }
         end
 

--- a/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
@@ -26,6 +26,7 @@ module Cocina
           @name_title_vals_index = name_title_vals_index
         end
 
+        # rubocop:disable Metrics/PerceivedComplexity
         def write
           if contributor.type == 'unspecified others'
             write_etal
@@ -41,6 +42,9 @@ module Cocina
                     name_title_group = name_title_vals_index[parallel_contrib_name_val][title_from_contrib]
                     write_parallel_contributor(contributor, contrib_name, parallel_contrib_name, name_title_group, altrepgroup_id)
                   else
+                    # TODO:  want a way to notify that we hit a problem - either notifier or HB error
+                    #  OR validate for semantic correctness upon creation/update so we can't get here.
+                    #  notifier.warn("For contributor name '#{parallel_contrib_name_val}', no title matching '#{title_from_contrib}'")
                     write_parallel_contributor(contributor, contrib_name, parallel_contrib_name, nil, altrepgroup_id)
                   end
                 end
@@ -50,6 +54,7 @@ module Cocina
             end
           end
         end
+        # rubocop:enable Metrics/PerceivedComplexity
 
         private
 

--- a/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
+++ b/app/services/cocina/to_fedora/descriptive/contributor_writer.rb
@@ -13,28 +13,37 @@ module Cocina
         # @params [Nokogiri::XML::Builder] xml
         # @params [Cocina::Models::Contributor] contributor
         # @params [IdGenerator] id_generator
-        # @params [String] name_title_group_indexes
-        def self.write(xml:, contributor:, id_generator:, name_title_group_indexes: {})
-          new(xml: xml, contributor: contributor, id_generator: id_generator, name_title_group_indexes: name_title_group_indexes).write
+        # @params [Hash<String=>Hash<String => Integer>>] name_title_vals_index key: contrib_name_val, value: { title_val => name_title_group }
+        #    e.g.  {"Israel Meir"=>{"Mishnah berurah. English"=>1}, "Israel Meir in Hebrew characters"=>{"Mishnah berurah in Hebrew characters"=>2}}
+        def self.write(xml:, contributor:, id_generator:, name_title_vals_index: {})
+          new(xml: xml, contributor: contributor, id_generator: id_generator, name_title_vals_index: name_title_vals_index).write
         end
 
-        def initialize(xml:, contributor:, id_generator:, name_title_group_indexes: {})
+        def initialize(xml:, contributor:, id_generator:, name_title_vals_index: {})
           @xml = xml
           @contributor = contributor
           @id_generator = id_generator
-          @name_title_group_indexes = name_title_group_indexes
+          @name_title_vals_index = name_title_vals_index
         end
 
         def write
           if contributor.type == 'unspecified others'
             write_etal
           elsif contributor.name.present?
-            parallel_values = contributor.name.first.parallelValue
+            contrib_name = contributor.name.first
+            parallel_values = contrib_name.parallelValue
             if parallel_values.present?
               altrepgroup_id = id_generator.next_altrepgroup
-              parallel_values.each_with_index do |parallel_value, index|
-                name_title_group = name_title_group_indexes.dig(0, index)
-                write_parallel_contributor(contributor, contributor.name.first, parallel_value, name_title_group, altrepgroup_id)
+              parallel_values.each do |parallel_contrib_name|
+                title_from_contrib = parallel_contrib_name.appliesTo&.first&.value
+                NameTitleGroup.value_strings(parallel_contrib_name)&.each do |parallel_contrib_name_val|
+                  if name_title_vals_index[parallel_contrib_name_val] && title_from_contrib
+                    name_title_group = name_title_vals_index[parallel_contrib_name_val][title_from_contrib]
+                    write_parallel_contributor(contributor, contrib_name, parallel_contrib_name, name_title_group, altrepgroup_id)
+                  else
+                    write_parallel_contributor(contributor, contrib_name, parallel_contrib_name, nil, altrepgroup_id)
+                  end
+                end
               end
             else
               write_contributor(contributor)
@@ -44,7 +53,7 @@ module Cocina
 
         private
 
-        attr_reader :xml, :contributor, :name_title_group_indexes, :id_generator
+        attr_reader :xml, :contributor, :name_title_vals_index, :id_generator
 
         def write_etal
           xml.name do
@@ -53,7 +62,22 @@ module Cocina
         end
 
         def write_contributor(contributor)
-          xml.name name_attributes(contributor, contributor.name.first, name_title_group_indexes[0]) do
+          first_contrib_name = contributor.name.first
+          title_from_contrib = first_contrib_name.appliesTo&.first&.value
+          name_title_group = nil
+          NameTitleGroup.value_strings(first_contrib_name)&.detect do |contrib_name_val|
+            name_title_group = if title_from_contrib
+                                 name_title_vals_index[contrib_name_val][title_from_contrib]
+                               else
+                                 # we may have a name_title_group from a primary contributor name, so
+                                 #  name_title_vals_index would look like this:
+                                 #  {"Shakespeare, William, 1564-1616"=>{"Hamlet"=>1}}
+                                 #  and we don't need to worry about WHICH title, because there is only one
+                                 name_title_vals_index[contrib_name_val]&.values&.first
+                               end
+          end
+
+          xml.name name_attributes(contributor, contributor.name.first, name_title_group) do
             contributor.name.each do |name|
               write_name(name)
             end

--- a/app/services/cocina/to_fedora/descriptive/title.rb
+++ b/app/services/cocina/to_fedora/descriptive/title.rb
@@ -225,7 +225,7 @@ module Cocina
           end.compact
         end
 
-        # @return [Integer] the integer to be used for a nameTitleGroup attrbute
+        # @return [Integer] the integer to be used for a nameTitleGroup attribute
         def name_title_group_number(title_value)
           # name_title_vals_index is [Hash<String, Hash<String, Integer>]
           #   with contrib name value as key,

--- a/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
+++ b/spec/services/cocina/from_fedora/descriptive/titles_spec.rb
@@ -253,25 +253,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
             ]
           },
           {
-            structuredValue: [
-              {
-                type: 'title',
-                value: 'Shaʻare ha-ḳedushah'
-              },
-              {
-                structuredValue: [
-                  {
-                    value: 'Vital, Ḥayyim ben Joseph',
-                    type: 'name'
-                  },
-                  {
-                    value: '1542 or 1543-1620',
-                    type: 'life dates'
-                  }
-                ],
-                type: 'name'
-              }
-            ],
+            value: 'Shaʻare ha-ḳedushah',
             type: 'uniform'
           }
         ]
@@ -302,25 +284,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
       it 'creates value from the authority record' do
         expect(build).to eq [
           {
-            structuredValue: [
-              {
-                value: 'Tractatus de intellectus emendatione. German',
-                type: 'title'
-              },
-              {
-                structuredValue: [
-                  {
-                    value: 'Spinoza, Benedictus de',
-                    type: 'name'
-                  },
-                  {
-                    value: '1632-1677',
-                    type: 'life dates'
-                  }
-                ],
-                type: 'name'
-              }
-            ],
+            value: 'Tractatus de intellectus emendatione. German',
             type: 'uniform'
           }
         ]
@@ -340,10 +304,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
         XML
       end
 
-      before do
-        allow(notifier).to receive(:warn)
-      end
-
       it 'parses' do
         expect { Cocina::Models::Description.new(title: build, purl: 'https://purl.stanford.edu/aa666bb1234') }.not_to raise_error
       end
@@ -351,12 +311,7 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
       it 'creates value from the authority record and warns' do
         expect(build).to eq [
           {
-            structuredValue: [
-              {
-                value: 'Hamlet',
-                type: 'title'
-              }
-            ],
+            value: 'Hamlet',
             type: 'uniform',
             uri: 'http://id.loc.gov/authorities/names/n80008522',
             source: {
@@ -365,7 +320,6 @@ RSpec.describe Cocina::FromFedora::Descriptive::Titles do
             }
           }
         ]
-        expect(notifier).to have_received(:warn).with('Name not found for title group')
       end
     end
 

--- a/spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb
@@ -598,39 +598,40 @@ RSpec.describe 'MODS relatedItem <--> cocina mappings' do
       let(:mods) do
         <<~XML
           <relatedItem type="constituent">
-            <titleInfo nameTitleGroup="1">
+            <titleInfo type="uniform" nameTitleGroup="1">
               <title>Contradizione</title>
             </titleInfo>
-            <name type="personal" nameTitleGroup="1">
+            <name type="personal" usage="primary" nameTitleGroup="1">
               <namePart>Bacewicz, Grayna.</namePart>
             </name>
           </relatedItem>
           <relatedItem type="constituent">
-            <titleInfo nameTitleGroup="1">
+            <titleInfo type="uniform" nameTitleGroup="1">
               <title>Concerto in one movement, marimba, orchestra</title>
             </titleInfo>
-            <name type="personal" nameTitleGroup="1">
+            <name type="personal" usage="primary" nameTitleGroup="1">
               <namePart>Diemer, Emma Lou.</namePart>
             </name>
           </relatedItem>
         XML
       end
 
+      # two distinct nameTitleGroups
       let(:roundtrip_mods) do
         <<~XML
           <relatedItem type="constituent">
-            <titleInfo nameTitleGroup="1">
+            <titleInfo type="uniform" nameTitleGroup="1">
               <title>Contradizione</title>
             </titleInfo>
-            <name type="personal" nameTitleGroup="1">
+            <name usage="primary" type="personal" nameTitleGroup="1">
               <namePart>Bacewicz, Grayna.</namePart>
             </name>
           </relatedItem>
           <relatedItem type="constituent">
-            <titleInfo nameTitleGroup="2">
+            <titleInfo type="uniform" nameTitleGroup="2">
               <title>Concerto in one movement, marimba, orchestra</title>
             </titleInfo>
-            <name type="personal" nameTitleGroup="2">
+            <name usage="primary" type="personal" nameTitleGroup="2">
               <namePart>Diemer, Emma Lou.</namePart>
             </name>
           </relatedItem>
@@ -647,16 +648,8 @@ RSpec.describe 'MODS relatedItem <--> cocina mappings' do
             {
               title: [
                 {
-                  structuredValue: [
-                    {
-                      type: 'title',
-                      value: 'Contradizione'
-                    },
-                    {
-                      value: 'Bacewicz, Grayna.',
-                      type: 'name'
-                    }
-                  ]
+                  value: 'Contradizione',
+                  type: 'uniform'
                 }
               ],
               contributor: [
@@ -666,7 +659,8 @@ RSpec.describe 'MODS relatedItem <--> cocina mappings' do
                       value: 'Bacewicz, Grayna.'
                     }
                   ],
-                  type: 'person'
+                  type: 'person',
+                  status: 'primary'
                 }
               ],
               type: 'has part'
@@ -674,16 +668,8 @@ RSpec.describe 'MODS relatedItem <--> cocina mappings' do
             {
               title: [
                 {
-                  structuredValue: [
-                    {
-                      type: 'title',
-                      value: 'Concerto in one movement, marimba, orchestra'
-                    },
-                    {
-                      value: 'Diemer, Emma Lou.',
-                      type: 'name'
-                    }
-                  ]
+                  value: 'Concerto in one movement, marimba, orchestra',
+                  type: 'uniform'
                 }
               ],
               contributor: [
@@ -693,7 +679,8 @@ RSpec.describe 'MODS relatedItem <--> cocina mappings' do
                       value: 'Diemer, Emma Lou.'
                     }
                   ],
-                  type: 'person'
+                  type: 'person',
+                  status: 'primary'
                 }
               ],
               type: 'has part'

--- a/spec/services/cocina/mapping/descriptive/mods/title_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/title_info_spec.rb
@@ -1221,6 +1221,80 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
     end
   end
 
+  describe 'Uniform title with multiple corporate authors' do
+    # based on jp357bb8866
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <titleInfo usage="primary">
+            <title>Primary title</title>
+          </titleInfo>
+          <titleInfo type="uniform" nameTitleGroup="1">
+            <title>Uniform title</title>
+          </titleInfo>
+          <name type="corporate" nameTitleGroup="1">
+            <namePart>nameTitleGroup corp</namePart>
+          </name>
+          <name type="corporate">
+            <namePart>2nd corp</namePart>
+          </name>
+        XML
+      end
+
+      # add status primary to nameTitleGroup name
+      let(:roundtrip_mods) do
+        <<~XML
+          <titleInfo usage="primary">
+            <title>Primary title</title>
+          </titleInfo>
+          <titleInfo type="uniform" nameTitleGroup="1">
+            <title>Uniform title</title>
+          </titleInfo>
+          <name type="corporate" nameTitleGroup="1" usage="primary">
+            <namePart>nameTitleGroup corp</namePart>
+          </name>
+          <name type="corporate">
+            <namePart>2nd corp</namePart>
+          </name>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          title: [
+            {
+              value: 'Primary title',
+              status: 'primary'
+            },
+            {
+              value: 'Uniform title',
+              type: 'uniform'
+            }
+          ],
+          contributor: [
+            {
+              name: [
+                {
+                  value: 'nameTitleGroup corp'
+                }
+              ],
+              type: 'organization',
+              status: 'primary'
+            },
+            {
+              name: [
+                {
+                  value: '2nd corp'
+                }
+              ],
+              type: 'organization'
+            }
+          ]
+        }
+      end
+    end
+  end
+
   # Data error handling
 
   describe 'Complex multilingual title' do

--- a/spec/services/cocina/mapping/descriptive/mods/title_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/title_info_spec.rb
@@ -329,13 +329,13 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
   end
 
   describe 'Uniform title with authority and primary title' do
-    # How to ID: titleInfo type="uniform"
-    # NOTE: For MODS roundtrip of uniform titles, assign the nameTitleGroup to
-    # 1) name with status "primary" in contributor with status "primary" or
-    # 2) first name in contributor with status "primary" or
-    # 3) if "appliesTo" is present, the title that matches that value
+    # How to ID assign nameTitleGroup to MODS from cocina:
+    #  for cocina title of type "uniform", look for:
+    # 1) name of status "primary" within a contributor of status "primary" or
+    # 2) first name in a contributor with status "primary" or
+    # 3) if "appliesTo" value is present in name, the title that matches that value
     # If none of those criteria are met in Cocina, do not assign nameTitleGroup in MODS
-    xit 'update not implemented' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <titleInfo usage="primary">
@@ -391,7 +391,7 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
   end
 
   describe 'Uniform title with multiple namePart subelements' do
-    xit 'update not implemented' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <titleInfo type="uniform" nameTitleGroup="1">
@@ -443,7 +443,7 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
   end
 
   describe 'Name-title authority plus additional contributor not part of uniform title' do
-    xit 'update not implemented' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <titleInfo type="uniform" authority="naf" authorityURI="http://id.loc.gov/authorities/names/"
@@ -511,13 +511,7 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
   describe 'Uniform title with repetition of author' do
     # Adapted from kd992vz2371
     # Ignore usage and nameTitleGroup when determining duplication; all subelements of name should be exact duplication
-    let(:warnings) do
-      [
-        Notification.new(msg: 'Duplicate name entry')
-      ]
-    end
-
-    xit 'update not implemented' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <titleInfo type="uniform" nameTitleGroup="1">
@@ -529,6 +523,19 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
             <namePart type="date">active 1230</namePart>
           </name>
           <name type="personal">
+            <namePart>Guillaume</namePart>
+            <namePart type="termsOfAddress">de Lorris</namePart>
+            <namePart type="date">active 1230</namePart>
+          </name>
+        XML
+      end
+
+      let(:roundtrip_mods) do
+        <<~XML
+          <titleInfo type="uniform" nameTitleGroup="1">
+            <title>Roman de la Rose. 1878</title>
+          </titleInfo>
+          <name type="personal" usage="primary" nameTitleGroup="1">
             <namePart>Guillaume</namePart>
             <namePart type="termsOfAddress">de Lorris</namePart>
             <namePart type="date">active 1230</namePart>
@@ -566,37 +573,22 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
               ],
               type: 'person',
               status: 'primary'
-            },
-            {
-              name: [
-                {
-                  structuredValue: [
-                    {
-                      value: 'Guillaume',
-                      type: 'name'
-                    },
-                    {
-                      value: 'de Lorris',
-                      type: 'term of address'
-                    },
-                    {
-                      value: 'active 1230',
-                      type: 'activity dates'
-                    }
-                  ]
-                }
-              ],
-              type: 'person'
             }
           ]
         }
+      end
+
+      let(:warnings) do
+        [
+          Notification.new(msg: 'Duplicate name entry')
+        ]
       end
     end
   end
 
   describe 'Uniform title with repetition of author plus role' do
     # Adapted from bf818dg3045
-    xit 'update not implemented' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <titleInfo>
@@ -906,10 +898,105 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
     end
   end
 
+  describe 'Parallel uniform title in nameTitleGroup with parallel contributor NAME' do
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <titleInfo type="uniform" nameTitleGroup="1" altRepGroup="1">
+            <title>Mishnah berurah. English</title>
+          </titleInfo>
+          <titleInfo type="uniform" nameTitleGroup="2" altRepGroup="1">
+            <title>Mishnah berurah in Hebrew characters</title>
+          </titleInfo>
+          <name type="personal" usage="primary" altRepGroup="2" nameTitleGroup="1">
+            <namePart>Israel Meir</namePart>
+            <namePart type="termsOfAddress">ha-Kohen</namePart>
+          </name>
+          <name type="personal" altRepGroup="2" nameTitleGroup="2">
+            <namePart>Israel Meir in Hebrew characters</namePart>
+            <namePart type="date">1838-1933</namePart>
+          </name>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          title: [
+            {
+              parallelValue: [
+                {
+                  value: 'Mishnah berurah. English'
+                },
+                {
+                  value: 'Mishnah berurah in Hebrew characters'
+                }
+              ],
+              type: 'uniform'
+            }
+          ],
+          contributor: [
+            {
+              name: [
+                {
+                  parallelValue: [
+                    {
+                      structuredValue: [
+                        {
+                          value: 'Israel Meir',
+                          type: 'name'
+                        },
+                        {
+                          value: 'ha-Kohen',
+                          type: 'term of address'
+                        }
+                      ],
+                      status: 'primary',
+                      appliesTo: [
+                        {
+                          value: 'Mishnah berurah. English'
+                        }
+                      ]
+                    },
+                    {
+                      structuredValue: [
+                        {
+                          value: 'Israel Meir in Hebrew characters',
+                          type: 'name'
+                        },
+                        {
+                          value: '1838-1933',
+                          type: 'life dates'
+                        }
+                      ],
+                      appliesTo: [
+                        {
+                          value: 'Mishnah berurah in Hebrew characters'
+                        }
+                      ]
+                    }
+                  ],
+                  type: 'person',
+                  status: 'primary'
+                }
+              ]
+            }
+          ]
+        }
+      end
+    end
+  end
+
   describe 'Multilingual uniform title' do
     # adapted from cv621pf3709
     # NOTE: clunky workaround for MARC data
-    xit 'updated spec not implemented' do
+
+    # How to ID assign nameTitleGroup to MODS from cocina:
+    #  for cocina title of type "uniform", look for:
+    # 1) name of status "primary" within a contributor of status "primary" or
+    # 2) first name in a contributor with status "primary" or
+    # 3) if "appliesTo" value is present in name, the title that matches that value
+    # If none of those criteria are met in Cocina, do not assign nameTitleGroup in MODS
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <titleInfo>
@@ -1098,7 +1185,7 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
   end
 
   describe 'Uniform title with corporate author' do
-    xit 'updated spec not implemented' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <titleInfo type="uniform" nameTitleGroup="1">
@@ -1210,25 +1297,7 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
               ]
             },
             {
-              structuredValue: [
-                {
-                  value: 'Shaʻare ha-ḳedushah',
-                  type: 'title'
-                },
-                {
-                  structuredValue: [
-                    {
-                      value: 'Vital, Ḥayyim ben Joseph',
-                      type: 'name'
-                    },
-                    {
-                      value: '1542 or 1543-1620',
-                      type: 'life dates'
-                    }
-                  ],
-                  type: 'name'
-                }
-              ],
+              value: 'Shaʻare ha-ḳedushah',
               type: 'uniform'
             }
           ],

--- a/spec/services/cocina/mapping/descriptive/mods/title_info_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/title_info_spec.rb
@@ -1326,6 +1326,212 @@ RSpec.describe 'MODS titleInfo <--> cocina mappings' do
     end
   end
 
+  describe 'unmatching nameTitleGroup' do
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <titleInfo type="uniform" nameTitleGroup="1" altRepGroup="1">
+            <title>English title</title>
+          </titleInfo>
+          <titleInfo type="uniform" nameTitleGroup="3" altRepGroup="1">
+            <title>Esperanto title</title>
+          </titleInfo>
+          <name type="personal" usage="primary" altRepGroup="2" nameTitleGroup="1">
+            <namePart>Vinsky Cat</namePart>
+          </name>
+          <name type="personal" altRepGroup="2" nameTitleGroup="4">
+            <namePart>Wingnut Cat in Esperanto</namePart>
+          </name>
+        XML
+      end
+
+      # remove unmatched nameTitleGroup from titleInfo and name elements
+      let(:roundtrip_mods) do
+        <<~XML
+          <titleInfo type="uniform" nameTitleGroup="1" altRepGroup="1">
+            <title>English title</title>
+          </titleInfo>
+          <titleInfo type="uniform" altRepGroup="1">
+            <title>Esperanto title</title>
+          </titleInfo>
+          <name type="personal" usage="primary" altRepGroup="2" nameTitleGroup="1">
+            <namePart>Vinsky Cat</namePart>
+          </name>
+          <name type="personal" altRepGroup="2">
+            <namePart>Wingnut Cat in Esperanto</namePart>
+          </name>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          title: [
+            {
+              parallelValue: [
+                {
+                  value: 'English title'
+                },
+                {
+                  value: 'Esperanto title'
+                }
+              ],
+              type: 'uniform'
+            }
+          ],
+          contributor: [
+            {
+              name: [
+                {
+                  parallelValue: [
+                    {
+                      value: 'Vinsky Cat',
+                      status: 'primary',
+                      appliesTo: [
+                        {
+                          value: 'English title'
+                        }
+                      ]
+                    },
+                    {
+                      value: 'Wingnut Cat in Esperanto'
+                    }
+                  ],
+                  type: 'person',
+                  status: 'primary'
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      let(:warnings) do
+        [
+          Notification.new(msg: "For name 'Wingnut Cat in Esperanto', no title matching nameTitleGroup 4.")
+        ]
+      end
+    end
+  end
+
+  describe 'unmatching appliesTo' do
+    it_behaves_like 'cocina MODS mapping' do
+      let(:cocina) do
+        {
+          title: [
+            {
+              parallelValue: [
+                {
+                  value: 'English title'
+                },
+                {
+                  value: 'Esperanto title'
+                }
+              ],
+              type: 'uniform'
+            }
+          ],
+          contributor: [
+            {
+              name: [
+                {
+                  parallelValue: [
+                    {
+                      value: 'Vinsky Cat',
+                      status: 'primary',
+                      appliesTo: [
+                        {
+                          value: 'English title'
+                        }
+                      ]
+                    },
+                    {
+                      value: 'Wingnut Cat in Esperanto',
+                      appliesTo: [
+                        {
+                          value: 'Unmatched value'
+                        }
+                      ]
+                    }
+                  ],
+                  type: 'person',
+                  status: 'primary'
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      # remove unmatched appliesTo value from contributor
+      let(:roundtrip_cocina) do
+        {
+          title: [
+            {
+              parallelValue: [
+                {
+                  value: 'English title'
+                },
+                {
+                  value: 'Esperanto title'
+                }
+              ],
+              type: 'uniform'
+            }
+          ],
+          contributor: [
+            {
+              name: [
+                {
+                  parallelValue: [
+                    {
+                      value: 'Vinsky Cat',
+                      status: 'primary',
+                      appliesTo: [
+                        {
+                          value: 'English title'
+                        }
+                      ]
+                    },
+                    {
+                      value: 'Wingnut Cat in Esperanto'
+                    }
+                  ],
+                  type: 'person',
+                  status: 'primary'
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      let(:mods) do
+        <<~XML
+          <titleInfo type="uniform" nameTitleGroup="1" altRepGroup="1">
+            <title>English title</title>
+          </titleInfo>
+          <titleInfo type="uniform" altRepGroup="1">
+            <title>Esperanto title</title>
+          </titleInfo>
+          <name type="personal" usage="primary" altRepGroup="2" nameTitleGroup="1">
+            <namePart>Vinsky Cat</namePart>
+          </name>
+          <name type="personal" altRepGroup="2">
+            <namePart>Wingnut Cat in Esperanto</namePart>
+          </name>
+        XML
+      end
+
+      # TODO:  want a way to notify that we hit a problem - either notifier or HB error
+      #  OR validate for semantic correctness upon creation/update so we can't get here.
+      # let(:warnings) do
+      #   [
+      #     Notification.new(msg: "For contributor name 'Wingnut Cat in Esperanto', no title matching 'Unmatched value'")
+      #   ]
+      # end
+    end
+  end
+
   describe 'Multiple titles with primary' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do


### PR DESCRIPTION
HOLD for final signoff by @justinlittman and @arcadiafalcone;  I believe this is ready for prime time.

## WAIT FOR the following before merging:

- ~~@arcadiafalcone will need to address the five failing related_item mapping specs (all part of one mapping spec)
    from /spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb:597~~
    ```
    rspec ./spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb[1:16:1:1:3] # MODS relatedItem <--> cocina mappings Multiple related items with nameTitleGroups behaves like MODS cocina mapping when mapping from MODS (to cocina) MODS maps to expected cocina
    rspec ./spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb[1:16:1:3:1] # MODS relatedItem <--> cocina mappings Multiple related items with nameTitleGroups behaves like MODS cocina mapping when mapping from roundtrip MODS (to cocina) roundtrip MODS maps to expected cocina
    rspec ./spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb[1:16:1:3:3] # MODS relatedItem <--> cocina mappings Multiple related items with nameTitleGroups behaves like MODS cocina mapping when mapping from roundtrip MODS (to cocina) roundtrip cocina maps to normalized roundtrip MODS
    rspec ./spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb[1:16:1:3:2] # MODS relatedItem <--> cocina mappings Multiple related items with nameTitleGroups behaves like MODS cocina mapping when mapping from roundtrip MODS (to cocina) roundtrip cocina maps to roundtrip MODS
    rspec ./spec/services/cocina/mapping/descriptive/mods/related_item_spec.rb[1:16:1:2:1] # MODS relatedItem <--> cocina mappings Multiple related items with nameTitleGroups behaves like MODS cocina mapping when mapping to MODS (from cocina) cocina Description maps to expected MODS
    ```
- ~~Arcadia should look at the specs I changed so they would pass -- they are in the 2 last commits.~~
    These are uniform title mappings that already existed.
    - spec/services/cocina/from_fedora/descriptive/titles_spec.rb
    - spec/services/cocina/mapping/descriptive/mods/title_info_spec.rb - a couple places
- **Arcadia  has found at least one more real life example of a gnarly case that should be added to the specs** (and hopefully work) ... and I would prefer we add it in as a separate PR.
- ~~SDR deploy testing~~
- **new spec**
- **SDR testing showing IMPROVEMENT**

## Why was this change made? 🤔

(re)implement Arcadia's mappings for MODS nameTitleGroup, or "uniform title mappings"

It is possible that the code I wrote is inefficient - maybe calling the methods in NameTitleGroups more often than is strictly required.  I don't care, as the code works, and it only affects uniform title mappings.

Fixes #2699

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

mapping specs.

### After (my branch)

this is NOT good.

```
Status (n=500000; not using Missing for success/different/error stats):
  Success:   494186 (98.918%)
  Different: 5347 (1.07%)
  Mapping error:     58 (0.012%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     409 (0.082%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

### Before (main branch)

```
Status (n=500000; not using Missing for success/different/error stats):
  Success:   498956 (99.873%)
  Different: 577 (0.115%)
  Mapping error:     58 (0.012%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     409 (0.082%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```


