### PR TITLE
more name deduping for MODS -> cocina mappings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,7 @@ Metrics/ClassLength:
     - 'app/services/cocina/from_fedora/descriptive/access.rb'
     - 'app/services/cocina/from_fedora/descriptive/admin_metadata.rb'
     - 'app/services/cocina/from_fedora/descriptive/identifier_type.rb'
+    - 'app/services/cocina/normalizers/mods/name_normalizer.rb'
     - 'app/services/cocina/normalizers/mods/subject_normalizer.rb'
     - 'app/services/cocina/normalizers/mods_normalizer.rb'
     - 'app/services/cocina/object_creator.rb'

--- a/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
@@ -2380,11 +2380,11 @@ RSpec.describe 'MODS name <--> cocina mappings' do
                   uri: 'http://id.loc.gov/authorities/names/n50025011',
                   source: {
                     code: 'naf',
-                    uri: 'http://id.loc.gov/authorities/names/n50025011'
+                    uri: 'http://id.loc.gov/authorities/names/'
                   }
                 }
               ],
-              type: 'person',
+              type: 'family',
               role: [
                 {
                   value: 'editor'
@@ -2393,12 +2393,6 @@ RSpec.describe 'MODS name <--> cocina mappings' do
             }
           ]
         }
-      end
-
-      let(:warnings) do
-        [
-          Notification.new(msg: 'Duplicate name entry')
-        ]
       end
     end
   end

--- a/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
@@ -2116,7 +2116,7 @@ RSpec.describe 'MODS name <--> cocina mappings' do
   end
 
   describe 'Duplicate names, one with primary' do
-    xit 'new MODS cocina mapping' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <name type="personal" usage="primary">
@@ -2142,8 +2142,7 @@ RSpec.describe 'MODS name <--> cocina mappings' do
             {
               name: [
                 {
-                  value: 'Dunnett, Dorothy',
-                  status: 'primary'
+                  value: 'Dunnett, Dorothy'
                 }
               ],
               type: 'person',
@@ -2162,7 +2161,7 @@ RSpec.describe 'MODS name <--> cocina mappings' do
   end
 
   describe 'Duplicate names, one with role' do
-    xit 'new MODS cocina mapping' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <name type="personal">
@@ -2176,6 +2175,9 @@ RSpec.describe 'MODS name <--> cocina mappings' do
           </name>
         XML
       end
+
+      # dedupping does not allow for normalized roundtrips
+      let(:skip_normalization) { true }
 
       let(:roundtrip_mods) do
         <<~XML
@@ -2217,7 +2219,7 @@ RSpec.describe 'MODS name <--> cocina mappings' do
   end
 
   describe 'Duplicate names, same role' do
-    xit 'new MODS cocina mapping' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <name type="personal">
@@ -2275,7 +2277,7 @@ RSpec.describe 'MODS name <--> cocina mappings' do
   end
 
   describe 'Duplicate names, different roles' do
-    xit 'new MODS cocina mapping' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <name type="personal">
@@ -2306,6 +2308,9 @@ RSpec.describe 'MODS name <--> cocina mappings' do
           </name>
         XML
       end
+
+      # dedupping does not allow for normalized roundtrips
+      let(:skip_normalization) { true }
 
       let(:cocina) do
         {
@@ -2339,7 +2344,7 @@ RSpec.describe 'MODS name <--> cocina mappings' do
   end
 
   describe 'Duplicate names, different attributes' do
-    xit 'new MODS cocina mapping' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <name type="personal">
@@ -2394,6 +2399,14 @@ RSpec.describe 'MODS name <--> cocina mappings' do
           ]
         }
       end
+
+      # As of 4/6/22, Arcadia would like this to warn, but is okay without it for now.
+      #   This warning is not critical path for getting off Fedora 3
+      # let(:warnings) do
+      #   [
+      #     Notification.new(msg: 'Duplicate name entry')
+      #   ]
+      # end
     end
   end
 

--- a/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
@@ -2176,9 +2176,6 @@ RSpec.describe 'MODS name <--> cocina mappings' do
         XML
       end
 
-      # dedupping does not allow for normalized roundtrips
-      let(:skip_normalization) { true }
-
       let(:roundtrip_mods) do
         <<~XML
           <name type="personal">
@@ -2308,9 +2305,6 @@ RSpec.describe 'MODS name <--> cocina mappings' do
           </name>
         XML
       end
-
-      # dedupping does not allow for normalized roundtrips
-      let(:skip_normalization) { true }
 
       let(:cocina) do
         {

--- a/spec/services/cocina/normalizers/mods/name_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/mods/name_normalizer_spec.rb
@@ -168,6 +168,18 @@ RSpec.describe Cocina::Normalizers::Mods::NameNormalizer do
             <namePart type="termsOfAddress">de Lorris</namePart>
             <namePart type="date">active 1230</namePart>
           </name>
+          <name type="personal">
+            <namePart>Cat, Vinsky</namePart>
+            <role>
+              <roleTerm type="text">author</roleTerm>
+            </role>
+          </name>
+          <name type="personal">
+            <namePart>Cat, Vinsky</namePart>
+            <role>
+              <roleTerm type="text">editor</roleTerm>
+            </role>
+          </name>
           <relatedItem>
             <name>
               <namePart>Dunnett, Dorothy</namePart>
@@ -186,6 +198,15 @@ RSpec.describe Cocina::Normalizers::Mods::NameNormalizer do
         <mods #{MODS_ATTRIBUTES}>
           <name>
             <namePart>Dunnett, Dorothy</namePart>
+          </name>
+          <name type="personal">
+            <namePart>Cat, Vinsky</namePart>
+            <role>
+              <roleTerm type="text">author</roleTerm>
+            </role>
+            <role>
+              <roleTerm type="text">editor</roleTerm>
+            </role>
           </name>
           <name type="personal" usage="primary">
             <namePart>Guillaume</namePart>


### PR DESCRIPTION
## Why was this change made? 🤔

This PR implements new mappings from Arcadia for further contributor deduping on MODS -> cocina mappings, which she added as specs in PR #3819.

Fixes #3820

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


### this branch (WITH the changes)

```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99782 (99.864%)
  Different: 122 (0.122%)
  Mapping error:     14 (0.014%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

### main (WITHOUT the changes)

```
Status (n=100000; not using Missing for success/different/error stats):
  Success:   99782 (99.864%)
  Different: 122 (0.122%)
  Mapping error:     14 (0.014%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     82 (0.082%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

## Proof that it does something useful:

### this branch (WITH the changes)

```
$ bin/validate-cocina-roundtrip -d druid:fy043gc0716 -f -q

Status (n=1; not using Missing for success/different/error stats):
  Success:   1 (100.0%)
  Different: 0 (0.0%)
```

### main (WITHOUT the changes)

```
$ bin/validate-cocina-roundtrip -d druid:fy043gc0716 -f -q

Status (n=1; not using Missing for success/different/error stats):
  Success:   0 (0.0%)
  Different: 1 (100.0%)
```

