### PR TITLE
don't add collection info to 856 when collection not released to searchworks

### DIFF
--- a/spec/services/update_marc_record_service_spec.rb
+++ b/spec/services/update_marc_record_service_spec.rb
@@ -506,12 +506,42 @@ RSpec.describe UpdateMarcRecordService do
       end
     end
 
-    context 'when an object with a collection' do
+    context 'when an object with a collection has no release tags' do
       let(:cocina_object) do
         build(:dro, id: druid).new(
           structural: structural_metadata
         )
       end
+
+      it 'does not return information for the collection object' do
+        allow(CocinaObjectStore).to receive(:find).with(collection_druid).and_return(collection)
+        expect(umrs.get_x2_collection_info).to eq('')
+      end
+    end
+
+    context 'when an object with a collection that is not released to searchworks' do
+      let(:cocina_object) do
+        build(:dro, id: druid).new(
+          structural: structural_metadata
+        )
+      end
+
+      let(:release_data) { { 'Searchworks' => { 'release' => false } } }
+
+      it 'does not return information for the collection object' do
+        allow(CocinaObjectStore).to receive(:find).with(collection_druid).and_return(collection)
+        expect(umrs.get_x2_collection_info).to eq('')
+      end
+    end
+
+    context 'when an object with a collection that is released to searchworks' do
+      let(:cocina_object) do
+        build(:dro, id: druid).new(
+          structural: structural_metadata
+        )
+      end
+
+      let(:release_data) { { 'Searchworks' => { 'release' => true } } }
 
       it 'returns the appropriate information for the collection object' do
         allow(CocinaObjectStore).to receive(:find).with(collection_druid).and_return(collection)
@@ -939,7 +969,7 @@ RSpec.describe UpdateMarcRecordService do
       let(:release_data) { { 'Searchworks' => { 'release' => true } } }
 
       it 'returns true' do
-        expect(umrs.released_to_searchworks?).to be true
+        expect(umrs.released_to_searchworks?(cocina_object)).to be true
       end
     end
 
@@ -947,7 +977,7 @@ RSpec.describe UpdateMarcRecordService do
       let(:release_data) { { 'searchworks' => { 'release' => true } } }
 
       it 'returns true' do
-        expect(umrs.released_to_searchworks?).to be true
+        expect(umrs.released_to_searchworks?(cocina_object)).to be true
       end
     end
 
@@ -955,7 +985,7 @@ RSpec.describe UpdateMarcRecordService do
       let(:release_data) { { 'SearchWorks' => { 'release' => true } } }
 
       it 'returns true' do
-        expect(umrs.released_to_searchworks?).to be true
+        expect(umrs.released_to_searchworks?(cocina_object)).to be true
       end
     end
 
@@ -963,7 +993,7 @@ RSpec.describe UpdateMarcRecordService do
       let(:release_data) { { 'Searchworks' => { 'release' => false } } }
 
       it 'returns false' do
-        expect(umrs.released_to_searchworks?).to be false
+        expect(umrs.released_to_searchworks?(cocina_object)).to be false
       end
     end
 
@@ -971,7 +1001,7 @@ RSpec.describe UpdateMarcRecordService do
       let(:release_data) { { 'Searchworks' => { 'bogus' => 'yup' } } }
 
       it 'returns false' do
-        expect(umrs.released_to_searchworks?).to be false
+        expect(umrs.released_to_searchworks?(cocina_object)).to be false
       end
     end
 
@@ -979,7 +1009,7 @@ RSpec.describe UpdateMarcRecordService do
       let(:release_data) { {} }
 
       it 'returns false' do
-        expect(umrs.released_to_searchworks?).to be false
+        expect(umrs.released_to_searchworks?(cocina_object)).to be false
       end
     end
 
@@ -987,7 +1017,7 @@ RSpec.describe UpdateMarcRecordService do
       let(:release_data) { { 'Revs' => { 'release' => true } } }
 
       it 'returns false' do
-        expect(umrs.released_to_searchworks?).to be false
+        expect(umrs.released_to_searchworks?(cocina_object)).to be false
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #4297 - do not add collection info to 856 if collection not released to searchworks

I don't believe we checked for this in the past (but perhaps it is an uncommon occurrence).  The code used to be in `app/models/dor/update_marc_record_service.rb` before it was moved sometime mid-2022, but digging back to spring 2022, the code looks basically the same as it does now.

~~[HOLD] until we know this answer to this question: do we skip if the collection has *no* release tags (also implies not released), or only skip if the collection explicitly has a "false" release tag (which is what the example druid in the ticket has, item: https://argo.stanford.edu/view/druid:mv522rq4275, associated collection: https://argo.stanford.edu/view/druid:gk894yk3598)~~  validated

## How was this change tested? 🤨

Updated tests