### PR TITLE
Added a file counts report

### DIFF
--- a/app/reports/file_counts.rb
+++ b/app/reports/file_counts.rb
@@ -13,7 +13,12 @@ class FileCounts
   SQL = <<~SQL.squish.freeze
     SELECT DISTINCT(external_identifier),
       content_type,
-      JSONB_ARRAY_LENGTH(JSONB_PATH_QUERY(structural, '$.contains.structural.contains')) AS count
+      JSONB_ARRAY_LENGTH(
+        JSONB_PATH_QUERY_ARRAY(
+          structural,
+          '$.contains[*].structural.contains[*].filename'
+        )
+      ) AS count
     FROM dros
     ORDER BY count DESC
   SQL

--- a/app/reports/file_counts.rb
+++ b/app/reports/file_counts.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Generates a report of SDR objects, their types and the number of files they
+# contain.
+#
+# bin/rails r -e production "FileCounts.report"
+#
+# Or if you want to limit the results (e.g. top 100)
+#
+# bin/rails r -e production "FileCounts.report(100)"
+#
+class FileCounts
+  SQL = <<~SQL.squish.freeze
+    SELECT DISTINCT(external_identifier),
+      content_type,
+      JSONB_ARRAY_LENGTH(JSONB_PATH_QUERY(structural, '$.contains.structural.contains')) AS count
+    FROM dros
+    ORDER BY count DESC
+  SQL
+
+  def self.report(limit = 'ALL')
+    sql = "#{SQL} LIMIT #{limit}"
+    puts 'druid,content_type,file_count'
+    ActiveRecord::Base.connection.execute(sql).each do |row|
+      puts "#{row['external_identifier']},#{row['content_type']},#{row['count']}"
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

I wanted to test sul-embed with an SDR object with lots of files so I wrote this report to find objects with lots of files. If my understanding of Cocina is correct it the JSONPath should select and count all the filenames out of the structural metadata.

If it's working, the SDR object with the most files is https://argo.stanford.edu/view/druid:rm242zg2446 

## How was this change tested? 🤨

Ran it on `sdr-infra.stanford.edu` against Stage and Production databases. 

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



