### PR TITLE
add versions/is_open endpoint

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -49,6 +49,12 @@ class VersionsController < ApplicationController
     render build_error('Unable to check if openable due to preservation client error', e, status: :internal_server_error)
   end
 
+  def open?
+    render plain: VersionService.open?(@cocina_object)
+  rescue Dor::WorkflowException => e
+    render build_error('Unable to check if a version is open due to workflow client error', e, status: :internal_server_error)
+  end
+
   private
 
   # JSON-API error response

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,8 @@ Rails.application.routes.draw do
       resources :versions, only: [:create, :index] do
         collection do
           get 'openable'
+          # question mark needs to be encoded in a URL and it's not worth it.
+          get 'is_open', action: :open?
           get 'current'
           post 'current/close', action: 'close_current'
         end

--- a/openapi.yml
+++ b/openapi.yml
@@ -1009,6 +1009,23 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
+  '/v1/objects/{object_id}/versions/is_open':
+    get:
+      tags:
+        - versions
+      summary: Query to determine whether version is currently open for this object
+      description: ''
+      operationId: 'versions#is_open'
+      responses:
+        '200':
+          description: OK
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
   '/v1/objects/{object_id}/versions/current':
     get:
       tags:

--- a/spec/requests/versions_spec.rb
+++ b/spec/requests/versions_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe 'Operations regarding object versions' do
         allow(VersionService).to receive(:can_open?).and_return(false)
       end
 
-      it 'returns true' do
+      it 'returns false' do
         get '/v1/objects/druid:mx123qw2323/versions/openable',
             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response.body).to eq('false')
@@ -163,6 +163,47 @@ RSpec.describe 'Operations regarding object versions' do
         get '/v1/objects/druid:mx123qw2323/versions/openable',
             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response.body).to eq('{"errors":[{"status":"500","title":"Unable to check if openable due to preservation client error","detail":"Oops, a 500"}]}')
+        expect(response.status).to eq 500
+      end
+    end
+  end
+
+  describe '/versions/is_open' do
+    context 'when a version is open' do
+      before do
+        allow(VersionService).to receive(:open?).and_return(true)
+      end
+
+      it 'returns true' do
+        get '/v1/objects/druid:mx123qw2323/versions/is_open',
+            headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response.body).to eq('true')
+        expect(response).to be_successful
+      end
+    end
+
+    context 'when a version is not open' do
+      before do
+        allow(VersionService).to receive(:open?).and_return(false)
+      end
+
+      it 'returns false' do
+        get '/v1/objects/druid:mx123qw2323/versions/is_open',
+            headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response.body).to eq('false')
+        expect(response).to be_successful
+      end
+    end
+
+    context 'when workflow client call fails' do
+      before do
+        allow(VersionService).to receive(:open?).and_raise(Dor::WorkflowException, 'Oops, a 500')
+      end
+
+      it 'returns an error' do
+        get '/v1/objects/druid:mx123qw2323/versions/is_open',
+            headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response.body).to eq('{"errors":[{"status":"500","title":"Unable to check if a version is open due to workflow client error","detail":"Oops, a 500"}]}')
         expect(response.status).to eq 500
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔

For sul-dlss/argo/issues/3493, we need a way to check if a versionWF is in the "open" state for an object.  We can't use the opposite of "openable?" because "is_open" may be used for objects that are not yet accessioned -- they have only gotten as far as the `open` step in the `versionWF`.

I named it `is_open` rather than `open?` because in a URL, the question mark would need to be encoded and it didn't seem worth it.

This adds an endpoint and we already had the internal method to check.  Whee!

## How was this change tested? 🤨

specs

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



