### PR TITLE
Exempt UR APO from ApoExistenceValidator.

### DIFF
--- a/app/validators/cocina/apo_existence_validator.rb
+++ b/app/validators/cocina/apo_existence_validator.rb
@@ -11,6 +11,9 @@ module Cocina
 
     # @return [Boolean] false if the APO is not in the repository
     def valid?
+      # Always valid if UR APO
+      return true if apo_id == Settings.ur_admin_policy.druid
+
       begin
         apo = CocinaObjectStore.find(apo_id)
         @error = "Expected '#{apo_id}' to be an AdminPolicy but it is a #{apo.class}" unless apo.admin_policy?

--- a/spec/validators/cocina/apo_existence_validator_spec.rb
+++ b/spec/validators/cocina/apo_existence_validator_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe Cocina::ApoExistenceValidator do
     end
   end
 
+  context 'with a dor object with a UR APO' do
+    let(:item) { build(:dro, admin_policy_id: 'druid:hv992ry2431') }
+
+    it 'returns true' do
+      expect(validator.valid?).to be true
+    end
+  end
+
   context 'when a dor object as an APO that is not found' do
     let(:item) { build(:dro, admin_policy_id: 'druid:df123cd4567') }
 


### PR DESCRIPTION
## Why was this change made? 🤔
To allow seeding in Argo (which requires UR APO).


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

