### PR TITLE
adjustment to report - slashes are optional at end of URL

### DIFF
--- a/app/reports/unusual_language_source_uris.rb
+++ b/app/reports/unusual_language_source_uris.rb
@@ -5,7 +5,7 @@
 class UnusualLanguageSourceUris
   JSON_PATH1 = '$.**.language.**.uri' # both language.uri and language.script.uri
   JSON_PATH2 = '$.**.valueLanguage.**.uri' # both valueLanguage.uri and valueLanguage.valueScript.uri
-  REGEX = '^(?!(http|https)(://id\.loc\.gov/vocabulary/(iso639-2|languages)/)).*' # not "http(s)://id.loc.gov/vocabulary/iso639-2(/)"
+  REGEX = '^(?!(http|https)(://id\.loc\.gov/vocabulary/(iso639-2|languages)/?)).*' # not "http(s)://id.loc.gov/vocabulary/iso639-2(/)"
   # or "http(s)://id.loc.gov/vocabulary/languages(/)"
   SQL = <<~SQL.squish.freeze
     SELECT (jsonb_path_query_array(description, '#{JSON_PATH1} ? (@ like_regex "#{REGEX}")') ||


### PR DESCRIPTION
## Why was this change made? 🤔

Follow on to #4182 ... slashes were supposed to be optional at end of URL.  See https://github.com/sul-dlss/dor-services-app/issues/4179#issuecomment-1216900775


## How was this change tested? 🤨

Ran report on production and verified it worked as expected



