### PR TITLE
Do not assume all identification metadata has barcodes

### DIFF
--- a/app/controllers/metadata_refresh_controller.rb
+++ b/app/controllers/metadata_refresh_controller.rb
@@ -24,6 +24,9 @@ class MetadataRefreshController < ApplicationController
     return [] unless @cocina_object.identification&.catalogLinks
 
     @identifiers ||= @cocina_object.identification.catalogLinks.filter_map { |clink| "catkey:#{clink.catalogRecordId}" if clink.catalog == 'symphony' }.tap do |id|
+      # Not all Cocina objects have identification metadata that includes barcodes (e.g., collections)
+      next unless @cocina_object.identification.try(:barcode)
+
       id << "barcode:#{@cocina_object.identification.barcode}" if @cocina_object.identification.barcode
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes a production bug: https://app.honeybadger.io/projects/50568/faults/84622595

This exception is raised when acting on a collection: collection identification metadata does not include barcodes, so this raises a `NoMethodError`.


## How was this change tested? 🤨

CI
