### PR TITLE
Remove capistrano-rvm and other bits added to help deploy to ubuntu boxes

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -27,7 +27,6 @@ require 'capistrano/passenger'
 require 'capistrano/rails/migrations'
 require 'dlss/capistrano'
 require 'whenever/capistrano'
-require 'capistrano/rvm'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,6 @@ group :deployment do
   gem 'capistrano-bundler'
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
-  gem 'capistrano-rvm'
   gem 'capistrano-shared_configs'
   gem 'dlss-capistrano', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,9 +95,6 @@ GEM
     capistrano-rails (1.6.2)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
     cocina-models (0.80.0)
@@ -469,7 +466,6 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-passenger
   capistrano-rails
-  capistrano-rvm
   capistrano-shared_configs
   cocina-models (~> 0.80.0)
   committee (~> 4.4)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -54,7 +54,3 @@ set :honeybadger_env, fetch(:stage)
 
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'
-
-# the honeybadger gem should integrate automatically with capistrano-rvm but it
-# doesn't appear to do so on our new Ubuntu boxes :shrug:
-set :rvm_map_bins, fetch(:rvm_map_bins, []).push('honeybadger')


### PR DESCRIPTION
## Why was this change made? 🤔

We are handling this via puppet instead, by ensuring a default system bashrc is executed, which will take care of RVM bootstrapping.


## How was this change tested? 🤨

CI + QA
