### PR TITLE
point honeybadger to master branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,8 @@ gem 'equivalent-xml' # for diffing MODS
 gem 'faraday', '~> 2.0'
 gem 'faraday-retry'
 
-# Fix for https://github.com/honeybadger-io/honeybadger-ruby/issues/435
-gem 'honeybadger', github: 'honeybadger-io/honeybadger-ruby', branch: 'fix-invalid-sessions'
+# Fix for https://github.com/honeybadger-io/honeybadger-ruby/issues/435 (fix has been merged to master, but a new gem release has yet to be cut)
+gem 'honeybadger', github: 'honeybadger-io/honeybadger-ruby', branch: 'master'
 
 gem 'jbuilder'
 gem 'jsonpath', '~> 1.1' # used for metadata reports

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/honeybadger-io/honeybadger-ruby.git
-  revision: 887592a3aab27735e6a1f83446347ea5c50d9736
-  branch: fix-invalid-sessions
+  revision: 77542a6d5978c9042d47c699f1f13987c27b1953
+  branch: master
   specs:
     honeybadger (4.12.1)
 


### PR DESCRIPTION
## Why was this change made? 🤔

https://github.com/honeybadger-io/honeybadger-ruby/issues/435 has been fixed in the `master` branch by https://github.com/honeybadger-io/honeybadger-ruby/pull/441 but a new gem version with the fix has yet to be cut (and we need to be able to deploy this project, which we can't since the commit `Gemfile.lock` points to is now missing from Github).


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



