### PR TITLE
Separates publish into own queue.

### DIFF
--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -3,7 +3,7 @@
 # Publish metadata for an object as a background job
 # Both accessionWF and releaseWF use this step.
 class PublishJob < ApplicationJob
-  queue_as :default
+  queue_as :publish
 
   # @param [String] druid the identifier of the fedora_item to be published
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,6 @@
+# This is only used locally. shared_configs overrides.
 :concurrency: 6
 :queues:
   - default
   - low
+  - publish


### PR DESCRIPTION
refs #3972

## Why was this change made? 🤔
Allow greater control over concurrency of publish job.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



