### PR TITLE
Only return symphony catatalogRecordIds

### DIFF
--- a/app/reports/invalid_language_uris.rb
+++ b/app/reports/invalid_language_uris.rb
@@ -12,7 +12,7 @@ class InvalidLanguageUris
             jsonb_path_query_array(description, '#{JSON_PATH2} ? (@ like_regex "^.*\.html$")') ||
             jsonb_path_query_array(description, '#{JSON_PATH2} ? (@ like_regex "^(?!https?://).*$")')) ->> 0 as contrib,
            external_identifier,
-           jsonb_path_query(identification, '$.catalogLinks.catalogRecordId') ->> 0 as catkey,
+           jsonb_path_query(identification, '$.catalogLinks[*] ? (@.catalog == "symphony").catalogRecordId') ->> 0 as catkey,
            jsonb_path_query(structural, '$.isMemberOf') ->> 0 as collection_id
            FROM "dros" WHERE
            (jsonb_path_exists(description, '#{JSON_PATH1} ? (@ like_regex "^(?!https?://).*$")') OR

--- a/app/reports/invalid_location_uris.rb
+++ b/app/reports/invalid_location_uris.rb
@@ -6,7 +6,7 @@ class InvalidLocationUris
   JSON_PATH = '$.**.event.location'
   SQL = <<~SQL.squish.freeze
     SELECT dros.external_identifier, a #>> '{0,value}' as value, a #>> '{0,uri}' as uri, a #>> '{0,code}' as code,
-           jsonb_path_query(dros.identification, '$.catalogLinks.catalogRecordId') ->> 0 as catkey,
+           jsonb_path_query(dros.identification, '$.catalogLinks[*] ? (@.catalog == "symphony").catalogRecordId') ->> 0 as catkey,
            jsonb_path_query(dros.structural, '$.isMemberOf') ->> 0 as collection_id
            FROM "dros",
            jsonb_path_query_array(dros.description, '#{JSON_PATH} ? (@.uri like_regex "^(?!https?://).*$" || @.uri like_regex "^.*\.html$")') a
@@ -25,7 +25,7 @@ class InvalidLocationUris
     result = ActiveRecord::Base.connection.execute(sql)
 
     result.to_a.map do |row|
-      [row['external_identifier'], row['catkey'], row['collection_id'], row['uri'], row['code'], row['value']].join(',')
+      [row['external_identifier'], row['catkey'], row['collection_id'], row['uri'], row['code'], "\"#{row['value']}\""].join(',')
     end
   end
 end

--- a/app/reports/invalid_name_uris.rb
+++ b/app/reports/invalid_name_uris.rb
@@ -8,7 +8,7 @@ class InvalidNameUris
     SELECT (jsonb_path_query_array(description, '#{JSON_PATH} ? (@ like_regex "^.*\.html$")') ||
             jsonb_path_query_array(description, '#{JSON_PATH} ? (@ like_regex "^(?!https?://).*$")')) ->> 0 as contrib,
            external_identifier,
-           jsonb_path_query(identification, '$.catalogLinks.catalogRecordId') ->> 0 as catkey,
+           jsonb_path_query(identification, '$.catalogLinks[*] ? (@.catalog == "symphony").catalogRecordId') ->> 0 as catkey,
            jsonb_path_query(structural, '$.isMemberOf') ->> 0 as collection_id
            FROM "dros" WHERE
            (jsonb_path_exists(description, '#{JSON_PATH} ? (@ like_regex "^(?!https?://).*$")') OR


### PR DESCRIPTION


## Why was this change made? 🤔

This excludes others like 'previous symphony'

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



