### PR TITLE
require description and significance parameters for VersionsController.create

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -24,7 +24,7 @@ class VersionsController < ApplicationController
   end
 
   def create
-    updated_cocina_object = VersionService.open(@cocina_object, open_params, event_factory: EventFactory)
+    updated_cocina_object = VersionService.open(@cocina_object, create_params, event_factory: EventFactory)
 
     add_headers(updated_cocina_object)
     render json: Cocina::Models.without_metadata(updated_cocina_object)
@@ -46,7 +46,7 @@ class VersionsController < ApplicationController
   end
 
   def openable
-    render plain: VersionService.can_open?(@cocina_object, open_params).to_s
+    render plain: VersionService.can_open?(@cocina_object, openable_params).to_s
   rescue Preservation::Client::Error => e
     render build_error('Unable to check if openable due to preservation client error', e, status: :internal_server_error)
   end
@@ -70,7 +70,13 @@ class VersionsController < ApplicationController
     }
   end
 
-  def open_params
+  def create_params
+    params.require(:description)
+    params.require(:significance)
+    openable_params # return _all_ allowed params as hash with symbolized keys
+  end
+
+  def openable_params
     params.permit(
       :assume_accessioned,
       :description,

--- a/openapi.yml
+++ b/openapi.yml
@@ -62,7 +62,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'          
+                $ref: '#/components/schemas/ErrorResponse'
       parameters:
         - name: barcode
           in: query
@@ -91,7 +91,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'          
+                $ref: '#/components/schemas/ErrorResponse'
       parameters:
         - name: barcode
           in: query
@@ -198,7 +198,7 @@ paths:
             enum:
               - accessionWF
               - releaseWF
-            example: releaseWF
+          example: releaseWF
         - name: lane-id
           in: query
           description: Lane for prioritizing the work
@@ -237,7 +237,6 @@ paths:
             enum:
               - accessionWF
               - assemblyWF
-            example: assemblyWF
         - name: significance
           in: query
           description: the significance of the version change (if versioning is needed)
@@ -248,20 +247,19 @@ paths:
               - minor
               - major
               - admin
-            example: admin
         - name: description
           in: query
           description: the description of the version change (if versioning is needed)
           required: false
           schema:
             type: string
-            example: 'Re-accessioning this object'
+          example: 'Re-accessioning this object'
         - name: opening_user_name
           in: query
           description: the username of the person creating the version (if versioning is needed)
           schema:
             type: string
-            example: 'some_sunetid'
+          example: 'some_sunetid'
   '/v1/objects/{id}/preserve':
     post:
       tags:
@@ -1148,7 +1146,7 @@ paths:
           required: true
           schema:
             type: string
-            example: 'Adding thumbnail'
+          example: 'Adding thumbnail'
         - name: significance
           in: query
           description: set significance of version change (akin to semantic versioning)
@@ -1172,7 +1170,7 @@ paths:
           required: false
           schema:
             type: string
-            example: 'vinsky'
+          example: 'some_sunetid'
   /v1/objects:
     post:
       tags:

--- a/openapi.yml
+++ b/openapi.yml
@@ -1142,6 +1142,37 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
+        - name: description
+          in: query
+          description: short description for object version being opened
+          required: true
+          schema:
+            type: string
+            example: 'Adding thumbnail'
+        - name: significance
+          in: query
+          description: set significance of version change (akin to semantic versioning)
+          required: true
+          schema:
+            type: string
+            enum:
+                - major
+                - minor
+                - admin
+        - name: assume_accessioned
+          in: query
+          description: If true, does not check whether object has been accessioned
+          required: false
+          schema:
+            type: boolean
+            default: false
+        - name: opening_user_name
+          in: query
+          description: username to include in version event
+          required: false
+          schema:
+            type: string
+            example: 'vinsky'
   /v1/objects:
     post:
       tags:


### PR DESCRIPTION
## Why was this change made? 🤔

This is part of a series of tickets to ensure that object versions, moving forward, will always have a description and a tag.

Fixes #3906

## How was this change tested? 🤨

specs, ran all integration tests on qa

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



