### PR TITLE
Don't require user_name on delete

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1357,7 +1357,7 @@ paths:
         - name: user_name
           in: query
           description: Username of user requesting delete
-          required: true
+          required: false
           schema:
             type: string
 components:


### PR DESCRIPTION


## Why was this change made? 🤔

The dor-services-client doesn't support it yet.

## How was this change tested? 🤨
