### PR TITLE
two small touchups: remove commented cruft, better HB notification on failure to configure Folio client

### DIFF
--- a/config/initializers/folio_client.rb
+++ b/config/initializers/folio_client.rb
@@ -17,5 +17,5 @@ rescue StandardError => e
   # prevent running tests or rails console on laptop.  would also prevent deployment or startup
   # of dor-services-app if configuration was incorrect (missing settings, stale password, etc).
   Rails.logger.warn("Error configuring FolioClient: #{e}")
-  Honeybadger.notify('Error configuring FolioClient')
+  Honeybadger.notify(e)
 end

--- a/spec/services/catalog/marc_comparison_service_spec.rb
+++ b/spec/services/catalog/marc_comparison_service_spec.rb
@@ -138,8 +138,6 @@ RSpec.describe Catalog::MarcComparisonService do
   before do
     allow(Catalog::SymphonyReader).to receive(:new).with(catkey: symphony_catkey).and_return(mock_symphony_reader)
     allow(Catalog::FolioReader).to receive(:new).with(folio_instance_hrid: "a#{symphony_catkey}").and_return(mock_folio_reader)
-    # allow(symphony_marc_obj).to_receive(:is_a?).with(MARC::Record).and_return(true)
-    # allow(folio_marc_obj).to_receive(:is_a?).with(MARC::Record).and_return(true)
   end
 
   describe '#diff_marc_for_catkey' do


### PR DESCRIPTION
## Why was this change made? 🤔

see PR title (also similar change to client init in https://github.com/sul-dlss/hydra_etd/pull/1428/files)

## How was this change tested? 🤨

unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



