### PR TITLE
exemplar report for source codes without uris for descendants of certain properties

### DIFF
--- a/app/reports/descendant_source_code_no_uri.rb
+++ b/app/reports/descendant_source_code_no_uri.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Report on properties with a descendant source.code without a corresponding uri.
+
+# Invoke via:
+# bin/rails r -e production "DescendantSourceCodeNoUri.report"
+class DescendantSourceCodeNoUri
+  # NOTE: Prefer strict JSON querying over lax when using the `.**` operator, per
+  #       https://www.postgresql.org/docs/14/functions-json.html#STRICT-AND-LAX-MODES
+  #
+  # > The .** accessor can lead to surprising results when using the lax mode.
+  # > ... This happens because the .** accessor selects both the segments array
+  # > and each of its elements, while the .HR accessor automatically unwraps
+  # > arrays when using the lax mode. To avoid surprising results, we recommend
+  # > using the .** accessor only in the strict mode.
+  JSONB_PATH = 'strict $.**.contributor.**.name[*] ? (exists(@.source.code)) ? (!(exists(@.uri)))'
+  SQL = <<~SQL.squish.freeze
+    SELECT dros.external_identifier as item_druid,
+           desc_value->'source'->'code' as source_code,
+           desc_value->'value' as name_value,
+           jsonb_path_query(dros.structural, '$.isMemberOf') ->> 0 as collection_druid
+           FROM "dros",
+           jsonb_path_query(dros.description, '#{JSONB_PATH}') desc_value
+           WHERE
+           NOT jsonb_path_exists(dros.identification, '$.catalogLinks[*] ? (@.catalog == "symphony").catalogRecordId')
+           AND jsonb_path_exists(dros.description, '#{JSONB_PATH}')
+  SQL
+
+  def self.report
+    puts "item_druid,collection_druid,collection_name,source_code\n"
+    rows(SQL).compact.each { |row| puts row }
+  end
+
+  def self.rows(sql_query)
+    sql_result_rows = ActiveRecord::Base.connection.execute(sql_query).to_a
+
+    sql_result_rows.map do |row|
+      collection_druid = row['collection_druid']
+      collection_name = Collection.find_by(external_identifier: collection_druid)&.label
+
+      [
+        row['item_druid'],
+        collection_druid,
+        "\"#{collection_name}\"",
+        row['name_value'],
+        row['source_code']
+      ].join(',')
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Related to #4238 

I also paired with Arcadia so she can, at a minimum, change the path expression for the different properties she's interested in, but possibly write some of her own reports in the future.   The tricky ones stump Mike and me, so she will likely reach out for help at times.

## How was this change tested? 🤨

Ran report, checked the results, until it made sense.

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



