### PR TITLE
Change virtual object creation to assume a single member order

### DIFF
--- a/app/services/reset_content_metadata_service.rb
+++ b/app/services/reset_content_metadata_service.rb
@@ -6,6 +6,8 @@ class ResetContentMetadataService
     new(cocina_item:).reset(constituent_druids:)
   end
 
+  MAX_MEMBER_ORDERS = 1
+
   attr_reader :cocina_item, :notifier
 
   def initialize(cocina_item:)
@@ -17,41 +19,42 @@ class ResetContentMetadataService
   def reset(constituent_druids: [])
     flag_multiple_member_orders!
 
-    member_orders = if constituent_druids.empty?
-                      empty_member_orders
-                    else
-                      empty_member_orders + regenerated_member_order(constituent_druids)
-                    end
-
-    cocina_item.new(structural: new_structural(member_orders))
+    cocina_item.new(
+      structural: structural.new(
+        hasMemberOrders: Array.wrap(new_member_orders(constituent_druids))
+      )
+    )
   end
 
   private
 
   def flag_multiple_member_orders!
-    member_orders = cocina_item.structural&.hasMemberOrders&.count { |order| order.members.any? }
-    return if member_orders.nil? || member_orders < 2
+    return if member_orders_count <= MAX_MEMBER_ORDERS
 
     notifier.error("item #{cocina_item.externalIdentifier} has multiple member orders")
   end
 
-  def empty_member_orders
-    Array(cocina_item.structural&.hasMemberOrders&.select { |order| order.members.empty? })
+  def member_orders_count
+    return 0 if member_orders.nil?
+
+    member_orders.count
   end
 
-  def new_structural(member_orders)
-    return Cocina::Models::DROStructural.new(hasMemberOrders: member_orders) if cocina_item.structural.nil?
-
-    cocina_item.structural.new(
-      hasMemberOrders: member_orders
-    )
+  def member_orders
+    cocina_item.structural&.hasMemberOrders
   end
 
-  def regenerated_member_order(constituent_druids)
-    [
-      {
-        members: constituent_druids
-      }
-    ]
+  def member_order
+    Array.wrap(member_orders).first
+  end
+
+  def new_member_orders(constituent_druids)
+    return if constituent_druids.empty? && member_order.to_h.keys.in?([[], [:members]])
+
+    member_order.to_h.merge(members: constituent_druids)
+  end
+
+  def structural
+    cocina_item.structural || Cocina::Models::DROStructural
   end
 end

--- a/spec/services/reset_content_metadata_service_spec.rb
+++ b/spec/services/reset_content_metadata_service_spec.rb
@@ -265,11 +265,8 @@ RSpec.describe ResetContentMetadataService do
             structural: {
               hasMemberOrders: [
                 {
-                  members: [],
+                  members: constituent_druids,
                   viewingDirection: 'left-to-right'
-                },
-                {
-                  members: constituent_druids
                 }
               ]
             }


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes sul-dlss/argo#3945

This commit changes the behavior of a service used in virtual object creation. It simplifies the code by assuming, and enforcing during virtual object creation, that a Cocina item may have no more than one member order. This change was cleared by @andrewjbtw.


## How was this change tested? 🤨

CI & successfully integration-tested in QA
