### PR TITLE
Handle DROWithMetadata in SynchronousIndexer.

### DIFF
--- a/app/services/synchronous_indexer.rb
+++ b/app/services/synchronous_indexer.rb
@@ -4,7 +4,7 @@
 # When we can't have latency in the indexing, we can use this class to directly call dor-indexing-app
 class SynchronousIndexer
   def self.reindex_remotely_from_cocina(cocina_object:, created_at:, updated_at:)
-    body = { cocina_object: cocina_object, created_at: created_at, updated_at: updated_at }.to_json
+    body = { cocina_object: Cocina::Models.without_metadata(cocina_object), created_at: created_at, updated_at: updated_at }.to_json
     result = connection.put('reindex_from_cocina', body, { 'Content-Type' => 'application/json' })
     return if result.success?
 

--- a/spec/services/synchronous_indexer_spec.rb
+++ b/spec/services/synchronous_indexer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SynchronousIndexer do
     let(:dro) { create(:dro) }
     let(:cocina_object) { dro.to_cocina }
     let(:created_at) { Time.zone.now }
-    let(:req_body) { { cocina_object: cocina_object, created_at: created_at, updated_at: created_at }.to_json }
+    let(:req_body) { { cocina_object: dro.to_cocina, created_at: created_at, updated_at: created_at }.to_json }
 
     context 'with a successful request' do
       before do
@@ -18,7 +18,15 @@ RSpec.describe SynchronousIndexer do
           .to_return(status: 200, body: '', headers: {})
       end
 
-      it { is_expected.to be_nil }
+      context 'with a DRO' do
+        it { is_expected.to be_nil }
+      end
+
+      context 'with a DROWithMetadata' do
+        let(:cocina_object) { Cocina::Models.with_metadata(dro.to_cocina, '1') }
+
+        it { is_expected.to be_nil }
+      end
     end
 
     context 'with an unsuccessful request' do


### PR DESCRIPTION
## Why was this change made? 🤔
So that SynchronousIndexer passes a cocina object without metadata. DIA does not expect the metadata.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

