### PR TITLE
Rake task to find objects missing from the index and output a list of…

### DIFF
--- a/lib/tasks/missing_druids.rake
+++ b/lib/tasks/missing_druids.rake
@@ -8,8 +8,8 @@ namespace :missing_druids do
     druids_from_solr = []
 
     loop do
-      results = SolrService.query('*:*', fl: 'id', rows: 10000, start: druids_from_solr.length, sort: 'id asc')
-      break if results.empty?
+      results = SolrService.query('id:*', fl: 'id', rows: 10_000_000, sort: 'id asc', wt: 'csv')
+      break unless results.empty?
 
       results.each { |r| druids_from_solr << r['id'] }
       sleep(0.5)

--- a/lib/tasks/missing_druids.rake
+++ b/lib/tasks/missing_druids.rake
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+namespace :missing_druids do
+  desc 'Find unindexed druids'
+  task unindexed_objects: :environment do
+    druids = []
+
+    models = [AdminPolicy, Collection, Dro]
+
+    models.each do |model|
+      model.find_each do |object|
+        current_druid = object.external_identifier
+        result = SolrService.query("id:#{current_druid}")
+        next unless result.empty?
+
+        puts "#{current_druid} (#{model}) not found in SOLR"
+        druids << current_druid
+      end
+    end
+
+    File.open('missing_druids.txt', 'w') do |file|
+      druids.each do |druid|
+        file.write("#{druid}\n")
+      end
+    end
+  end
+end

--- a/lib/tasks/missing_druids.rake
+++ b/lib/tasks/missing_druids.rake
@@ -3,25 +3,31 @@
 namespace :missing_druids do
   desc 'Find unindexed druids'
   task unindexed_objects: :environment do
-    druids = []
-
     models = [AdminPolicy, Collection, Dro]
+    druids_from_db = []
+    druids_from_solr = []
+
+    loop do
+      results = SolrService.query('*:*', fl: 'id', rows: 10000, start: druids_from_solr.length, sort: 'id asc')
+      break if results.empty?
+
+      results.each { |r| druids_from_solr << r['id'] }
+      sleep(0.5)
+    end
+    puts "Retrieved #{druids_from_solr.length} druids from SOLR"
 
     models.each do |model|
       model.find_each do |object|
-        current_druid = object.external_identifier
-        result = SolrService.query("id:#{current_druid}")
-        next unless result.empty?
-
-        puts "#{current_druid} (#{model}) not found in SOLR"
-        druids << current_druid
+        druids_from_db << object.external_identifier
       end
     end
+    puts "Retrieved #{druids_from_db.length} druids from DB"
+
+    missing_druids = druids_from_db - druids_from_solr
+    puts "Missing #{missing_druids.length} druids in SOLR"
 
     File.open('missing_druids.txt', 'w') do |file|
-      druids.each do |druid|
-        file.write("#{druid}\n")
-      end
+      missing_druids.map { |druid| file.write("#{druid}\n") }
     end
   end
 end


### PR DESCRIPTION
… druids

## Why was this change made? 🤔

Part of [dor-indexing-app/843](https://github.com/sul-dlss/dor_indexing_app/issues/843)

This initial rake task will be used to produce a report to determine the extent of missing druids in the index. It is possible that this rake task will be relatively temporary, but depending on the number of missing items, we may want to keep it for recurring reporting as further work on 843 continues.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



