### PR TITLE
[HOLD] Mark DOI as registered when object is in graveyard APO

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,6 +11,10 @@ ur_admin_policy:
   agreement: druid:wv961pm7301
   label: Ur-APO
 
+# Graveyard Admin Policy
+graveyard_admin_policy:
+  druid: 'druid:kg712km1576' # This value varies by environment and is managed in shared_configs
+
 content:
   base_dir: '/dor/workspace'
 

--- a/spec/services/cocina/to_datacite/attributes_spec.rb
+++ b/spec/services/cocina/to_datacite/attributes_spec.rb
@@ -58,6 +58,32 @@ RSpec.describe Cocina::ToDatacite::Attributes do
         }
       )
     end
+
+    context 'when APO is graveyard APO' do
+      let(:apo_druid) { Settings.graveyard_admin_policy.druid }
+
+      it 'creates the attributes hash' do
+        expect(attributes).to eq(
+          {
+            event: 'hide',
+            url: 'https://purl.stanford.edu/bb666bb1234',
+            creators: [],
+            contributors: [],
+            fundingReferences: [],
+            dates: [],
+            publicationYear: '2011',
+            publisher: 'Stanford Digital Repository',
+            titles: [{ title: }],
+            alternateIdentifiers: [
+              {
+                alternateIdentifier: purl,
+                alternateIdentifierType: 'PURL'
+              }
+            ]
+          }
+        )
+      end
+    end
   end
 
   context 'with an embargo' do


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes sul-dlss/happy-heron#2750

This commit adds a new check to the class that maps Cocina objects to Datacite attributes: if the object is in the SDR Graveyard APO, use the `register` event instead of the `publish` event. This has the effect of making sure DOIs of decommissioned (soft-deleted) objects are no longer findable.


## How was this change tested? 🤨

CI
