### PR TITLE
Refactor catkeys/barcode fetching method

### DIFF
--- a/app/controllers/metadata_refresh_controller.rb
+++ b/app/controllers/metadata_refresh_controller.rb
@@ -23,9 +23,7 @@ class MetadataRefreshController < ApplicationController
   private
 
   def identifiers
-    return [] unless @cocina_object.identification&.catalogLinks
-
-    @identifiers ||= @cocina_object.identification.catalogLinks.filter_map { |clink| "catkey:#{clink.catalogRecordId}" if clink.catalog == 'symphony' && clink.refresh }.tap do |id|
+    RefreshMetadataAction.identifiers(cocina_object: @cocina_object).tap do |id|
       # Not all Cocina objects have identification metadata that includes barcodes (e.g., collections)
       next unless @cocina_object.identification.try(:barcode)
 

--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -322,10 +322,6 @@ class CocinaObjectStore
     cocina_request_object.new(label: label, description: description_props)
   end
 
-  def catkeys_for(cocina_request_object)
-    cocina_request_object.identification&.catalogLinks&.filter_map { |clink| "catkey:#{clink.catalogRecordId}" if clink.catalog == 'symphony' && clink.refresh }
-  end
-
   # Converts from Cocina::Models::RequestDRO|RequestCollection|RequestAdminPolicy to Cocina::Models::DRO|Collection||AdminPolicy
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/CyclomaticComplexity

--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -309,8 +309,7 @@ class CocinaObjectStore
   def sync_from_symphony(cocina_request_object, druid)
     return cocina_request_object if cocina_request_object.admin_policy?
 
-    catkeys = catkeys_for(cocina_request_object)
-
+    catkeys = RefreshMetadataAction.identifiers(cocina_object: cocina_request_object)
     return cocina_request_object if catkeys.blank?
 
     result = RefreshMetadataAction.run(identifiers: catkeys, cocina_object: cocina_request_object, druid: druid)

--- a/app/services/refresh_metadata_action.rb
+++ b/app/services/refresh_metadata_action.rb
@@ -12,6 +12,12 @@ class RefreshMetadataAction
     new(identifiers: identifiers, cocina_object: cocina_object, druid: druid).run
   end
 
+  # @param [Cocina::Models::DRO|Collection|APO|Agreement|RequestDRO|RequestCollection|RequestAPO|RequestAgreement] cocina_object
+  # @return [Array] Refreshable identifiers in the object
+  def self.identifiers(cocina_object:)
+    cocina_object.identification&.catalogLinks&.filter_map { |clink| "catkey:#{clink.catalogRecordId}" if clink.catalog == 'symphony' && clink.refresh }
+  end
+
   # @param [Array<String>] identifiers the set of identifiers that might be resolvable
   # @param [Cocina::Models::DRO|Collection|APO|Agreement|RequestDRO|RequestCollection|RequestAPO|RequestAgreement] cocina_object to refresh
   # @param [string] druid

--- a/app/services/refresh_metadata_action.rb
+++ b/app/services/refresh_metadata_action.rb
@@ -15,7 +15,7 @@ class RefreshMetadataAction
   # @param [Cocina::Models::DRO|Collection|APO|Agreement|RequestDRO|RequestCollection|RequestAPO|RequestAgreement] cocina_object
   # @return [Array] Refreshable identifiers in the object
   def self.identifiers(cocina_object:)
-    cocina_object.identification&.catalogLinks&.filter_map { |clink| "catkey:#{clink.catalogRecordId}" if clink.catalog == 'symphony' && clink.refresh }
+    cocina_object.identification.catalogLinks.filter_map { |clink| "catkey:#{clink.catalogRecordId}" if clink.catalog == 'symphony' && clink.refresh }
   end
 
   # @param [Array<String>] identifiers the set of identifiers that might be resolvable

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -280,8 +280,10 @@ RSpec.describe CocinaObjectStore do
 
       context 'when a Collection' do
         let(:requested_cocina_object) do
-          instance_double(Cocina::Models::RequestCollection, admin_policy?: false, identification: nil, to_h: cocina_hash, description: request_description, dro?: false, collection?: true)
+          instance_double(Cocina::Models::RequestCollection, admin_policy?: false, identification: request_identification, to_h: cocina_hash, description: request_description, dro?: false,
+                                                             collection?: true)
         end
+        let(:request_identification) { instance_double(Cocina::Models::RequestIdentification, catalogLinks: []) }
 
         it 'maps and saves to Fedora' do
           expect(cocina_object_store.create(requested_cocina_object)).to cocina_object_with cocina_object_with_metadata

--- a/spec/services/refresh_metadata_action_spec.rb
+++ b/spec/services/refresh_metadata_action_spec.rb
@@ -4,73 +4,114 @@ require 'rails_helper'
 
 RSpec.describe RefreshMetadataAction do
   include Dry::Monads[:result]
-
-  subject(:refresh) { described_class.run(identifiers: ['catkey:123'], cocina_object: cocina_object, druid: druid) }
-
   let(:druid) { 'druid:bc753qt7345' }
-  let(:apo_druid) { 'druid:pp000pp0000' }
   let(:description) do
     {
       title: [{ value: 'However am I going to be' }],
       purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
     }
   end
-  let(:cocina_object) do
-    build(:dro, id: druid).new(description: description)
-  end
 
-  let(:mods) do
-    <<~XML
-      <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.7">
-        <titleInfo>
-          <title>Paying for College</title>
-        </titleInfo>
-      </mods>
-    XML
-  end
+  describe '#refresh' do
+    subject(:refresh) { described_class.run(identifiers: ['catkey:123'], cocina_object: cocina_object, druid: druid) }
 
-  before do
-    allow(ModsService).to receive(:fetch).and_return(mods)
-    allow(Honeybadger).to receive(:notify)
-  end
+    let(:apo_druid) { 'druid:pp000pp0000' }
+    let(:cocina_object) do
+      build(:dro, id: druid).new(description: description)
+    end
 
-  it 'gets the data and returns success' do
-    expect(refresh.success?).to be(true)
-    expect(refresh.value!.description_props).to eq({
-                                                     title: [{ value: 'Paying for College' }],
-                                                     purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
-                                                   })
-    expect(refresh.value!.mods_ng_xml).to be_equivalent_to(Nokogiri::XML(mods))
-    expect(Honeybadger).not_to have_received(:notify)
-  end
+    let(:mods) do
+      <<~XML
+        <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.7">
+          <titleInfo>
+            <title>Paying for College</title>
+          </titleInfo>
+        </mods>
+      XML
+    end
 
-  context 'when fetch_metadata fails' do
     before do
-      allow(ModsService).to receive(:fetch).and_raise(SymphonyReader::ResponseError)
+      allow(ModsService).to receive(:fetch).and_return(mods)
+      allow(Honeybadger).to receive(:notify)
     end
 
-    it 'gets the data and puts it in descMetadata and Honeybadger notifies' do
-      expect { refresh }.to raise_error(SymphonyReader::ResponseError)
+    it 'gets the data and returns success' do
+      expect(refresh.success?).to be(true)
+      expect(refresh.value!.description_props).to eq({
+                                                       title: [{ value: 'Paying for College' }],
+                                                       purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+                                                     })
+      expect(refresh.value!.mods_ng_xml).to be_equivalent_to(Nokogiri::XML(mods))
+      expect(Honeybadger).not_to have_received(:notify)
+    end
+
+    context 'when fetch_metadata fails' do
+      before do
+        allow(ModsService).to receive(:fetch).and_raise(SymphonyReader::ResponseError)
+      end
+
+      it 'gets the data and puts it in descMetadata and Honeybadger notifies' do
+        expect { refresh }.to raise_error(SymphonyReader::ResponseError)
+      end
+    end
+
+    context 'when fetch_metadata returns nil' do
+      before do
+        allow(ModsService).to receive(:fetch).and_return(nil)
+      end
+
+      it 'returns a Dry::Monads::Result::Failure object' do
+        expect(refresh.failure?).to be(true)
+      end
+    end
+
+    context 'when Descriptive.props returns nil' do
+      before do
+        allow(Cocina::Models::Mapping::FromMods::Description).to receive(:props).and_return(nil)
+      end
+
+      it 'returns a Dry::Monads::Result::Failure object' do
+        expect(refresh.failure?).to be(true)
+      end
     end
   end
 
-  context 'when fetch_metadata returns nil' do
-    before do
-      allow(ModsService).to receive(:fetch).and_return(nil)
+  describe '#identifiers' do
+    subject(:indentifiers) { described_class.identifiers(cocina_object: cocina_object) }
+
+    let(:identification) { instance_double(Cocina::Models::RequestIdentification, catalogLinks: catalog_links) }
+    let(:cocina_object) do
+      instance_double(Cocina::Models::RequestDRO, admin_policy?: false, identification: identification, to_h: {}, dro?: true, collection?: false)
     end
 
-    it 'returns a Dry::Monads::Result::Failure object' do
-      expect(refresh.failure?).to be(true)
-    end
-  end
+    context 'when a valid identifier' do
+      let(:catalog_links) do
+        [Cocina::Models::CatalogLink.new(catalog: 'symphony', catalogRecordId: 'nope123', refresh: false),
+         Cocina::Models::CatalogLink.new(catalog: 'symphony', catalogRecordId: 'yup123', refresh: true),
+         Cocina::Models::CatalogLink.new(catalog: 'previous symphony', catalogRecordId: 'old123', refresh: true)]
+      end
 
-  context 'when Descriptive.props returns nil' do
-    before do
-      allow(Cocina::Models::Mapping::FromMods::Description).to receive(:props).and_return(nil)
+      it 'returns only the valid symphony identifier with refresh == true' do
+        expect(indentifiers).to eq(['catkey:yup123'])
+      end
     end
 
-    it 'returns a Dry::Monads::Result::Failure object' do
-      expect(refresh.failure?).to be(true)
+    context 'when no identifiers' do
+      let(:catalog_links) { [] }
+
+      it 'returns an empty array' do
+        expect(indentifiers).to eq([])
+      end
+    end
+
+    context 'when no valid identifiers' do
+      let(:catalog_links) do
+        [Cocina::Models::CatalogLink.new(catalog: 'symphony', catalogRecordId: 'nope123', refresh: false)]
+      end
+
+      it 'returns an empty array' do
+        expect(indentifiers).to eq([])
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

After working on #3993 (modifying how barcode/catkeys are refreshed), I thought it would be wise to remove the duplication of the logic I modified and place in a central location as well.  

Added some tests too.

Question: is there a reason the refresh action in the controller goes digging for a barcode while the cocina object store class does not?  Should they work the same way (i.e. by moving that bit of logic out of the controller and into the single "identifiers" method)?

## How was this change tested? 🤨

New tests
