### PR TITLE
ignore nfs files when building file list for preservation

### DIFF
--- a/app/services/preserve/file_inventory_builder.rb
+++ b/app/services/preserve/file_inventory_builder.rb
@@ -54,7 +54,7 @@ module Preserve
 
       # reject any files in the metadata folder that start with .nfs followed by digits (e.g. .nfsNNNNNN)
       #  see https://github.com/sul-dlss/dor-services-app/issues/4450
-      metadata_file_group.signature_hash.reject! { |_, file_sig| file_sig.paths.any?(/\A(.nfs)\d+\z/) }
+      metadata_file_group.signature_hash.reject! { |_, file_sig| file_sig.paths.any?(/\A\.nfs\d+\z/) }
       metadata_file_group
     end
   end

--- a/app/services/preserve/file_inventory_builder.rb
+++ b/app/services/preserve/file_inventory_builder.rb
@@ -48,7 +48,14 @@ module Preserve
 
     # @return [Moab::FileGroup] Traverse the metadata directory and generate a metadata group
     def metadata_file_group
-      Moab::FileGroup.new(group_id: 'metadata').group_from_directory(metadata_dir)
+      metadata_file_group = Moab::FileGroup.new(group_id: 'metadata').group_from_directory(metadata_dir)
+
+      return unless metadata_file_group # this can be nil if there are no metadata files
+
+      # reject any files in the metadata folder that start with .nfs followed by digits (e.g. .nfsNNNNNN)
+      #  see https://github.com/sul-dlss/dor-services-app/issues/4450
+      metadata_file_group.signature_hash.reject! { |_, file_sig| file_sig.paths.any?(/\A(.nfs)\d+\z/) }
+      metadata_file_group
     end
   end
 end

--- a/spec/fixtures/workspace/ab/123/cd/4567/ab123cd4567/metadata/.nfs123456
+++ b/spec/fixtures/workspace/ab/123/cd/4567/ab123cd4567/metadata/.nfs123456
@@ -1,0 +1,1 @@
+File to be ignored

--- a/spec/services/preserve/file_inventory_builder_spec.rb
+++ b/spec/services/preserve/file_inventory_builder_spec.rb
@@ -37,6 +37,16 @@ RSpec.describe Preserve::FileInventoryBuilder do
       expect(result).to be_instance_of Moab::FileInventory
       expect(result.groups.size).to eq 2
     end
+
+    it 'includes the correct content files from contentMetadata' do
+      expect(result.groups[0].file_count).to eq(4) # four content files
+      expect(result.groups[0].path_list).to eq(['00000001.jp2', '00000001.jp2', '1.html', '2.html'])
+    end
+
+    it 'excludes .nfs files from inventory of metadata files' do
+      expect(result.groups[1].file_count).to eq(2) # two metadata files (excludes the .nfs file!)
+      expect(result.groups[1].path_list).to eq(['contentMetadata.xml', 'descMetadata.xml'])
+    end
   end
 
   describe '#content_inventory' do


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #4450 - ignore .nfs files from metadata directory when building bag for preservation ingest

This changed `FileInventoryBuilder` is used by the `PreservationIngestService` to prepare the bag for sending to preservation, so I believe this change will exclude the .nfs files.  See https://github.com/sul-dlss/dor-services-app/blob/main/app/services/preservation_ingest_service.rb#L20-L22

## How was this change tested? 🤨

Added an example `.nfs` file to the existing fixtures used by the spec I changed, and then verified that the new tests which ensure it's not there fail before the code fix and pass after it.