### PR TITLE
Report on invalid EDTF in MODS dates

### DIFF
--- a/bin/reports/report-desc-edtf
+++ b/bin/reports/report-desc-edtf
@@ -24,18 +24,10 @@ formats = [
 ]
 
 Report.new(name: 'desc-edtf', dsids: ['descMetadata']).run do |ng_xml|
-  errors = []
+union_xpath_selector = date_els.map { |el| "//mods:#{el}[@encoding='edtf']" }.join(' | ')
+errors = ng_xml.xpath(union_xpath_selector, mods: MODS_NS).filter_map do |el|
+  el.content unless formats.any? { |format| format.match?(el.content) }
+end
 
-  date_els.each do |el_name|
-    ng_xml.xpath("//mods:#{el_name}[@encoding='edtf']", mods: MODS_NS).each do |el|
-      # at least one of the formats must match or else we've found an error
-      errors.push(el.content) unless formats.map { |format| format.match? el.content }.any?
-    end
-  end
-
-  if errors.empty?
-    false
-  else
-    errors.join(';')
-  end
+errors.join(';').presence
 end

--- a/bin/reports/report-desc-edtf
+++ b/bin/reports/report-desc-edtf
@@ -24,10 +24,10 @@ formats = [
 ]
 
 Report.new(name: 'desc-edtf', dsids: ['descMetadata']).run do |ng_xml|
-union_xpath_selector = date_els.map { |el| "//mods:#{el}[@encoding='edtf']" }.join(' | ')
-errors = ng_xml.xpath(union_xpath_selector, mods: MODS_NS).filter_map do |el|
-  el.content unless formats.any? { |format| format.match?(el.content) }
-end
+  union_xpath_selector = date_els.map { |el| "//mods:#{el}[@encoding='edtf']" }.join(' | ')
+  errors = ng_xml.xpath(union_xpath_selector, mods: MODS_NS).filter_map do |el|
+    el.content unless formats.any? { |format| format.match?(el.content) }
+  end
 
-errors.join(';').presence
+  errors.join(';').presence
 end

--- a/bin/reports/report-desc-edtf
+++ b/bin/reports/report-desc-edtf
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+date_els = %w[
+  dateCreated
+  dateIssued
+  dateCaptured
+  dateValid
+  dateModified
+  copyrightDate
+  dateOther
+].freeze
+
+formats = [
+  /^-?\d{4}$/,                                               # 1997 or -1997
+  /^\d{4}-\d{2}$/,                                           # 1997-05
+  /^\d{4}-\d{2}-\d{2}$/,                                     # 1997-07-16
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}\+\d{2}:\d{2}$/,            # 1997-07-16T19:20+01:00
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2}$/,      # 1997-07-16T19:20:30+01:00
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\+\d{2}:\d{2}$/  # 1997-07-16T19:20:30.123+01:00
+]
+
+Report.new(name: 'desc-edtf', dsids: ['descMetadata']).run do |ng_xml|
+  errors = []
+
+  date_els.each do |el_name|
+    ng_xml.xpath("//mods:#{el_name}[@encoding='edtf']", mods: MODS_NS).each do |el|
+      # at least one of the formats must match or else we've found an error
+      errors.push(el.content) unless formats.map { |format| format.match? el.content }.any?
+    end
+  end
+
+  if errors.empty?
+    false
+  else
+    errors.join(';')
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

As part of migration we needed a report for what look like invalid EDTF values in MODS records.

Closes #3797

## How was this change tested? 🤨

Ran the report on sdr-deply against the full set of druids.txt.

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



