### PR TITLE
README: add info about running reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ This is started automatically during a deploy via capistrano
 
 
 ## Other tools
+
+### Running Reports
+
+There is information about how to run reports on the sdr-infra VM in the [cocina-models README](https://github.com/sul-dlss/cocina-models#running-reports-in-dsa).  This approach has two advantages:
+- sdr-infra connects to the DSA database as read-only
+- no resource competition with production DSA processing
+
 ### Generating a list of druids from Solr query
 ```
 $ bin/generate-druid-list 'is_governed_by_ssim:"info:fedora/druid:rp029yq2361"'


### PR DESCRIPTION
## Why was this change made? 🤔

sul-dlss/cocina-models/pull/520 put information about running reports in the cocina-models README, but since the report code lives in this repo, it makes sense to say something about it in this README also.

screenshot:

![image](https://user-images.githubusercontent.com/96775/188018077-782957b4-9a17-488d-8e6f-949017755354.png)

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



