### PR TITLE
add sourceid and barcode (for items if avaialble) to public XML identity metadata

### DIFF
--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -80,13 +80,15 @@ module Publish
     def public_identity_metadata
       catkeys = Array(public_cocina.identification&.catalogLinks).filter_map { |link| link.catalogRecordId if link.catalog == SYMPHONY }
       nodes = catkeys.map { |catkey| "  <otherId name=\"catkey\">#{catkey}</otherId>" }
+      nodes << "  <otherId name=\"barcode\">#{public_cocina.identification.barcode}</otherId>" if public_cocina.dro? && public_cocina.identification.barcode
 
       Nokogiri::XML(
         <<~XML
           <identityMetadata>
             <objectType>#{public_cocina.collection? ? 'collection' : 'item'}</objectType>
             <objectLabel>#{Cocina::Models::Builders::TitleBuilder.build(public_cocina.description.title)}</objectLabel>
-          #{nodes.join("\n")}
+            <sourceId source="sul">#{public_cocina.identification.sourceId}</sourceId>
+            #{nodes.join("\n")}
           </identityMetadata>
         XML
       )

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe 'Display metadata' do
           <identityMetadata>
             <objectType>item</objectType>
             <objectLabel>Hello</objectLabel>
+            <sourceId source="sul">sul:1234</sourceId>
           </identityMetadata>
           <rightsMetadata>
             <access type="discover">

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe Publish::PublicXmlService do
           description:,
           structural:,
           identification: {
+            barcode: '36105132211504',
             catalogLinks: [
               { catalog: 'previous symphony', catalogRecordId: '9001001001', refresh: false },
               { catalog: 'symphony', catalogRecordId: '129483625', refresh: true }
@@ -161,12 +162,14 @@ RSpec.describe Publish::PublicXmlService do
         expect(ng_xml.at_xpath('/publicObject/@publishVersion').value).to eq("cocina-models/#{Cocina::Models::VERSION}")
       end
 
-      it 'has identityMetadata with catkeys' do
+      it 'has identityMetadata with catkeys, barcode and sourceId' do
         expected = <<~XML
           <identityMetadata>
             <objectType>item</objectType>
             <objectLabel>Constituent label &amp; A Special character</objectLabel>
+            <sourceId source="sul">sul:123</sourceId>
             <otherId name="catkey">129483625</otherId>
+            <otherId name="barcode">36105132211504</otherId>
           </identityMetadata>
         XML
         expect(ng_xml.at_xpath('/publicObject/identityMetadata').to_xml).to be_equivalent_to expected


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #4095 - publish sourceId (always) and barcode (for items only when available) to identityMetadata public XML

## How was this change tested? 🤨
 
Updated test


