### PR TITLE
Handle empty titles when mapping uniform titles.

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/titles.rb
+++ b/app/services/cocina/from_fedora/descriptive/titles.rb
@@ -96,11 +96,9 @@ module Cocina
                                 NameBuilder.build(name_elements: [name_node], notifier: notifier)[:name]
                               end
           structured_values.each { |structured_value| structured_value[:type] = 'name' }
-          {
-            structuredValue: [
-              { type: 'title' }.merge(TitleBuilder.build(title_info_element: node, notifier: notifier))
-            ].concat(structured_values)
-          }.merge(common_attributes(node, display_types: display_types))
+          title = TitleBuilder.build(title_info_element: node, notifier: notifier)
+          structured_values.unshift({ type: 'title' }.merge(title)) if title
+          { structuredValue: structured_values }.merge(common_attributes(node, display_types: display_types))
         end
 
         # @param [Hash<Symbol,String>] value


### PR DESCRIPTION
closes #3752

## Why was this change made? 🤔
Handle anomalous data without raising.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

