### PR TITLE
[HOLD] add HB notification for updating marc as part of virtual object creation

### DIFF
--- a/app/services/constituent_service.rb
+++ b/app/services/constituent_service.rb
@@ -75,6 +75,9 @@ class ConstituentService
 
       next unless cocina_item.identification&.catalogLinks&.any? { |link| link.catalog == 'symphony' }
 
+      msg = "ConstituentService is about to call Catalog::UpdateMarc856RecordService for #{constituent_druid} in #{virtual_object_druid}"
+      Honeybadger.notify("[DEBUG NOTIFICATION] #{msg}")
+
       Catalog::UpdateMarc856RecordService.update(cocina_item, thumbnail_service: ThumbnailService.new(cocina_item))
     end
   end


### PR DESCRIPTION
HOLD - as it may become clear in testing on stage/qa that we don't need this HB notification in production.

## Why was this change made? 🤔

Andrew and I are spelunking on whether or not virtual object manipulation
- actually calls out to update marc records with 856s now, and under which circumstances
- whether it needs to, or if this could be covered by the publish step in the releaseWF.

tagging @mjgiarlo as he may remember more information from 2019 (!) to help us with this.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



