### PR TITLE
Updated w3cdtf report

### DIFF
--- a/bin/reports/report-desc-w3cdtf-updated
+++ b/bin/reports/report-desc-w3cdtf-updated
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../../lib/report'
+
+date_elements = %w[
+  dateCreated
+  dateIssued
+  dateCaptured
+  dateValid
+  dateModified
+  copyrightDate
+  dateOther
+].freeze
+
+formats = [
+  /^\d{4}$/,                                                 # 1997
+  /^\d{4}-\d{2}$/,                                           # 1997-05
+  /^\d{4}-\d{2}-\d{2}$/,                                     # 1997-07-16
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/,                         # 1997-07-16T19:20
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/,                   # 1997-07-16T19:20:30
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+$/,              # 1997-07-16T19:20:30.45
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}\+\d{2}:\d{2}$/,            # 1997-07-16T19:20+01:00
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2}$/,      # 1997-07-16T19:20:30+01:00
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\+\d{2}:\d{2}$/  # 1997-07-16T19:20:30.123+01:00
+]
+
+Report.new(name: 'desc-w3cdtf-updated', dsids: ['descMetadata']).run do |ng_xml|
+  mods_paths = date_elements.map { |element| "//mods:#{element}[@encoding='w3cdtf']" }.join(' | ')
+
+  errors = ng_xml.xpath(mods_paths, mods: MODS_NS).filter_map do |element|
+    element.content unless formats.any? { |format| format.match?(element.content) }
+  end
+
+  errors.join(';').presence
+end


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #3848. 

## How was this change tested? 🤨
Report run on sdr-deploy against `druids.txt`. Report is attached to the issue. 8016 druids identified with invalid date patterns. 

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



