### PR TITLE
Move symphony specific logic from Marc856Generator to SymphonyWriter.

### DIFF
--- a/app/services/catalog/symphony_writer.rb
+++ b/app/services/catalog/symphony_writer.rb
@@ -6,15 +6,20 @@ require 'shellwords'
 module Catalog
   # Writes the stub 856 record for sending to symphony
   class SymphonyWriter
-    def self.save(marc_856_records)
-      new.save(marc_856_records)
+    def self.save(cocina_object:, marc_856_data:)
+      new(cocina_object:, marc_856_data:).save
     end
 
-    def save(marc_856_records)
-      return if marc_856_records.blank?
+    def initialize(cocina_object:, marc_856_data:)
+      @cocina_object = cocina_object
+      @marc_856_data = marc_856_data
+    end
+
+    def save
+      return if catkeys.empty? && previous_catkeys.empty?
 
       symphony_file_name = "#{Settings.release.symphony_path}/sdr-purl-856s"
-      marc_856_records.each do |record|
+      records.each do |record|
         command = "#{Settings.release.write_856_script} #{Shellwords.escape(new_856_record(record))} #{Shellwords.escape(symphony_file_name)}"
         run_write_script(command)
       end
@@ -30,10 +35,38 @@ module Catalog
 
     private
 
+    attr_reader :marc_856_data, :cocina_object
+
+    def records
+      # first create "blank" records for any previous catkeys
+      new_records = previous_catkeys.map { |previous_catkey| new_identifier_record(previous_catkey) }
+
+      # For only the first current catkey, add the 856 record if it is released to searchworks
+      # Otherwise, just add the "blank" record
+      unless catkeys.empty?
+        catkey = catkeys.first
+        new_record = new_identifier_record(catkey)
+        new_record.merge!(marc_856_data) if released_to_searchworks?
+        new_records << new_record
+      end
+      new_records
+    end
+
     def new_856_record(record)
       return identifier_prefix(record[:catalog_record_id], record[:druid]) if record[:subfields].blank?
 
       "#{identifier_prefix(record[:catalog_record_id], record[:druid])}.856. #{marc_856_for(record)}"
+    end
+
+    def new_identifier_record(catalog_record_id)
+      {
+        catalog_record_id:,
+        druid:
+      }
+    end
+
+    def druid
+      @druid ||= @cocina_object.externalIdentifier.delete_prefix('druid:')
     end
 
     def identifier_prefix(catalog_record_id, druid)
@@ -49,6 +82,30 @@ module Catalog
       end
 
       marc856
+    end
+
+    def catkeys
+      @catkeys ||= fetch_catalog_record_ids(current: true)
+    end
+
+    def previous_catkeys
+      @previous_catkeys ||= fetch_catalog_record_ids(current: false)
+    end
+
+    # List of current or previous ckeys for the cocina object (depending on parameter passed)
+    # @param current [boolean] if you want the current or previous ckeys
+    # @return [Array] previous or current catkeys for the object in an array, empty array if none exist
+    def fetch_catalog_record_ids(current:)
+      return [] unless @cocina_object.respond_to?(:identification) && @cocina_object.identification
+
+      ckey_type = current ? 'symphony' : 'previous symphony'
+      @cocina_object.identification.catalogLinks.select { |link| link.catalog == ckey_type }.map(&:catalogRecordId)
+    end
+
+    def released_to_searchworks?
+      released_for = ::ReleaseTags.for(cocina_object:)
+      rel = released_for.transform_keys { |key| key.to_s.upcase }
+      rel.dig('SEARCHWORKS', 'release').presence || false
     end
   end
 end

--- a/app/services/catalog/update_marc_856_record_service.rb
+++ b/app/services/catalog/update_marc_856_record_service.rb
@@ -13,11 +13,15 @@ module Catalog
     end
 
     def update
-      marc_856_records = Marc856Generator.create(@cocina_object, thumbnail_service: @thumbnail_service)
+      return if cocina_object.admin_policy?
 
-      return if marc_856_records.blank?
+      marc_856_data = Marc856Generator.create(cocina_object, thumbnail_service:, catalog: 'symphony')
 
-      SymphonyWriter.save(marc_856_records)
+      SymphonyWriter.save(cocina_object:, marc_856_data:)
     end
+
+    private
+
+    attr_reader :cocina_object, :thumbnail_service
   end
 end

--- a/spec/services/catalog/symphony_writer_spec.rb
+++ b/spec/services/catalog/symphony_writer_spec.rb
@@ -3,121 +3,203 @@
 require 'rails_helper'
 
 RSpec.describe Catalog::SymphonyWriter do
-  subject(:symphony_writer) { described_class.new }
+  subject(:symphony_writer) { described_class.new(cocina_object:, marc_856_data:) }
 
   let(:druid) { 'druid:bc123dg9393' }
   let(:bare_druid) { druid.delete_prefix('druid:') }
   let(:collection_druid) { 'druid:cc111cc1111' }
   let(:collection_bare_druid) { collection_druid.delete_prefix('druid:') }
 
-  describe '.write_symphony_records' do
-    subject(:writer) { symphony_writer.save marc_records }
+  let(:marc_856_data) do
+    {
+      indicators: '41',
+      subfields: [
+        { code: 'z', value: nil },
+        { code: 'u', value: "https://purl.stanford.edu/#{bare_druid}" },
+        { code: 'x', value: 'SDR-PURL' },
+        { code: 'x', value: 'item' },
+        { code: 'x', value: 'barcode:36105216275185' },
+        { code: 'x', value: "file:#{bare_druid}%2Fwt183gy6220_00_0001.jp2" },
+        { code: 'x', value: "collection:#{collection_bare_druid}:8832162:Collection label & A Special character" },
+        { code: 'x', value: nil },
+        { code: 'x', value: 'rights:world' }
+      ]
+    }
+  end
 
+  describe '.save' do
     let(:fixtures) { './spec/fixtures' }
     let(:output_file) do
       "#{fixtures}/sdr_purl/sdr-purl-856s"
     end
 
+    let(:cocina_object) { build(:dro, id: druid).new(identification:) }
+    let(:release_service) { instance_double(ReleaseTags::IdentityMetadata, released_for: release_data) }
+    let(:release_data) { { 'Searchworks' => { 'release' => true } } }
+
     before do
       Settings.release.symphony_path = "#{fixtures}/sdr_purl"
+      allow(ReleaseTags::IdentityMetadata).to receive(:for).and_return(release_service)
     end
 
     after do
       FileUtils.rm_f(output_file)
     end
 
-    context 'when a single record' do
-      let(:marc_records) do
-        [
-          {
-            catalog_record_id: '8832162',
-            druid: bare_druid,
-            indicators: '41',
-            subfields: [
-              { code: 'z', value: nil },
-              { code: 'u', value: "https://purl.stanford.edu/#{bare_druid}" },
-              { code: 'x', value: 'SDR-PURL' },
-              { code: 'x', value: 'item' },
-              { code: 'x', value: 'barcode:36105216275185' },
-              { code: 'x', value: "file:#{bare_druid}%2Fwt183gy6220_00_0001.jp2" },
-              { code: 'x', value: "collection:#{collection_bare_druid}:8832162:Collection label & A Special character" },
-              { code: 'x', value: nil },
-              { code: 'x', value: 'rights:world' }
-            ]
-          }
-        ]
+    context 'when a single catkey that has been released to Searchworks' do
+      let(:identification) do
+        {
+          sourceId: 'sul:8832162',
+          catalogLinks: [
+            {
+              catalog: 'symphony',
+              catalogRecordId: '8832162'
+            }
+          ]
+        }
       end
+
       let(:marc856_file) do
         "8832162\tbc123dg9393\t.856. 41|uhttps://purl.stanford.edu/bc123dg9393|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:bc123dg9393%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111:8832162:Collection label & A Special character|xrights:world"
       end
 
       it 'writes the record' do
         expect(File).not_to exist(output_file)
-        expect(writer).not_to be_nil
+        symphony_writer.save
         expect(File).to exist(output_file)
         expect(File.read(output_file)).to eq "#{marc856_file}\n"
       end
     end
 
-    context 'when multiple records including special characters' do
-      let(:marc_records) do
-        [
-          {
-            catalog_record_id: '123',
-            druid: bare_druid
-          },
-          {
-            catalog_record_id: '456',
-            druid: bare_druid
-          },
-          {
-            catalog_record_id: '8832162',
-            druid: bare_druid,
-            indicators: '41',
-            subfields: [
-              { code: 'z', value: nil },
-              { code: 'u', value: "https://purl.stanford.edu/#{bare_druid}" },
-              { code: 'x', value: 'SDR-PURL' },
-              { code: 'x', value: 'item' },
-              { code: 'x', value: 'barcode:36105216275185' },
-              { code: 'x', value: "file:#{bare_druid}%2Fwt183gy6220_00_0001.jp2" },
-              { code: 'x', value: "collection:#{collection_bare_druid}:8832162:Collection label & A Special character" },
-              { code: 'x', value: "label:we call this a 'part'" },
-              { code: 'x', value: 'sort:123' },
-              { code: 'x', value: 'rights:world' }
-            ]
-          }
-        ]
+    context 'when a single catkey that has not been released to Searchworks' do
+      let(:identification) do
+        {
+          sourceId: 'sul:8832162',
+          catalogLinks: [
+            {
+              catalog: 'symphony',
+              catalogRecordId: '8832162'
+            }
+          ]
+        }
+      end
+
+      let(:release_data) { {} }
+
+      let(:marc856_file) do
+        "8832162\tbc123dg9393\t"
+      end
+
+      it 'writes the record' do
+        expect(File).not_to exist(output_file)
+        symphony_writer.save
+        expect(File).to exist(output_file)
+        expect(File.read(output_file)).to eq "#{marc856_file}\n"
+      end
+    end
+
+    context 'when previous and current catkeys (including special characters)' do
+      let(:identification) do
+        {
+          sourceId: 'sul:8832162',
+          catalogLinks: [
+            {
+              catalog: 'previous symphony',
+              catalogRecordId: '8832160'
+            },
+            {
+              catalog: 'previous symphony',
+              catalogRecordId: '8832161'
+            },
+            {
+              catalog: 'symphony',
+              catalogRecordId: '8832162'
+            }
+          ]
+        }
+      end
+
+      let(:marc_856_data) do
+        {
+          indicators: '41',
+          subfields: [
+            { code: 'z', value: nil },
+            { code: 'u', value: "https://purl.stanford.edu/#{bare_druid}" },
+            { code: 'x', value: 'SDR-PURL' },
+            { code: 'x', value: 'item' },
+            { code: 'x', value: 'barcode:36105216275185' },
+            { code: 'x', value: "file:#{bare_druid}%2Fwt183gy6220_00_0001.jp2" },
+            { code: 'x', value: "collection:#{collection_bare_druid}:8832162:Collection label & A Special character" },
+            { code: 'x', value: "label:we call this a 'part'" },
+            { code: 'x', value: 'sort:123' },
+            { code: 'x', value: 'rights:world' }
+          ]
+        }
       end
       let(:marc856_file) do
         [
-          "123\tbc123dg9393\t",
-          "456\tbc123dg9393\t",
+          "8832160\tbc123dg9393\t",
+          "8832161\tbc123dg9393\t",
           "8832162\tbc123dg9393\t.856. 41|uhttps://purl.stanford.edu/bc123dg9393|xSDR-PURL|xitem|xbarcode:36105216275185|xfile:bc123dg9393%2Fwt183gy6220_00_0001.jp2|xcollection:cc111cc1111:8832162:Collection label & A Special character|xlabel:we call this a 'part'|xsort:123|xrights:world"
         ]
       end
 
       it 'writes the record' do
-        expect(writer).not_to be_nil
+        symphony_writer.save
         expect(File).to exist(output_file)
         expect(File.read(output_file)).to eq "#{marc856_file[0]}\n#{marc856_file[1]}\n#{marc856_file[2]}\n"
       end
     end
 
-    context 'when an empty array' do
-      let(:marc_records) { {} }
+    context 'when onlt previous catkeys' do
+      let(:identification) do
+        {
+          sourceId: 'sul:8832162',
+          catalogLinks: [
+            {
+              catalog: 'previous symphony',
+              catalogRecordId: '8832160'
+            },
+            {
+              catalog: 'previous symphony',
+              catalogRecordId: '8832161'
+            }
+          ]
+        }
+      end
 
-      it 'does nothing' do
-        expect(writer).to be_nil
-        expect(File).not_to exist(output_file)
+      let(:marc_856_data) do
+        {
+          indicators: '41',
+          subfields: [
+            { code: 'z', value: nil }
+          ]
+        }
+      end
+      let(:marc856_file) do
+        [
+          "8832160\tbc123dg9393\t",
+          "8832161\tbc123dg9393\t"
+        ]
+      end
+
+      it 'writes the record' do
+        symphony_writer.save
+        expect(File).to exist(output_file)
+        expect(File.read(output_file)).to eq "#{marc856_file[0]}\n#{marc856_file[1]}\n"
       end
     end
 
-    context 'when nil' do
-      let(:marc_records) { nil }
+    context 'when no catalog links' do
+      let(:identification) do
+        {
+          sourceId: 'sul:8832162',
+          catalogLinks: []
+        }
+      end
 
       it 'does nothing' do
-        expect(writer).to be_nil
+        symphony_writer.save
         expect(File).not_to exist(output_file)
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔
Allow Marc856Generator to be used by FolioWriter as well.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

