### PR TITLE
[refactor] CocinaObjectStore#cocina_to_ar_save now returns an object with metadata

### DIFF
--- a/app/controllers/administrative_tags_controller.rb
+++ b/app/controllers/administrative_tags_controller.rb
@@ -32,9 +32,7 @@ class AdministrativeTagsController < ApplicationController
     render status: :conflict, plain: e.message
   else
     # Broadcast this update action to a topic
-    Notifications::ObjectUpdated.publish(model: Cocina::Models.without_metadata(@cocina_object),
-                                         created_at: @cocina_object.created,
-                                         modified_at: @cocina_object.modified)
+    Notifications::ObjectUpdated.publish(model: @cocina_object)
     head :created
   end
 
@@ -54,9 +52,7 @@ class AdministrativeTagsController < ApplicationController
     render status: :conflict, plain: e.message
   else
     # Broadcast this update action to a topic
-    Notifications::ObjectUpdated.publish(model: Cocina::Models.without_metadata(@cocina_object),
-                                         created_at: @cocina_object.created,
-                                         modified_at: @cocina_object.modified)
+    Notifications::ObjectUpdated.publish(model: @cocina_object)
     head :no_content
   end
 
@@ -66,9 +62,6 @@ class AdministrativeTagsController < ApplicationController
     render status: :not_found, plain: e.message
   else
     # Broadcast this update action to a topic
-    Notifications::ObjectUpdated.publish(model: Cocina::Models.without_metadata(@cocina_object),
-                                         created_at: @cocina_object.created,
-                                         modified_at: @cocina_object.modified)
-    head :no_content
+    Notifications::ObjectUpdated.publish(model: @cocina_object)
   end
 end

--- a/app/models/repository_record.rb
+++ b/app/models/repository_record.rb
@@ -12,4 +12,8 @@ class RepositoryRecord < ApplicationRecord
     # lock column is just an integer sequence.
     [external_identifier, lock.to_s].join('=')
   end
+
+  def to_cocina_with_metadata
+    Cocina::Models.with_metadata(to_cocina, external_lock, created: created_at.utc, modified: updated_at.utc)
+  end
 end

--- a/app/services/notifications/object_updated.rb
+++ b/app/services/notifications/object_updated.rb
@@ -4,33 +4,31 @@ module Notifications
   # Send a message to a RabbitMQ exchange that an item has been updated.
   # The primary use case here is that an index may need to be updated (dor-indexing-app)
   class ObjectUpdated
-    def self.publish(model:, created_at:, modified_at:)
+    def self.publish(model:)
       return unless Settings.rabbitmq.enabled
 
       Rails.logger.debug "Publishing Rabbitmq Message for updating #{model.externalIdentifier}"
-      new(model:, created_at:, modified_at:, channel: RabbitChannel.instance).publish
+      new(model:, channel: RabbitChannel.instance).publish
       Rails.logger.debug "Published Rabbitmq Message for updating #{model.externalIdentifier}"
     end
 
-    def initialize(model:, created_at:, modified_at:, channel:)
+    def initialize(model:, channel:)
       @model = model
-      @created_at = created_at
-      @modified_at = modified_at
       @channel = channel
     end
 
     def publish
       message = {
-        model: model.to_h,
-        created_at: created_at.to_datetime.httpdate,
-        modified_at: modified_at.to_datetime.httpdate
+        model: Cocina::Models.without_metadata(model).to_h,
+        created_at: model.created.to_datetime.httpdate,
+        modified_at: model.modified.to_datetime.httpdate
       }
       exchange.publish(message.to_json, routing_key:)
     end
 
     private
 
-    attr_reader :model, :created_at, :modified_at, :channel
+    attr_reader :model, :channel
 
     def exchange
       channel.topic('sdr.objects.updated')
@@ -38,7 +36,7 @@ module Notifications
 
     # Using the project as a routing key because listeners may only care about their projects.
     def routing_key
-      model.is_a?(Cocina::Models::AdminPolicy) ? 'SDR' : AdministrativeTags.project(identifier: model.externalIdentifier).first
+      model.is_a?(Cocina::Models::AdminPolicyWithMetadata) ? 'SDR' : AdministrativeTags.project(identifier: model.externalIdentifier).first
     end
   end
 end

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe CocinaObjectStore do
 
       it 'saves to datastore' do
         expect(AdminPolicy.find_by(external_identifier: cocina_object.externalIdentifier)).to be_nil
-        expect(store.send(:cocina_to_ar_save, cocina_object, skip_lock: true)).to match([kind_of(Time), kind_of(Time), kind_of(String)])
+        expect(store.save(cocina_object, skip_lock: true)).to be_kind_of Cocina::Models::AdminPolicyWithMetadata
         expect(AdminPolicy.find_by(external_identifier: cocina_object.externalIdentifier)).not_to be_nil
       end
     end
@@ -186,7 +186,7 @@ RSpec.describe CocinaObjectStore do
 
       it 'saves to datastore' do
         expect(Collection.find_by(external_identifier: cocina_object.externalIdentifier)).to be_nil
-        expect(store.send(:cocina_to_ar_save, cocina_object, skip_lock: true)).to match([kind_of(Time), kind_of(Time), kind_of(String)])
+        expect(store.save(cocina_object, skip_lock: true)).to be_kind_of Cocina::Models::CollectionWithMetadata
         expect(Collection.find_by(external_identifier: cocina_object.externalIdentifier)).not_to be_nil
       end
     end

--- a/spec/services/notifications/object_updated_spec.rb
+++ b/spec/services/notifications/object_updated_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe Notifications::ObjectUpdated do
-  subject(:publish) { described_class.publish(model:, created_at:, modified_at:) }
+  subject(:publish) { described_class.publish(model: model.to_cocina_with_metadata) }
 
-  let(:data) { { data: '455' } }
   let(:created_at) { '04 Feb 2022' }
-  let(:modified_at) { '04 Feb 2022' }
+  let(:updated_at) { '04 Feb 2022' }
   let(:channel) { instance_double(Notifications::RabbitChannel, topic:) }
   let(:topic) { instance_double(Bunny::Exchange, publish: true) }
-  let(:message) { "{\"model\":{\"data\":\"455\"},\"created_at\":\"#{created_at.to_datetime.httpdate}\",\"modified_at\":\"#{modified_at.to_datetime.httpdate}\"}" }
+  let(:message) { "{\"model\":#{model_json},\"created_at\":\"Fri, 04 Feb 2022 00:00:00 GMT\",\"modified_at\":\"Fri, 04 Feb 2022 00:00:00 GMT\"}" }
+  let(:model_json) { model.to_cocina.to_json }
 
   context 'when RabbitMQ is enabled' do
     before do
@@ -19,10 +19,7 @@ RSpec.describe Notifications::ObjectUpdated do
     end
 
     context 'when called with a DRO' do
-      let(:model) do
-        instance_double(Cocina::Models::DRO,
-                        externalIdentifier: 'druid:123', to_h: data)
-      end
+      let(:model) { build(:ar_dro, created_at:, updated_at:) }
 
       before do
         allow(AdministrativeTags).to receive(:project).and_return(['h2'])
@@ -31,16 +28,12 @@ RSpec.describe Notifications::ObjectUpdated do
       it 'is successful' do
         publish
         expect(topic).to have_received(:publish).with(message, routing_key: 'h2')
-        expect(AdministrativeTags).to have_received(:project).with(identifier: 'druid:123')
+        expect(AdministrativeTags).to have_received(:project).with(identifier: model.external_identifier)
       end
     end
 
     context 'when called with an AdminPolicy' do
-      let(:model) { build(:admin_policy) }
-
-      before do
-        allow(model).to receive(:to_h).and_return(data)
-      end
+      let(:model) { build(:ar_admin_policy, created_at:, updated_at:) }
 
       it 'is successful' do
         publish
@@ -55,10 +48,7 @@ RSpec.describe Notifications::ObjectUpdated do
     end
 
     context 'when called with a DRO' do
-      let(:model) do
-        instance_double(Cocina::Models::DRO,
-                        externalIdentifier: 'druid:123', to_h: data)
-      end
+      let(:model) { build(:ar_dro, created_at:, updated_at:) }
 
       it 'does not receive a message' do
         publish


### PR DESCRIPTION
Rather than an array which has the same data, but relies on the consumer knowing the order.

## Why was this change made? 🤔

We don't have to remember what is in the array and in which order.


## How was this change tested? 🤨

CI