### PR TITLE
Report on form type in MODS

### DIFF
--- a/bin/reports/report-desc-form_types
+++ b/bin/reports/report-desc-form_types
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/unique_report'
+
+UniqueReport.new(name: 'desc-form_types', dsids: ['descMetadata']).run do |ng_xml|
+  ng_xml.xpath('//mods:form/@type', mods: MODS_NS).map(&:content)
+end


### PR DESCRIPTION

## Why was this change made? 🤔

We needed a report of what form types are in use in MODS descriptive metadata.

Closes #3781

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



