### PR TITLE
Stop using Dor::PidUtils

### DIFF
--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe CocinaObjectStore do
       let(:description_props) do
         {
           title: [{ value: 'The Well-Grounded Rubyist' }],
-          purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+          purl: Purl.for(druid: druid)
         }
       end
 

--- a/spec/services/refresh_metadata_action_spec.rb
+++ b/spec/services/refresh_metadata_action_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RefreshMetadataAction do
   let(:description) do
     {
       title: [{ value: 'However am I going to be' }],
-      purl: "https://purl.stanford.edu/#{Dor::PidUtils.remove_druid_prefix(druid)}"
+      purl: Purl.for(druid: druid)
     }
   end
 


### PR DESCRIPTION


## Why was this change made? 🤔
Purl.for() is more concise and we're decoupling from dor-services


## How was this change tested? 🤨
CI


