### PR TITLE
File sizes report

### DIFF
--- a/app/reports/file_sizes.rb
+++ b/app/reports/file_sizes.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Generates a report of SDR objects ids and their total size in bytes
+#
+# bin/rails r -e production "FileSizes.report"
+#
+# Or if you want to limit the results (e.g. top 100)
+#
+# bin/rails r -e production "FileSizes.report(100)"
+#
+class FileSizes
+  SQL = <<~SQL.squish.freeze
+    SELECT dros.external_identifier, SUM(files.size) AS size_bytes
+    FROM dros,
+      LATERAL (
+        SELECT JSONB_ARRAY_ELEMENTS(
+          JSONB_PATH_QUERY_ARRAY(
+            structural,
+            '$.contains[*].structural.contains[*].size'
+          )
+        )::NUMERIC AS size
+        FROM dros dros2
+        WHERE dros2.external_identifier = dros.external_identifier
+      ) AS files
+    GROUP BY dros.external_identifier
+    ORDER BY size_bytes DESC
+  SQL
+
+  def self.report(limit = 'ALL')
+    sql = "#{SQL} LIMIT #{limit}"
+    puts 'druid,size_bytes'
+    ActiveRecord::Base.connection.execute(sql).each do |row|
+      puts "#{row['external_identifier']},#{row['size_bytes'].to_i}"
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

I thought it could be interesting to have a report that generated the file sizes for objects by querying the Cocina. In production it took 07:57 to generate the top ten:

```
$ bin/rails r -e production "FileSizes.report(10)"
```

```csv
druid,size_bytes
druid:tc646zc6154,5924462712275
druid:hn683db0520,3996542922303
druid:jw191jc5840,3958397136776
druid:yy759hp4897,3893031401640
druid:gx410cs0527,3695106416640
druid:pn552ht1089,3200147796304
druid:jf301dx7536,2934381031128
druid:kw792th2190,2931077798578
druid:dc086ym2763,2791747154683
druid:kf921gd3855,2571824274964
```

## How was this change tested? 🤨

Running on sdr-infra.

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



