### PR TITLE
turn 2 specs back on

### DIFF
--- a/spec/jobs/publish_job_spec.rb
+++ b/spec/jobs/publish_job_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe PublishJob do
     end
   end
 
-  context 'when fails dark validation', skip: 'not sure why this is skipped - flaky?' do
+  context 'when fails dark validation' do
     let(:valid) { false }
     let(:invalid_filenames) { ['foo.txt', 'bar.txt'] }
 

--- a/spec/jobs/shelve_job_spec.rb
+++ b/spec/jobs/shelve_job_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ShelveJob do
     end
   end
 
-  context 'when fails dark validation', skip: 'turned off until preassembly can make valid dark objects' do
+  context 'when fails dark validation' do
     let(:valid) { false }
     let(:invalid_filenames) { ['foo.txt', 'bar.txt'] }
 


### PR DESCRIPTION
## Why was this change made? 🤔

preassembly can now make dark objects, so these specs should now work and be executed.

fixes #4366

## How was this change tested? 🤨

it's specs - running the specs

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



