### PR TITLE
remove two spurious xit statements from mapping name_spec

### DIFF
--- a/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
@@ -2902,8 +2902,6 @@ RSpec.describe 'MODS name <--> cocina mappings' do
 
     context 'with empty name value and empty role value' do
       # from pd967mn2579, see https://github.com/sul-dlss/dor-services-app/issues/1161
-      xit 'to implement: if cocina gets empty values, MODS should not create empty elements'
-
       # NOTE: cocina -> MODS
       it_behaves_like 'cocina MODS mapping' do
         let(:cocina) do
@@ -2949,8 +2947,6 @@ RSpec.describe 'MODS name <--> cocina mappings' do
     end
 
     context 'with empty name value and missing role' do
-      xit 'to implement: if cocina gets empty values, MODS should not create empty elements'
-
       # NOTE: cocina -> MODS
       it_behaves_like 'cocina MODS mapping' do
         let(:cocina) do


### PR DESCRIPTION
## Why was this change made? 🤔

Because we have specs that pass right underneath, implying these xit lines are no longer needed.  I also asked Arcadia.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



