### PR TITLE
Adds feature for syncing catalog links.

### DIFF
--- a/app/services/catalog/add_folio_catalog_links_service.rb
+++ b/app/services/catalog/add_folio_catalog_links_service.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Catalog
+  # Adds Folio catalog links to cocina object based on symphony catalog links.
+  # This is for use prior to switch over from folio. After that this should be
+  # removed.
+  class AddFolioCatalogLinksService
+    def self.add(cocina_object)
+      new(cocina_object).add
+    end
+
+    def initialize(cocina_object)
+      @cocina_object = cocina_object
+    end
+
+    def add
+      return cocina_object if cocina_object.admin_policy?
+      return cocina_object if cocina_object.identification.catalogLinks.blank?
+
+      cocina_object.new(identification: cocina_object.identification.new(catalogLinks: synced_catalog_links))
+    end
+
+    private
+
+    attr_reader :cocina_object
+
+    # The following catkeys are valid but are from Lane Medical Library records
+    # that will not be migrated. They should remain in the record for now but
+    # no HRIDs should be generated based on them.
+    LANE_NOT_MIGRATING = %w[
+      10872078
+      10906003
+      11574734
+      11718696
+      12208745
+      12307427
+      12718359
+      12811199
+      13638174
+      11827181
+      12311317
+    ].freeze
+
+    def synced_catalog_links
+      catalog_links = []
+      cocina_object.identification.catalogLinks.each do |catalog_link|
+        next if non_lane_folio_link?(catalog_link)
+
+        if migrate_catalog_link?(catalog_link)
+          catalog_links << Cocina::Models::FolioCatalogLink.new(catalog: 'folio', catalogRecordId: "a#{catalog_link.catalogRecordId}",
+                                                                refresh: catalog_link.refresh)
+        end
+        catalog_links << catalog_link
+      end
+      catalog_links
+    end
+
+    def non_lane_folio_link?(catalog_link)
+      # Keep Lane folio catalog links (start with L)
+      catalog_link.catalog == 'folio' && !catalog_link.catalogRecordId.start_with?('L')
+    end
+
+    def migrate_catalog_link?(catalog_link)
+      catalog_link.catalog == 'symphony' && LANE_NOT_MIGRATING.exclude?(catalog_link.catalogRecordId)
+    end
+  end
+end

--- a/app/services/create_object_service.rb
+++ b/app/services/create_object_service.rb
@@ -36,6 +36,7 @@ class CreateObjectService
     updated_cocina_request_object = add_description(updated_cocina_request_object)
     cocina_object = cocina_from_request(updated_cocina_request_object, druid, assign_doi)
     cocina_object = assign_doi(cocina_object) if assign_doi
+    cocina_object = Catalog::AddFolioCatalogLinksService.add(cocina_object) if Settings.enabled_features.sync_cataloglinks
     cocina_object_with_metadata = CocinaObjectStore.store(cocina_object, skip_lock: true)
     add_project_tag(druid, cocina_request_object)
     # This creates version 1.0.0 (Initial Version)

--- a/app/services/update_object_service.rb
+++ b/app/services/update_object_service.rb
@@ -30,6 +30,8 @@ class UpdateObjectService
     # If this is a collection and the title has changed, then reindex the children.
     update_items = need_to_update_members?
 
+    @cocina_object = Catalog::AddFolioCatalogLinksService.add(cocina_object) if Settings.enabled_features.sync_cataloglinks
+
     # Only update if already exists in PG (i.e., added by create or migration).
     cocina_object_with_metadata = CocinaObjectStore.store(cocina_object, skip_lock:)
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,6 +6,7 @@ enabled_features:
   postgres: false
   file_hierarchy_validation: true
   read_folio: false
+  sync_cataloglinks: false
 
 # Ur Admin Policy
 ur_admin_policy:

--- a/spec/services/catalog/add_folio_catalog_links_service_spec.rb
+++ b/spec/services/catalog/add_folio_catalog_links_service_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Catalog::AddFolioCatalogLinksService do
+  subject(:synced_object) { described_class.new(cocina_object).add }
+
+  context 'when the object does not have catalog links (AdminPolicy)' do
+    let(:cocina_object) { build(:admin_policy) }
+
+    it 'does not change the object' do
+      expect(synced_object).to eq cocina_object
+    end
+  end
+
+  context 'when the catalog links are empty' do
+    let(:cocina_object) { build(:dro) }
+
+    it 'does not change the object' do
+      expect(synced_object).to eq cocina_object
+    end
+  end
+
+  context 'when there are catalog links' do
+    let(:cocina_object) do
+      build(:dro).new(identification: {
+                        sourceId: 'sul:1234',
+                        catalogLinks: [
+                          { catalog: 'symphony', catalogRecordId: '12345', refresh: true },
+                          { catalog: 'symphony', catalogRecordId: '23456', refresh: false },
+                          # Not migrating.
+                          { catalog: 'symphony', catalogRecordId: '10872078', refresh: false },
+                          { catalog: 'previous symphony', catalogRecordId: '34567', refresh: false },
+                          { catalog: 'folio', catalogRecordId: 'a45678', refresh: false },
+                          { catalog: 'previous folio', catalogRecordId: 'a56789', refresh: false },
+                          # Lane record should not be dropped.
+                          { catalog: 'folio', catalogRecordId: 'L6789', refresh: false }
+                        ]
+                      })
+    end
+
+    it 'syncs the catalogLinks' do
+      expect(synced_object.identification.catalogLinks.map(&:to_h)).to eq [
+        { catalog: 'folio', catalogRecordId: 'a12345', refresh: true },
+        { catalog: 'symphony', catalogRecordId: '12345', refresh: true },
+        { catalog: 'folio', catalogRecordId: 'a23456', refresh: false },
+        { catalog: 'symphony', catalogRecordId: '23456', refresh: false },
+        { catalog: 'symphony', catalogRecordId: '10872078', refresh: false },
+        { catalog: 'previous symphony', catalogRecordId: '34567', refresh: false },
+        { catalog: 'previous folio', catalogRecordId: 'a56789', refresh: false },
+        { catalog: 'folio', catalogRecordId: 'L6789', refresh: false }
+      ]
+    end
+  end
+
+  context 'when there is no existing folio link' do
+    let(:cocina_object) do
+      build(:dro).new(identification: {
+                        sourceId: 'sul:1234',
+                        catalogLinks: [
+                          { catalog: 'symphony', catalogRecordId: '12345', refresh: true }
+                        ]
+                      })
+    end
+
+    it 'adds the catalogLinks' do
+      expect(synced_object.identification.catalogLinks.map(&:to_h)).to eq [
+        { catalog: 'folio', catalogRecordId: 'a12345', refresh: true },
+        { catalog: 'symphony', catalogRecordId: '12345', refresh: true }
+      ]
+    end
+  end
+
+  context 'when add is called multiple times' do
+    let(:cocina_object) do
+      build(:dro).new(identification: {
+                        sourceId: 'sul:1234',
+                        catalogLinks: [
+                          { catalog: 'symphony', catalogRecordId: '12345', refresh: true }
+                        ]
+                      })
+    end
+    let(:resynced_object) { described_class.new(synced_object).add }
+
+    it 'syncs the catalogLinks' do
+      expect(synced_object.identification.catalogLinks.map(&:to_h)).to eq [
+        { catalog: 'folio', catalogRecordId: 'a12345', refresh: true },
+        { catalog: 'symphony', catalogRecordId: '12345', refresh: true }
+      ]
+      expect(resynced_object.identification.catalogLinks.map(&:to_h)).to eq [
+        { catalog: 'folio', catalogRecordId: 'a12345', refresh: true },
+        { catalog: 'symphony', catalogRecordId: '12345', refresh: true }
+      ]
+    end
+  end
+
+  context 'when a collection' do
+    let(:cocina_object) do
+      build(:collection).new(identification: {
+                               sourceId: 'sul:1234',
+                               catalogLinks: [
+                                 { catalog: 'symphony', catalogRecordId: '12345', refresh: true }
+                               ]
+                             })
+    end
+
+    it 'syncs the catalogLinks' do
+      expect(synced_object.identification.catalogLinks.map(&:to_h)).to eq [
+        { catalog: 'folio', catalogRecordId: 'a12345', refresh: true },
+        { catalog: 'symphony', catalogRecordId: '12345', refresh: true }
+      ]
+    end
+  end
+end

--- a/spec/services/create_object_service_spec.rb
+++ b/spec/services/create_object_service_spec.rb
@@ -100,6 +100,20 @@ RSpec.describe CreateObjectService do
       end
     end
 
+    context 'when syncing catalog links' do
+      let(:requested_cocina_object) { build(:request_dro) }
+
+      before do
+        allow(Catalog::AddFolioCatalogLinksService).to receive(:add).and_call_original
+        allow(Settings.enabled_features).to receive(:sync_cataloglinks).and_return(true)
+      end
+
+      it 'invokes AddFolioCatalogLinksService' do
+        store.create(requested_cocina_object)
+        expect(Catalog::AddFolioCatalogLinksService).to have_received(:add).with(Cocina::Models::DRO)
+      end
+    end
+
     context 'when fails refreshing from symphony' do
       let(:requested_cocina_object) { build(:request_dro, catkeys: ['999123']) }
 


### PR DESCRIPTION
closes #4376

## Why was this change made? 🤔
Allow Symphony and Folio catalog links to peacefully co-exist during the transition.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

