### PR TITLE
add versions/current/update endpoint

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -43,6 +43,12 @@ class VersionsController < ApplicationController
     render build_error('Unable to close version', e)
   end
 
+  def update_current
+    render plain: VersionService.update_open_version(@cocina_object, update_params).to_s
+  rescue Dor::WorkflowException => e
+    render build_error('Unable to check if a version is open due to workflow client error', e, status: :internal_server_error)
+  end
+
   def openable
     render plain: VersionService.can_open?(@cocina_object, open_params).to_s
   rescue Preservation::Client::Error => e
@@ -73,6 +79,13 @@ class VersionsController < ApplicationController
       :assume_accessioned,
       :description,
       :opening_user_name,
+      :significance
+    ).to_h.symbolize_keys
+  end
+
+  def update_params
+    params.permit(
+      :description,
       :significance
     ).to_h.symbolize_keys
   end

--- a/app/models/object_version.rb
+++ b/app/models/object_version.rb
@@ -49,7 +49,7 @@ class ObjectVersion < ApplicationRecord
   # @param [String] druid
   # @param [Symbol] significance which part of the version tag to increment
   #  :major, :minor, :admin (see VersionTag#increment)
-  # @param [String] description optional text describing version change
+  # @param [String] description text describing version change
   # @return [ObjectVersion] created ObjectVersion
   def self.update_current_version(druid, significance: nil, description: nil)
     return if significance.nil? && description.nil?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
         collection do
           get 'openable'
           get 'current'
+          post 'current/update', action: 'update_current'
           post 'current/close', action: 'close_current'
         end
       end

--- a/openapi.yml
+++ b/openapi.yml
@@ -1026,6 +1026,23 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
+  '/v1/objects/{object_id}/versions/current/update':
+    post:
+      tags:
+        - versions
+      summary: Update metadata for the currently open version for this object
+      description: ''
+      operationId: 'versions#update_current'
+      responses:
+        '200':
+          description: OK
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
   '/v1/objects/{object_id}/versions/current/close':
     post:
       tags:

--- a/spec/models/object_version_spec.rb
+++ b/spec/models/object_version_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe ObjectVersion, type: :model do
     end
   end
 
-  describe '#update_version' do
+  describe '#update_current_version' do
     context 'when description and significance not provided' do
       before do
         described_class.create(druid: druid, version: 1, tag: '1.0.0')
@@ -106,7 +106,7 @@ RSpec.describe ObjectVersion, type: :model do
 
       it 'does not update' do
         described_class.update_current_version(druid: druid, significance: :minor)
-        expect(described_class.find_by(druid: druid, version: 1).version).to eq(1)
+        expect(described_class.current_version(druid).version).to eq(1)
       end
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

For https://github.com/sul-dlss/argo/issues/3493, we need a way to update an objects _open_ version description and "significance" (tag).  This provides the endpoint necessary.  

## How was this change tested? 🤨

specs

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



