### PR TITLE
[Hold] add comments explaining the 3 different edtf date reports

### DIFF
--- a/app/reports/bad_edtf_dates.rb
+++ b/app/reports/bad_edtf_dates.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# This report is incomplete, as it only finds edtf dates with the encoding as a direct property of date
+#   (i.e.  date.structuredValue.encoding is not found -- see invalid_edtf_structured_dates.rb)
+# This report may have been superseded by invalid_edtf_dates.rb.
 # Invoke via:
 # bin/rails r -e production "BadEdtfDates.report"
 class BadEdtfDates

--- a/app/reports/invalid_edtf_dates.rb
+++ b/app/reports/invalid_edtf_dates.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+# This report is hopefully complete, finding dates with *indicated* edtf encoding
+#   - with the encoding as a direct property of date
+#   - with structuredValues
+#   etc.
+#  NOTE:  it does NOT find the structuredValues with value level encoding on only ONE
+#   of the values;  invalid_edtf_structured_dates.rb finds those cases.
+#  NOTE:  it is believed that this report supersedes bad_edtf_dates.rb
 # Invoke via:
 # bin/rails r -e production "InvalidEdtfDates.report"
 class InvalidEdtfDates

--- a/app/reports/invalid_edtf_structured_dates.rb
+++ b/app/reports/invalid_edtf_structured_dates.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# This report is incomplete, as it only finds edtf dates with structuredValues, per its spec
+#   (https://github.com/sul-dlss/dor-services-app/issues/4218)
+#  NOTE:  this report DOES find the structuredValues with value level encoding on only ONE
+#   of the values;  invalid_edtf_dates.rb does NOT find those cases.
 # Invoke via:
 # bin/rails r -e production "InvalidEdtfStructuredDates.report"
 class InvalidEdtfStructuredDates


### PR DESCRIPTION
[Hold as I think this PR will be superseded shortly]

## Why was this change made? 🤔

To keep developers from ripping their hair out trying to puzzle out why there are 3 different reports for invalid edtf dates.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



