### PR TITLE
Bump preservation-client to 5.1.1 to pick up higher timeout value

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,7 +301,7 @@ GEM
     patience_diff (1.2.0)
       optimist (~> 3.0)
     pg (1.4.5)
-    preservation-client (5.1.0)
+    preservation-client (5.1.1)
       activesupport (>= 4.2, < 8)
       faraday (~> 2.0)
       moab-versioning (>= 5.0.0, < 7)


### PR DESCRIPTION
## Why was this change made? 🤔

To allow long-running preservation operations to complete without timing out.

Connects to sul-dlss/moab-versioning#266

## How was this change tested? 🤨

CI and tested in stage.
