### PR TITLE
Fix Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apk add --update --no-cache  \
 # Get bundler 2.0
 RUN gem install bundler
 
-RUN mkdir /app
+RUN mkdir -p /app/tmp/pids
 WORKDIR /app
 
 COPY Gemfile Gemfile.lock ./


### PR DESCRIPTION
## Why was this change made? 🤔
```
argo-dor-services-app-1  | Running server
argo-dor-services-app-1  | Puma starting in single mode...
argo-dor-services-app-1  | * Puma version: 5.6.4 (ruby 2.7.5-p203) ("Birdie's Version")
argo-dor-services-app-1  | *  Min threads: 5
argo-dor-services-app-1  | *  Max threads: 5
argo-dor-services-app-1  | *  Environment: production
argo-dor-services-app-1  | *          PID: 1
argo-dor-services-app-1  | I, [2022-05-10T18:40:50.310479 #1]  INFO -- honeybadger: ** [Honeybadger] Initializing Honeybadger Error Tracker for Ruby. Ship it! version=4.12.1 framework=rails level=1 pid=1
argo-dor-services-app-1  | * Listening on http://0.0.0.0:3000
argo-dor-services-app-1  | /usr/local/bundle/gems/puma-5.6.4/lib/puma/launcher.rb:248:in `write': No such file or directory @ rb_sysopen - tmp/pids/server.pid (Errno::ENOENT)
```

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Local

