### PR TITLE
update openapi.yml and gems for cocina-models 0.84.0 (DOI exceptions)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'rails', '~> 7.0'
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.83.0'
+gem 'cocina-models', '~> 0.84.0'
 gem 'datacite', '~> 0.3.0'
 gem 'dor-workflow-client', '~> 5.0'
 gem 'druid-tools', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.83.0)
+    cocina-models (0.84.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -485,7 +485,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.83.0)
+  cocina-models (~> 0.84.0)
   committee (~> 4.4)
   config
   datacite (~> 0.3.0)

--- a/openapi.yml
+++ b/openapi.yml
@@ -2138,8 +2138,18 @@ components:
               # description: An alphabet or other notation used to represent a
               #   language or other symbolic system of the descriptive element value.
     DOI:
-      type: string
       description: Digital Object Identifier (https://www.doi.org)
+      oneOf:
+        - $ref: '#/components/schemas/DoiPattern'
+        - $ref: '#/components/schemas/DoiExceptions'
+    DoiExceptions:
+      type: string
+      description: pre-existing Digital Object Identifiers (https://www.doi.org) not matching the pattern (case insensitive)
+      pattern: '^10\.(25740\/([vV][aA]90-[cC][tT]15|[sS][yY][xX][aA]-[mM]256|12[qQ][fF]-5243|65[jJ]8-6114)|25936\/629[tT]-[bB][xX]79)$'
+      example: '10.25740/12qF-5243'
+    DoiPattern:
+      type: string
+      description: Digital Object Identifier (https://www.doi.org) regex pattern # The prod and test prefixes are permitted
       pattern: '^10\.(25740|80343)\/[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
       example: '10.25740/bc123df4567'
     DRO:


### PR DESCRIPTION
## Why was this change made? 🤔

To use cocina-models that accommodate the DOI exceptions. And to be in sync.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



