### PR TITLE
Remove unnecessary rescue blocks

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,14 +11,6 @@ class ApplicationController < ActionController::API
     }, status: :bad_request
   end
 
-  # No longer be necessary when remove Fedora.
-  rescue_from(Cocina::Mapper::UnexpectedBuildError) do |e|
-    json_api_error(status: :unprocessable_entity,
-                   title: 'Unexpected Cocina::Mapper.build error',
-                   message: e.cause,
-                   meta: { backtrace: e.cause&.backtrace })
-  end
-
   before_action :check_auth_token
 
   TOKEN_HEADER = 'Authorization'

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -13,21 +13,6 @@ class ObjectsController < ApplicationController
     raise e
   end
 
-  # No longer be necessary when remove Fedora.
-  rescue_from(Cocina::Mapper::UnexpectedBuildError) do |e|
-    json_api_error(status: :unprocessable_entity,
-                   title: 'Unexpected Cocina::Mapper.build error',
-                   message: e.cause,
-                   meta: { backtrace: e.cause.backtrace })
-  end
-
-  # No longer be necessary when remove Fedora.
-  rescue_from(SolrConnectionError) do |e|
-    json_api_error(status: :internal_server_error,
-                   title: 'Unable to reach Solr',
-                   message: e.message)
-  end
-
   def create
     return json_api_error(status: :service_unavailable, message: 'Registration is temporarily disabled') unless Settings.enabled_features.registration
 

--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -17,8 +17,6 @@ class CocinaObjectStore
   # Retrieves a Cocina object from the datastore.
   # @param [String] druid
   # @return [Cocina::Models::DROWithMetadata, Cocina::Models::CollectionWithMetadata, Cocina::Models::AdminPolicyWithMetadata] cocina_object
-  # @raise [SolrConnectionError] raised when cannot connect to Solr. This error will no longer be raised when Fedora is removed.
-  # @raise [Cocina::Mapper::UnexpectedBuildError] raised when an mapping error occurs. This error will no longer be raised when Fedora is removed.
   # @raise [CocinaObjectNotFoundError] raised when the requested Cocina object is not found.
   def self.find(druid)
     new.find(druid)


### PR DESCRIPTION
## Why was this change made? 🤔

We don't have Mapping errors anymore.

## How was this change tested? 🤨
CI