### PR TITLE
Refactor ShelvingService

### DIFF
--- a/spec/services/shelvable_files_stager_spec.rb
+++ b/spec/services/shelvable_files_stager_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe ShelvableFilesStager do
-  subject(:stage) { described_class.stage(druid, content_metadata, shelve_diff, content_dir) }
+  subject(:stage) { described_class.stage(druid, preserve_diff, shelve_diff, content_dir) }
 
   let(:workspace_root) { Dir.mktmpdir }
   let(:druid) { 'druid:jq937jp0017' }
-  let(:content_metadata) { '<contentMetadata/>' }
+  let(:preserve_diff) { instance_double(Moab::FileGroupDifference, file_deltas: { added: [] }) }
   let(:workspace_druid) { DruidTools::Druid.new(druid, workspace_root) }
 
   # create an empty workspace location for object content files
@@ -20,11 +20,9 @@ RSpec.describe ShelvableFilesStager do
   let(:shelve_diff) { inventory_diff.group_difference('content') }
 
   context 'when the manifest files are not in the workspace' do
-    let(:preservation_diff) { instance_double(Moab::FileInventoryDifference, group_difference: group_diff) }
-    let(:group_diff) { instance_double(Moab::FileGroupDifference, file_deltas: file_deltas) }
+    let(:preserve_diff) { instance_double(Moab::FileGroupDifference, file_deltas: file_deltas) }
 
     before do
-      allow(Preservation::Client.objects).to receive(:content_inventory_diff).and_return(preservation_diff)
       # create the one modified file:
       FileUtils.touch(content_dir.join('SUB2_b2000_1.bvals'))
     end

--- a/spec/services/shelving_service_spec.rb
+++ b/spec/services/shelving_service_spec.rb
@@ -49,7 +49,9 @@ RSpec.describe ShelvingService do
 
   let(:stacks_root) { Dir.mktmpdir }
   let(:workspace_root) { Dir.mktmpdir }
-  let(:mock_diff) { instance_double(Moab::FileGroupDifference) }
+  let(:mock_shelve_diff) { instance_double(Moab::FileGroupDifference) }
+  let(:content_inventory_diff) { instance_double(Moab::FileInventoryDifference, group_difference: group_difference) }
+  let(:group_difference) { instance_double(Moab::FileGroupDifference) }
   let(:workflow_client) { instance_double(Dor::Workflow::Client, workflows: workflows) }
   let(:workflows) { ['accessionWF', 'registrationWF'] }
   let(:stacks_object_pathname) { Pathname(DruidTools::StacksDruid.new(druid, stacks_root).path) }
@@ -58,7 +60,8 @@ RSpec.describe ShelvingService do
     allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
     allow(Settings.stacks).to receive_messages(local_stacks_root: stacks_root, local_workspace_root: workspace_root)
     allow(Cocina::ToXml::ContentMetadataGenerator).to receive(:generate).and_return(content_metadata)
-    allow(Preservation::Client.objects).to receive(:shelve_content_diff).and_return(mock_diff)
+    allow(Preservation::Client.objects).to receive(:shelve_content_diff).and_return(mock_shelve_diff)
+    allow(Preservation::Client.objects).to receive(:content_inventory_diff).and_return(content_inventory_diff)
     allow(ShelvableFilesStager).to receive(:stage)
     allow(DigitalStacksService).to receive(:remove_from_stacks)
     allow(DigitalStacksService).to receive(:rename_in_stacks)
@@ -76,10 +79,10 @@ RSpec.describe ShelvingService do
       # make sure the DigitalStacksService is getting the correct delete, rename, and shelve requests
       # (These methods are unit tested in digital_stacks_service_spec.rb)
       described_class.shelve(cocina_object)
-      expect(ShelvableFilesStager).to have_received(:stage).with(druid, content_metadata, mock_diff, Pathname)
-      expect(DigitalStacksService).to have_received(:remove_from_stacks).with(stacks_object_pathname, mock_diff)
-      expect(DigitalStacksService).to have_received(:rename_in_stacks).with(stacks_object_pathname, mock_diff)
-      expect(DigitalStacksService).to have_received(:shelve_to_stacks).with(Pathname, stacks_object_pathname, mock_diff)
+      expect(ShelvableFilesStager).to have_received(:stage).with(druid, group_difference, mock_shelve_diff, Pathname)
+      expect(DigitalStacksService).to have_received(:remove_from_stacks).with(stacks_object_pathname, mock_shelve_diff)
+      expect(DigitalStacksService).to have_received(:rename_in_stacks).with(stacks_object_pathname, mock_shelve_diff)
+      expect(DigitalStacksService).to have_received(:shelve_to_stacks).with(Pathname, stacks_object_pathname, mock_shelve_diff)
       expect(Cocina::ToXml::ContentMetadataGenerator).to have_received(:generate).with(druid: druid, structural: structural, type: Cocina::Models::ObjectType.book)
     end
   end
@@ -100,10 +103,10 @@ RSpec.describe ShelvingService do
       # make sure the DigitalStacksService is getting the correct delete, rename, and shelve requests
       # (These methods are unit tested in digital_stacks_service_spec.rb)
       described_class.shelve(cocina_object)
-      expect(ShelvableFilesStager).to have_received(:stage).with(druid, content_metadata, mock_diff, Pathname)
-      expect(DigitalStacksService).to have_received(:remove_from_stacks).with(stacks_object_pathname, mock_diff)
-      expect(DigitalStacksService).to have_received(:rename_in_stacks).with(stacks_object_pathname, mock_diff)
-      expect(DigitalStacksService).to have_received(:shelve_to_stacks).with(Pathname, stacks_object_pathname, mock_diff)
+      expect(ShelvableFilesStager).to have_received(:stage).with(druid, group_difference, mock_shelve_diff, Pathname)
+      expect(DigitalStacksService).to have_received(:remove_from_stacks).with(stacks_object_pathname, mock_shelve_diff)
+      expect(DigitalStacksService).to have_received(:rename_in_stacks).with(stacks_object_pathname, mock_shelve_diff)
+      expect(DigitalStacksService).to have_received(:shelve_to_stacks).with(Pathname, stacks_object_pathname, mock_shelve_diff)
       expect(Cocina::ToXml::ContentMetadataGenerator).to have_received(:generate).with(druid: druid, structural: structural, type: Cocina::Models::ObjectType.book)
     end
   end


### PR DESCRIPTION


## Why was this change made? 🤔
Previously both ShelvableFilesStager and ShelvingService needed to be aware of ContentMetadata. Now that concern is wholly within ShelvingService


## How was this change tested? 🤨


