### PR TITLE
Adds async event creation consumer.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'rss', '~> 0.2' # used for metadata reports
 gem 'ruby-cache', '~> 0.3.0'
 gem 'sidekiq', '~> 6.0'
 gem 'sidekiq-statistic'
+gem 'sneakers', '~> 2.11'
 gem 'tty-progressbar' # to show progress when running migration script
 gem 'uuidtools', '~> 2.1.4'
 gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -396,6 +396,8 @@ GEM
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     scrub_rb (1.0.1)
+    serverengine (2.0.7)
+      sigdump (~> 0.2.2)
     set (1.0.2)
     sidekiq (6.5.1)
       connection_pool (>= 2.2.2)
@@ -404,12 +406,19 @@ GEM
     sidekiq-statistic (1.4.0)
       sidekiq (>= 5.0)
       tilt (~> 2.0)
+    sigdump (0.2.4)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    sneakers (2.11.0)
+      bunny (~> 2.12)
+      concurrent-ruby (~> 1.0)
+      rake
+      serverengine (~> 2.0.5)
+      thor
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
@@ -525,6 +534,7 @@ DEPENDENCIES
   sidekiq (~> 6.0)
   sidekiq-statistic
   simplecov
+  sneakers (~> 2.11)
   spring
   spring-watcher-listen (~> 2.0.0)
   stanford-mods (~> 2.6)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,30 @@ To spin up a local development server:
 
   `bundle exec rails s`
 
+## Setup RabbitMQ
+You must set up the durable rabbitmq queues that bind to the exchange where workflow messages are published.
+
+```sh
+RAILS_ENV=production bin/rake rabbitmq:setup
+```
+This is going to create queues for this application that bind to some topics.
+
+## RabbitMQ queue workers
+In a development environment you can start sneakers this way:
+```sh
+WORKERS=CreateEventJob bin/rake sneakers:run
+```
+
+but on the production machines we use systemd to do the same:
+```sh
+sudo /usr/bin/systemctl start sneakers
+sudo /usr/bin/systemctl stop sneakers
+sudo /usr/bin/systemctl status sneakers
+```
+
+This is started automatically during a deploy via capistrano
+
+
 ## Other tools
 ### Generating a list of druids from Solr query
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'config/application'
+require 'sneakers/tasks'
 
 Rails.application.load_tasks

--- a/app/jobs/create_event_job.rb
+++ b/app/jobs/create_event_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Create an Event
+class CreateEventJob
+  include Sneakers::Worker
+
+  # This worker will connect to "dsa.create-event" queue
+  # env is set to nil since by default the actual queue name would be
+  # "dsa.create-event_development"
+  from_queue 'dsa.create-event', env: nil
+
+  def work(msg_str)
+    Rails.logger.info("Msg_str: #{msg_str}")
+    msg = JSON.parse(msg_str).with_indifferent_access
+    Rails.logger.info("Msg: #{msg}")
+    Rails.logger.info("Event_type: #{msg[:event_type]}")
+    Event.create!(druid: msg[:druid], event_type: msg[:event_type], data: msg[:data])
+    ack!
+  end
+end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -9,6 +9,10 @@ ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }
 # Default deploy_to directory is /var/www/my_app
 set :deploy_to, "/opt/app/dor_services/#{fetch(:application)}"
 
+# Manage sneakers via systemd (from dlss-capistrano gem)
+set :sneakers_systemd_role, :worker
+set :sneakers_systemd_use_hooks, true
+
 # Default value for :scm is :git
 # set :scm, :git
 

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+conn = Bunny.new(hostname: Settings.rabbitmq.hostname,
+                 vhost: Settings.rabbitmq.vhost,
+                 username: Settings.rabbitmq.username,
+                 password: Settings.rabbitmq.password)
+Sneakers.configure connection: conn
+Sneakers.logger.level = Logger::INFO
+Sneakers.error_reporters << proc { |exception, _worker, context_hash| Honeybadger.notify(exception, context_hash) }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -58,6 +58,7 @@ sdr:
 rabbitmq:
   enabled: false
   hostname: localhost
+  vhost: /
   username: guest
   password: guest
 

--- a/lib/tasks/rabbitmq.rake
+++ b/lib/tasks/rabbitmq.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :rabbitmq do
+  desc 'Setup routing'
+  task setup: :environment do
+    require 'bunny'
+
+    conn = Bunny.new(hostname: Settings.rabbitmq.hostname,
+                     vhost: Settings.rabbitmq.vhost,
+                     username: Settings.rabbitmq.username,
+                     password: Settings.rabbitmq.password).tap(&:start)
+
+    channel = conn.create_channel
+
+    # connect topic to the queue
+
+    exchange = channel.topic('sdr.objects.event')
+    queue = channel.queue('dsa.create-event', durable: true)
+    queue.bind(exchange, routing_key: '#')
+
+    conn.close
+  end
+end

--- a/spec/jobs/create_event_job_spec.rb
+++ b/spec/jobs/create_event_job_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreateEventJob, type: :job do
+  subject(:perform) { described_class.new.work(msg.to_json) }
+
+  let(:msg) do
+    {
+      druid:,
+      event_type:,
+      data:
+    }
+  end
+
+  let(:druid) { 'druid:bb408qn5061' }
+
+  let(:event_type) { 'druid_version_replicated' }
+
+  let(:data) do
+    {
+      host: 'preservation-catalog-qa-02.stanford.edu',
+      version: 19,
+      invoked_by: 'preservation-catalog',
+      parts_info: [
+        {
+          md5: '1a528419dea59d86cfd0c456e9f10024',
+          size: 123630,
+          s3_key: 'bb/408/qn/5061/bb408qn5061.v0019.zip'
+        }
+      ],
+      endpoint_name: 'aws_s3_east_1'
+    }
+  end
+
+  before do
+    allow(Event).to receive(:create!)
+  end
+
+  it 'creates event' do
+    perform
+    expect(Event).to have_received(:create!).with(druid:, event_type:, data:)
+  end
+end


### PR DESCRIPTION
refs https://github.com/sul-dlss/preservation_catalog/issues/1860

## Why was this change made? 🤔
Resilience for Pres Cat's event reporting.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



