### PR TITLE
Adjusts queues used for publish and unpublish jobs.

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -110,7 +110,7 @@ class ObjectsController < ApplicationController
   def publish
     result = BackgroundJobResult.create
     EventFactory.create(druid: params[:id], event_type: 'publish_request_received', data: { background_job_result_id: result.id })
-    PublishJob.set(queue:).perform_later(druid: params[:id], background_job_result: result, workflow: params[:workflow])
+    PublishJob.set(queue: publish_queue).perform_later(druid: params[:id], background_job_result: result, workflow: params[:workflow])
     head :created, location: result
   end
 
@@ -124,7 +124,7 @@ class ObjectsController < ApplicationController
   def unpublish
     result = BackgroundJobResult.create
     EventFactory.create(druid: params[:id], event_type: 'unpublish_request_received', data: { background_job_result_id: result.id })
-    UnpublishJob.set(queue:).perform_later(druid: params[:id], background_job_result: result)
+    UnpublishJob.set(queue: publish_queue).perform_later(druid: params[:id], background_job_result: result)
     head :accepted, location: result
   end
 
@@ -172,6 +172,10 @@ class ObjectsController < ApplicationController
 
   def queue
     params['lane-id'] == 'low' ? :low : :default
+  end
+
+  def publish_queue
+    params['lane-id'] == 'low' ? :publish_low : :publish_default
   end
 
   def workflow_client

--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -3,7 +3,7 @@
 # Publish metadata for an object as a background job
 # Both accessionWF and releaseWF use this step.
 class PublishJob < ApplicationJob
-  queue_as :publish
+  queue_as :publish_default
 
   # @param [String] druid the identifier of the fedora_item to be published
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info

--- a/app/jobs/unpublish_job.rb
+++ b/app/jobs/unpublish_job.rb
@@ -2,7 +2,7 @@
 
 # Unpublished Druid in the background
 class UnpublishJob < ApplicationJob
-  queue_as :default
+  queue_as :publish_default
 
   def perform(druid:, background_job_result:)
     background_job_result.processing!

--- a/spec/requests/publish_object_spec.rb
+++ b/spec/requests/publish_object_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Publish object' do
     it 'calls Publish::MetadataTransferService and returns 201' do
       post "/v1/objects/#{druid}/publish?workflow=releaseWF&lane-id=low", headers: { 'Authorization' => "Bearer #{jwt}" }
 
-      expect(PublishJob).to have_received(:set).with(queue: :low)
+      expect(PublishJob).to have_received(:set).with(queue: :publish_low)
       expect(job).to have_received(:perform_later)
         .with(druid:, background_job_result: BackgroundJobResult, workflow: 'releaseWF')
       expect(response).to have_http_status(:created)

--- a/spec/requests/unpublish_object_spec.rb
+++ b/spec/requests/unpublish_object_spec.rb
@@ -5,14 +5,20 @@ require 'rails_helper'
 RSpec.describe 'Unpublishes an Object' do
   let(:druid) { 'druid:mx123qw2323' }
   let(:object) { build(:ar_dro, external_identifier: druid) }
+  let(:job) { class_double(UnpublishJob, perform_later: nil) }
 
   before do
     allow(CocinaObjectStore).to receive(:find).and_return(object)
+    allow(UnpublishJob).to receive(:set).and_return(job)
   end
 
   context 'when an unpublish request is successful' do
     it 'returns a 202 response' do
       post "/v1/objects/#{druid}/unpublish", headers: { 'Authorization' => "Bearer #{jwt}" }
+
+      expect(UnpublishJob).to have_received(:set).with(queue: :publish_default)
+      expect(job).to have_received(:perform_later)
+        .with(druid:, background_job_result: BackgroundJobResult)
       expect(response).to have_http_status(:accepted)
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔
Provide greater control over publish and unpublish, which hit purl fetcher.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

