### PR TITLE
Fix bug with pruning Access druids

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'datacite', '~> 0.3.0'
 gem 'dor-rights-auth', '>= 1.5.0' # required for new CDL rights
 gem 'dor-services', '~> 9.6'
 gem 'dor-workflow-client', '~> 4.0'
+gem 'druid-tools', '~> 2.2'
 gem 'marc'
 gem 'moab-versioning', '~> 5.0', require: 'moab/stanford'
 gem 'preservation-client', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,7 @@ GEM
       faraday-retry
       nokogiri (~> 1.6)
       zeitwerk (~> 2.1)
-    druid-tools (2.1.0)
+    druid-tools (2.2.1)
       deprecation
     dry-configurable (0.14.0)
       concurrent-ruby (~> 1.0)
@@ -567,6 +567,7 @@ DEPENDENCIES
   dor-services (~> 9.6)
   dor-services-client
   dor-workflow-client (~> 4.0)
+  druid-tools (~> 2.2)
   dry-monads
   dry-schema (~> 1.4)
   equivalent-xml

--- a/app/services/prune_service.rb
+++ b/app/services/prune_service.rb
@@ -9,10 +9,9 @@ class PruneService
 
   # @raise [Errno::ENOTEMPTY] if the directory is not empty
   def prune!
-    this_path = druid.pathname
-    parent = this_path.parent
-    parent.rmtree if parent.exist? && parent != druid.base_pathname
-    prune_ancestors parent.parent
+    target = druid.pruning_base
+    target.rmtree if target.exist? && target != druid.base_pathname
+    prune_ancestors target.parent
   end
 
   # @param [Pathname] outermost_branch The branch at which pruning begins


### PR DESCRIPTION
## Why was this change made? 🤔

Do not delete the parent when pruning Access druids, since these druids lack the extra leaf (ID) directory that non-Access druids have. This is causing unintentional pruning of the Stacks.


## How was this change tested? 🤨

CI
