### PR TITLE
Validates that only file content type has file hierarchies.

### DIFF
--- a/app/validators/cocina/file_hierarchy_validator.rb
+++ b/app/validators/cocina/file_hierarchy_validator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Cocina
+  # Validates only only file content types have filenames with hierarchy (e.g., foo/bar.txt)
+  class FileHierarchyValidator
+    def initialize(cocina_object)
+      @cocina_object = cocina_object
+    end
+
+    attr_reader :error
+
+    # @return [Boolean] false if file hierarchy is present, but not file content type
+    def valid?
+      @error = 'File hierarchy present, but content type is not file' if file_hierarchy_present? && !file_content_type?
+      @error.nil?
+    end
+
+    private
+
+    attr_reader :cocina_object
+
+    def file_hierarchy_present?
+      cocina_object.structural.contains.any? { |file_set| file_set.structural.contains.any? { |file| file.filename.include?('/') } }
+    end
+
+    def file_content_type?
+      Cocina::ToXml::ContentType.map(cocina_object.type) == 'file'
+    end
+  end
+end

--- a/app/validators/cocina/object_validator.rb
+++ b/app/validators/cocina/object_validator.rb
@@ -25,6 +25,10 @@ module Cocina
       # Only DROs have collection membership
       validator = Cocina::CollectionExistenceValidator.new(cocina_object)
       raise ValidationError, validator.error unless validator.valid?
+
+      # Only DROs hav files
+      validator = Cocina::FileHierarchyValidator.new(cocina_object)
+      raise ValidationError, validator.error unless validator.valid?
     end
 
     private

--- a/spec/validators/cocina/file_hierarchy_validator_spec.rb
+++ b/spec/validators/cocina/file_hierarchy_validator_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::FileHierarchyValidator do
+  let(:validator) { described_class.new(cocina_object) }
+  let(:cocina_object) do
+    instance_double(Cocina::Models::DRO, structural:, type:)
+  end
+
+  let(:structural) do
+    Cocina::Models::DROStructural.new(
+      { contains: [{ externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/8d17c28b-5b3e-477e-912c-f168a1f4213f',
+                     type: Cocina::Models::FileSetType.file,
+                     version: 1,
+                     structural: { contains: [{ externalIdentifier: 'https://cocina.sul.stanford.edu/file/be451fd9-7908-4559-9e81-8d6f496a3181',
+                                                type: Cocina::Models::ObjectType.file,
+                                                label: 'story1u.txt',
+                                                filename:,
+                                                size: 7888,
+                                                version: 1,
+                                                hasMessageDigests: [{ type: 'sha1',
+                                                                      digest: '61dfac472b7904e1413e0cbf4de432bda2a97627' },
+                                                                    { type: 'md5', digest: 'e2837b9f02e0b0b76f526eeb81c7aa7b' }],
+                                                access: { view: 'world', download: 'world' },
+                                                administrative: { publish: true, sdrPreserve: false, shelve: true },
+                                                hasMimeType: 'text/plain' }] },
+                     label: 'Folder 1' }],
+        isMemberOf: ['druid:bb077hj4590'] }
+    )
+  end
+
+  context 'when hierarchy is present and content type is file' do
+    let(:filename) { 'folder1PuSu/story1u.txt' }
+    let(:type) { Cocina::Models::ObjectType.object }
+
+    it 'is valid' do
+      expect(validator.valid?).to be true
+      expect(validator.error).to be_nil
+    end
+  end
+
+  context 'when hierarchy is not present and content type is not file' do
+    let(:filename) { 'story1u.txt' }
+    let(:type) { Cocina::Models::ObjectType.book }
+
+    it 'is valid' do
+      expect(validator.valid?).to be true
+      expect(validator.error).to be_nil
+    end
+  end
+
+  context 'when hierarchy is present and content type is not file' do
+    let(:filename) { 'folder1PuSu/story1u.txt' }
+    let(:type) { Cocina::Models::ObjectType.book }
+
+    it 'is invalid' do
+      expect(validator.valid?).to be false
+      expect(validator.error).to be 'File hierarchy present, but content type is not file'
+    end
+  end
+end

--- a/spec/validators/cocina/object_validator_spec.rb
+++ b/spec/validators/cocina/object_validator_spec.rb
@@ -5,10 +5,12 @@ require 'rails_helper'
 RSpec.describe Cocina::ObjectValidator do
   let(:apo_existence_validator) { instance_double(Cocina::ApoExistenceValidator, valid?: true) }
   let(:collection_existence_validator) { instance_double(Cocina::CollectionExistenceValidator, valid?: true) }
+  let(:file_hierarchy_validator) { instance_double(Cocina::FileHierarchyValidator, valid?: true) }
 
   before do
     allow(Cocina::ApoExistenceValidator).to receive(:new).and_return(apo_existence_validator)
     allow(Cocina::CollectionExistenceValidator).to receive(:new).and_return(collection_existence_validator)
+    allow(Cocina::FileHierarchyValidator).to receive(:new).and_return(file_hierarchy_validator)
   end
 
   context 'when a request DRO' do
@@ -19,6 +21,7 @@ RSpec.describe Cocina::ObjectValidator do
 
       expect(apo_existence_validator).to have_received(:valid?)
       expect(collection_existence_validator).to have_received(:valid?)
+      expect(file_hierarchy_validator).to have_received(:valid?)
     end
   end
 
@@ -30,6 +33,7 @@ RSpec.describe Cocina::ObjectValidator do
 
       expect(apo_existence_validator).to have_received(:valid?)
       expect(collection_existence_validator).to have_received(:valid?)
+      expect(file_hierarchy_validator).to have_received(:valid?)
     end
   end
 
@@ -41,6 +45,7 @@ RSpec.describe Cocina::ObjectValidator do
 
       expect(apo_existence_validator).to have_received(:valid?)
       expect(collection_existence_validator).not_to have_received(:valid?)
+      expect(file_hierarchy_validator).not_to have_received(:valid?)
     end
   end
 end


### PR DESCRIPTION
refs https://github.com/sul-dlss/dor-services-app/issues/4256

## Why was this change made? 🤔
To only allow the use of file hierarchies for content types that are supported in access.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

