### PR TITLE
strip metadata before publishing embargo release message to queue

### DIFF
--- a/app/services/notifications/embargo_lifted.rb
+++ b/app/services/notifications/embargo_lifted.rb
@@ -13,7 +13,7 @@ module Notifications
     end
 
     def initialize(model:, channel:)
-      @model = model
+      @model = Cocina::Models.without_metadata(model)
       @channel = channel
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes sul-dlss/happy-heron#2230

We need to strip the metadata from the cocina model before publishing to the queue, since the consumer (currently H2) does not expect it to be there.

## How was this change tested? 🤨

Updated specs to verify metadata is stripped when publishing the message.

