### PR TITLE
Fix the output of the missing druid rake task

### DIFF
--- a/lib/tasks/missing_druids.rake
+++ b/lib/tasks/missing_druids.rake
@@ -19,7 +19,7 @@ namespace :missing_druids do
       missing_druids.map { |druid| file.write("#{druid}\n") }
     end
 
-    message = "Retrieved #{druids_from_solr.length} druids from SOLR\nRetrieved #{druids_from_db.length} druids from DB\nMissing #{missing_druids.length} druids in SOLR"
+    message = "Retrieved #{druids_from_solr.length} druids from SOLR\nRetrieved #{druids_from_db.flatten.length} druids from DB\nMissing #{missing_druids.length} druids in SOLR"
     puts message unless missing_druids.empty?
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

I noticed this output in the cron email for stage/qa:
```
Retrieved 32187 druids from SOLR
Retrieved 3 druids from DB
Missing 172 druids in SOLR
```

`Retrieved 3 druids from DB` is obviously not accurate, the actual number is the combination of Dro/Collection/AdminPolicy counts (the 3).


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



