### PR TITLE
Fix Rails 6.1 deprecation warning.

### DIFF
--- a/app/models/object_version.rb
+++ b/app/models/object_version.rb
@@ -63,7 +63,10 @@ class ObjectVersion < ApplicationRecord
 
     if significance
       # Greatest version with a tag.
-      last_object_version = ObjectVersion.where(druid: druid).where.not(tag: nil, version: current_object_version.version).order(version: :desc).first
+      last_object_version = ObjectVersion.where(druid: druid)
+                                         .where.not(tag: nil)
+                                         .where.not(version: current_object_version.version)
+                                         .order(version: :desc).first
       last_tag = VersionTag.parse(last_object_version.tag)
       current_object_version.tag = last_tag.increment(significance).to_s
     end


### PR DESCRIPTION
## Why was this change made? 🤔
```
DEPRECATION WARNING: NOT conditions will no longer behave as NOR in Rails 6.1. To continue using NOR conditions, NOT each condition individually (`.where.not(:tag => ...).where.not(:version => ...)`). (called from update_current_version at /Users/jlittman/data/sdr/dor-services-app/app/models/object_version.rb:66)
```


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



