### PR TITLE
Align purls and external identifiers.

### DIFF
--- a/spec/dor/update_marc_record_service_spec.rb
+++ b/spec/dor/update_marc_record_service_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
   let(:druid) { 'druid:bc123dg9393' }
   let(:bare_druid) { druid.delete_prefix('druid:') }
   let(:collection_druid) { 'druid:cc111cc1111' }
+  let(:collection_bare_druid) { collection_druid.delete_prefix('druid:') }
   let(:dro_object_label) { 'A generic label' }
   let(:collection_label) { 'A collection label' }
   let(:release_service) { instance_double(ReleaseTags::IdentityMetadata, released_for: release_data) }
@@ -24,7 +25,7 @@ RSpec.describe Dor::UpdateMarcRecordService do
   let(:collection_descriptive_metadata_basic) do
     {
       title: [{ value: 'Collection label & A Special character' }],
-      purl: "https://purl.stanford.edu/#{bare_druid}"
+      purl: "https://purl.stanford.edu/#{collection_bare_druid}"
     }
   end
   let(:identity_metadata_basic) do

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -13,11 +13,11 @@ FactoryBot.define do
     description do
       {
         title: [{ value: 'Test Collection' }],
-        purl: 'https://purl.stanford.edu/hp308wm0436'
+        purl: "https://purl.stanford.edu/#{external_identifier.delete_prefix('druid:')}"
       }
     end
     sequence(:identification) do |n|
-      { sourceId: "googlebooks:#{n}" }
+      { sourceId: "googlebooks:c#{n}" }
     end
     administrative do
       { hasAdminPolicy: 'druid:hy787xj5878' }

--- a/spec/factories/dros.rb
+++ b/spec/factories/dros.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     description do
       {
         title: [{ value: 'Test DRO' }],
-        purl: 'https://purl.stanford.edu/xz456jk0987'
+        purl: "https://purl.stanford.edu/#{external_identifier.delete_prefix('druid:')}"
       }
     end
     sequence(:identification) do |n|

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -57,7 +57,14 @@ RSpec.describe Collection do
 
     context 'when sourceId is unique' do
       let(:cocina_object2) do
-        cocina_collection.new(externalIdentifier: 'druid:dd645sg2172', identification: { sourceId: 'sul:PC0170_s3_USC_2010-10-09_141959_0032' })
+        cocina_collection.new(
+          externalIdentifier: 'druid:dd645sg2172',
+          identification: { sourceId: 'sul:PC0170_s3_USC_2010-10-09_141959_0032' },
+          description: {
+            title: [{ value: 'Test Collection' }],
+            purl: 'https://purl.stanford.edu/dd645sg2172'
+          }
+        )
       end
 
       it 'does not raise' do
@@ -68,7 +75,14 @@ RSpec.describe Collection do
 
     context 'when sourceId is not unique' do
       let(:cocina_object2) do
-        cocina_collection.new(externalIdentifier: 'druid:dd645sg2172', identification: { sourceId: 'sul:PC0170_s3_USC_2010-10-09_141959_0031' })
+        cocina_collection.new(
+          externalIdentifier: 'druid:dd645sg2172',
+          identification: { sourceId: 'sul:PC0170_s3_USC_2010-10-09_141959_0031' },
+          description: {
+            title: [{ value: 'Test Collection' }],
+            purl: 'https://purl.stanford.edu/dd645sg2172'
+          }
+        )
       end
 
       it 'raises' do

--- a/spec/models/dro_spec.rb
+++ b/spec/models/dro_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Dro do
                               version: 1,
                               description: {
                                 title: [{ value: 'Test DRO' }],
-                                purl: 'https://purl.stanford.edu/xz456jk0987'
+                                purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
                               },
                               access: { view: 'world', download: 'world' },
                               administrative: { hasAdminPolicy: 'druid:hy787xj5878' },
@@ -62,7 +62,7 @@ RSpec.describe Dro do
                               administrative: { hasAdminPolicy: 'druid:hy787xj5878' },
                               description: {
                                 title: [{ value: 'Test DRO' }],
-                                purl: 'https://purl.stanford.edu/xz456jk0987'
+                                purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
                               },
                               geographic: {
                                 iso19139: '<?xml version="1.0"?><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">...'
@@ -169,7 +169,14 @@ RSpec.describe Dro do
 
     context 'when sourceId is unique' do
       let(:cocina_object2) do
-        minimal_cocina_dro.new(externalIdentifier: 'druid:dd645sg2172', identification: { sourceId: 'sul:PC0170_s3_USC_2010-10-09_141959_0032' })
+        minimal_cocina_dro.new(
+          externalIdentifier: 'druid:dd645sg2172',
+          identification: { sourceId: 'sul:PC0170_s3_USC_2010-10-09_141959_0032' },
+          description: {
+            title: [{ value: 'Test DRO' }],
+            purl: 'https://purl.stanford.edu/dd645sg2172'
+          }
+        )
       end
 
       it 'does not raise' do
@@ -180,7 +187,14 @@ RSpec.describe Dro do
 
     context 'when sourceId is not unique' do
       let(:cocina_object2) do
-        minimal_cocina_dro.new(externalIdentifier: 'druid:dd645sg2172', identification: { sourceId: 'sul:PC0170_s3_USC_2010-10-09_141959_0031' })
+        minimal_cocina_dro.new(
+          externalIdentifier: 'druid:dd645sg2172',
+          identification: { sourceId: 'sul:PC0170_s3_USC_2010-10-09_141959_0031' },
+          description: {
+            title: [{ value: 'Test DRO' }],
+            purl: 'https://purl.stanford.edu/dd645sg2172'
+          }
+        )
       end
 
       it 'raises' do

--- a/spec/services/cocina/mapping/structural/virtual_object_spec.rb
+++ b/spec/services/cocina/mapping/structural/virtual_object_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Fedora item content metadata <--> Cocina DRO structural mappings
           },
           description: {
             title: [{ value: 'Number 1' }],
-            purl: 'https://example.com'
+            purl: 'https://purl.stanford.edu/gj047zn0886'
           },
           type: Cocina::Models::ObjectType.image,
           structural: child_structural1,
@@ -41,7 +41,7 @@ RSpec.describe 'Fedora item content metadata <--> Cocina DRO structural mappings
           },
           description: {
             title: [{ value: 'Number 2' }],
-            purl: 'https://example.com'
+            purl: 'https://purl.stanford.edu/tm207xk5096'
           },
           type: Cocina::Models::ObjectType.image,
           structural: child_structural2,

--- a/spec/services/cocina/object_creator_spec.rb
+++ b/spec/services/cocina/object_creator_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe Cocina::ObjectCreator do
           },
           'description' => {
             'title' => [{ 'value' => 'Mountain Biking Utah' }],
-            'purl' => Purl.for(druid: druid)
+            'purl' => Purl.for(druid: 'druid:bb010dx6027')
           }
         }
       end

--- a/spec/services/cocina/to_datacite/event_dates_spec.rb
+++ b/spec/services/cocina/to_datacite/event_dates_spec.rb
@@ -6,7 +6,7 @@ require 'rails_helper'
 RSpec.describe Cocina::ToDatacite::Event do
   let(:cocina_description) do
     cocina[:title] = [{ value: 'title' }]
-    cocina[:purl] = 'https://purl.stanford.edu/zg154pd4168'
+    cocina[:purl] = 'https://purl.stanford.edu/cc123dd1234'
     Cocina::Models::Description.new(cocina)
   end
   let(:cocina_item) do

--- a/spec/services/cocina/to_datacite/event_pub_year_spec.rb
+++ b/spec/services/cocina/to_datacite/event_pub_year_spec.rb
@@ -6,7 +6,7 @@ require 'rails_helper'
 RSpec.describe Cocina::ToDatacite::Event do
   let(:cocina_description) do
     cocina[:title] = [{ value: 'title' }]
-    cocina[:purl] = 'https://purl.stanford.edu/zg154pd4168'
+    cocina[:purl] = 'https://purl.stanford.edu/cc123dd1234'
     Cocina::Models::Description.new(cocina)
   end
   let(:cocina_item) do

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -813,7 +813,13 @@ RSpec.describe CocinaObjectStore do
         end
 
         before do
-          store.send(:cocina_to_ar_save, cocina_object.new(externalIdentifier: 'druid:dd645sg2172'), skip_lock: true)
+          store.send(:cocina_to_ar_save, cocina_object.new(
+                                           externalIdentifier: 'druid:dd645sg2172',
+                                           description: {
+                                             title: [{ value: 'Test Collection' }],
+                                             purl: 'https://purl.stanford.edu/dd645sg2172'
+                                           }
+                                         ), skip_lock: true)
         end
 
         it 'raises' do

--- a/spec/services/item_query_service_spec.rb
+++ b/spec/services/item_query_service_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe ItemQueryService do
           label: 'Dummy DRO',
           description: {
             title: [{ value: 'Dummy DRO' }],
-            purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
+            purl: "https://purl.stanford.edu/#{constituent_druids[0].delete_prefix('druid:')}"
           },
           access: { view: 'citation-only', download: 'none' },
           administrative: { hasAdminPolicy: 'druid:df123cd4567' },
@@ -288,7 +288,7 @@ RSpec.describe ItemQueryService do
           label: 'Dummy DRO',
           description: {
             title: [{ value: 'Dummy DRO' }],
-            purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
+            purl: "https://purl.stanford.edu/#{constituent_druids[1].delete_prefix('druid:')}"
           },
           access: { view: 'dark' },
           administrative: { hasAdminPolicy: 'druid:df123cd4567' },

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -4,12 +4,6 @@ require 'rails_helper'
 
 RSpec.describe Publish::MetadataTransferService do
   let(:druid) { 'bc123df4567' }
-  let(:description) do
-    {
-      title: [{ value: 'Constituent label &amp; A Special character' }],
-      purl: "https://purl.stanford.edu/#{druid}"
-    }
-  end
 
   let(:access) { {} }
 
@@ -18,7 +12,10 @@ RSpec.describe Publish::MetadataTransferService do
                             type: Cocina::Models::ObjectType.object,
                             label: 'google download barcode 36105049267078',
                             version: 1,
-                            description: description,
+                            description: {
+                              title: [{ value: 'Constituent label &amp; A Special character' }],
+                              purl: "https://purl.stanford.edu/#{druid}"
+                            },
                             identification: { sourceId: 'sul:123' },
                             access: access,
                             structural: { contains: [], isMemberOf: ['druid:xh235dd9059'] },
@@ -45,7 +42,10 @@ RSpec.describe Publish::MetadataTransferService do
                                    type: Cocina::Models::ObjectType.collection,
                                    label: 'some collection object',
                                    version: 1,
-                                   description: description,
+                                   description: {
+                                     title: [{ value: 'Constituent label &amp; A Special character' }],
+                                     purl: 'https://purl.stanford.edu/xh235dd9059'
+                                   },
                                    identification: { sourceId: 'sul:123' },
                                    access: {},
                                    administrative: { hasAdminPolicy: 'druid:fg890hx1234' })
@@ -135,7 +135,10 @@ RSpec.describe Publish::MetadataTransferService do
                                          type: Cocina::Models::ObjectType.collection,
                                          label: 'some collection object',
                                          version: 1,
-                                         description: description,
+                                         description: {
+                                           title: [{ value: 'Constituent label &amp; A Special character' }],
+                                           purl: 'https://purl.stanford.edu/xh235dd9059'
+                                         },
                                          identification: { sourceId: 'sul:123' },
                                          access: { view: 'world' },
                                          administrative: { hasAdminPolicy: 'druid:fg890hx1234' })

--- a/spec/services/publish/public_desc_metadata_service_spec.rb
+++ b/spec/services/publish/public_desc_metadata_service_spec.rb
@@ -340,7 +340,7 @@ RSpec.describe Publish::PublicDescMetadataService do
 
         let(:description) do
           { title: [{ value: 'Slides, IA, Geodesic Domes [1 of 2]' }],
-            purl: 'https://purl.stanford.edu/zb871zd0767',
+            purl: 'https://purl.stanford.edu/bc123df4567',
             form: [{ value: 'still image', type: 'resource type',
                      source: { value: 'MODS resource types' } }, { value: 'photographs, color transparencies', type: 'form' }],
             identifier: [{ displayLabel: 'Image ID', type: 'local', value: 'M1090_S15_B01_F01_0055' }],


### PR DESCRIPTION
## Why was this change made? 🤔
Next cocina models release is going to require that purls and external identifiers match.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



