### PR TITLE
Pass user_name to the delete service

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -150,7 +150,7 @@ class ObjectsController < ApplicationController
   end
 
   def destroy
-    DeleteService.destroy(@cocina_object)
+    DeleteService.destroy(@cocina_object, user_name: params[:user_name])
     head :no_content
   rescue StandardError => e
     json_api_error(status: :internal_server_error,

--- a/app/services/delete_service.rb
+++ b/app/services/delete_service.rb
@@ -12,12 +12,13 @@ class DeleteService
   #   - Removes content from purl
   #   - Removes active workflows
   # @param [Cocina::Models::DRO|AdminPolicy||Collection] cocina object wish to remove
-  def self.destroy(cocina_object, event_factory: EventFactory)
-    new(cocina_object, event_factory).destroy
+  def self.destroy(cocina_object, user_name:, event_factory: EventFactory)
+    new(cocina_object, user_name, event_factory).destroy
   end
 
-  def initialize(cocina_object, event_factory)
+  def initialize(cocina_object, user_name, event_factory)
     @cocina_object = Cocina::Models.without_metadata(cocina_object)
+    @user_name = user_name
     @event_factory = event_factory
   end
 
@@ -27,12 +28,12 @@ class DeleteService
     cleanup_purl_doc_cache
     remove_active_workflows
     delete_from_dor
-    event_factory.create(druid: druid, event_type: 'delete', data: { request: cocina_object.to_h, source_id: cocina_object&.identification&.sourceId })
+    event_factory.create(druid: druid, event_type: 'delete', data: { request: cocina_object.to_h, source_id: cocina_object&.identification&.sourceId, user_name: user_name })
   end
 
   private
 
-  attr_reader :cocina_object, :event_factory
+  attr_reader :cocina_object, :event_factory, :user_name
 
   def cleanup_stacks
     stacks_druid = DruidTools::StacksDruid.new(druid, Settings.stacks.local_stacks_root)

--- a/openapi.yml
+++ b/openapi.yml
@@ -1354,6 +1354,12 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
+        - name: user_name
+          in: query
+          description: Username of user requesting delete
+          required: true
+          schema:
+            type: string
 components:
   schemas:
     Access:

--- a/spec/requests/destroy_spec.rb
+++ b/spec/requests/destroy_spec.rb
@@ -4,17 +4,26 @@ require 'rails_helper'
 
 RSpec.describe 'Destroy Object' do
   let(:druid) { 'druid:mx123qw2323' }
-  let(:object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid) }
+  let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid) }
+
+  let(:params) do
+    {
+      user_name: 'some_person'
+    }
+  end
 
   before do
-    allow(CocinaObjectStore).to receive(:find).and_return(object)
+    allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
     allow(DeleteService).to receive(:destroy).and_return(nil)
   end
 
   context 'when the request is successful' do
     it 'returns a 204 response' do
-      delete "/v1/objects/#{druid}", headers: { 'Authorization' => "Bearer #{jwt}" }
+      delete "/v1/objects/#{druid}",
+             params: params,
+             headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.status).to eq(204)
+      expect(DeleteService).to have_received(:destroy).with(cocina_object, **params)
     end
   end
 
@@ -24,7 +33,9 @@ RSpec.describe 'Destroy Object' do
     end
 
     it 'returns a 500 response' do
-      delete "/v1/objects/#{druid}", headers: { 'Authorization' => "Bearer #{jwt}" }
+      delete "/v1/objects/#{druid}",
+             params: params,
+             headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response.status).to eq(500)
       expect(response.message).to eq 'Internal Server Error'
     end

--- a/spec/services/delete_service_spec.rb
+++ b/spec/services/delete_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe DeleteService do
-  let(:service) { described_class.new(cocina_object, event_factory) }
+  let(:service) { described_class.new(cocina_object, user_name, event_factory) }
 
   let(:cocina_object) { build(:dro, id: druid, source_id: source_id) }
 
@@ -12,6 +12,8 @@ RSpec.describe DeleteService do
   let(:source_id) { 'hydrus:object-63-sdr-client' }
 
   let(:event_factory) { class_double(EventFactory, create: nil) }
+
+  let(:user_name) { 'some_person' }
 
   let(:client) { instance_double(Dor::Workflow::Client, delete_all_workflows: nil) }
 
@@ -27,7 +29,7 @@ RSpec.describe DeleteService do
     it 'creates an event' do
       service.destroy
 
-      expect(event_factory).to have_received(:create).with(druid: druid, event_type: 'delete', data: { request: cocina_object.to_h, source_id: source_id })
+      expect(event_factory).to have_received(:create).with(druid: druid, event_type: 'delete', data: { request: cocina_object.to_h, source_id: source_id, user_name: user_name })
     end
   end
 

--- a/spec/services/delete_service_spec.rb
+++ b/spec/services/delete_service_spec.rb
@@ -24,11 +24,10 @@ RSpec.describe DeleteService do
   describe '#destroy' do
     before do
       allow(CocinaObjectStore).to receive(:destroy)
+      described_class.destroy(cocina_object, user_name: user_name, event_factory: event_factory)
     end
 
     it 'creates an event' do
-      service.destroy
-
       expect(event_factory).to have_received(:create).with(druid: druid, event_type: 'delete', data: { request: cocina_object.to_h, source_id: source_id, user_name: user_name })
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #4013 this passes a user_name to the delete service in order to record in the event.

If there is more to this ticket, please comment and I'm happy to address.

## How was this change tested? 🤨

Updated unit tests.

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



