### PR TITLE
Use rspec for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,16 @@ docker-compose up db # use -d to daemonize/run in background
 And if you haven't yet prepared the test database, run:
 
 ```shell
-RAILS_ENV=test rails db:test:prepare
+RAILS_ENV=test bundle exec rails db:test:prepare
 ```
 
 To run the tests:
 
-  `bundle exec rake`
+  `bundle exec rspec`
 
-To run rubocop separately (auto run with tests):
+To run rubocop:
 
-  `bundle exec rake rubocop`
+  `bundle exec rubocop`
 
 ## Console and Development Server
 


### PR DESCRIPTION
## Why was this change made? 🤔

rubocop seems to behave differently under rake than when invoking it
directly:

```
$ rake rubocop
app/services/cocina/from_fedora/dro.rb:46:7: W: Lint/ShadowedException: Do not shadow rescued Exceptions.
      rescue Rubydora::FedoraInvalidRequest, StandardError => e ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/services/cocina_object_store.rb:155:3: W: Lint/ShadowedException: Do not shadow rescued Exceptions.
  rescue Rubydora::FedoraInvalidRequest, StandardError => e ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/services/events_migration_service.rb:19:3: W: Lint/ShadowedException: Do not shadow rescued Exceptions.
  rescue Rubydora::FedoraInvalidRequest, StandardError => e ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/fedora_migrator.rb:86:3: W: Lint/ShadowedException: Do not shadow rescued Exceptions.
  rescue Rubydora::FedoraInvalidRequest, StandardError => e ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

481 files inspected, 4 offenses detectedk
```

whereas

```
$ bundle exec rubocop
Inspecting 481 files
.................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

481 files inspected, no offenses detected
```

Even though we don't all use bundle exec we should probably update the
docs to reflect that rake won't currently work.

## How was this change tested? 🤨

unit tests

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



