### PR TITLE
Add honeybadger check-ins to cron jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ sudo /usr/bin/systemctl status sneakers
 
 This is started automatically during a deploy via capistrano
 
+## Cron check-ins
+
+Some cron jobs (configured via the `whenever` gem) are integrated with Honeybadger check-ins. These cron jobs will check-in with HB (via a curl request to an HB endpoint) whenever run. If a cron job does not check-in as expected, HB will alert.
+
+Cron check-ins are configured in the following locations:
+
+1. `config/schedule.rb`: This specifies which cron jobs check-in and what setting keys to use for the checkin key. See this file for more details.
+2. `config/settings.yml`: Stubs out a check-in key for each cron job. Since we may not want to have a check-in for all environments, this stub key will be used and produce a null check-in.
+3. `config/settings/production.yml` in `shared_configs`: This contains the actual check-in keys.
+4. HB notification page: Check-ins are configured per project in HB. To configure a check-in, the cron schedule will be needed, which can be found with `bundle exec whenever`. After a check-in is created, the check-in key will be available. (If the URL is `https://api.honeybadger.io/v1/check_in/rkIdpB` then the check-in key will be `rkIdpB`).
 
 ## Other tools
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -21,14 +21,25 @@
 
 # Learn more: http://github.com/javan/whenever
 
+# Load rubyconfig gem so that we have access to env-specific settings
+require 'config'
+
+Config.load_and_set_settings(Config.setting_files('config', 'production'))
+
+# These define jobs that checkin with Honeybadger.
+# If changing the schedule of one of these jobs, also update at https://app.honeybadger.io/projects/50568/check_ins
+job_type :rake, "cd :path && :environment_variable=:environment bundle exec rake :task --silent :output && curl 'https://api.honeybadger.io/v1/check_in/:check_in"
+
 # Suppress warnings to avoid unnecessary cron emails.
 env 'RUBYOPT', '-W0'
 
 every :day, at: '2:16am' do
+  set :check_in, Settings.honeybadger_checkins.embargo_release
   rake 'dsa:embargo_release'
 end
 
 # Run this an on off minute to avoid Google Books every 15 minutes
 every :day, at: '8:35pm' do
+  set :check_in, Settings.honeybadger_checkins.missing_druids
   rake 'missing_druids:unindexed_objects'
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -105,3 +105,7 @@ from_fedora_data_errors:
 datacite:
   prefix: '10.80343'
   host: fake.datacite.example.com
+
+honeybadger_checkins:
+  embargo_release: foo
+  missing_druids: bar


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #4293

This commit uses honeybadger check-ins to ensure regularly scheduled cron jobs are running, like the approach already being used in prescat and H2.


## How was this change tested? 🤨

CI
