### PR TITLE
VersionMigrationService provides defaults for tag and description 

### DIFF
--- a/app/services/version_migration_service.rb
+++ b/app/services/version_migration_service.rb
@@ -42,10 +42,10 @@ class VersionMigrationService
   end
 
   def tag_for(version)
-    version_md.tag_for_version(version.to_s).presence
+    version_md.tag_for_version(version.to_s).presence || "#{current_version}.0.0"
   end
 
   def description_for(version)
-    version_md.description_for_version(version.to_s).presence
+    version_md.description_for_version(version.to_s).presence || "Version #{tag_for(version)}"
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

We want to avoid ObjectVersions without description or tag;  this will allow us to provide defaults for missing data upon migration.

Fixes #3904


## How was this change tested? 🤨

spec

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



