### PR TITLE
no need to memoize results only used once

### DIFF
--- a/app/services/goobi_service.rb
+++ b/app/services/goobi_service.rb
@@ -87,7 +87,7 @@ class GoobiService
   # @return [String] first goobi workflow tag value if one exists (default from config if none)
   def goobi_workflow_name
     dpg_workflow_tag_id = 'DPG : Workflow : '
-    content_tag = AdministrativeTags.for(identifier: cocina_obj.externalIdentifier).select { |tag| tag.include?(dpg_workflow_tag_id) }
+    content_tag = AdministrativeTags.for(identifier: cocina_obj.externalIdentifier).select { |tag| tag.start_with?(dpg_workflow_tag_id) }
     content_tag.empty? ? Settings.goobi.default_goobi_workflow_name : content_tag[0].split(':').last.strip
   end
 
@@ -132,7 +132,7 @@ class GoobiService
   # @return [boolean]
   def goobi_ocr_tag_present?
     dpg_goobi_ocr_tag = 'DPG : OCR : TRUE'
-    AdministrativeTags.for(identifier: cocina_obj.externalIdentifier).any? { |tag| tag.casecmp(dpg_goobi_ocr_tag).zero? } # case insensitive compare
+    AdministrativeTags.for(identifier: cocina_obj.externalIdentifier).any? { |tag| tag.casecmp?(dpg_goobi_ocr_tag) } # case insensitive compare
   end
 
   # returns the first collection_id the object is contained in (if any)

--- a/app/services/goobi_service.rb
+++ b/app/services/goobi_service.rb
@@ -86,11 +86,9 @@ class GoobiService
   # returns the name of the goobiworkflow in the object by examining the objects tags
   # @return [String] first goobi workflow tag value if one exists (default from config if none)
   def goobi_workflow_name
-    @goobi_workflow_name ||= begin
-      dpg_workflow_tag_id = 'DPG : Workflow : '
-      content_tag = AdministrativeTags.for(identifier: cocina_obj.externalIdentifier).select { |tag| tag.include?(dpg_workflow_tag_id) }
-      content_tag.empty? ? Settings.goobi.default_goobi_workflow_name : content_tag[0].split(':').last.strip
-    end
+    dpg_workflow_tag_id = 'DPG : Workflow : '
+    content_tag = AdministrativeTags.for(identifier: cocina_obj.externalIdentifier).select { |tag| tag.include?(dpg_workflow_tag_id) }
+    content_tag.empty? ? Settings.goobi.default_goobi_workflow_name : content_tag[0].split(':').last.strip
   end
 
   def catkey
@@ -133,10 +131,8 @@ class GoobiService
   # returns true or false depending if the specially defined goobi DPG ocr tag is present in the object
   # @return [boolean]
   def goobi_ocr_tag_present?
-    @goobi_ocr_tag_present ||= begin
-      dpg_goobi_ocr_tag = 'DPG : OCR : TRUE'
-      AdministrativeTags.for(identifier: cocina_obj.externalIdentifier).any? { |tag| tag.casecmp(dpg_goobi_ocr_tag).zero? } # case insensitive compare
-    end
+    dpg_goobi_ocr_tag = 'DPG : OCR : TRUE'
+    AdministrativeTags.for(identifier: cocina_obj.externalIdentifier).any? { |tag| tag.casecmp(dpg_goobi_ocr_tag).zero? } # case insensitive compare
   end
 
   # returns the first collection_id the object is contained in (if any)
@@ -148,7 +144,7 @@ class GoobiService
   # returns the name of the first collection the object is contained in (if any)
   # @return [String] first collection name the item is in (blank if none)
   def collection_name
-    @collection_name ||= collection_id == '' ? '' : CocinaObjectStore.find(collection_id).label
+    collection_id == '' ? '' : CocinaObjectStore.find(collection_id).label
   end
 
   def title_or_label


### PR DESCRIPTION
## Why was this change made? 🤔

This issue sul-dlss/common-accessioning#1043 discusses intermittent problems with the goobi service sending data during registration.  I can't think of a reason for this (particularly as the tags used to determine the workflow name we send to goobi are in local database and so there should be nothing like a race condition for when they are available).

I did notice that we memoize certain values in the goobi service, including the value that apparently sometimes gets set as the default incorrectly, for no apparent reason (they are used only once per instance).  I don't have a reason that this would explain the intermittency, but just putting this up for discussion/reaction.

## How was this change tested? 🤨

Existing tests
