### PR TITLE
Default required DRO & collection metadata to an empty hash instead of nil

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,7 +4,12 @@
 class Collection < ApplicationRecord
   # @return [Cocina::Models::Collection] Cocina collection
   def to_cocina
-    Cocina::Models::Collection.new({
+    Cocina::Models::Collection.new(to_h)
+  end
+
+  # @return [Hash] collection instance as a hash
+  def to_h
+    {
       cocinaVersion: cocina_version,
       type: collection_type,
       externalIdentifier: external_identifier,
@@ -13,8 +18,8 @@ class Collection < ApplicationRecord
       access: access,
       administrative: administrative,
       description: description,
-      identification: identification
-    }.compact)
+      identification: identification || {}
+    }.compact
   end
 
   # @param [Cocina::Models::Collection] Cocina collection

--- a/app/models/dro.rb
+++ b/app/models/dro.rb
@@ -4,7 +4,12 @@
 class Dro < ApplicationRecord
   # @return [Cocina::Models::DRO] Cocina Digital Repository Object
   def to_cocina
-    Cocina::Models::DRO.new({
+    Cocina::Models::DRO.new(to_h)
+  end
+
+  # @return [Hash] DRO/item instance as a hash
+  def to_h
+    {
       cocinaVersion: cocina_version,
       type: content_type,
       externalIdentifier: external_identifier,
@@ -14,9 +19,9 @@ class Dro < ApplicationRecord
       administrative: administrative,
       description: description,
       identification: identification,
-      structural: structural,
+      structural: structural || {},
       geographic: geographic
-    }.compact)
+    }.compact
   end
 
   # @param [Cocina::Models::DRO] Cocina Digital Repository Object

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe Collection do
     end
   end
 
+  describe 'to_h' do
+    context 'with a collection lacking identification metadata' do
+      let(:collection) { create(:collection, external_identifier: druid, identification: nil) }
+
+      it 'returns a valid Cocina hash' do
+        expect { Cocina::Models::Collection.new(collection.to_h) }.not_to raise_error(Cocina::Models::ValidationError)
+      end
+    end
+  end
+
   describe 'from_cocina' do
     let(:collection) { described_class.from_cocina(cocina_collection) }
 

--- a/spec/models/dro_spec.rb
+++ b/spec/models/dro_spec.rb
@@ -102,6 +102,16 @@ RSpec.describe Dro do
 
   let(:source_id) { 'googlebooks:9999999' }
 
+  describe 'to_h' do
+    context 'with a DRO lacking structural metadata' do
+      let(:dro) { create(:dro, external_identifier: druid, structural: nil) }
+
+      it 'returns a valid Cocina hash' do
+        expect { Cocina::Models::DRO.new(dro.to_h) }.not_to raise_error(Cocina::Models::ValidationError)
+      end
+    end
+  end
+
   describe 'to_cocina' do
     context 'with minimal DRO' do
       let(:dro) { create(:dro, external_identifier: druid) }


### PR DESCRIPTION
## Why was this change made? 🤔

Patches a bug we are seeing in QA since QA has collections w/o identification metadata (and DROs w/o structural metadata) and cocina-models 0.70.0 now requires both of these.


## How was this change tested? 🤨

CI + tested in QA
