### PR TITLE
update_marc_records_service: 856 |x for _set_ is no longer needed

### DIFF
--- a/app/models/dor/update_marc_record_service.rb
+++ b/app/models/dor/update_marc_record_service.rb
@@ -50,9 +50,8 @@ module Dor
     # Subfield x #4 (optional): the barcode if known (<identityMetadata><otherId name="barcode">, recorded as barcode:barcode-value
     # Subfield x #5 (optional): the file-id to be used as thumb if available, recorded as file:file-id-value
     # Subfield x #6..n (optional): Collection(s) this object is a member of, recorded as collection:druid-value:ckey-value:title
-    # Subfield x #7..n (optional): Set(s) this object is a member of, recorded as set:druid-value:ckey-value:title
-    # Subfield x #8..n (optional): label and part sort keys for the member
-    # Subfield x #9..n (optional): High-level rights summary
+    # Subfield x #7..n (optional): label and part sort keys for the member
+    # Subfield x #8..n (optional): High-level rights summary
     def generate_symphony_records
       return [] unless ckeys?
 
@@ -91,7 +90,6 @@ module Dor
       new856 += "|xbarcode:#{@cocina_object.identification.barcode}" if @cocina_object.identification.respond_to?(:barcode) && @cocina_object.identification.barcode
       new856 += "|xfile:#{thumb}" unless thumb.nil?
       new856 += get_x2_collection_info unless get_x2_collection_info.nil?
-      new856 += get_x2_constituent_info unless get_x2_constituent_info.nil?
       new856 += get_x2_part_info unless get_x2_part_info.nil?
       new856 += get_x2_rights_info unless get_x2_rights_info.nil?
       new856
@@ -160,18 +158,6 @@ module Dor
       collection_info
     end
 
-    # returns the constituent information subfields if exists
-    # @return [String] the constituent information druid-value:catkey-value:title format
-    def get_x2_constituent_info
-      dor_items_for_constituents.map do |cons_obj_druid|
-        cons_obj = CocinaObjectStore.find(cons_obj_druid)
-        cons_obj_id = cons_obj_druid.sub('druid:', '')
-        cons_obj_title = Cocina::Models::TitleBuilder.build(cons_obj.description.title)
-        catkey = cons_obj.identification&.catalogLinks&.find { |link| link.catalog == 'symphony' }
-        "|xset:#{cons_obj_id}:#{catkey&.catalogRecordId}:#{cons_obj_title}"
-      end.join
-    end
-
     def get_x2_part_info
       title_info = @cocina_object.description&.title&.first
       return unless title_info.respond_to?(:structuredValue) && title_info.structuredValue
@@ -227,12 +213,6 @@ module Dor
 
     def released_for
       ::ReleaseTags.for(cocina_object: @cocina_object)
-    end
-
-    def dor_items_for_constituents
-      return [] unless @cocina_object.respond_to?(:structural) && @cocina_object.structural
-
-      @cocina_object.structural.isMemberOf
     end
 
     # adapted from mods_display

--- a/spec/dor/update_marc_record_service_spec.rb
+++ b/spec/dor/update_marc_record_service_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
       it 'generates a single symphony record' do
         # rubocop:disable Layout/LineLength
         expect(generate_symphony_records).to eq [
-          "8832162\tbc123dg9393\t.856. 41|uhttps://purl.stanford.edu/bc123dg9393|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:bc123dg9393%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111:8832162:Collection label & A Special character|xset:cc111cc1111:8832162:Collection label & A Special character|xrights:world"
+          "8832162\tbc123dg9393\t.856. 41|uhttps://purl.stanford.edu/bc123dg9393|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:bc123dg9393%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111:8832162:Collection label & A Special character|xrights:world"
         ]
       end
     end
@@ -289,7 +289,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
       it 'generates symphony record with a z subfield' do
         expect(generate_symphony_records).to match_array [
-          "8832162\tbc123dg9393\t.856. 41|zAvailable to Stanford-affiliated users.|uhttps://purl.stanford.edu/bc123dg9393|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:bc123dg9393%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111:8832162:Collection label & A Special character|xset:cc111cc1111:8832162:Collection label & A Special character|xrights:group=stanford"
+          "8832162\tbc123dg9393\t.856. 41|zAvailable to Stanford-affiliated users.|uhttps://purl.stanford.edu/bc123dg9393|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:bc123dg9393%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111:8832162:Collection label & A Special character|xrights:group=stanford"
         ]
       end
     end
@@ -311,7 +311,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
         expect(generate_symphony_records).to match_array [
           "123\tbc123dg9393\t",
           "456\tbc123dg9393\t",
-          "8832162\tbc123dg9393\t.856. 41|uhttps://purl.stanford.edu/bc123dg9393|xSDR-PURL|xitem|xfile:bc123dg9393%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111:8832162:Collection label & A Special character|xset:cc111cc1111:8832162:Collection label & A Special character|xrights:world"
+          "8832162\tbc123dg9393\t.856. 41|uhttps://purl.stanford.edu/bc123dg9393|xSDR-PURL|xitem|xfile:bc123dg9393%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111:8832162:Collection label & A Special character|xrights:world"
         ]
       end
     end
@@ -1286,44 +1286,6 @@ RSpec.describe Dor::UpdateMarcRecordService do
 
       it 'returns false' do
         expect(umrs.released_to_searchworks?).to be false
-      end
-    end
-  end
-
-  describe 'dor_items_for_constituents' do
-    context 'when not a member of any collection' do
-      let(:cocina_object) do
-        Cocina::Models::DRO.new(externalIdentifier: druid,
-                                type: Cocina::Models::ObjectType.object,
-                                label: dro_object_label,
-                                version: 1,
-                                description: descriptive_metadata_basic,
-                                identification: { sourceId: 'sul:123' },
-                                access: {},
-                                administrative: { hasAdminPolicy: apo_druid },
-                                structural: {})
-      end
-
-      it 'returns empty array if no relationships' do
-        expect(umrs.send(:dor_items_for_constituents)).to eq([])
-      end
-    end
-
-    context 'when a member of a collection' do
-      let(:cocina_object) do
-        Cocina::Models::DRO.new(externalIdentifier: druid,
-                                type: Cocina::Models::ObjectType.object,
-                                label: dro_object_label,
-                                version: 1,
-                                description: descriptive_metadata_basic,
-                                identification: { sourceId: 'sul:123' },
-                                access: {},
-                                administrative: { hasAdminPolicy: apo_druid },
-                                structural: structural_metadata)
-      end
-
-      it 'successfully determines constituent druid' do
-        expect(umrs.send(:dor_items_for_constituents)).to eq([collection_druid])
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Per Andrew, when we export an 856 to Symphony, we no longer need |x for SET;  set objects are passé, and the information in |x for "set" is exactly the same as the information in |x for "collection"

Fixes #3871

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



