### PR TITLE
Allow label to be a blank string

### DIFF
--- a/app/models/repository_record.rb
+++ b/app/models/repository_record.rb
@@ -5,7 +5,8 @@ class RepositoryRecord < ApplicationRecord
   self.abstract_class = true
   self.locking_column = 'lock'
 
-  validates :external_identifier, :cocina_version, :label, :version, presence: true
+  validates :external_identifier, :cocina_version, :version, presence: true
+  validates :label, length: { minimum: 0, allow_nil: false }
 
   def external_lock
     # This should be opaque, but this makes troubeshooting easier.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,18 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  activerecord:
+    errors:
+      models:
+        admin_policy:
+          attributes:
+            label:
+              invalid: can't be nil
+        collection:
+          attributes:
+            label:
+              invalid: can't be nil
+        dro:
+          attributes:
+            label:
+              invalid: can't be nil

--- a/spec/models/admin_policy_spec.rb
+++ b/spec/models/admin_policy_spec.rb
@@ -89,8 +89,8 @@ RSpec.describe AdminPolicy do
     subject(:apo) { described_class.create }
 
     it 'tells you if fields are missing' do
-      expect(apo.errors.attribute_names).to eq %i[external_identifier cocina_version
-                                                  label version administrative]
+      expect(apo.errors.attribute_names).to match_array %i[external_identifier cocina_version
+                                                           label version administrative]
     end
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -96,10 +96,10 @@ RSpec.describe Collection do
     subject(:collection) { described_class.create }
 
     it 'tells you if fields are missing' do
-      expect(collection.errors.attribute_names).to eq %i[external_identifier
-                                                         cocina_version label
-                                                         version access administrative
-                                                         description identification]
+      expect(collection.errors.attribute_names).to match_array %i[external_identifier
+                                                                  cocina_version
+                                                                  version label access administrative
+                                                                  description identification]
     end
   end
 end

--- a/spec/models/dro_spec.rb
+++ b/spec/models/dro_spec.rb
@@ -208,9 +208,17 @@ RSpec.describe Dro do
     subject(:dro) { described_class.create }
 
     it 'tells you if fields are missing' do
-      expect(dro.errors.attribute_names).to eq %i[external_identifier cocina_version label version
-                                                  content_type access administrative
-                                                  description identification structural]
+      expect(dro.errors.attribute_names).to match_array %i[external_identifier cocina_version label version
+                                                           content_type access administrative
+                                                           description identification structural]
+    end
+
+    context 'when label is an empty string' do
+      subject(:dro) { described_class.create(label: '') }
+
+      it 'is not an error' do
+        expect(dro.errors.attribute_names).not_to include(:label)
+      end
     end
   end
 end


### PR DESCRIPTION


## Why was this change made? 🤔

We no longer require a meaningful label to be set. Label is a legacy of Fedora

Fixes #4134

## How was this change tested? 🤨


