### PR TITLE
add new report; ignore any txt or csv files at root of app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,7 @@ coverage/*
 /config/settings/*.local.yml
 /cache
 /tls
-druids.txt
 config/settings.local.yml
-results.txt
 /results
-cache-files.txt
+*.txt
+*.csv

--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,11 @@ coverage/*
 /config/settings/*.local.yml
 /cache
 /tls
+# Ignore any input druid list to reports or roundtrip validation
 *druids*.txt
 config/settings.local.yml
 results.txt
 /results
 cache-files.txt
+# Ignore any output of reports
 *.csv

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,9 @@ coverage/*
 /config/settings/*.local.yml
 /cache
 /tls
+*druids*.txt
 config/settings.local.yml
+results.txt
 /results
-*.txt
+cache-files.txt
 *.csv

--- a/bin/reports/report-top-level-desc-note_types
+++ b/bin/reports/report-top-level-desc-note_types
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/unique_report'
+
+UniqueReport.new(name: 'top-level-desc-note_types', dsids: ['descMetadata']).run do |ng_xml|
+  ng_xml.xpath('//mods:note/@type', mods: MODS_NS).filter_map do |note|
+    note.content if note.ancestors.size == 3
+    # why three ancestors indicates a note is at the top level? good question!
+    # because (1) is the note itself (e.g. <note type="summary">A note</note>)
+    # and (2) is the mods document
+    # and (3) is the XML wrapper added by nokogiri
+    # anything more than 3 levels means the note is not at the top level
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3826 - new report for note types at top level only...also gitignore .txt and .csv files at root of app directory (if you run report locally, you may get these files and don't want to commit them)

## How was this change tested? 🤨

Running example report on sdr-deploy