### PR TITLE
Remove invalid iso8601 pattern

### DIFF
--- a/app/validators/date_time_validator.rb
+++ b/app/validators/date_time_validator.rb
@@ -30,7 +30,6 @@ class DateTimeValidator
   ].freeze
 
   ISO8601_FORMATS = COMMON_FORMATS + [
-    Regexp.new("^#{YEAR}#{MONTH}--$"),
     Regexp.new("^#{YEAR}#{MONTH}#{DAY}$"),
     Regexp.new("^#{YEAR}#{MONTH}#{DAY}T#{HOUR}#{MINUTE}$"),
     Regexp.new("^#{YEAR}#{MONTH}#{DAY}T#{HOUR}#{MINUTE}#{SECOND}$"),


### PR DESCRIPTION
## Why was this change made? 🤔

This is not a valid ISO8601 date.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



