### PR TITLE
Remove the vestiges of ActiveFedora

### DIFF
--- a/bin/clean-druid-list
+++ b/bin/clean-druid-list
@@ -23,7 +23,7 @@ count = 0
 File.open(options[:output], 'w') do |file|
   druids.each_with_index do |druid, index|
     puts "Finding #{druid} (#{index + 1})"
-    next if ActiveFedora::SolrService.query('*:*', fl: 'id', rows: 1, fq: "id:\"#{druid}\"").empty?
+    next if SolrService.query('*:*', fl: 'id', rows: 1, fq: "id:\"#{druid}\"").empty?
 
     file.write("#{druid}\n")
     count += 1

--- a/bin/generate-druid-list
+++ b/bin/generate-druid-list
@@ -27,7 +27,7 @@ query = ARGV[0]
 druids = []
 
 loop do
-  results = ActiveFedora::SolrService.query('*:*', fl: 'id', rows: 10000, fq: query, start: druids.length, sort: 'id asc')
+  results = SolrService.query('*:*', fl: 'id', rows: 10000, fq: query, start: druids.length, sort: 'id asc')
   break if results.empty? || (options[:sample] && druids.size >= options[:sample])
 
   results.each { |r| druids << r['id'] }

--- a/config/application.rb
+++ b/config/application.rb
@@ -79,8 +79,6 @@ module DorServices
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
-    # If an object isn't found in DOR, return a 404
-    config.action_dispatch.rescue_responses['ActiveFedora::ObjectNotFoundError'] = :not_found
     # This makes sure our Postgres enums function are persisted to the schema
     config.active_record.schema_format = :sql
     # Set up a session store so we can access the Sidekiq Web UI

--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,4 +1,3 @@
 ---
 exceptions:
-  ignore:
-    - 'ActiveFedora::ObjectNotFoundError'
+  ignore: []

--- a/config/initializers/activefedora_solr_updates.rb
+++ b/config/initializers/activefedora_solr_updates.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-# Cannot just do:
-#   ::ENABLE_SOLR_UPDATES = false
-# Because "warning: already initialized constant ENABLE_SOLR_UPDATES".
-# ActiveFedora assigns a default (if unassigned) and we cannot pre-empt it from here.
-
-self.class.send(:remove_const, 'ENABLE_SOLR_UPDATES') if self.class.const_defined?(:ENABLE_SOLR_UPDATES)
-self.class.const_set(:ENABLE_SOLR_UPDATES, false)


### PR DESCRIPTION
## Why was this change made? 🤔

We don't have ActiveFedora in the stack anymore.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



