### PR TITLE
Rails passes a hash of options to #to_xml, not kwargs

### DIFF
--- a/app/services/publish/public_desc_metadata_service.rb
+++ b/app/services/publish/public_desc_metadata_service.rb
@@ -17,8 +17,9 @@ module Publish
     end
 
     # @return [String] Public descriptive medatada XML
-    def to_xml(include_access_conditions: true, prefixes: nil, template: nil)
-      ng_xml(include_access_conditions: include_access_conditions).to_xml
+    # @params [Hash] _opts ({}) Rails sends args when rendering XML but we ignore them
+    def to_xml(_opts = {})
+      ng_xml(include_access_conditions: true).to_xml
     end
 
     # @return [Nokogiri::XML::Document]

--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -14,8 +14,8 @@ module Publish
 
     # @raise [Dor::DataError]
     # rubocop:disable Metrics/AbcSize
-    # @note Rails sends args when rendering XML but we ignore them
-    def to_xml(**)
+    # @params [Hash] _opts ({}) Rails sends args when rendering XML but we ignore them
+    def to_xml(_opts = {})
       pub = Nokogiri::XML('<publicObject/>').root
       pub['id'] = public_cocina.externalIdentifier
       pub['published'] = Time.now.utc.xmlschema


### PR DESCRIPTION

## Why was this change made? 🤔
This PR makes this differentiation, because Ruby 3 is not as tolerant of this ambiguity


## How was this change tested? 🤨
CI

