### PR TITLE
update to cocina-models 0.85.0; update openapi.yml to remove parallelContributor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'rails', '~> 7.0'
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.84.0'
+gem 'cocina-models', '~> 0.85.0'
 gem 'datacite', '~> 0.3.0'
 gem 'dor-workflow-client', '~> 5.0'
 gem 'druid-tools', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.84.5)
+    cocina-models (0.85.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -485,7 +485,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.84.0)
+  cocina-models (~> 0.85.0)
   committee (~> 4.4)
   config
   datacite (~> 0.3.0)

--- a/openapi.yml
+++ b/openapi.yml
@@ -1791,11 +1791,6 @@ components:
         valueAt:
           description: URL or other pointer to the location of the contributor information.
           type: string
-        parallelContributor:
-          description: For multiple representations of information about the same contributor (e.g. in different languages).
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveParallelContributor"
     ControlledDigitalLendingAccess:
       type: object
       properties:
@@ -2019,44 +2014,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DescriptiveValue"
-    DescriptiveParallelContributor:
-      description: Value model for multiple representations of information about the same contributor (e.g. in different languages).
-      deprecated: true
-      type: object
-      additionalProperties: false
-      properties:
-        name:
-          description: Names associated with a contributor.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
-        type:
-          description: Entity type of the contributor (person, organization, etc.).
-          type: string
-        status:
-          description: Status of the contributor relative to other parallel contributors (e.g. the primary author among a group of contributors).
-          type: string
-        role:
-          description: Relationships of the contributor to the resource or to an event in its history.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
-        identifier:
-          description: Identifiers and URIs associated with the contributor entity.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
-        note:
-          description: Other information associated with the contributor.
-          type: array
-          items:
-            $ref: "#/components/schemas/DescriptiveValue"
-        valueAt:
-          description: URL or other pointer to the location of the contributor information.
-          type: string
-        valueLanguage:
-          # description: Language of the descriptive element value
-          $ref: "#/components/schemas/DescriptiveValueLanguage"
     DescriptiveParallelEvent:
       description: Value model for multiple representations of information about the same event (e.g. in different languages).
       type: object


### PR DESCRIPTION
## Why was this change made? 🤔

Removing usused parallelContributor from cocina-models and thus this API;  using updated cocina-models gem with this change.

Part of https://github.com/sul-dlss/cocina-models/issues/532

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



