### PR TITLE
Rename active record factories.

### DIFF
--- a/spec/factories/admin_policies.rb
+++ b/spec/factories/admin_policies.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :admin_policy do
+  factory :ar_admin_policy, class: 'AdminPolicy' do
     cocina_version { '0.0.1' }
     external_identifier { 'druid:jt959wc5586' }
     label { 'Test Admin Policy' }

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :collection do
+  factory :ar_collection, class: 'Collection' do
     cocina_version { '0.0.1' }
     external_identifier { generate(:unique_druid) }
     collection_type { Cocina::Models::ObjectType.collection }

--- a/spec/factories/dros.rb
+++ b/spec/factories/dros.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :dro do
+  factory :ar_dro, class: 'Dro' do
     cocina_version { '0.0.1' }
     external_identifier { generate(:unique_druid) }
     content_type { Cocina::Models::ObjectType.book }

--- a/spec/models/admin_policy_spec.rb
+++ b/spec/models/admin_policy_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe AdminPolicy do
 
   describe 'to_cocina' do
     context 'with minimal admin_policy' do
-      let(:admin_policy) { create(:admin_policy) }
+      let(:admin_policy) { create(:ar_admin_policy) }
 
       it 'returns a Cocina::Model::AdminPolicy' do
         expect(admin_policy.to_cocina).to cocina_object_with(minimal_cocina_admin_policy)
@@ -47,7 +47,7 @@ RSpec.describe AdminPolicy do
     end
 
     context 'with complete AdminPolicy' do
-      let(:admin_policy) { create(:admin_policy, :with_admin_policy_description) }
+      let(:admin_policy) { create(:ar_admin_policy, :with_admin_policy_description) }
 
       it 'returns a Cocina::Model::AdminPolicy' do
         expect(admin_policy.to_cocina).to cocina_object_with(cocina_admin_policy)

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Collection do
   let(:source_id) { 'googlebooks:9999999' }
 
   describe 'to_cocina' do
-    let(:collection) { create(:collection, external_identifier: druid) }
+    let(:collection) { create(:ar_collection, external_identifier: druid) }
     let(:source_id) { collection.identification['sourceId'] }
 
     it 'returns a Cocina::Model::Collection' do

--- a/spec/models/dro_spec.rb
+++ b/spec/models/dro_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Dro do
 
   describe 'to_cocina' do
     context 'with minimal DRO' do
-      let(:dro) { create(:dro, external_identifier: druid) }
+      let(:dro) { create(:ar_dro, external_identifier: druid) }
       let(:source_id) { dro.identification['sourceId'] }
 
       it 'returns a Cocina::Model::DRO' do
@@ -113,7 +113,7 @@ RSpec.describe Dro do
     end
 
     context 'with complete DRO' do
-      let(:dro) { create(:dro, :with_geographic, external_identifier: druid) }
+      let(:dro) { create(:ar_dro, :with_geographic, external_identifier: druid) }
       let(:source_id) { dro.identification['sourceId'] }
 
       it 'returns a Cocina::Model::DRO' do

--- a/spec/requests/collections_for_object_spec.rb
+++ b/spec/requests/collections_for_object_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Get the object' do
     end
   end
 
-  let(:collection_records) { [create(:collection)] }
+  let(:collection_records) { [create(:ar_collection)] }
   let(:collections) { collection_records.map(&:to_cocina).map { |cocina_object| Cocina::Models.without_metadata(cocina_object) } }
 
   let(:expected) do
@@ -21,7 +21,7 @@ RSpec.describe 'Get the object' do
     }
   end
 
-  let(:dro_record) { create(:dro, isMemberOf: collections.map(&:externalIdentifier)) }
+  let(:dro_record) { create(:ar_dro, isMemberOf: collections.map(&:externalIdentifier)) }
   let(:dro) { dro_record.to_cocina }
 
   let(:response_model) { JSON.parse(response.body).deep_symbolize_keys }
@@ -47,7 +47,7 @@ RSpec.describe 'Get the object' do
   end
 
   describe 'more than one collection' do
-    let(:collection_records) { [create(:collection), create(:collection)] }
+    let(:collection_records) { [create(:ar_collection), create(:ar_collection)] }
 
     it 'returns an empty array for collections' do
       get "/v1/objects/#{dro.externalIdentifier}/query/collections",

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe CocinaObjectStore do
         end
 
         context 'when found in postgres' do
-          let!(:ar_cocina_object) { create(:dro) }
+          let!(:ar_cocina_object) { create(:ar_dro) }
 
           it 'returns from postgres' do
             expect(described_class.find(ar_cocina_object.external_identifier)).to be_instance_of(Cocina::Models::DROWithMetadata)
@@ -618,7 +618,7 @@ RSpec.describe CocinaObjectStore do
       end
 
       context 'when object is a DRO' do
-        let(:ar_cocina_object) { create(:dro) }
+        let(:ar_cocina_object) { create(:ar_dro) }
 
         it 'returns Cocina::Models::DROWithMetadata' do
           expect(store.send(:ar_to_cocina_find, ar_cocina_object.external_identifier)).to be_instance_of(Cocina::Models::DROWithMetadata)
@@ -626,7 +626,7 @@ RSpec.describe CocinaObjectStore do
       end
 
       context 'when object is an AdminPolicy' do
-        let(:ar_cocina_object) { create(:admin_policy) }
+        let(:ar_cocina_object) { create(:ar_admin_policy) }
 
         it 'returns Cocina::Models::AdminPolicy' do
           expect(store.send(:ar_to_cocina_find, ar_cocina_object.external_identifier)).to be_instance_of(Cocina::Models::AdminPolicyWithMetadata)
@@ -634,7 +634,7 @@ RSpec.describe CocinaObjectStore do
       end
 
       context 'when object is a Collection' do
-        let(:ar_cocina_object) { create(:collection) }
+        let(:ar_cocina_object) { create(:ar_collection) }
 
         it 'returns Cocina::Models::Collection' do
           expect(store.send(:ar_to_cocina_find, ar_cocina_object.external_identifier)).to be_instance_of(Cocina::Models::CollectionWithMetadata)
@@ -650,7 +650,7 @@ RSpec.describe CocinaObjectStore do
       end
 
       context 'when object is a DRO' do
-        let(:ar_cocina_object) { create(:dro) }
+        let(:ar_cocina_object) { create(:ar_dro) }
 
         it 'returns true' do
           expect(store.ar_exists?(ar_cocina_object.external_identifier)).to be(true)
@@ -658,7 +658,7 @@ RSpec.describe CocinaObjectStore do
       end
 
       context 'when object is an AdminPolicy' do
-        let(:ar_cocina_object) { create(:admin_policy) }
+        let(:ar_cocina_object) { create(:ar_admin_policy) }
 
         it 'returns true' do
           expect(store.ar_exists?(ar_cocina_object.external_identifier)).to be(true)
@@ -666,7 +666,7 @@ RSpec.describe CocinaObjectStore do
       end
 
       context 'when object is a Collection' do
-        let(:ar_cocina_object) { create(:collection) }
+        let(:ar_cocina_object) { create(:ar_collection) }
 
         it 'returns true' do
           expect(store.ar_exists?(ar_cocina_object.external_identifier)).to be(true)
@@ -705,7 +705,7 @@ RSpec.describe CocinaObjectStore do
         end
 
         context 'when checking lock succeeds' do
-          let(:ar_cocina_object) { create(:dro) }
+          let(:ar_cocina_object) { create(:ar_dro) }
           let(:lock) { "#{ar_cocina_object.external_identifier}=#{ar_cocina_object.lock}" }
 
           let(:cocina_object) do
@@ -723,7 +723,7 @@ RSpec.describe CocinaObjectStore do
         end
 
         context 'when checking lock fails' do
-          let!(:ar_cocina_object) { create(:dro) }
+          let!(:ar_cocina_object) { create(:ar_dro) }
           let(:lock) { '64e8320d19d62ddb73c501276c5655cf' }
 
           let(:cocina_object) do

--- a/spec/services/synchronous_indexer_spec.rb
+++ b/spec/services/synchronous_indexer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SynchronousIndexer do
   describe '.reindex_remotely_from_cocina' do
     subject(:reindex) { described_class.reindex_remotely_from_cocina(cocina_object: cocina_object, created_at: created_at, updated_at: created_at) }
 
-    let(:dro) { create(:dro) }
+    let(:dro) { create(:ar_dro) }
     let(:cocina_object) { dro.to_cocina }
     let(:created_at) { Time.zone.now }
     let(:req_body) { { cocina_object: dro.to_cocina, created_at: created_at, updated_at: created_at }.to_json }


### PR DESCRIPTION
## Why was this change made? 🤔
To avoid naming conflicts when start using cocina model factories.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



