### PR TITLE
[refactor] Extract lock generation from the CocinaObjectStore

### DIFF
--- a/app/models/admin_policy.rb
+++ b/app/models/admin_policy.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 # Model for an AdminPolicy.
-class AdminPolicy < ApplicationRecord
-  self.locking_column = 'lock'
-
+class AdminPolicy < RepositoryRecord
   # @return [Cocina::Models::AdminPolicy] Cocina Administrative Policy
   def to_cocina
     Cocina::Models::AdminPolicy.new(to_h)

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 # Model for a Collection.
-class Collection < ApplicationRecord
-  self.locking_column = 'lock'
-
+class Collection < RepositoryRecord
   # @return [Cocina::Models::Collection] Cocina collection
   def to_cocina
     Cocina::Models::Collection.new(to_h)

--- a/app/models/dro.rb
+++ b/app/models/dro.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 # Model for a Digital Repository Object.
-class Dro < ApplicationRecord
-  self.locking_column = 'lock'
-
+class Dro < RepositoryRecord
   # @return [Cocina::Models::DRO] Cocina Digital Repository Object
   def to_cocina
     Cocina::Models::DRO.new(to_h)

--- a/app/models/repository_record.rb
+++ b/app/models/repository_record.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Depends on the child class having an external_identifier and lock columns.
+class RepositoryRecord < ApplicationRecord
+  self.abstract_class = true
+  self.locking_column = 'lock'
+
+  def external_lock
+    # This should be opaque, but this makes troubeshooting easier.
+    # The external_identifier is included so that there is enough entropy such
+    # that the lock can't be used for an object it doesn't belong to as the
+    # lock column is just an integer sequence.
+    [external_identifier, lock.to_s].join('=')
+  end
+end

--- a/spec/factories/dros.rb
+++ b/spec/factories/dros.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     content_type { Cocina::Models::ObjectType.book }
     label { 'Test DRO' }
     version { 1 }
+    lock { 0 }
     access do
       { view: 'world', download: 'world' }
     end


### PR DESCRIPTION


## Why was this change made? 🤔

The model can encapsulate the lock generation.

## How was this change tested? 🤨
Test suite.


