### PR TITLE
fix mappings of duplicate names and duplicate roles

### DIFF
--- a/app/services/cocina/normalizers/mods/name_normalizer.rb
+++ b/app/services/cocina/normalizers/mods/name_normalizer.rb
@@ -104,11 +104,13 @@ module Cocina
           dup_name_node.to_s.strip.gsub(/\s+/, ' ')
         end
 
-        # ensure all roles for uniq name node are included
+        # ensure all roles for each uniq name node are present
+        # @return [Array<Nokogiri::XML::Node] the uniq name nodes with all roles present
         def include_all_uniq_roles(uniq_name_nodes, base_node)
+          names_to_roles = name_comparitor_2_role_nodes(base_node) # compute this once
           uniq_name_nodes.each do |uniq_name_node|
-            role_nodes = uniq_name_comparitor_2_role_nodes(base_node)[name_node_comparitor(uniq_name_node)]
-            next if role_nodes.blank? || role_nodes.size < 2
+            role_nodes = names_to_roles[name_node_comparitor(uniq_name_node)]
+            next if role_nodes.blank?
 
             uniq_name_node.xpath('mods:role', mods: 'http://www.loc.gov/mods/v3').each(&:unlink)
             role_nodes.each { |role_node| uniq_name_node.add_child(role_node) }
@@ -116,14 +118,14 @@ module Cocina
           uniq_name_nodes
         end
 
-        def uniq_name_comparitor_2_role_nodes(base_node)
-          role_nodes = base_node.xpath('mods:name/mods:role', mods: 'http://www.loc.gov/mods/v3')
-          # we can use name_node_comparitor to get uniq role nodes
-          uniq_role_nodes = role_nodes.uniq { |role_node| name_node_comparitor(role_node) }
-          return {} if uniq_role_nodes.size < 2
-
+        # @return [Hash<String, Array[Nokogiri::XML::Node]] key is the string comparitor for a name node;
+        #   value is an Array of uniq role nodes
+        def name_comparitor_2_role_nodes(base_node)
           result = {}
-          uniq_role_nodes.each do |role_node|
+
+          # we must do this outside the loop in case of duplicate name nodes
+          all_role_nodes = base_node.xpath('mods:name/mods:role', mods: 'http://www.loc.gov/mods/v3')
+          all_role_nodes.each do |role_node|
             name_comparitor = name_node_comparitor(role_node.parent)
             result[name_comparitor] = if result[name_comparitor]
                                         result[name_comparitor] << role_node
@@ -131,7 +133,8 @@ module Cocina
                                         [role_node]
                                       end
           end
-          result
+
+          result.each { |_k, role_nodes| role_nodes.uniq! { |role_node| name_node_comparitor(role_node) } }
         end
 
         def normalize_type

--- a/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/name_spec.rb
@@ -2339,7 +2339,7 @@ RSpec.describe 'MODS name <--> cocina mappings' do
 
   describe 'Duplicate names, multiple nameParts and role' do
     # adapted from dg193dh3423
-    xit 'new mapping' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <name type="personal" usage="primary">
@@ -2396,6 +2396,12 @@ RSpec.describe 'MODS name <--> cocina mappings' do
             }
           ]
         }
+      end
+
+      let(:warnings) do
+        [
+          Notification.new(msg: 'Duplicate name entry')
+        ]
       end
     end
   end

--- a/spec/services/cocina/normalizers/mods/name_normalizer_spec.rb
+++ b/spec/services/cocina/normalizers/mods/name_normalizer_spec.rb
@@ -180,6 +180,17 @@ RSpec.describe Cocina::Normalizers::Mods::NameNormalizer do
               <roleTerm type="text">editor</roleTerm>
             </role>
           </name>
+          <name type="personal" nameTitleGroup="2">
+             <namePart>Sheng, Bright</namePart>
+             <namePart type="date">1955-</namePart>
+           </name>
+           <name type="personal">
+             <namePart>Sheng, Bright</namePart>
+             <namePart type="date">1955-</namePart>
+             <role>
+               <roleTerm authority="marcrelator" type="code">prf</roleTerm>
+             </role>
+           </name>
           <relatedItem>
             <name>
               <namePart>Dunnett, Dorothy</namePart>
@@ -213,6 +224,13 @@ RSpec.describe Cocina::Normalizers::Mods::NameNormalizer do
             <namePart type="termsOfAddress">de Lorris</namePart>
             <namePart type="date">active 1230</namePart>
           </name>
+          <name type="personal">
+             <namePart>Sheng, Bright</namePart>
+             <namePart type="date">1955-</namePart>
+             <role>
+               <roleTerm authority="marcrelator" type="code">prf</roleTerm>
+             </role>
+           </name>
           <relatedItem>
             <name>
               <namePart>Dunnett, Dorothy</namePart>


### PR DESCRIPTION
## Why was this change made? 🤔

Fix tricky mapping cases of duplicate names with different and with duplicate roles.  

This is needed to allow nameTitleGroup mappings to roundtrip cleanly.  (pre-req for #2699)

It implements code to address Arcadia's spec from PR #3833

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

### this branch (WITH the changes)

```
Status (n=500000; not using Missing for success/different/error stats):
  Success:   498954 (99.872%)
  Different: 579 (0.116%)
  Mapping error:     58 (0.012%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     409 (0.082%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

newly FIXED by this change:

```
dp606qf3711
my600kt7127
dq777fd7798
ps224vb7864
tp799zw8035
bm573pj6336
nq532xt8911
nn541ty6736
mb664by0012
nh525ks0876
fj106nc5491
```

newly BROKEN by this change:

```
qj486pp4549
qt763ck5870
wz991vb9658
yk340vn1168
```

### main (WITHOUT the changes)

```
Status (n=500000; not using Missing for success/different/error stats):
  Success:   498947 (99.871%)
  Different: 586 (0.117%)
  Mapping error:     58 (0.012%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     409 (0.082%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```