### PR TITLE
Catch highly nested values in date validation reports

### DIFF
--- a/app/reports/bad_edtf_dates.rb
+++ b/app/reports/bad_edtf_dates.rb
@@ -16,7 +16,7 @@ class BadEdtfDates
   end
 
   def report
-    bad_values = path.on(dro.description.to_json).filter_map do |date_value|
+    bad_values = path.on(dro.description.to_json).uniq.filter_map do |date_value|
       Date.edtf!(date_value)
       nil
     rescue ArgumentError
@@ -33,7 +33,7 @@ class BadEdtfDates
   attr_reader :dro
 
   def path
-    @path ||= JsonPath.new('$..date[*][?(@.encoding.code == "edtf")]*.value')
+    @path ||= JsonPath.new('$..date..[?(@.encoding.code == "edtf")]..value')
   end
 
   def collection_id

--- a/app/reports/bad_iso8601_dates.rb
+++ b/app/reports/bad_iso8601_dates.rb
@@ -16,7 +16,7 @@ class BadIso8601Dates
   end
 
   def report
-    bad_values = path.on(dro.description.to_json).filter_map do |date_value|
+    bad_values = path.on(dro.description.to_json).uniq.filter_map do |date_value|
       DateTime.iso8601(date_value)
       nil
     rescue Date::Error
@@ -33,7 +33,7 @@ class BadIso8601Dates
   attr_reader :dro
 
   def path
-    @path ||= JsonPath.new('$..date[*][?(@.encoding.code == "iso8601")]*.value')
+    @path ||= JsonPath.new('$..date..[?(@.encoding.code == "iso8601")]..value')
   end
 
   def collection_id

--- a/app/reports/bad_w3cdtf_dates.rb
+++ b/app/reports/bad_w3cdtf_dates.rb
@@ -16,7 +16,7 @@ class BadW3cdtfDates
   end
 
   def report
-    bad_values = path.on(dro.description.to_json).filter_map do |date_value|
+    bad_values = path.on(dro.description.to_json).uniq.filter_map do |date_value|
       Time.w3cdtf(date_value)
       nil
     rescue ArgumentError
@@ -28,7 +28,7 @@ class BadW3cdtfDates
       #
       # So we catch the false positives from the upstream gem and allow
       # these two patterns to validate
-      /\A\d{4}(-0[1-9]|1[0-2])?\Z/.match?(date_value)
+      /\A\d{4}(-0[1-9]|1[0-2])?\Z/.match(date_value)&.to_s
     end
 
     return if bad_values.empty?
@@ -41,7 +41,7 @@ class BadW3cdtfDates
   attr_reader :dro
 
   def path
-    @path ||= JsonPath.new('$..date[*][?(@.encoding.code == "w3cdtf")]*.value')
+    @path ||= JsonPath.new('$..date..[?(@.encoding.code == "w3cdtf")]..value')
   end
 
   def collection_id


### PR DESCRIPTION
## Why was this change made? 🤔

This commit adds some trickier cases to the date validation reports. This likely doesn't change the overall report very much given most of our data is simpler than this accounts for, but does give us a fuller picture of how much date validation work lies ahead of being able to switch on date validation at cocina creation time.

It also fixes the output of the W3CDTF report to include bad values, as specified, instead of literal `true`s

## How was this change tested? 🤨

Ran on stage and prod.
