### PR TITLE
Remove unused DataErrorNotifier#warn

### DIFF
--- a/app/services/cocina/from_fedora/data_error_notifier.rb
+++ b/app/services/cocina/from_fedora/data_error_notifier.rb
@@ -12,23 +12,10 @@ module Cocina
         @druid = druid
       end
 
-      # Notify for a non-critical data error.
-      # @param [String] message
-      # @param [Hash<String, String>] context to add to warning context
-      def warn(message, context = {})
-        return unless Settings.from_fedora_data_errors.notify_warn
-
-        Honeybadger.notify("[DATA WARNING] #{message}",
-                           tags: 'data_warning',
-                           context: { druid: druid }.merge(context))
-      end
-
       # Notify for a critical data error.
       # @param [String] message
       # @param [Hash<String, String>] context to add to error context
       def error(message, context = {})
-        return unless Settings.from_fedora_data_errors.notify_error
-
         Honeybadger.notify("[DATA ERROR] #{message}",
                            tags: 'data_error',
                            context: { druid: druid }.merge(context))

--- a/spec/services/cocina/from_fedora/data_error_notifier_spec.rb
+++ b/spec/services/cocina/from_fedora/data_error_notifier_spec.rb
@@ -7,39 +7,19 @@ RSpec.describe Cocina::FromFedora::DataErrorNotifier do
     described_class.new(druid: 'druid:zq087nd5094')
   end
 
-  context 'when enabled' do
+  describe '#error' do
+    subject(:notifiy_error) { notifier.error('Fix it! Fix it! Fix it!', { type: 'robot' }) }
+
     before do
       allow(Honeybadger).to receive(:notify)
-      allow(Settings.from_fedora_data_errors).to receive(:notify_warn).and_return(true)
-      allow(Settings.from_fedora_data_errors).to receive(:notify_error).and_return(true)
-    end
-
-    it 'Honeybadger notifies for warning' do
-      notifier.warn('Danger, Will Robinson!', { type: 'robot' })
-      expect(Honeybadger).to have_received(:notify).with('[DATA WARNING] Danger, Will Robinson!', { context: { druid: 'druid:zq087nd5094', type: 'robot' }, tags: 'data_warning' })
     end
 
     it 'Honeybadger notifies for error' do
-      notifier.error('Fix it! Fix it! Fix it!', { type: 'robot' })
-      expect(Honeybadger).to have_received(:notify).with('[DATA ERROR] Fix it! Fix it! Fix it!', { context: { druid: 'druid:zq087nd5094', type: 'robot' }, tags: 'data_error' })
-    end
-  end
-
-  context 'when disabled' do
-    before do
-      allow(Honeybadger).to receive(:notify)
-      allow(Settings.from_fedora_data_errors).to receive(:notify_warn).and_return(false)
-      allow(Settings.from_fedora_data_errors).to receive(:notify_error).and_return(false)
-    end
-
-    it 'No notification for warning' do
-      notifier.warn('Danger, Will Robinson!', { type: 'robot' })
-      expect(Honeybadger).not_to have_received(:notify)
-    end
-
-    it 'No notification for error' do
-      notifier.error('Fix it! Fix it! Fix it!', { type: 'robot' })
-      expect(Honeybadger).not_to have_received(:notify)
+      notifiy_error
+      expect(Honeybadger).to have_received(:notify)
+        .with('[DATA ERROR] Fix it! Fix it! Fix it!',
+              { context: { druid: 'druid:zq087nd5094', type: 'robot' },
+                tags: 'data_error' })
     end
   end
 end


### PR DESCRIPTION


## Why was this change made? 🤔

And remove feature flags because we're happy with this behavior now.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



