### PR TITLE
Add access condition note mapping to support type validation

### DIFF
--- a/spec/services/cocina/mapping/descriptive/mods/access_condition_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/access_condition_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'MODS accessCondition <--> cocina mappings' do
   end
 
   describe 'Restrictions on access type without spaces' do
-    it_behaves_like 'MODS cocina mapping' do
+    xit 'new MODS cocina mapping - not implemented' do
       let(:mods) do
         <<~XML
           <accessCondition type="restrictionsOnAccess">Available to Stanford researchers only.</accessCondition>

--- a/spec/services/cocina/mapping/descriptive/mods/access_condition_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/access_condition_spec.rb
@@ -55,6 +55,35 @@ RSpec.describe 'MODS accessCondition <--> cocina mappings' do
     end
   end
 
+  describe 'Restrictions on access type without spaces' do
+    it_behaves_like 'MODS cocina mapping' do
+      let(:mods) do
+        <<~XML
+          <accessCondition type="restrictionsOnAccess">Available to Stanford researchers only.</accessCondition>
+        XML
+      end
+
+      let(:roundtrip_mods) do
+        <<~XML
+          <accessCondition type="restriction on access">Available to Stanford researchers only.</accessCondition>
+        XML
+      end
+
+      let(:cocina) do
+        {
+          access: {
+            note: [
+              {
+                value: 'Available to Stanford researchers only.',
+                type: 'access restriction'
+              }
+            ]
+          }
+        }
+      end
+    end
+  end
+
   describe 'Restriction on use and reproduction type' do
     it_behaves_like 'MODS cocina mapping' do
       let(:mods) do


### PR DESCRIPTION
Implementation ticket #3865 

## Why was this change made? 🤔
Add mapping for variant access note type


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



