### PR TITLE
Bump cocina-models version to 0.89.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.89.0)
+    cocina-models (0.89.1)
       activesupport
       deprecation
       dry-struct (~> 1.0)


### PR DESCRIPTION
## Why was this change made? 🤔

To keep pace with cocina-models releases

## How was this change tested? 🤨

CI
