### PR TITLE
bump preservation-client to 6.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'dor-workflow-client', '~> 5.0'
 gem 'druid-tools', '~> 2.2'
 gem 'marc'
 gem 'moab-versioning', '~> 6.0', require: 'moab/stanford'
-gem 'preservation-client', '~> 5.0'
+gem 'preservation-client', '~> 6.0'
 # Pinning stanford-mods since >=3 breaks dor-services.
 gem 'stanford-mods', '~> 2.6'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,7 +301,7 @@ GEM
     patience_diff (1.2.0)
       optimist (~> 3.0)
     pg (1.4.5)
-    preservation-client (5.2.0)
+    preservation-client (6.1.0)
       activesupport (>= 4.2, < 8)
       faraday (~> 2.0)
       moab-versioning (>= 5.0.0, < 7)
@@ -508,7 +508,7 @@ DEPENDENCIES
   okcomputer
   parallel
   pg
-  preservation-client (~> 5.0)
+  preservation-client (~> 6.0)
   pry-byebug
   puma (~> 5.3)
   rack-console


### PR DESCRIPTION
## Why was this change made? 🤔

none of the pres client changes are to methods used by dor-services-app, based on a grep for pres client invocations

(this is just meant to allow automated dependency updates to keep pres client updated)

## How was this change tested? 🤨

unit tests

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



