### PR TITLE
better error messages for metadata refresh from symphony

### DIFF
--- a/app/controllers/metadata_refresh_controller.rb
+++ b/app/controllers/metadata_refresh_controller.rb
@@ -8,8 +8,8 @@ class MetadataRefreshController < ApplicationController
     result = RefreshMetadataAction.run(identifiers: identifiers,
                                        cocina_object: @cocina_object, druid: @cocina_object.externalIdentifier)
     if result.failure?
-      return json_api_error(status: :unprocessable_entity, title: 'No resolvable identifiers',
-                            message: "#{@cocina_object.externalIdentifier} had no resolvable identifiers: #{identifiers.inspect}")
+      return json_api_error(status: :unprocessable_entity, title: 'No available catkeys or barcodes',
+                            message: "#{@cocina_object.externalIdentifier} had no catkeys marked as refreshable: #{identifiers.inspect}")
     end
 
     CocinaObjectStore.save(@cocina_object.new(description: result.value!.description_props))

--- a/app/services/marc_service.rb
+++ b/app/services/marc_service.rb
@@ -59,7 +59,7 @@ class MarcService
   def marc_record
     SymphonyReader.new(catkey: catkey, barcode: barcode).to_marc
   rescue SymphonyReader::NotFound
-    raise CatalogRecordNotFoundError, "Catalog record not found with #{[catkey, barcode].join(' and ')}"
+    raise CatalogRecordNotFoundError, "Catalog record not found. Catkey: #{catkey} | Barcode: #{barcode}"
   rescue SymphonyReader::ResponseError => e
     raise CatalogResponseError, "Error getting record from catalog: #{e.message}"
   end

--- a/spec/requests/metadata_refresh_spec.rb
+++ b/spec/requests/metadata_refresh_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'Refresh metadata' do
       post '/v1/objects/druid:mk420bs7601/refresh_metadata',
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to match("#{druid} had no resolvable identifiers")
+      expect(response.body).to match("#{druid} had no catkeys marked as refreshable")
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Based on testing of https://github.com/sul-dlss/argo/pull/3681 and discussion in https://stanfordlib.slack.com/archives/C09M7P91R/p1652304265980159

1. The error message you get in Argo when a catkey is not found and there is no barcode in the record is confusing and looks like this: 

```
An error occurred while attempting to refresh metadata: Catkey not found in Symphony (Catalog record not found with 6671606567 and )
```
It makes more sense to clearly label the catkey and barcode values sent (or make it clear they are blank via the label)

2. The error message you get in Argo when there is a catkey but it is not set to refresh also gives a technically correct but not very useful error message:

```
An error occurred while attempting to refresh metadata: No resolvable identifiers (druid:bb009qd5948 had no resolvable identifiers: [])
```
In this case, it makes more sense to give the user a clue that the catkeys also need to be set as refreshable or else they will not work.

## How was this change tested? 🤨

Existing tests


