### PR TITLE
Fix monkeypatching of AdministrativeTags.

### DIFF
--- a/lib/administrative_tags.rb
+++ b/lib/administrative_tags.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Monkeypatch to retrieve tags using dor-services-client so that does not need to be run on dor-services-app server.
+class AdministrativeTags
+  @@tag_cache = {} # rubocop:disable Style/ClassVars
+
+  def self.project(identifier:)
+    tag = self.for(identifier: identifier).find { |check_tag| check_tag.start_with?('Project :') }
+
+    return [] unless tag
+
+    [tag.split(' : ', 2).last]
+  end
+
+  def self.content_type(identifier:)
+    tag = self.for(identifier: identifier).find { |check_tag| check_tag.start_with?('Process : Content Type :') }
+
+    return [] unless tag
+
+    [tag.split(' : ').last]
+  end
+
+  def self.for(identifier:)
+    cached_tags = @@tag_cache[identifier]
+    return cached_tags if cached_tags
+
+    resp = connection.get do |req|
+      req.url "v1/objects/#{identifier}/administrative_tags"
+    end
+
+    raise "Error getting administrative tags for #{identifier}" unless resp.success?
+
+    tags = JSON.parse(resp.body)
+
+    @@tag_cache[identifier] = tags
+    tags
+  end
+
+  def self.cache(identifier:, tags:)
+    @@tag_cache[identifier] = tags
+  end
+
+  # rubocop:disable Style/ClassVars
+  def self.connection
+    @@connection ||= Faraday.new(Settings.dor_services.url) do |builder|
+      builder.use Faraday::Request::UrlEncoded
+
+      builder.adapter Faraday.default_adapter
+      builder.headers[:user_agent] = 'fedora-loader'
+      builder.headers[:authorization] = "Bearer #{Settings.dor_services.token}"
+    end
+  end
+  # rubocop:enable Style/ClassVars
+  private_class_method :connection
+end

--- a/lib/fedora_cache.rb
+++ b/lib/fedora_cache.rb
@@ -2,6 +2,7 @@
 
 require 'dry/monads'
 require 'zip'
+require 'administrative_tags'
 
 # Support local caching of DOR content (for validating cocina mappings)
 class FedoraCache

--- a/lib/fedora_loader.rb
+++ b/lib/fedora_loader.rb
@@ -3,61 +3,6 @@
 require 'fedora_cache'
 require 'active_fedora/solr_service'
 
-# Monkeypatch to retrieve tags using dor-services-client so that does not need to be run on dor-services-app server.
-class AdministrativeTags
-  @@tag_cache = {} # rubocop:disable Style/ClassVars
-
-  def self.project(identifier:)
-    tag = self.for(identifier: identifier).find { |check_tag| check_tag.start_with?('Project :') }
-
-    return [] unless tag
-
-    [tag.split(' : ', 2).last]
-  end
-
-  def self.content_type(identifier:)
-    tag = self.for(identifier: identifier).find { |check_tag| check_tag.start_with?('Process : Content Type :') }
-
-    return [] unless tag
-
-    [tag.split(' : ').last]
-  end
-
-  def self.for(identifier:)
-    cached_tags = @@tag_cache[identifier]
-    return cached_tags if cached_tags
-
-    resp = connection.get do |req|
-      req.url "v1/objects/#{identifier}/administrative_tags"
-    end
-
-    raise "Error getting administrative tags for #{identifier}" unless resp.success?
-
-    tags = JSON.parse(resp.body)
-
-    @@tag_cache[identifier] = tags
-    tags
-  end
-
-  def self.cache(identifier:, tags:)
-    @@tag_cache[identifier] = tags
-  end
-
-  # rubocop:disable Style/ClassVars
-  def self.connection
-    @@connection ||= Faraday.new(Settings.dor_services.url) do |builder|
-      builder.use ErrorFaradayMiddleware
-      builder.use Faraday::Request::UrlEncoded
-
-      builder.adapter Faraday.default_adapter
-      builder.headers[:user_agent] = 'fedora-loader'
-      builder.headers[TOKEN_HEADER] = "Bearer #{Settings.dor_services.token}"
-    end
-  end
-  # rubocop:enable Style/ClassVars
-  private_class_method :connection
-end
-
 module ActiveFedora
   # Monkeypatch to avoid hitting Solr.
   class SolrService

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ SimpleCov.start :rails do
   add_filter '/lib/report.rb'
   add_filter '/lib/unique_report.rb'
   add_filter '/lib/cache_cocina_object_store.rb'
+  add_filter '/lib/administrative_tags.rb'
   add_filter '/bin/'
 end
 


### PR DESCRIPTION
## Why was this change made? 🤔
Fix monkeypatching of AdministrativeTags for caching.

```
/opt/app/deploy/sdr-deploy/shared/bundle/ruby/2.7.0/gems/pg-1.3.5/lib/pg/connection.rb:637:in `async_connect_or_reset': FATAL:  password authentication failed for user "postgres" (PG::ConnectionBad)
        from /opt/app/deploy/sdr-deploy/shared/bundle/ruby/2.7.0/gems/pg-1.3.5/lib/pg/connection.rb:707:in `new'
        from /opt/app/deploy/sdr-deploy/shared/bundle/ruby/2.7.0/gems/pg-1.3.5/lib/pg.rb:69:in `connect'
        from /opt/app/deploy/sdr-deploy/shared/bundle/ruby/2.7.0/gems/activerecord-5.2.7/lib/active_record/connection_adapters/postgresql_adapter.rb:692:in `connect'
        from /opt/app/deploy/sdr-deploy/shared/bundle/ruby/2.7.0/gems/activerecord-5.2.7/lib/active_record/connection_adapters/postgresql_adapter.rb:223:in `initialize'
```


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

sdr-deploy


