### PR TITLE
Unopaque locks.

### DIFF
--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -184,7 +184,8 @@ class CocinaObjectStore
   end
 
   def fedora_lock_for(fedora_object)
-    ActiveSupport::Digest.hexdigest(fedora_object.pid + fedora_object.modified_date.to_datetime.iso8601)
+    # This should be opaque, but this makes troubeshooting easier.
+    [fedora_object.pid, fedora_object.modified_date.to_datetime.iso8601].join('=')
   end
 
   # @return [Array] array consisting of created date and modified date
@@ -274,7 +275,8 @@ class CocinaObjectStore
   end
 
   def ar_lock_for(ar_cocina_object)
-    ActiveSupport::Digest.hexdigest(ar_cocina_object.external_identifier + ar_cocina_object.lock.to_s)
+    # This should be opaque, but this makes troubeshooting easier.
+    [ar_cocina_object.external_identifier, ar_cocina_object.lock.to_s].join('=')
   end
 
   # Find an ActiveRecord Cocina object.

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe 'Update object' do
       doi: '10.25740/gg777gg7777'
     }
   end
-  let(:etag) { ActiveSupport::Digest.hexdigest(druid + modified.iso8601) }
+  let(:etag) { "#{druid}=#{modified.iso8601}" }
 
   let(:headers) do
     {
@@ -398,7 +398,7 @@ RSpec.describe 'Update object' do
       allow(Dor).to receive(:find).with(other_druid).and_return(item)
     end
 
-    let(:etag) { ActiveSupport::Digest.hexdigest(other_druid + modified.iso8601) }
+    let(:etag) { "#{other_druid}=#{modified.iso8601}" }
 
     let(:item) do
       Dor::Item.new(pid: other_druid,

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CocinaObjectStore do
 
   let(:date) { Time.zone.now }
 
-  let(:lock) { ActiveSupport::Digest.hexdigest(druid + date.to_datetime.iso8601) }
+  let(:lock) { "#{druid}=#{date.to_datetime.iso8601}" }
 
   describe 'to Fedora' do
     let(:item) { instance_double(Dor::Item, pid: druid, modified_date: date.to_time) }
@@ -706,7 +706,7 @@ RSpec.describe CocinaObjectStore do
 
         context 'when checking lock succeeds' do
           let(:ar_cocina_object) { create(:dro) }
-          let(:lock) { ActiveSupport::Digest.hexdigest(ar_cocina_object.external_identifier + ar_cocina_object.lock.to_s) }
+          let(:lock) { "#{ar_cocina_object.external_identifier}=#{ar_cocina_object.lock}" }
 
           let(:cocina_object) do
             Cocina::Models.with_metadata(ar_cocina_object.to_cocina, lock, created: ar_cocina_object.created_at.utc, modified: ar_cocina_object.updated_at.utc)


### PR DESCRIPTION
## Why was this change made? 🤔
Opaque locks are difficult to troubleshoot. Since this is an internal API opaque locks are unnecessary.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



