### PR TITLE
Stop making reference to Dor::VERSION

### DIFF
--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -19,7 +19,7 @@ module Publish
       pub = Nokogiri::XML('<publicObject/>').root
       pub['id'] = public_cocina.externalIdentifier
       pub['published'] = Time.now.utc.xmlschema
-      pub['publishVersion'] = "dor-services/#{Dor::VERSION}"
+      pub['publishVersion'] = "cocina-models/#{Cocina::Models::VERSION}"
       pub.add_child(public_identity_metadata.root) # add in modified identityMetadata datastream
       pub.add_child(public_content_metadata.root) if public_content_metadata.xpath('//resource').any?
       pub.add_child(public_rights_metadata)

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'Display metadata' do
       expect(response).to be_successful
       expect(response.body).to be_equivalent_to <<~XML
         <?xml version="1.0" encoding="UTF-8"?>
-        <publicObject id="druid:mk420bs7601" published="#{now.utc.xmlschema}" publishVersion="dor-services/#{Dor::VERSION}">
+        <publicObject id="druid:mk420bs7601" published="#{now.utc.xmlschema}" publishVersion="cocina-models/#{Cocina::Models::VERSION}">
           <identityMetadata>
             <objectType>item</objectType>
             <objectLabel>Hello</objectLabel>

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Publish::PublicXmlService do
       end
 
       it 'a published version' do
-        expect(ng_xml.at_xpath('/publicObject/@publishVersion').value).to eq("dor-services/#{Dor::VERSION}")
+        expect(ng_xml.at_xpath('/publicObject/@publishVersion').value).to eq("cocina-models/#{Cocina::Models::VERSION}")
       end
 
       it 'has identityMetadata with catkeys' do


### PR DESCRIPTION

## Why was this change made? 🤔
We are decoupling from dor-services


## How was this change tested? 🤨

There doesn't appear to be any code that references this property, but many fixtures have it populated: https://github.com/search?p=2&q=org%3Asul-dlss+publishVersion&type=Code

