### PR TITLE
Replacing :doi: placeholder in h2 citations

### DIFF
--- a/spec/services/create_object_service_spec.rb
+++ b/spec/services/create_object_service_spec.rb
@@ -199,5 +199,21 @@ RSpec.describe CreateObjectService do
         expect(result.identification.doi).to eq '10.80343/bc123df4567'
       end
     end
+
+    context 'when the citation includes placeholders' do
+      let(:requested_cocina_object) { build(:request_dro).new(description:) }
+      let(:description) do
+        {
+          title: [{ value: 'My Work' }],
+          note: [{ type: 'preferred citation', value: 'Keller, Michael. (2022). My Work. Stanford Digital Repository. Available at :link:. :doi:' }]
+        }
+      end
+
+      it 'replaces the placeholders with the PURL and DOI' do
+        result = store.create(requested_cocina_object, assign_doi: true)
+        expect(result.description.note.first.value).to include 'https://purl.stanford.edu/bc123df4567'
+        expect(result.description.note.first.value).to include 'https://doi.org/10.80343/bc123df4567'
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Goes with H2 PR https://github.com/sul-dlss/happy-heron/pull/2718 which adds a DOI placeholder to the exported citation. 

## How was this change tested? 🤨
Unit, deploying to QA, running integration test for h2 object creation. 

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



