### PR TITLE
Fix bug in validate-cocina with sample option

### DIFF
--- a/bin/validate-cocina
+++ b/bin/validate-cocina
@@ -69,8 +69,8 @@ def validate(clazz, sample_size, processes)
   end.flatten
 end
 
-results = validate(Dro, options[:sample_size],
-                   options[:processes]) + validate(Collection, options[:sample_size], options[:processes]) + validate(AdminPolicy, options[:sample_size], options[:processes])
+results = validate(Dro, options[:sample],
+                   options[:processes]) + validate(Collection, options[:sample], options[:processes]) + validate(AdminPolicy, options[:sample], options[:processes])
 
 CSV.open('validate-cocina.csv', 'w') do |writer|
   writer << %w[druid type message]


### PR DESCRIPTION

## Why was this change made? 🤔

The option is called `sample`, not `sample_size`. Without this change, every run operates against the entire environment.


## How was this change tested? 🤨

CI + ran `bin/validate-cocina`


