### PR TITLE
Move validation for path and body identifier on update to the controller

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -55,6 +55,10 @@ class ObjectsController < ApplicationController
 
   def update
     cocina_object = Cocina::Models.build(params.except(:action, :controller, :id).to_unsafe_h)
+
+    # Ensure the id in the path matches the id in the post body.
+    raise Cocina::ValidationError, "Identifier on the query and in the body don't match" if params[:id] != cocina_object.externalIdentifier
+
     # ETag / optimistic locking is optional.
     etag = from_etag(request.headers['If-Match'])
     updated_cocina_object = if etag

--- a/app/services/cocina/object_updater.rb
+++ b/app/services/cocina/object_updater.rb
@@ -154,8 +154,6 @@ module Cocina
 
     # rubocop:disable Style/GuardClause
     def validate
-      raise ValidationError, "Identifier on the query and in the body don't match" if fedora_object.pid != cocina_object.externalIdentifier
-
       if has_changed?(:description) && Settings.enabled_features.validate_descriptive_roundtrip.update
         result = DescriptionRoundtripValidator.valid_from_cocina?(cocina_object)
         raise RoundtripValidationError, result.failure unless result.success?


### PR DESCRIPTION


## Why was this change made? 🤔
This ensures we continue to have the validation even after we remove the Fedora object store
Fixes #3901


## How was this change tested? 🤨
Test suite


