### PR TITLE
Adds a delete event when purging.

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -172,7 +172,7 @@ class ObjectsController < ApplicationController
   end
 
   def destroy
-    DeleteService.destroy(@cocina_object.externalIdentifier)
+    DeleteService.destroy(@cocina_object)
     head :no_content
   rescue StandardError => e
     json_api_error(status: :internal_server_error,


### PR DESCRIPTION
closes #4002

## Why was this change made? 🤔
Allow tracking of purged objects.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



