### PR TITLE
Avoid excessive HB alerting when running validate-cocina.

### DIFF
--- a/bin/validate-cocina
+++ b/bin/validate-cocina
@@ -10,6 +10,10 @@ require_relative '../config/environment'
 require 'optparse'
 require 'tty-progressbar'
 
+Honeybadger.configure do |config|
+  config.exceptions.ignore += [Cocina::Models::ValidationError]
+end
+
 # how many druids to process as a single advance unit of the progress bar
 def num_for_progress_advance(count)
   return 1 if count < 100


### PR DESCRIPTION
## Why was this change made? 🤔
So that we don't accidentally use up HB quota.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



