### PR TITLE
Add report for single-entry parallelValues

### DIFF
--- a/bin/reports/report-desc-low_parallel_values
+++ b/bin/reports/report-desc-low_parallel_values
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+Report.new(name: 'desc-low_parallel_values', dsids: ['descMetadata'], yield_cocina: true).run do |cocina|
+  def deep_locate(object, results = [], &block)
+    case object
+    when Hash
+      results.push(object) if object.any?(&block)
+
+      deep_locate(object.values, results, &block)
+    when Array
+      object.each { |value| deep_locate(value, results, &block) }
+    end
+
+    results
+  end
+
+  deep_locate(cocina.to_h) { |attr, value| attr == :parallelValue && value.count == 1 }.present?
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3795

To accomplish this, modify the Report class so it can map Fedora content to Cocina and report on that.


## How was this change tested? 🤨

CI and tested the new report and an existing report on sdr-deploy
