### PR TITLE
Send public cocina to PURL-fetcher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,6 +476,7 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -21,16 +21,16 @@ module Publish
       # Retrieve release tags from identityMetadata and all collections this item is a member of
       release_tags = ReleaseTags.for(cocina_object:)
 
-      transfer_metadata(release_tags)
-      publish_notify_on_success
+      public_cocina = PublicCocinaService.create(cocina_object)
+      transfer_metadata(release_tags, public_cocina)
+      publish_notify_on_success(public_cocina)
     end
 
     private
 
     attr_reader :cocina_object
 
-    def transfer_metadata(release_tags)
-      public_cocina = PublicCocinaService.create(cocina_object)
+    def transfer_metadata(release_tags, public_cocina)
       public_nokogiri = PublicXmlService.new(public_cocina:,
                                              released_for: release_tags,
                                              thumbnail_service: @thumbnail_service)
@@ -76,8 +76,8 @@ module Publish
     ##
     # When publishing a PURL, we notify purl-fetcher of changes.
     #
-    def publish_notify_on_success
-      Faraday.post(purl_services_url)
+    def publish_notify_on_success(public_cocina)
+      Faraday.post(purl_services_url, public_cocina.to_json, { 'Content-Type' => 'application/json' })
     end
 
     ##

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Publish::MetadataTransferService do
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/{"cocinaVersion"/, 'cocina.json')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<publicObject/, 'public')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<mods:mods/, 'mods')
-          expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(no_args)
+          expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(cocina_object)
         end
 
         let(:release_tags) do
@@ -171,7 +171,7 @@ RSpec.describe Publish::MetadataTransferService do
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/{"cocinaVersion"/, 'cocina.json')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<publicObject/, 'public')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<mods:mods/, 'mods')
-          expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(no_args)
+          expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(cocina_object)
           expect_any_instance_of(described_class).to receive(:republish_members!).with(no_args)
         end
 
@@ -183,7 +183,7 @@ RSpec.describe Publish::MetadataTransferService do
   end
 
   describe '#publish_notify_on_success' do
-    subject(:notify) { service.send(:publish_notify_on_success) }
+    subject(:notify) { service.send(:publish_notify_on_success, cocina_object) }
 
     context 'when purl-fetcher is configured' do
       before do


### PR DESCRIPTION
## Why was this change made? 🤔

This will help reduce load on the purl-fetcher server as we don't need to load xml from the filesystem

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



