### PR TITLE
report: invalid name uris tweaked per #4185

### DIFF
--- a/app/reports/invalid_name_uris.rb
+++ b/app/reports/invalid_name_uris.rb
@@ -4,15 +4,22 @@
 # bin/rails r -e production "InvalidNameUris.report"
 class InvalidNameUris
   JSON_PATH = '$.**.contributor.name.uri'
+  # These URIs have at least 2 trailing characters
+  URL_PATTERNS_IGNORED = [
+    'id\.loc\.gov/authorities/names/..',
+    'id\.loc\.gov/vocabulary/organizations/..',
+    'vocab.getty.edu/ulan/..',
+    'viaf.org/viaf/..'
+  ].freeze
+  REGEX = "\"^https?://(?!#{URL_PATTERNS_IGNORED.join('|')}).*$\"".freeze
+
   SQL = <<~SQL.squish.freeze
-    SELECT (jsonb_path_query_array(description, '#{JSON_PATH} ? (@ like_regex "^.*\.html$")') ||
-            jsonb_path_query_array(description, '#{JSON_PATH} ? (@ like_regex "^(?!https?://).*$")')) ->> 0 as contrib,
+    SELECT jsonb_path_query_array(description, '#{JSON_PATH} ? (@ like_regex #{REGEX})') as contrib,
            external_identifier,
            jsonb_path_query(identification, '$.catalogLinks[*] ? (@.catalog == "symphony").catalogRecordId') ->> 0 as catkey,
            jsonb_path_query(structural, '$.isMemberOf') ->> 0 as collection_id
            FROM "dros" WHERE
-           (jsonb_path_exists(description, '#{JSON_PATH} ? (@ like_regex "^(?!https?://).*$")') OR
-           jsonb_path_exists(description, '#{JSON_PATH} ? (@ like_regex "^.*\.html$")'))
+           jsonb_path_exists(description, '#{JSON_PATH} ? (@ like_regex #{REGEX})')
   SQL
 
   def self.report
@@ -27,7 +34,7 @@ class InvalidNameUris
 
     grouped = result.to_a.group_by { |row| row['external_identifier'] }
     grouped.map do |id, rows|
-      contrib = rows.map { |row| row['contrib'] }.join(';')
+      contrib = rows.map { |row| JSON.parse(row['contrib']) }.join(';')
       [id, rows.first['catkey'], rows.first['collection_id'], contrib].join(',')
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Report is dialing into unexpected name uris, per #4185

Closes #4185

Report is at: https://gist.github.com/ndushay/442ddf6df15c89fde40e4cf2b4cefb8f

## How was this change tested? 🤨

vz332dg7306 is a prod record Arcadia set up for testing, and it does appear on the report as expected.

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



