### PR TITLE
preservation-client is now version 5.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'dor-workflow-client', '~> 5.0'
 gem 'druid-tools', '~> 2.2'
 gem 'marc'
 gem 'moab-versioning', '~> 5.0', require: 'moab/stanford'
-gem 'preservation-client', '~> 4.0'
+gem 'preservation-client', '~> 5.0'
 # Pinning stanford-mods since >=3 breaks dor-services.
 gem 'stanford-mods', '~> 2.6'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,7 +293,7 @@ GEM
     patience_diff (1.2.0)
       optimist (~> 3.0)
     pg (1.4.3)
-    preservation-client (4.0.0)
+    preservation-client (5.0.0)
       activesupport (>= 4.2, < 8)
       faraday (~> 2.0)
       moab-versioning (~> 5.0)
@@ -501,7 +501,7 @@ DEPENDENCIES
   okcomputer
   parallel
   pg
-  preservation-client (~> 4.0)
+  preservation-client (~> 5.0)
   pry-byebug
   puma (~> 5.3)
   rack-console


### PR DESCRIPTION
## Why was this change made? 🤔

preservation-client version 5.0 removes primary_moab_location, which is never used here, thus perfectly safe here.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



