### PR TITLE
[HOLD] Republish collection members when collection is (re-)published

### DIFF
--- a/app/services/member_service.rb
+++ b/app/services/member_service.rb
@@ -4,10 +4,12 @@
 class MemberService
   # @param [String] druid the identifier of the collection
   # @param [Boolean] only_published when true, restrict to only published items
+  # @param [Boolean] exclude_opened when true, exclude opened items
   # @return [Array<Hash<String,String>>] the members of this collection
-  def self.for(druid, only_published: false)
+  def self.for(druid, only_published: false, exclude_opened: false)
     query = "is_member_of_collection_ssim:\"info:fedora/#{druid}\""
     query += ' published_dttsim:[* TO *]' if only_published
+    query += ' -processing_status_text_ssi:Opened' if exclude_opened
     args = {
       fl: 'id,objectType_ssim',
       rows: 100_000_000

--- a/spec/services/member_service_spec.rb
+++ b/spec/services/member_service_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MemberService do
+  let(:druid) { 'druid:bc123df4567' }
+
+  before do
+    allow(SolrService).to receive(:query)
+  end
+
+  describe '.for' do
+    it 'queries for members' do
+      described_class.for(druid)
+      expect(SolrService).to have_received(:query)
+        .with(/#{druid}/, anything)
+        .once
+    end
+
+    context 'with only_published param' do
+      it 'queries for published members only' do
+        described_class.for(druid, only_published: true)
+        expect(SolrService).to have_received(:query)
+          .with(/#{druid}.+published_dttsim:/, anything)
+          .once
+      end
+    end
+
+    context 'with exclude_opened param' do
+      it 'queries for non-opened members only' do
+        described_class.for(druid, exclude_opened: true)
+        expect(SolrService).to have_received(:query)
+          .with(/#{druid}.+processing_status_text_ssi:Opened/, anything)
+          .once
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #4195

This commit changes the `Publish::MetadataTransferService` such that when a collection is (re-)published, its members are (re-)published. Not all members, though: only those members that are 1) already published, and 2) not in the `Opened` state. It does this work using the existing `MemberService` which is extended here to add a param excluding items in the `Opened` state.


## How was this change tested? 🤨

CI. This needs testing in a deployed environment. Will work with Andrew on that.
