### PR TITLE
Report on desc metadata identifier type

### DIFF
--- a/bin/reports/report-desc-identifier-type
+++ b/bin/reports/report-desc-identifier-type
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/unique_report'
+
+UniqueReport.new(name: 'desc-identifier_types', dsids: ['descMetadata']).run do |ng_xml|
+  ng_xml.xpath('//mods:identifier/@type', mods: MODS_NS).map(&:content)
+end


### PR DESCRIPTION
## Why was this change made? 🤔
Fixes #3783. 

## How was this change tested? 🤨
Run on sdr-deploy: `bin/reports/report-desc-identifier-type -i druids.txt`

There were 48 values in the result, including `""`, which may appear as a blank line in the attached file, depending on how you're viewing it.  
[results-identifiers.txt](https://github.com/sul-dlss/dor-services-app/files/8398607/results-identifiers.txt)


⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



