### PR TITLE
mapping: allow restrictionsOnAccess in incoming MODS

### DIFF
--- a/app/services/cocina/from_fedora/descriptive/access.rb
+++ b/app/services/cocina/from_fedora/descriptive/access.rb
@@ -8,6 +8,7 @@ module Cocina
         ACCESS_CONDITION_TYPES = {
           'restriction on access' => 'access restriction',
           'restrictionOnAccess' => 'access restriction',
+          'restrictionsOnAccess' => 'access restriction',
           'useAndReproduction' => 'use and reproduction'
         }.freeze
 

--- a/app/services/cocina/normalizers/mods_normalizer.rb
+++ b/app/services/cocina/normalizers/mods_normalizer.rb
@@ -290,6 +290,9 @@ module Cocina
         ng_xml.xpath('//mods:accessCondition[@type="restrictionOnAccess"]', mods: MODS_NS).each do |node|
           node['type'] = 'restriction on access'
         end
+        ng_xml.xpath('//mods:accessCondition[@type="restrictionsOnAccess"]', mods: MODS_NS).each do |node|
+          node['type'] = 'restriction on access'
+        end
         ng_xml.xpath('//mods:accessCondition[@type="useAndReproduction"]', mods: MODS_NS).each do |node|
           node['type'] = 'use and reproduction'
         end

--- a/spec/services/cocina/mapping/descriptive/mods/access_condition_spec.rb
+++ b/spec/services/cocina/mapping/descriptive/mods/access_condition_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'MODS accessCondition <--> cocina mappings' do
   end
 
   describe 'Restrictions on access type without spaces' do
-    xit 'new MODS cocina mapping - not implemented' do
+    it_behaves_like 'MODS cocina mapping' do
       let(:mods) do
         <<~XML
           <accessCondition type="restrictionsOnAccess">Available to Stanford researchers only.</accessCondition>


### PR DESCRIPTION
## Why was this change made? 🤔

Apparently we want to allow MODS to have "restrictionsOnAccess" as a type in the accessCondition

Fixes #3865

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

### this branch (WITH the changes)

```
Status (n=250000; not using Missing for success/different/error stats):
  Success:   249484 (99.874%)
  Different: 279 (0.112%)
  Mapping error:     36 (0.014%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     201 (0.08%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```

**NEWLY FIXED by this branch:**  NONE

**NEWLY BROKEN by this branch:**  NONE

### WITHOUT the changes (main branch)

```
Status (n=250000; not using Missing for success/different/error stats):
  Success:   249484 (99.874%)
  Different: 279 (0.112%)
  Mapping error:     36 (0.014%)
  Create error:     0 (0.0%)
  Normalization error:     0 (0.0%)
  Missing from cache:     0 (0.0%)
  Unmapped:     0 (0.0%)
  Expected unmapped:     201 (0.08%)
  Bad cache:     0 (0.0%)
  Validate error:     0 (0.0%)
```
