### PR TITLE
add a feature flag to disable file hierarchy validation if needed

### DIFF
--- a/app/validators/cocina/object_validator.rb
+++ b/app/validators/cocina/object_validator.rb
@@ -26,7 +26,9 @@ module Cocina
       validator = Cocina::CollectionExistenceValidator.new(cocina_object)
       raise ValidationError, validator.error unless validator.valid?
 
-      # Only DROs hav files
+      return unless Settings.enabled_features.file_hierarchy_validation
+
+      # Only DROs have files
       validator = Cocina::FileHierarchyValidator.new(cocina_object)
       raise ValidationError, validator.error unless validator.valid?
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,7 @@ enabled_features:
   create_ur_admin_policy: false
   datacite_update: false
   postgres: false
+  file_hierarchy_validation: true
 
 # Ur Admin Policy
 ur_admin_policy:

--- a/spec/validators/cocina/object_validator_spec.rb
+++ b/spec/validators/cocina/object_validator_spec.rb
@@ -13,27 +13,47 @@ RSpec.describe Cocina::ObjectValidator do
     allow(Cocina::FileHierarchyValidator).to receive(:new).and_return(file_hierarchy_validator)
   end
 
-  context 'when a request DRO' do
-    let(:cocina_object) { instance_double(Cocina::Models::RequestDRO, dro?: true) }
+  context 'with file_hierarchy_validation on' do
+    before { allow(Settings.enabled_features).to receive(:file_hierarchy_validation).and_return(true) }
 
-    it 'validates' do
-      described_class.validate(cocina_object)
+    context 'when a request DRO' do
+      let(:cocina_object) { instance_double(Cocina::Models::RequestDRO, dro?: true) }
 
-      expect(apo_existence_validator).to have_received(:valid?)
-      expect(collection_existence_validator).to have_received(:valid?)
-      expect(file_hierarchy_validator).to have_received(:valid?)
+      it 'validates' do
+        described_class.validate(cocina_object)
+
+        expect(apo_existence_validator).to have_received(:valid?)
+        expect(collection_existence_validator).to have_received(:valid?)
+        expect(file_hierarchy_validator).to have_received(:valid?)
+      end
+    end
+
+    context 'when a DRO' do
+      let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: true, externalIdentifier: nil) }
+
+      it 'validates' do
+        described_class.validate(cocina_object)
+
+        expect(apo_existence_validator).to have_received(:valid?)
+        expect(collection_existence_validator).to have_received(:valid?)
+        expect(file_hierarchy_validator).to have_received(:valid?)
+      end
     end
   end
 
-  context 'when a DRO' do
-    let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: true, externalIdentifier: nil) }
+  context 'with file_hierarchy_validation off' do
+    before { allow(Settings.enabled_features).to receive(:file_hierarchy_validation).and_return(false) }
 
-    it 'validates' do
-      described_class.validate(cocina_object)
+    context 'when a DRO' do
+      let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: true, externalIdentifier: nil) }
 
-      expect(apo_existence_validator).to have_received(:valid?)
-      expect(collection_existence_validator).to have_received(:valid?)
-      expect(file_hierarchy_validator).to have_received(:valid?)
+      it 'does not validate the file_hierarchy' do
+        described_class.validate(cocina_object)
+
+        expect(apo_existence_validator).to have_received(:valid?)
+        expect(collection_existence_validator).to have_received(:valid?)
+        expect(file_hierarchy_validator).not_to have_received(:valid?)
+      end
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Part of #4363 

After identifying the objects that fail file hierarchy validation, we will need to temporarily disable it so those objects can be updated.  This adds a feature flag (which defaults to ON) with which we can disable when needed.


## How was this change tested? 🤨

Updated test


