### PR TITLE
Fix bug with generating thumbnail links for virtual objects

### DIFF
--- a/app/services/thumbnail_service.rb
+++ b/app/services/thumbnail_service.rb
@@ -24,8 +24,8 @@ class ThumbnailService
       end
     end
 
-    return if object.structural.hasMemberOrders.empty?
+    return if object.structural.hasMemberOrders.empty? || object.structural.hasMemberOrders.first.members.empty?
 
-    object.structural.hasMemberOrders.first.members.first
+    self.class.new(CocinaObjectStore.find(object.structural.hasMemberOrders.first.members.first)).thumb
   end
 end

--- a/spec/services/thumbnail_service_spec.rb
+++ b/spec/services/thumbnail_service_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe ThumbnailService do
 
     context 'for an item' do
       let(:druid) { 'druid:bc123df4567' }
-
       let(:object) { build(:dro, id: druid).new(structural:) }
 
       context 'with no structural metadata' do
@@ -66,16 +65,74 @@ RSpec.describe ThumbnailService do
       end
 
       context 'when an externalFile image resource is the only image' do
+        let(:member_object) do
+          create(
+            :ar_dro,
+            external_identifier: 'druid:cg767mn6478',
+            structural: {
+              contains: [
+                {
+                  type: Cocina::Models::FileSetType.image,
+                  externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/cg767mn6478-2064a12c-c97f-4c66-85eb-1693fd5ae56f',
+                  label: 'Object 1',
+                  version: 1,
+                  structural: {
+                    contains: [
+                      {
+                        type: Cocina::Models::ObjectType.file,
+                        externalIdentifier: 'https://cocina.sul.stanford.edu/file/cg767mn6478-2064a12c-c97f-4c66-85eb-1693fd5ae56f/2542A.tiff',
+                        label: '2542A.tiff',
+                        filename: '2542A.tiff',
+                        hasMimeType: 'image/tiff',
+                        size: 3_182_927,
+                        version: 1,
+                        access: {
+                          view: 'world',
+                          download: 'none'
+                        },
+                        administrative: {
+                          publish: false,
+                          sdrPreserve: true,
+                          shelve: false
+                        },
+                        hasMessageDigests: []
+                      },
+                      {
+                        type: Cocina::Models::ObjectType.file,
+                        externalIdentifier: 'https://cocina.sul.stanford.edu/file/cg767mn6478-2064a12c-c97f-4c66-85eb-1693fd5ae56f/2542A.jp2',
+                        label: '2542A.jp2',
+                        filename: '2542A.jp2',
+                        hasMimeType: 'image/jp2',
+                        size: 11_043,
+                        version: 1,
+                        access: {
+                          view: 'world',
+                          download: 'none'
+                        },
+                        administrative: {
+                          publish: true,
+                          sdrPreserve: false,
+                          shelve: true
+                        },
+                        hasMessageDigests: []
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          )
+        end
         let(:structural) do
           {
             hasMemberOrders: [{
-              members: ['cg767mn6478_1/2542A.jp2']
+              members: [member_object.external_identifier]
             }]
           }
         end
 
-        it 'returns the image as the thumb' do
-          expect(subject).to eq('cg767mn6478_1/2542A.jp2')
+        it 'returns the first image of the first member as the thumb' do
+          expect(subject).to eq('cg767mn6478/2542A.jp2')
         end
       end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #4456

This bug, as far as I can tell, has been around since we cocinized the thumbnail service which prior to this commit returned the druid of the first member of a virtual object as its thumbnail link. Instead, pass this druid back to the thumbnail service to get the expected thumbnail link (the bare druid followed by the filename of the first jp2 of the first member).


## How was this change tested? 🤨

- [x] CI
- [x] QA/stage
