### PR TITLE
TitleBuilder should be called with an array of titles

### DIFF
--- a/app/services/publish/public_desc_metadata_service.rb
+++ b/app/services/publish/public_desc_metadata_service.rb
@@ -109,7 +109,7 @@ module Publish
 
     def add_related_item_node_for_collection!(cocina_collection)
       title_node         = Nokogiri::XML::Node.new('title', doc)
-      title_node.content = Cocina::Models::TitleBuilder.build(cocina_collection)
+      title_node.content = Cocina::Models::TitleBuilder.build(cocina_collection.description.title)
 
       title_info_node = Nokogiri::XML::Node.new('titleInfo', doc)
       title_info_node.add_child(title_node)


### PR DESCRIPTION


## Why was this change made? 🤔
Otherwise it raises a deprecation warning about the argument provided


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



