### PR TITLE
Exclude the workflows.xml file from preservation.

### DIFF
--- a/app/services/preservation_metadata_extractor.rb
+++ b/app/services/preservation_metadata_extractor.rb
@@ -30,19 +30,11 @@ class PreservationMetadataExtractor
 
   # Generate all the required xml files
   def generate_xml
-    workflow_file = metadata_dir.join('workflows.xml')
-    workflow_file.open('w') { |f| f << workflow_xml }
-
     versions_file = metadata_dir.join('versionMetadata.xml')
     versions_file.open('w') { |f| f << version_xml }
 
     content_file = metadata_dir.join('contentMetadata.xml')
     content_file.open('w') { |f| f << content_xml }
-  end
-
-  # Get the workflow xml representation from the workflow service
-  def workflow_xml
-    WorkflowClientFactory.build.all_workflows_xml(cocina_object.externalIdentifier)
   end
 
   def version_xml

--- a/spec/services/preservation_metadata_extractor_spec.rb
+++ b/spec/services/preservation_metadata_extractor_spec.rb
@@ -12,10 +12,8 @@ RSpec.describe PreservationMetadataExtractor do
     subject(:extract) { instance.extract }
 
     let(:metadata_dir) { instance_double(Pathname) }
-    let(:workflow_path) { instance_double(Pathname, exist?: false, open: true) }
     let(:version_path) { instance_double(Pathname, exist?: false, open: true) }
     let(:content_path) { instance_double(Pathname, exist?: false, open: true) }
-    let(:workflow_file) { instance_double(File, :<< => nil) }
     let(:version_file) { instance_double(File, :<< => nil) }
     let(:content_file) { instance_double(File, :<< => nil) }
 
@@ -23,22 +21,16 @@ RSpec.describe PreservationMetadataExtractor do
       allow(workspace).to receive(:path).with('metadata', true).and_return('metadata_dir')
       expect(Pathname).to receive(:new).with('metadata_dir').and_return(metadata_dir)
       allow(Pathname).to receive(:new).and_call_original
-      allow(metadata_dir).to receive(:join).with('workflows.xml').and_return(workflow_path)
       allow(metadata_dir).to receive(:join).with('versionMetadata.xml').and_return(version_path)
       allow(metadata_dir).to receive(:join).with('contentMetadata.xml').and_return(content_path)
 
       allow(instance).to receive(:extract_cocina)
-      allow(workflow_path).to receive(:open).and_yield(workflow_file)
       allow(version_path).to receive(:open).and_yield(version_file)
       allow(content_path).to receive(:open).and_yield(content_file)
-
-      stub_request(:get, 'https://workflow.example.com/workflow/objects/druid:nc893zj8956/workflows')
-        .to_return(status: 200, body: '<workflow-stuff />', headers: {})
     end
 
     it 'extracts the metadata' do
       extract
-      expect(workflow_file).to have_received(:<<).with('<workflow-stuff />')
       expect(version_file).to have_received(:<<)
         .with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<versionMetadata objectId=\"druid:nc893zj8956\"/>\n")
       expect(content_file).to have_received(:<<)


### PR DESCRIPTION
closes #554

## Why was this change made? 🤔
It isn't used.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



