### PR TITLE
do not add blank sourceIDs

### DIFF
--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -80,6 +80,7 @@ module Publish
     def public_identity_metadata
       catkeys = Array(public_cocina.identification&.catalogLinks).filter_map { |link| link.catalogRecordId if link.catalog == SYMPHONY }
       nodes = catkeys.map { |catkey| "  <otherId name=\"catkey\">#{catkey}</otherId>" }
+      nodes << "  <sourceId source=\"sul\">#{public_cocina.identification.sourceId}</sourceId>" if public_cocina.identification.sourceId.present?
       nodes << "  <otherId name=\"barcode\">#{public_cocina.identification.barcode}</otherId>" if public_cocina.dro? && public_cocina.identification.barcode
 
       Nokogiri::XML(
@@ -87,7 +88,6 @@ module Publish
           <identityMetadata>
             <objectType>#{public_cocina.collection? ? 'collection' : 'item'}</objectType>
             <objectLabel>#{Cocina::Models::Builders::TitleBuilder.build(public_cocina.description.title)}</objectLabel>
-            <sourceId source="sul">#{public_cocina.identification.sourceId}</sourceId>
             #{nodes.join("\n")}
           </identityMetadata>
         XML

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -274,6 +274,16 @@ RSpec.describe Publish::PublicXmlService do
         expect(ng_xml.at_xpath('/publicObject/rdf:RDF', 'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#')).to be
         expect(ng_xml.at_xpath('/publicObject/oai_dc:dc', 'oai_dc' => 'http://www.openarchives.org/OAI/2.0/oai_dc/')).to be
       end
+
+      it 'has identityMetadata without a sourceId' do
+        expected = <<~XML
+          <identityMetadata>
+            <objectType>collection</objectType>
+            <objectLabel>Constituent label &amp; A Special character</objectLabel>
+          </identityMetadata>
+        XML
+        expect(ng_xml.at_xpath('/publicObject/identityMetadata').to_xml).to be_equivalent_to expected
+      end
     end
 
     context 'with external references' do


### PR DESCRIPTION
## Why was this change made? 🤔

Follow on from #4096 - this prevents blank sourceIDs from being added to public XML (e.g. for collections which do not have them).

## How was this change tested? 🤨

Added a test