### PR TITLE
only refresh catkeys/barcodes that are marked to refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Note that the application has a web UI for monitoring Sidekiq activity at `/queu
 
 ## Running Tests
 
+NOTE: you need to be running at least Ruby 2.7.4 in order for the tests to pass (using the cocina factories).
+
 First, ensure the database container is spun up:
 
 ```shell
@@ -137,7 +139,7 @@ Usage: bin/generate-cache [options]
     -a, --auto                       Automatically choose sample based on 14 day cycle.
     -d, --druids DRUIDS              List of druids (instead of druids.txt).
     -i, --input INPUT                Input filename, otherwise druids.txt.
-    -k, --skip SKIP                  Number of druids to skip.    
+    -k, --skip SKIP                  Number of druids to skip.
     -h, --help                       Displays help.
 
 $ bin/generate-cache
@@ -211,7 +213,7 @@ $ bin/validate-to-mods -h
 Usage: bin/validate-to-mods [options]
     -s, --sample SAMPLE              Sample size, otherwise all druids.
     -u, --unique-filename            Result file named for branch and runtime
-    -i, --input FILENAME             File containing list of druids (instead of druids.txt).    
+    -i, --input FILENAME             File containing list of druids (instead of druids.txt).
     -h, --help                       Displays help.
 
 $ bin/validate-to-mods
@@ -234,7 +236,7 @@ Usage: bin/validate-desc-cocina-roundtrip [options]
     -r, --random                     Select random druids.
     -f, --fast                       Do not write results files.
     -d, --druids DRUIDS              List of druids (instead of druids.txt).
-    -i, --input FILENAME             File containing list of druids (instead of druids.txt).    
+    -i, --input FILENAME             File containing list of druids (instead of druids.txt).
     -h, --help                       Displays help.
 
 $ bin/validate-desc-cocina-roundtrip -s 10 -r

--- a/app/controllers/metadata_refresh_controller.rb
+++ b/app/controllers/metadata_refresh_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Gets the catkey or barcode from identityMetadata and returns the catalog info
+# Given a cocina object, fetch the available refreshable catkey or barcodes and returns the catalog info
 class MetadataRefreshController < ApplicationController
   before_action :load_cocina_object
 
@@ -25,7 +25,7 @@ class MetadataRefreshController < ApplicationController
   def identifiers
     return [] unless @cocina_object.identification&.catalogLinks
 
-    @identifiers ||= @cocina_object.identification.catalogLinks.filter_map { |clink| "catkey:#{clink.catalogRecordId}" if clink.catalog == 'symphony' }.tap do |id|
+    @identifiers ||= @cocina_object.identification.catalogLinks.filter_map { |clink| "catkey:#{clink.catalogRecordId}" if clink.catalog == 'symphony' && clink.refresh }.tap do |id|
       # Not all Cocina objects have identification metadata that includes barcodes (e.g., collections)
       next unless @cocina_object.identification.try(:barcode)
 

--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -324,7 +324,7 @@ class CocinaObjectStore
   end
 
   def catkeys_for(cocina_request_object)
-    cocina_request_object.identification&.catalogLinks&.filter_map { |clink| "catkey:#{clink.catalogRecordId}" if clink.catalog == 'symphony' }
+    cocina_request_object.identification&.catalogLinks&.filter_map { |clink| "catkey:#{clink.catalogRecordId}" if clink.catalog == 'symphony' && clink.refresh }
   end
 
   # Converts from Cocina::Models::RequestDRO|RequestCollection|RequestAdminPolicy to Cocina::Models::DRO|Collection||AdminPolicy

--- a/app/services/refresh_metadata_action.rb
+++ b/app/services/refresh_metadata_action.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Look into identityMetadata for compliant ids and use them to fetch
-# descriptive metadata from Symphony.  Put the fetched value in the descMetadata
+# Use resolvable identifiers to fetch descriptive metadata from Symphony.
 class RefreshMetadataAction
   include Dry::Monads[:result]
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #3847 - check to be sure catkey/barcodes are refresh-able before pulling

Also, update some related code comments to better reflect reality.

Finally, add a note about dor-services-app ruby version needed for testing to the readme


## How was this change tested? 🤨

Added a new test