### PR TITLE
set CDL rights when boolean is set to true

### DIFF
--- a/app/services/update_marc_record_service.rb
+++ b/app/services/update_marc_record_service.rb
@@ -173,11 +173,10 @@ class UpdateMarcRecordService
     values << 'rights:dark' if @access.view == 'dark'
 
     if @access.view == 'world'
-      values << 'rights:cdl' if @access.download == 'stanford'
       values << 'rights:world' if @access.download == 'world'
       values << 'rights:citation' if @access.download == 'none'
     end
-
+    values << 'rights:cdl' if @access.controlledDigitalLending
     values << 'rights:group=stanford' if @access.view == 'stanford' && @access.download == 'stanford'
     values << "rights:location=#{@access.location}" if @access.location
 

--- a/spec/services/update_marc_record_service_spec.rb
+++ b/spec/services/update_marc_record_service_spec.rb
@@ -103,6 +103,26 @@ RSpec.describe UpdateMarcRecordService do
       download: 'stanford'
     }
   end
+  let(:access_world_stanford) do
+    {
+      view: 'world',
+      download: 'stanford'
+    }
+  end
+  let(:access_stanford_download_none) do
+    {
+      view: 'stanford',
+      download: 'none',
+      controlledDigitalLending: false
+    }
+  end
+  let(:access_stanford_cdl) do
+    {
+      view: 'stanford',
+      download: 'none',
+      controlledDigitalLending: true
+    }
+  end
   let(:access_location) do
     {
       view: 'location-based',
@@ -864,14 +884,25 @@ RSpec.describe UpdateMarcRecordService do
       it { is_expected.to eq '|xrights:group=stanford' }
     end
 
+    context 'with view-world stanford-download rights' do
+      let(:cocina_object) do
+        build(:dro, id: druid).new(access: access_world_stanford)
+      end
+
+      it { is_expected.to eq '' }
+    end
+
+    context 'with stanford-only download none rights' do
+      let(:cocina_object) do
+        build(:dro, id: druid).new(access: access_stanford_download_none)
+      end
+
+      it { is_expected.to eq '' }
+    end
+
     context 'with CDL rights' do
       let(:cocina_object) do
-        build(:dro, id: druid).new(
-          access: {
-            view: 'world',
-            download: 'stanford'
-          }
-        )
+        build(:dro, id: druid).new(access: access_stanford_cdl)
       end
 
       it { is_expected.to eq '|xrights:cdl' }


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #4085 - updates to setting of rights when creating MARC records sent to searchworks

- For any object with `controlledDigitalLending` set to true, we will set CDL rights in the marc.  This is a fix of missing behavior.
- We will *not* set CDL rights anymore for objects with view=world and download=stanford (this seems wrong to Andrew and me).  Instead rights will now be blank in the marc.  This is a change in existing behavior.
- We will continue to leave rights blank for records with view=stanford and download=none.  This is the current behavior but had a test now to verify.  This behavior may change in the future if needed.

## How was this change tested? 🤨

New/updated tests