### PR TITLE
[refactor] Provide a default event_factory for the VersionService

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -113,11 +113,11 @@ class ObjectsController < ApplicationController
     updated_cocina_object = @cocina_object
     # if this is an existing versionable object, open and close it without starting accessionWF
     if VersionService.can_open?(@cocina_object)
-      updated_cocina_object = VersionService.open(@cocina_object, **version_open_params, event_factory: EventFactory)
-      VersionService.close(updated_cocina_object, **version_close_params.merge(start_accession: false), event_factory: EventFactory)
+      updated_cocina_object = VersionService.open(@cocina_object, **version_open_params)
+      VersionService.close(updated_cocina_object, **version_close_params.merge(start_accession: false))
     # if this is an existing accessioned object that is currently open, just close it without starting accessionWF
     elsif VersionService.open?(@cocina_object)
-      VersionService.close(@cocina_object, **version_close_params.merge(start_accession: false), event_factory: EventFactory)
+      VersionService.close(@cocina_object, **version_close_params.merge(start_accession: false))
     end
 
     # initialize workflow

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -24,7 +24,7 @@ class VersionsController < ApplicationController
   end
 
   def create
-    updated_cocina_object = VersionService.open(@cocina_object, **create_params, event_factory: EventFactory)
+    updated_cocina_object = VersionService.open(@cocina_object, **create_params)
 
     add_headers(updated_cocina_object)
     render json: Cocina::Models.without_metadata(updated_cocina_object)
@@ -39,7 +39,7 @@ class VersionsController < ApplicationController
   end
 
   def close_current
-    VersionService.close(@cocina_object, **close_params, event_factory: EventFactory)
+    VersionService.close(@cocina_object, **close_params)
     render plain: "version #{@cocina_object.version} closed"
   rescue Dor::Exception => e
     render build_error('Unable to close version', e)

--- a/app/services/embargo_release_service.rb
+++ b/app/services/embargo_release_service.rb
@@ -49,11 +49,11 @@ class EmbargoReleaseService
     end
     Rails.logger.info("Releasing embargo for #{druid}")
 
-    updated_cocina_object = VersionService.open(cocina_object, description: 'embargo released', significance: 'admin', event_factory: EventFactory)
+    updated_cocina_object = VersionService.open(cocina_object, description: 'embargo released', significance: 'admin')
 
     updated_cocina_object = release_cocina_object(updated_cocina_object)
 
-    VersionService.close(updated_cocina_object, event_factory: EventFactory)
+    VersionService.close(updated_cocina_object)
 
     EventFactory.create(druid: druid, event_type: 'embargo_released', data: {})
 

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -2,32 +2,38 @@
 
 # Open and close versions
 class VersionService
-  # @param [String] :significance set significance (major/minor/patch) of version change
-  # @param [String] :description set description of version change
-  # @param [String] :opening_user_name add opening username to the events datastream
-  # @param [Boolean] :assume_accessioned If true, does not check whether object has been accessioned.
-  def self.open(cocina_object, event_factory:, description:, significance:, opening_user_name: nil, assume_accessioned: false)
+  # @param [Cocina::Models::DRO,Cocina::Models::Collection] cocina_object the item being acted upon
+  # @param [String] significance set significance (major/minor/patch) of version change
+  # @param [String] description set description of version change
+  # @param [String] opening_user_name add opening username to the events datastream
+  # @param [Boolean] assume_accessioned If true, does not check whether object has been accessioned.
+  # @param [Class] event_factory (EventFactory) the factory for creating events
+  def self.open(cocina_object, description:, significance:, event_factory: EventFactory, opening_user_name: nil, assume_accessioned: false)
     new(cocina_object, event_factory: event_factory).open(description: description,
                                                           significance: significance,
                                                           opening_user_name: opening_user_name,
                                                           assume_accessioned: assume_accessioned)
   end
 
-  # @param [Boolean] :assume_accessioned If true, does not check whether object has been accessioned.
+  # @param [Cocina::Models::DRO,Cocina::Models::Collection] cocina_object the item being acted upon
+  # @param [Boolean] assume_accessioned If true, does not check whether object has been accessioned.
   def self.can_open?(cocina_object, assume_accessioned: false)
     new(cocina_object).can_open?(assume_accessioned: assume_accessioned)
   end
 
+  # @param [Cocina::Models::DRO,Cocina::Models::Collection] cocina_object the item being acted upon
   def self.open?(cocina_object)
     new(cocina_object).open_for_versioning?
   end
 
-  # @param [String] :description describes the version change
-  # @param [Symbol] :significance which part of the version tag to increment
+  # @param [Cocina::Models::DRO,Cocina::Models::Collection] cocina_object the item being acted upon
+  # @param [String] description describes the version change
+  # @param [Symbol] significance which part of the version tag to increment
   #  :major, :minor, :admin (see Dor::VersionTag#increment)
-  # @param [String] :user_name add username to the events datastream
-  # @param [Boolean] :start_accession set to true if you want accessioning to start (default), false otherwise
-  def self.close(cocina_object, event_factory:, description: nil, significance: nil, user_name: nil, start_accession: true)
+  # @param [String] user_name add username to the events datastream
+  # @param [Boolean] start_accession (true) set to true if you want accessioning to start, false otherwise
+  # @param [Class] event_factory (EventFactory) the factory for creating events
+  def self.close(cocina_object, event_factory: EventFactory, description: nil, significance: nil, user_name: nil, start_accession: true)
     new(cocina_object, event_factory: event_factory).close(description: description,
                                                            significance: significance,
                                                            user_name: user_name,
@@ -38,16 +44,18 @@ class VersionService
     new(cocina_object).accessioning?
   end
 
+  # @param [Cocina::Models::DRO,Cocina::Models::Collection] cocina_object the item being acted upon
+  # @param [Class] event_factory (nil) the factory for creating events
   def initialize(cocina_object, event_factory: nil)
     @cocina_object = cocina_object
     @event_factory = event_factory
   end
 
   # Increments the version number and initializes versioningWF for the object
-  # @param [String] :significance set significance (major/minor/patch) of version change
-  # @param [String] :description set description of version change
-  # @param [String] :opening_user_name add opening username to the events datastream
-  # @param [Boolean] :assume_accessioned If true, does not check whether object has been accessioned.
+  # @param [String] significance set significance (major/minor/patch) of version change
+  # @param [String] description set description of version change
+  # @param [String] opening_user_name add opening username to the events datastream
+  # @param [Boolean] assume_accessioned If true, does not check whether object has been accessioned.
   # @return [Cocina::Models::DRO, Cocina::Models::AdminPolicy, Cocina::Models::Collection] updated cocina object
   # @raise [Dor::Exception] if the object hasn't been accessioned, or if a version is already opened
   # @raise [Preservation::Client::Error] if bad response from preservation catalog.

--- a/spec/requests/start_accession_spec.rb
+++ b/spec/requests/start_accession_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
            params: params,
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, default_start_accession_workflow, version: '2')
-      expect(VersionService).to have_received(:open).with(cocina_object, **params, event_factory: EventFactory)
-      expect(VersionService).to have_received(:close).with(updated_cocina_object, **close_params, event_factory: EventFactory)
+      expect(VersionService).to have_received(:open).with(cocina_object, **params)
+      expect(VersionService).to have_received(:close).with(updated_cocina_object, **close_params)
     end
 
     it 'can override the default workflow' do
@@ -87,8 +87,8 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
            params: params.merge(workflow: 'accessionWF'),
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'accessionWF', version: '2')
-      expect(VersionService).to have_received(:open).with(cocina_object, **params, event_factory: EventFactory)
-      expect(VersionService).to have_received(:close).with(updated_cocina_object, **close_params, event_factory: EventFactory)
+      expect(VersionService).to have_received(:open).with(cocina_object, **params)
+      expect(VersionService).to have_received(:close).with(updated_cocina_object, **close_params)
     end
   end
 
@@ -106,7 +106,7 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
       expect(response).to have_http_status(:success)
       expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, default_start_accession_workflow, version: '1')
       expect(VersionService).not_to have_received(:open)
-      expect(VersionService).to have_received(:close).with(cocina_object, **close_params, event_factory: EventFactory)
+      expect(VersionService).to have_received(:close).with(cocina_object, **close_params)
     end
   end
 

--- a/spec/requests/versions_spec.rb
+++ b/spec/requests/versions_spec.rb
@@ -68,8 +68,7 @@ RSpec.describe 'Operations regarding object versions' do
         expect(response.body).to match(/version 1 closed/)
         expect(VersionService).to have_received(:close)
           .with(cocina_object_with_metadata,
-                **close_params,
-                event_factory: EventFactory)
+                **close_params)
       end
     end
 
@@ -119,7 +118,7 @@ RSpec.describe 'Operations regarding object versions' do
         expect(response.headers['Last-Modified']).to end_with 'GMT'
         expect(response.headers['X-Created-At']).to end_with 'GMT'
         expect(response.headers['ETag']).to match(%r{W/".+"})
-        expect(VersionService).to have_received(:open).with(cocina_object_with_metadata, **open_params, event_factory: EventFactory)
+        expect(VersionService).to have_received(:open).with(cocina_object_with_metadata, **open_params)
       end
     end
 

--- a/spec/services/embargo_release_service_spec.rb
+++ b/spec/services/embargo_release_service_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe EmbargoReleaseService do
     context 'when not open' do
       it 'lifts embargo' do
         service.release
-        expect(VersionService).to have_received(:open).with(cocina_object, description: 'embargo released', significance: 'admin', event_factory: EventFactory)
+        expect(VersionService).to have_received(:open).with(cocina_object, description: 'embargo released', significance: 'admin')
         expect(service).to have_received(:release_cocina_object).with(open_cocina_object)
-        expect(VersionService).to have_received(:close).with(released_cocina_object, event_factory: EventFactory)
+        expect(VersionService).to have_received(:close).with(released_cocina_object)
         expect(EventFactory).to have_received(:create).with(druid: druid, event_type: 'embargo_released', data: {})
         expect(Notifications::EmbargoLifted).to have_received(:publish).with(model: released_cocina_object)
       end


### PR DESCRIPTION

## Why was this change made? 🤔
This improves the readability of the code by not requiring a lot of boilerplate, while maintaining dependency injection.
fixes #3935


## How was this change tested? 🤨
Test suite

