### PR TITLE
closing an object version now allows blank description and/or significance

### DIFF
--- a/app/models/object_version.rb
+++ b/app/models/object_version.rb
@@ -52,13 +52,12 @@ class ObjectVersion < ApplicationRecord
   # @param [String] description optional text describing version change
   # @return [ObjectVersion] created ObjectVersion
   def self.update_current_version(druid, significance: nil, description: nil)
-    return if significance.nil? && description.nil?
+    return if significance.nil? && description.nil? # no need to update
 
     current_object_version = current_version(druid)
-
     return if current_object_version.nil? || current_object_version.version == 1
 
-    current_object_version.description = description if description
+    current_object_version.description = description.presence
 
     if significance
       # Greatest version with a tag.
@@ -68,13 +67,6 @@ class ObjectVersion < ApplicationRecord
     end
 
     current_object_version.save!
-  end
-
-  # @param [String] druid
-  # @return [Boolean] returns true if the current version has a tag and a description, false otherwise
-  def self.current_version_closeable?(druid)
-    current_object_version = current_version(druid)
-    (current_object_version&.tag && current_object_version&.description).present?
   end
 
   # @return [ObjectVersion] current ObjectVersion

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -82,14 +82,12 @@ class VersionService
   # @option opts [Boolean] :start_accession set to true if you want accessioning to start (default), false otherwise
   # @raise [Dor::Exception] if the object hasn't been opened for versioning, or if accessionWF has
   #   already been instantiated or the current version is missing a tag or description
-  # rubocop:disable Metrics/AbcSize
   def close(opts = {})
     # This can be removed after migration.
     VersionMigrationService.find_and_migrate(druid)
 
-    ObjectVersion.update_current_version(druid, description: opts[:description], significance: opts[:significance].to_sym) if opts[:description] && opts[:significance]
+    ObjectVersion.update_current_version(druid, description: opts[:description], significance: opts[:significance].to_sym) if opts[:description] || opts[:significance]
 
-    raise Dor::Exception, "latest version in versionMetadata for #{druid} requires tag and description before it can be closed" unless ObjectVersion.current_version_closeable?(druid)
     raise Dor::Exception, "Trying to close version #{cocina_object.version} on #{druid} which is not opened for versioning" unless open_for_versioning?
     raise Dor::Exception, "Trying to close version #{cocina_object.version} on #{druid} which has active assemblyWF" if active_assembly_wf?
     raise Dor::Exception, "accessionWF already created for versioned object #{druid}" if accessioning?
@@ -102,7 +100,6 @@ class VersionService
 
     event_factory.create(druid: druid, event_type: 'version_close', data: { who: opts[:user_name], version: cocina_object.version.to_s })
   end
-  # rubocop:enable Metrics/AbcSize
 
   # Performs checks on whether a new version can be opened for an object
   # @return [Void]

--- a/spec/models/object_version_spec.rb
+++ b/spec/models/object_version_spec.rb
@@ -147,38 +147,6 @@ RSpec.describe ObjectVersion, type: :model do
     end
   end
 
-  describe '#current_version_closeable?' do
-    context 'when it has a description and tag' do
-      before do
-        described_class.create(druid: druid, version: 1, tag: '1.0.0', description: 'Initial Version')
-      end
-
-      it 'is closeable' do
-        expect(described_class.current_version_closeable?(druid)).to be(true)
-      end
-    end
-
-    context 'when it does not have a description' do
-      before do
-        described_class.create(druid: druid, version: 1, tag: '1.0.0')
-      end
-
-      it 'is not closeable' do
-        expect(described_class.current_version_closeable?(druid)).to be(false)
-      end
-    end
-
-    context 'when it does not have a tag' do
-      before do
-        described_class.create(druid: druid, version: 1, description: 'Initial Version')
-      end
-
-      it 'is not closeable' do
-        expect(described_class.current_version_closeable?(druid)).to be(false)
-      end
-    end
-  end
-
   describe '#version_xml' do
     let(:expected_xml) do
       <<~XML


### PR DESCRIPTION
## Why was this change made? 🤔

So we don't need a data remediation oriented bulk action in argo to supply missing version descriptions and tags (ticketed as #3493).  

Since we already will have empty descriptions and/or tags in the object version in the database from the migration, we have a whole series of tickets to address blank versions in our postgres SDR and to have a database constraint and openapi layer enforcement and plugging any holes in SDR code that allow versions to be created without required fields and nice error messages for HB etc.

Fixes #3910


## How was this change tested? 🤨

specs

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



