### PR TITLE
Remove obsolete ENV vars from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,5 @@
 FROM ruby:3.1.2-alpine
 
-# Provide SSL defaults that work in dev/test environments where we do not require connections to secured services
-# These values are overrideable at both buildtime and runtime (hence the ARG/ENV combo).
-ARG SETTINGS__SSL__CERT_FILE=/app/spec/support/certs/spec.crt
-ARG SETTINGS__SSL__KEY_FILE=/app/spec/support/certs/spec.key
-ARG SETTINGS__SSL__KEY_PASS=thisisatleast4bytes
-ENV SETTINGS__SSL__CERT_FILE="${SETTINGS__SSL__CERT_FILE}"
-ENV SETTINGS__SSL__KEY_FILE="${SETTINGS__SSL__KEY_FILE}"
-ENV SETTINGS__SSL__KEY_PASS="${SETTINGS__SSL__KEY_PASS}"
-
 ENV RAILS_ENV=production
 
 # postgresql-client is required for invoke.sh


### PR DESCRIPTION


## Why was this change made? 🤔
These were for Fedora 3


## How was this change tested? 🤨
n/a