### PR TITLE
Cron missing druid rake task and add to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,12 @@ Usage: bin/clean-druid-list [options]
     -h, --help                       Displays help.
 
 Solr is used to determine if an item still exists.
+
+### Find druids missing from the SOLR index
+
+Run the missing druid rake task:
+```
+bundle exec rake missing_druids:unindexed_objects
+```
+This produces a `missing_druids.txt` file in the application root.
+

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -27,3 +27,8 @@ env 'RUBYOPT', '-W0'
 every :day, at: '2:16am' do
   rake 'dsa:embargo_release'
 end
+
+# Run this an on off minute to avoid Google Books every 15 minutes
+every :day, at: '8:35pm' do
+  rake 'missing_druids:unindexed_objects'
+end

--- a/lib/tasks/missing_druids.rake
+++ b/lib/tasks/missing_druids.rake
@@ -9,18 +9,17 @@ namespace :missing_druids do
 
     results = SolrService.query('id:*', fl: 'id', rows: 10_000_000, wt: 'csv')
     results.each { |r| druids_from_solr << r['id'] }
-    puts "Retrieved #{druids_from_solr.length} druids from SOLR"
 
     models.each do |model|
       druids_from_db << model.all.pluck(:external_identifier)
     end
-    puts "Retrieved #{druids_from_db.length} druids from DB"
 
     missing_druids = druids_from_db.flatten.sort - druids_from_solr.sort
-    puts "Missing #{missing_druids.length} druids in SOLR"
-
     File.open('missing_druids.txt', 'w') do |file|
       missing_druids.map { |druid| file.write("#{druid}\n") }
     end
+
+    message = "Retrieved #{druids_from_solr.length} druids from SOLR\nRetrieved #{druids_from_db.length} druids from DB\nMissing #{missing_druids.length} druids in SOLR"
+    puts message unless missing_druids.empty?
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

This documents the missing_druid rake task in the README and adds a cron task to run at 8:35pm. I chose this time to avoid the every 15 minute run of google books download and deposit. 


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



