### PR TITLE
Compare the opaque lock value for active-record based models

### DIFF
--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -256,12 +256,13 @@ class CocinaObjectStore
   end
 
   def ar_check_lock(cocina_object)
-    lock = Dro.where(external_identifier: cocina_object.externalIdentifier).limit(1).pluck(:lock).first ||
-           AdminPolicy.where(external_identifier: cocina_object.externalIdentifier).limit(1).pluck(:lock).first ||
-           Collection.where(external_identifier: cocina_object.externalIdentifier).limit(1).pluck(:lock).first
-    return if cocina_object.respond_to?(:lock) && lock&.to_s == cocina_object.lock
+    ar_object = Dro.find_by(external_identifier: cocina_object.externalIdentifier) ||
+                AdminPolicy.find_by(external_identifier: cocina_object.externalIdentifier) ||
+                Collection.find_by(external_identifier: cocina_object.externalIdentifier)
+    lock = ar_lock_for(ar_object)
+    return if cocina_object.respond_to?(:lock) && lock == cocina_object.lock
 
-    raise StaleLockError, "Expected lock of #{lock&.to_s} but received #{cocina_object.lock}."
+    raise StaleLockError, "Expected lock of #{lock} but received #{cocina_object.lock}."
   end
 
   # Find a Cocina object persisted by ActiveRecord.

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -706,9 +706,10 @@ RSpec.describe CocinaObjectStore do
 
         context 'when checking lock succeeds' do
           let(:ar_cocina_object) { create(:dro) }
+          let(:lock) { ActiveSupport::Digest.hexdigest(ar_cocina_object.external_identifier + ar_cocina_object.lock.to_s) }
 
           let(:cocina_object) do
-            Cocina::Models.with_metadata(ar_cocina_object.to_cocina, '0', created: ar_cocina_object.created_at.utc, modified: ar_cocina_object.updated_at.utc)
+            Cocina::Models.with_metadata(ar_cocina_object.to_cocina, lock, created: ar_cocina_object.created_at.utc, modified: ar_cocina_object.updated_at.utc)
           end
 
           let(:changed_cocina_object) do
@@ -723,9 +724,10 @@ RSpec.describe CocinaObjectStore do
 
         context 'when checking lock fails' do
           let!(:ar_cocina_object) { create(:dro) }
+          let(:lock) { '64e8320d19d62ddb73c501276c5655cf' }
 
           let(:cocina_object) do
-            Cocina::Models.with_metadata(ar_cocina_object.to_cocina, '0', created: ar_cocina_object.updated_at.utc, modified: ar_cocina_object.updated_at.utc)
+            Cocina::Models.with_metadata(ar_cocina_object.to_cocina, lock, created: ar_cocina_object.updated_at.utc, modified: ar_cocina_object.updated_at.utc)
           end
 
           let(:changed_cocina_object) do


### PR DESCRIPTION


## Why was this change made? 🤔

Fixes #3805

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



