### PR TITLE
Changes version open endpoint to return cocina object.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,4 +70,11 @@ class ApplicationController < ActionController::API
   def load_cocina_object
     @cocina_object = CocinaObjectStore.find(params[:object_id] || params[:id])
   end
+
+  # Adds headers from the cocina object.
+  def add_headers(cocina_object)
+    headers['X-Created-At'] = cocina_object.created.httpdate
+    headers['Last-Modified'] = cocina_object.modified.httpdate
+    headers['ETag'] = "W/\"#{cocina_object.lock}\""
+  end
 end

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -215,12 +215,6 @@ class ObjectsController < ApplicationController
     end
   end
 
-  def add_headers(cocina_object)
-    headers['X-Created-At'] = cocina_object.created.httpdate
-    headers['Last-Modified'] = cocina_object.modified.httpdate
-    headers['ETag'] = "W/\"#{cocina_object.lock}\""
-  end
-
   def from_etag(etag)
     return nil if etag.nil?
 

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -25,7 +25,9 @@ class VersionsController < ApplicationController
 
   def create
     updated_cocina_object = VersionService.open(@cocina_object, open_params, event_factory: EventFactory)
-    render plain: updated_cocina_object.version
+
+    add_headers(updated_cocina_object)
+    render json: Cocina::Models.without_metadata(updated_cocina_object)
   rescue Dor::Exception => e
     render build_error('Unable to open version', e)
   rescue Preservation::Client::Error => e

--- a/openapi.yml
+++ b/openapi.yml
@@ -1079,6 +1079,24 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/DRO'
+                  - $ref: '#/components/schemas/Collection'
+                  - $ref: '#/components/schemas/AdminPolicy'
+          headers:
+            ETag:
+              schema:
+                type: string
+            Last-Modified:
+              schema:
+                type: string
+            X-Created-At:
+              schema:
+                type: string
+
       parameters:
         - name: object_id
           in: path


### PR DESCRIPTION
## Why was this change made? 🤔
In some uses of the endpoint, the client intends to further update the cocina object. To do this, it needs a cocina object with the updated version AND the etag lock for the current version.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit


