### PR TITLE
Adds folio migrator.

### DIFF
--- a/app/services/migrators/folio.rb
+++ b/app/services/migrators/folio.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Migrators
+  # Migrator that adds Folio catalog links.
+  class Folio < Base
+    # A migrator must implement a migrate? method that returns true if the SDR object should be migrated.
+    def migrate?
+      return false if ar_cocina_object.is_a?(AdminPolicy)
+
+      Set.new(catalog_links_for(cocina_object)) != Set.new(catalog_links_for(migrated_cocina_object))
+    end
+
+    def migrate
+      ar_cocina_object[:identification] = migrated_cocina_object.identification.to_h
+    end
+
+    private
+
+    def catalog_links_for(cocina_object)
+      Array(cocina_object.identification&.catalogLinks)
+    end
+
+    def cocina_object
+      @cocina_object ||= ar_cocina_object.to_cocina
+    end
+
+    def migrated_cocina_object
+      @migrated_cocina_object ||= Catalog::AddFolioCatalogLinksService.add(cocina_object)
+    end
+  end
+end

--- a/spec/services/migrators/folio_spec.rb
+++ b/spec/services/migrators/folio_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Migrators::Folio do
+  subject(:migrator) { described_class.new(ar_cocina_object) }
+
+  let(:ar_cocina_object) { create(:ar_dro) }
+
+  let(:unmigrated_identification) do
+    {
+      sourceId: 'sul:1234',
+      catalogLinks: [
+        { catalog: 'symphony', catalogRecordId: '12345', refresh: true }
+      ]
+    }
+  end
+
+  let(:migrated_identification) do
+    {
+      sourceId: 'sul:1234',
+      catalogLinks: [
+        { catalog: 'folio', catalogRecordId: 'a12345', refresh: true },
+        { catalog: 'symphony', catalogRecordId: '12345', refresh: true }
+      ]
+    }
+  end
+
+  describe '.druids' do
+    it 'returns nil' do
+      expect(described_class.druids).to be_nil
+    end
+  end
+
+  describe '#migrate?' do
+    context 'when an AdminPolicy' do
+      let(:ar_cocina_object) { create(:ar_admin_policy) }
+
+      it 'returns false' do
+        expect(migrator.migrate?).to be false
+      end
+    end
+
+    context 'when no catalog links' do
+      let(:ar_cocina_object) { create(:ar_dro, identification: { sourceId: 'sul:1234' }) }
+
+      it 'returns false' do
+        expect(migrator.migrate?).to be false
+      end
+    end
+
+    context 'when not yet migrated' do
+      let(:ar_cocina_object) { create(:ar_collection, identification: unmigrated_identification) }
+
+      it 'returns true' do
+        expect(migrator.migrate?).to be true
+      end
+    end
+
+    context 'when migrated' do
+      let(:ar_cocina_object) { create(:ar_collection, identification: migrated_identification) }
+
+      it 'returns false' do
+        expect(migrator.migrate?).to be false
+      end
+    end
+  end
+
+  describe 'migrate' do
+    let(:ar_cocina_object) { create(:ar_dro, identification: unmigrated_identification) }
+
+    it 'adds Folio catalog links' do
+      migrator.migrate
+      expect(ar_cocina_object.identification).to match migrated_identification.with_indifferent_access
+    end
+  end
+
+  describe '#publish?' do
+    it 'returns false' do
+      expect(migrator.publish?).to be false
+    end
+  end
+
+  describe '#version?' do
+    it 'returns false' do
+      expect(migrator.version?).to be false
+    end
+  end
+end


### PR DESCRIPTION
closes #4376

## Why was this change made? 🤔
Add folio catalog links to existing cocina data to support Folio.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit
