### PR TITLE
Make the ETag value opaque.

### DIFF
--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -184,7 +184,7 @@ class CocinaObjectStore
   end
 
   def fedora_lock_for(fedora_object)
-    fedora_object.modified_date.to_datetime.iso8601
+    ActiveSupport::Digest.hexdigest(fedora_object.pid + fedora_object.modified_date.to_datetime.iso8601)
   end
 
   # @return [Array] array consisting of created date and modified date
@@ -273,7 +273,7 @@ class CocinaObjectStore
   end
 
   def ar_lock_for(ar_cocina_object)
-    ar_cocina_object.lock.to_s
+    ActiveSupport::Digest.hexdigest(ar_cocina_object.external_identifier + ar_cocina_object.lock.to_s)
   end
 
   # Find an ActiveRecord Cocina object.

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -133,12 +133,13 @@ RSpec.describe 'Update object' do
       doi: '10.25740/gg777gg7777'
     }
   end
+  let(:etag) { ActiveSupport::Digest.hexdigest(druid + modified.iso8601) }
 
   let(:headers) do
     {
       'Authorization' => "Bearer #{jwt}",
       'Content-Type' => 'application/json',
-      'If-Match' => "W/\"#{modified.iso8601}\""
+      'If-Match' => "W/\"#{etag}\""
     }
   end
 
@@ -468,6 +469,8 @@ RSpec.describe 'Update object' do
     before do
       allow(Dor).to receive(:find).with(other_druid).and_return(item)
     end
+
+    let(:etag) { ActiveSupport::Digest.hexdigest(other_druid + modified.iso8601) }
 
     let(:item) do
       Dor::Item.new(pid: other_druid,

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe CocinaObjectStore do
 
   let(:date) { Time.zone.now }
 
-  let(:lock) { date.to_datetime.iso8601 }
+  let(:lock) { ActiveSupport::Digest.hexdigest(druid + date.to_datetime.iso8601) }
 
   describe 'to Fedora' do
-    let(:item) { instance_double(Dor::Item, modified_date: date.to_time) }
+    let(:item) { instance_double(Dor::Item, pid: druid, modified_date: date.to_time) }
     let(:cocina_object) do
       Cocina::Models::DRO.new(
         type: Cocina::Models::ObjectType.book,
@@ -158,7 +158,7 @@ RSpec.describe CocinaObjectStore do
         let(:saved_cocina_object) { cocina_object_store.save(cocina_object_with_metadata) }
         let(:cocina_object_store) { described_class.new }
 
-        let(:lock) { date.utc.iso8601 }
+        let(:lock) { ActiveSupport::Digest.hexdigest(druid + date.utc.iso8601) }
 
         before do
           allow(Dor).to receive(:find).and_return(item)


### PR DESCRIPTION


## Why was this change made? 🤔
The RFC (https://datatracker.ietf.org/doc/html/rfc7232#section-2.3) specifies opqaue ETags, so opaqify them.


## How was this change tested? 🤨
