### PR TITLE
report: invalid location uris tweaked per #4188

### DIFF
--- a/app/reports/invalid_location_uris.rb
+++ b/app/reports/invalid_location_uris.rb
@@ -4,14 +4,26 @@
 # bin/rails r -e production "InvalidLocationUris.report"
 class InvalidLocationUris
   JSON_PATH = '$.**.event.location'
+  # These URIs have at least 2 trailing characters
+  URL_PATTERNS_IGNORED = [
+    'id\.loc\.gov/authorities/names/..',
+    'id.loc.gov/vocabulary/geographicAreas/..',
+    'id.loc.gov/vocabulary/countries/..',
+    'www.geonames.org/..',
+    'www.wikidata.org/wiki/..'
+  ].freeze
+  REGEX = "\"^https?://(?!#{URL_PATTERNS_IGNORED.join('|')}).*$\"".freeze
   SQL = <<~SQL.squish.freeze
-    SELECT dros.external_identifier, a #>> '{0,value}' as value, a #>> '{0,uri}' as uri, a #>> '{0,code}' as code,
+    SELECT dros.external_identifier,
+           event_location #>> '{0,value}' as value,
+           event_location #>> '{0,uri}' as uri,
+           event_location #>> '{0,code}' as code,
            jsonb_path_query(dros.identification, '$.catalogLinks[*] ? (@.catalog == "symphony").catalogRecordId') ->> 0 as catkey,
            jsonb_path_query(dros.structural, '$.isMemberOf') ->> 0 as collection_id
            FROM "dros",
-           jsonb_path_query_array(dros.description, '#{JSON_PATH} ? (@.uri like_regex "^(?!https?://).*$" || @.uri like_regex "^.*\.html$")') a
+           jsonb_path_query_array(dros.description, '#{JSON_PATH} ? (@.uri like_regex #{REGEX})') event_location
            WHERE
-           jsonb_path_exists(description, '#{JSON_PATH}.uri ? (@ like_regex "^(?!https?://).*$" || @ like_regex "^.*\.html$")')
+           jsonb_path_exists(description, '#{JSON_PATH}.uri ? (@ like_regex #{REGEX})')
   SQL
 
   def self.report


### PR DESCRIPTION
## Why was this change made? 🤔

Report is dialing into unexpected name uris

Closes #4188

Report is at: https://gist.github.com/ndushay/442ddf6df15c89fde40e4cf2b4cefb8f

## How was this change tested? 🤨

vz332dg7306 is a prod record Arcadia set up for testing, and it does appear on the report as expected.

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



