### PR TITLE
Rename MetadataService to ModsService.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -189,7 +189,7 @@ Rails/TimeZone:
 # Offense count: 1
 Style/ClassVars:
   Exclude:
-    - 'app/services/metadata_service.rb'
+    - 'app/services/mods_service.rb'
 
 # Offense count: 1
 Style/CombinableLoops:
@@ -212,7 +212,6 @@ Style/Documentation:
     - 'app/controllers/objects_controller.rb'
     - 'app/controllers/versions_controller.rb'
     - 'app/models/dor/update_marc_record_service.rb'
-    - 'app/services/metadata_service.rb'
     - 'app/services/publish/dublin_core_service.rb'
     - 'app/services/release_tags/identity_metadata.rb'
     - 'config/application.rb'

--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -381,7 +381,7 @@ class CocinaObjectStore
     description_props = result.value!.description_props
     # Remove PURL since this is still a request
     description_props.delete(:purl)
-    label = ModsService.label_from_mods(result.value!.mods_ng_xml)
+    label = ModsUtils.label(result.value!.mods_ng_xml)
     cocina_request_object.new(label: label, description: description_props)
   end
 

--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -381,7 +381,7 @@ class CocinaObjectStore
     description_props = result.value!.description_props
     # Remove PURL since this is still a request
     description_props.delete(:purl)
-    label = MetadataService.label_from_mods(result.value!.mods_ng_xml)
+    label = ModsService.label_from_mods(result.value!.mods_ng_xml)
     cocina_request_object.new(label: label, description: description_props)
   end
 

--- a/app/services/mods_service.rb
+++ b/app/services/mods_service.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 require 'cache'
-class MetadataError < RuntimeError; end
+class ModsServiceError < RuntimeError; end
 
-class MetadataService
+# Service for fetching MODS from the catalog and associated helper methods.
+class ModsService
   VALID_PREFIXES = %w[catkey barcode].freeze
   CATKEY_REGEX = /^\d+(:\d+)*$/.freeze
 
@@ -56,8 +57,8 @@ class MetadataService
     end
 
     def valid_identifier!(prefix, identifier)
-      raise MetadataError, "Unknown metadata prefix: #{prefix}" unless valid_prefix?(prefix)
-      raise MetadataError, "Invalid catkey: #{identifier}" unless valid_catkey?(identifier)
+      raise ModsServiceError, "Unknown metadata prefix: #{prefix}" unless valid_prefix?(prefix)
+      raise ModsServiceError, "Invalid catkey: #{identifier}" unless valid_catkey?(identifier)
     end
 
     def valid_prefix?(prefix)

--- a/app/services/mods_service.rb
+++ b/app/services/mods_service.rb
@@ -30,15 +30,8 @@ class ModsService
       end
     end
 
-    def label_from_mods(mods)
-      mods.root.add_namespace_definition('mods', 'http://www.loc.gov/mods/v3')
-      mods.xpath('/mods:mods/mods:titleInfo[1]')
-          .xpath('mods:title|mods:nonSort')
-          .collect(&:text).join(' ').strip
-    end
-
     def label_for(identifier)
-      label_from_mods(Nokogiri::XML(fetch(identifier)))
+      ModsUtils.label(Nokogiri::XML(fetch(identifier)))
     end
 
     private

--- a/app/services/mods_utils.rb
+++ b/app/services/mods_utils.rb
@@ -11,4 +11,11 @@ class ModsUtils
 
     title_info
   end
+
+  def self.label(ng_xml)
+    ng_xml.root.add_namespace_definition('mods', 'http://www.loc.gov/mods/v3')
+    ng_xml.xpath('/mods:mods/mods:titleInfo[1]')
+          .xpath('mods:title|mods:nonSort')
+          .collect(&:text).join(' ').strip
+  end
 end

--- a/app/services/refresh_metadata_action.rb
+++ b/app/services/refresh_metadata_action.rb
@@ -40,8 +40,8 @@ class RefreshMetadataAction
   # @raises SymphonyReader::ResponseError
   def mods
     @mods ||= begin
-      metadata_id = MetadataService.resolvable(identifiers).first
-      metadata_id.nil? ? nil : MetadataService.fetch(metadata_id.to_s)
+      metadata_id = ModsService.resolvable(identifiers).first
+      metadata_id.nil? ? nil : ModsService.fetch(metadata_id.to_s)
     end
   end
 

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Create object' do
     end
 
     before do
-      allow(MetadataService).to receive(:fetch).and_return(mods_from_symphony)
+      allow(ModsService).to receive(:fetch).and_return(mods_from_symphony)
     end
 
     it 'creates the collection' do
@@ -95,7 +95,7 @@ RSpec.describe 'Create object' do
       expect(response.body).to equal_cocina_model(expected)
       expect(response.status).to eq(201)
       expect(response.location).to eq "/v1/objects/#{druid}"
-      expect(MetadataService).to have_received(:fetch).with('catkey:8888')
+      expect(ModsService).to have_received(:fetch).with('catkey:8888')
     end
   end
 

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe 'Create object' do
         end
 
         before do
-          allow(MetadataService).to receive(:fetch).and_return(mods_from_symphony)
+          allow(ModsService).to receive(:fetch).and_return(mods_from_symphony)
         end
 
         it 'registers the object with the registration service and immediately indexes' do
@@ -161,7 +161,7 @@ RSpec.describe 'Create object' do
           expect(response.body).to equal_cocina_model(expected)
           expect(response.status).to eq(201)
           expect(response.location).to eq "/v1/objects/#{druid}"
-          expect(MetadataService).to have_received(:fetch).with('catkey:8888')
+          expect(ModsService).to have_received(:fetch).with('catkey:8888')
           expect(a_request(:put, 'https://dor-indexing-app.example.edu/dor/reindex_from_cocina').with do |req|
                    parsed_body = JSON.parse(req.body).deep_symbolize_keys
                    expect(parsed_body[:cocina_object]).to eq(expected.to_h)
@@ -174,7 +174,7 @@ RSpec.describe 'Create object' do
 
       context 'when connecting to symphony fails' do
         before do
-          allow(MetadataService).to receive(:fetch).and_raise(SymphonyReader::ResponseError)
+          allow(ModsService).to receive(:fetch).and_raise(SymphonyReader::ResponseError)
         end
 
         it 'draws an error message' do
@@ -189,7 +189,7 @@ RSpec.describe 'Create object' do
 
       context 'when symphony returns a 404' do
         before do
-          allow(MetadataService).to receive(:fetch).and_raise(SymphonyReader::NotFound, 'unable to find catkey')
+          allow(ModsService).to receive(:fetch).and_raise(SymphonyReader::NotFound, 'unable to find catkey')
         end
 
         it 'draws an error message' do

--- a/spec/requests/metadata_refresh_spec.rb
+++ b/spec/requests/metadata_refresh_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'Refresh metadata' do
 
   context 'when happy path' do
     before do
-      allow(MetadataService).to receive(:fetch).and_return(mods)
+      allow(ModsService).to receive(:fetch).and_return(mods)
     end
 
     it 'updates the metadata and saves the changes' do
@@ -98,7 +98,7 @@ RSpec.describe 'Refresh metadata' do
     end
 
     before do
-      allow(MetadataService).to receive(:fetch).and_return(mods)
+      allow(ModsService).to receive(:fetch).and_return(mods)
     end
 
     it 'updates the metadata and saves the changes' do
@@ -122,7 +122,7 @@ RSpec.describe 'Refresh metadata' do
     end
 
     before do
-      allow(MetadataService).to receive(:fetch).and_return(mods)
+      allow(ModsService).to receive(:fetch).and_return(mods)
     end
 
     it 'returns a 422 error' do

--- a/spec/services/mods_service_spec.rb
+++ b/spec/services/mods_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe MetadataService do
+RSpec.describe ModsService do
   let(:mods) { File.read(File.join(fixture_dir, 'mods_record.xml')) }
 
   describe '#resolvable' do
@@ -41,11 +41,11 @@ RSpec.describe MetadataService do
     end
 
     it 'raises an exception if an unknown metadata type is requested' do
-      expect { described_class.fetch('foo:bar') }.to raise_exception(MetadataError)
+      expect { described_class.fetch('foo:bar') }.to raise_exception(ModsServiceError)
     end
 
     it 'raises an exception if an invalid catkey is provided' do
-      expect { described_class.fetch('catkey:from server') }.to raise_exception(MetadataError)
+      expect { described_class.fetch('catkey:from server') }.to raise_exception(ModsServiceError)
     end
 
     it 'fetches a record based on barcode' do

--- a/spec/services/refresh_metadata_action_spec.rb
+++ b/spec/services/refresh_metadata_action_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe RefreshMetadataAction do
   end
 
   before do
-    allow(MetadataService).to receive(:fetch).and_return(mods)
+    allow(ModsService).to receive(:fetch).and_return(mods)
     allow(Honeybadger).to receive(:notify)
   end
 
@@ -54,7 +54,7 @@ RSpec.describe RefreshMetadataAction do
 
   context 'when fetch_metadata fails' do
     before do
-      allow(MetadataService).to receive(:fetch).and_raise(SymphonyReader::ResponseError)
+      allow(ModsService).to receive(:fetch).and_raise(SymphonyReader::ResponseError)
     end
 
     it 'gets the data and puts it in descMetadata and Honeybadger notifies' do
@@ -64,7 +64,7 @@ RSpec.describe RefreshMetadataAction do
 
   context 'when fetch_metadata returns nil' do
     before do
-      allow(MetadataService).to receive(:fetch).and_return(nil)
+      allow(ModsService).to receive(:fetch).and_return(nil)
     end
 
     it 'returns a Dry::Monads::Result::Failure object' do


### PR DESCRIPTION
## Why was this change made? 🤔
Everything is metadata; this service deals with MODS so it such be names as such.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



