### PR TITLE
Avoid custom matcher when a simple equals works

### DIFF
--- a/spec/models/admin_policy_spec.rb
+++ b/spec/models/admin_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe AdminPolicy do
   let(:minimal_cocina_admin_policy) do
     Cocina::Models::AdminPolicy.new({
-                                      cocinaVersion: '0.0.1',
+                                      cocinaVersion: Cocina::Models::VERSION,
                                       externalIdentifier: 'druid:jt959wc5586',
                                       type: Cocina::Models::ObjectType.admin_policy,
                                       label: 'Test Admin Policy',
@@ -20,7 +20,7 @@ RSpec.describe AdminPolicy do
 
   let(:cocina_admin_policy) do
     Cocina::Models::AdminPolicy.new({
-                                      cocinaVersion: '0.0.1',
+                                      cocinaVersion: Cocina::Models::VERSION,
                                       externalIdentifier: 'druid:jt959wc5586',
                                       type: Cocina::Models::ObjectType.admin_policy,
                                       label: 'Test Admin Policy',
@@ -42,7 +42,7 @@ RSpec.describe AdminPolicy do
       let(:admin_policy) { create(:ar_admin_policy) }
 
       it 'returns a Cocina::Model::AdminPolicy' do
-        expect(admin_policy.to_cocina).to cocina_object_with(minimal_cocina_admin_policy)
+        expect(admin_policy.to_cocina).to eq minimal_cocina_admin_policy
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe AdminPolicy do
       let(:admin_policy) { create(:ar_admin_policy, :with_admin_policy_description) }
 
       it 'returns a Cocina::Model::AdminPolicy' do
-        expect(admin_policy.to_cocina).to cocina_object_with(cocina_admin_policy)
+        expect(admin_policy.to_cocina).to eq cocina_admin_policy
       end
     end
   end

--- a/spec/models/dro_spec.rb
+++ b/spec/models/dro_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Dro do
 
   let(:minimal_cocina_dro) do
     Cocina::Models::DRO.new({
-                              cocinaVersion: '0.0.1',
+                              cocinaVersion: Cocina::Models::VERSION,
                               externalIdentifier: druid,
                               type: Cocina::Models::ObjectType.book,
                               label: 'Test DRO',
@@ -53,7 +53,7 @@ RSpec.describe Dro do
 
   let(:cocina_dro) do
     Cocina::Models::DRO.new({
-                              cocinaVersion: '0.0.1',
+                              cocinaVersion: Cocina::Models::VERSION,
                               externalIdentifier: druid,
                               type: Cocina::Models::ObjectType.book,
                               label: 'Test DRO',
@@ -108,7 +108,7 @@ RSpec.describe Dro do
       let(:source_id) { dro.identification['sourceId'] }
 
       it 'returns a Cocina::Model::DRO' do
-        expect(dro.to_cocina).to cocina_object_with(minimal_cocina_dro)
+        expect(dro.to_cocina).to eq(minimal_cocina_dro)
       end
     end
 
@@ -117,7 +117,7 @@ RSpec.describe Dro do
       let(:source_id) { dro.identification['sourceId'] }
 
       it 'returns a Cocina::Model::DRO' do
-        expect(dro.to_cocina).to cocina_object_with(cocina_dro)
+        expect(dro.to_cocina).to eq(cocina_dro)
       end
     end
   end


### PR DESCRIPTION


## Why was this change made? 🤔
This makes the spec code easier to follow


## How was this change tested? 🤨
CI