### PR TITLE
Allow empty constituents in openapi to allow clearing virtual objects.

### DIFF
--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -130,7 +130,9 @@ module Cocina
       # Note that a change to a book content type will generate completely new
       # structural metadata, and thus lead to a full replacement of the
       # contentMetadata with the new bookData node.
-      if cocina_object.structural&.contains.present? || cocina_object.structural&.hasMemberOrders&.first&.members&.present?
+      if cocina_object.structural&.contains.present? ||
+         cocina_object.structural&.hasMemberOrders&.first&.members&.present? ||
+         fedora_object.contentMetadata.ng_xml.xpath('//externalFile').present?
         fedora_object.contentMetadata.content = Cocina::ToFedora::ContentMetadataGenerator.generate(
           druid: cocina_object.externalIdentifier,
           type: cocina_object.type,

--- a/openapi.yml
+++ b/openapi.yml
@@ -3254,7 +3254,6 @@ components:
           $ref: '#/components/schemas/Druid'
         constituent_ids:
           type: array
-          minItems: 1
           items:
             $ref: '#/components/schemas/Druid'
     UpdateLegacyMetadata:

--- a/spec/requests/batch_create_virtual_objects_spec.rb
+++ b/spec/requests/batch_create_virtual_objects_spec.rb
@@ -107,13 +107,13 @@ RSpec.describe 'Batch creation of virtual objects' do
   end
 
   context 'when virtual_objects array has a hash w/ constituent_ids empty' do
-    it 'renders an error' do
+    it 'queues a background job to create a virtual object' do
       post '/v1/virtual_objects',
            params: { virtual_objects: [{ virtual_object_id: 'druid:bb111cc3333', constituent_ids: [] }] }.to_json,
            headers: { 'Authorization' => "Bearer #{jwt}", 'CONTENT_TYPE' => 'application/json' }
-      expect(CreateVirtualObjectsJob).not_to have_received(:perform_later)
-      expect(response).to have_http_status(:bad_request)
-      expect(body['errors'][0]['detail']).to eq('#/components/schemas/VirtualObjectRequest/properties/constituent_ids [] contains fewer than min items')
+      expect(CreateVirtualObjectsJob).to have_received(:perform_later)
+      expect(response).to have_http_status(:created)
+      expect(response.location).to match(%r{http://www.example.com/v1/background_job_results/\d+})
     end
   end
 


### PR DESCRIPTION
refs https://github.com/sul-dlss/argo/issues/2821

## Why was this change made? 🤔
To allow clearing constitutuents from a virtual object.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

QA

