### PR TITLE
Export release tags to the public cocina

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -16,10 +16,8 @@ class MetadataController < ApplicationController
   end
 
   def public_xml
-    release_tags = ReleaseTags.for(cocina_object: @cocina_object)
     public_cocina = Publish::PublicCocinaService.create(@cocina_object)
     service = Publish::PublicXmlService.new(public_cocina:,
-                                            released_for: release_tags,
                                             thumbnail_service: ThumbnailService.new(@cocina_object))
     render xml: service
   end

--- a/app/services/catalog/folio_writer.rb
+++ b/app/services/catalog/folio_writer.rb
@@ -42,7 +42,7 @@ module Catalog
       retry_connection do
         FolioClient.edit_marc_json(hrid: catalog_record_id) do |marc_json|
           marc_json['fields'].reject! { |field| (field['tag'] == '856') && (field['content'].include? purl_subfield) }
-          marc_json['fields'] << marc_856_field if released_to_searchworks?(cocina_object)
+          marc_json['fields'] << marc_856_field if ReleaseTags.released_to_searchworks?(cocina_object:)
         end
       end
     end
@@ -85,12 +85,6 @@ module Catalog
     def fetch_catalog_record_ids(current:)
       catalog_record_id_type = current ? 'folio' : 'previous folio'
       @cocina_object.identification.catalogLinks.filter_map { |link| link.catalogRecordId if link.catalog == catalog_record_id_type }
-    end
-
-    def released_to_searchworks?(cocina_object)
-      released_for = ::ReleaseTags.for(cocina_object:)
-      rel = released_for.transform_keys { |key| key.to_s.upcase } # upcase all release tags to make the check case insensitive
-      rel.dig('SEARCHWORKS', 'release').presence || false
     end
 
     def marc_856_field

--- a/app/services/catalog/marc_856_generator.rb
+++ b/app/services/catalog/marc_856_generator.rb
@@ -125,7 +125,7 @@ module Catalog
 
       collections.each do |collection_druid|
         collection = CocinaObjectStore.find(collection_druid)
-        next unless released_to_searchworks?(collection)
+        next unless ReleaseTags.released_to_searchworks?(cocina_object: collection)
 
         catalog_link = collection.identification&.catalogLinks&.find { |link| link.catalog == catalog }
         collection_info << { code: 'x', value: "collection:#{collection.externalIdentifier.sub('druid:', '')}:#{catalog_link&.catalogRecordId}:#{Cocina::Models::Builders::TitleBuilder.build(collection.description.title)}" }
@@ -159,12 +159,6 @@ module Catalog
       values << "rights:location=#{access.location}" if access.location
 
       values.map { |right| { code: 'x', value: right } }
-    end
-
-    def released_to_searchworks?(cocina_object)
-      released_for = ::ReleaseTags.for(cocina_object:)
-      rel = released_for.transform_keys { |key| key.to_s.upcase }
-      rel.dig('SEARCHWORKS', 'release').presence || false
     end
 
     # adapted from mods_display

--- a/app/services/catalog/symphony_writer.rb
+++ b/app/services/catalog/symphony_writer.rb
@@ -46,7 +46,7 @@ module Catalog
       unless catkeys.empty?
         catkey = catkeys.first
         new_record = new_identifier_record(catkey)
-        new_record.merge!(marc_856_data) if released_to_searchworks?
+        new_record.merge!(marc_856_data) if ReleaseTags.released_to_searchworks?(cocina_object:)
         new_records << new_record
       end
       new_records
@@ -100,12 +100,6 @@ module Catalog
 
       ckey_type = current ? 'symphony' : 'previous symphony'
       @cocina_object.identification.catalogLinks.select { |link| link.catalog == ckey_type }.map(&:catalogRecordId)
-    end
-
-    def released_to_searchworks?
-      released_for = ::ReleaseTags.for(cocina_object:)
-      rel = released_for.transform_keys { |key| key.to_s.upcase }
-      rel.dig('SEARCHWORKS', 'release').presence || false
     end
   end
 end

--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -18,11 +18,8 @@ module Publish
       republish_members!
       return unpublish unless discoverable?
 
-      # Retrieve release tags from identityMetadata and all collections this item is a member of
-      release_tags = ReleaseTags.for(cocina_object:)
-
       public_cocina = PublicCocinaService.create(cocina_object)
-      transfer_metadata(release_tags, public_cocina)
+      transfer_metadata(public_cocina)
       publish_notify_on_success(public_cocina)
     end
 
@@ -30,9 +27,8 @@ module Publish
 
     attr_reader :cocina_object
 
-    def transfer_metadata(release_tags, public_cocina)
+    def transfer_metadata(public_cocina)
       public_nokogiri = PublicXmlService.new(public_cocina:,
-                                             released_for: release_tags,
                                              thumbnail_service: @thumbnail_service)
       transfer_to_document_store(public_cocina.to_json, 'cocina.json')
       transfer_to_document_store(public_nokogiri.to_xml, 'public')

--- a/app/services/publish/public_cocina_service.rb
+++ b/app/services/publish/public_cocina_service.rb
@@ -26,8 +26,11 @@ module Publish
     attr_reader :cocina
 
     # remove partOfProject (similar to how we remove tags from identityMetadata)
+    # and rewrite release tags with the tags from the collection.
     def build_administrative
-      Cocina::Models::Administrative.new(cocina.administrative.to_h.except(:partOfProject))
+      Cocina::Models::Administrative.new(cocina.administrative.to_h
+        .except(:partOfProject)
+        .merge(releaseTags: ReleaseTags.for(cocina_object: cocina)))
     end
 
     def build_structural

--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -4,11 +4,9 @@ module Publish
   # Exports the full object XML that we display on purl.stanford.edu
   class PublicXmlService
     # @param [Cocina::Models::DRO, Cocina::Models::Collection] public_cocina a cocina object stripped of non-public data
-    # @param [Hash{String => Boolean}] released_for keys are Project name strings, values are boolean
     # @param [ThumbnailService] thumbnail_service
-    def initialize(public_cocina:, released_for:, thumbnail_service:)
+    def initialize(public_cocina:, thumbnail_service:)
       @public_cocina = public_cocina
-      @released_for = released_for
       @thumbnail_service = thumbnail_service
     end
 
@@ -41,7 +39,7 @@ module Publish
 
     private
 
-    attr_reader :released_for, :public_cocina
+    attr_reader :public_cocina
 
     # Generate XML structure for inclusion to Purl. This data is read by purl-fetcher.
     # @return [String] The XML release node as a string, with ReleaseDigest as the root document
@@ -49,8 +47,8 @@ module Publish
       @release_xml ||= begin
         builder = Nokogiri::XML::Builder.new do |xml|
           xml.releaseData do
-            released_for.each do |project, released_value|
-              xml.release(released_value['release'], to: project)
+            public_cocina.administrative.releaseTags.each do |tag|
+              xml.release(tag.release, to: tag.to)
             end
           end
         end

--- a/app/services/release_tags.rb
+++ b/app/services/release_tags.rb
@@ -6,109 +6,44 @@ class ReleaseTags
   #
   # Determine projects in which an item is released
   # @param cocina_object [Cocina::Models::DRO, Cocina::Models::Collection] the object to list release tags for
-  # @return [Hash{String => Boolean}] all namespaces, keys are Project name Strings, values are Boolean
+  # @return [Array<Cocina::Models::ReleaseTag>]
   def self.for(cocina_object:)
     new(cocina_object).released_for
+  end
+
+  def self.released_to_searchworks?(cocina_object:)
+    new(cocina_object).released_for
+                      .find { |tag| tag.to.casecmp?('Searchworks') }&.release || false
   end
 
   def initialize(cocina_object)
     @cocina_object = cocina_object
   end
 
+  attr_reader :cocina_object
+
   # Determine projects in which an item is released
   # @return [Hash{String => Boolean}] all namespaces, keys are Project name Strings, values are Boolean
   def released_for
-    # Get the most recent self tag for all targets and retain their result since most recent self always trumps any other non self tags
-    latest_self_tags = newest_release_tag self_release_tags(release_tags_by_project)
-    released_hash = latest_self_tags.transform_values do |payload|
-      { 'release' => payload.release }
+    all_tags_by_project = (item_tags + collection_tags).group_by(&:to)
+    all_tags_by_project.values.map do |project_tags|
+      project_tags.max_by(&:date)
     end
-
-    # With Self Tags resolved we now need to deal with tags on all sets this object is part of.
-    # Get all release tags on the item and strip out the what = self ones, we've already processed all the self tags on this item.
-    # This will be where we store all tags that apply, regardless of their timestamp:
-    potential_applicable_release_tags = tags_for_what_value(release_tags_for_item_and_all_governing_sets, 'collection')
-
-    # We now have the keys for all potential releases, we need to check the tags: the most recent timestamp with an explicit true or false wins.
-    # In a nil case, the lack of an explicit false tag we do nothing.
-    # Don't bother checking if already added to the release hash, they were added due to a self tag so that has won
-    (potential_applicable_release_tags.keys - released_hash.keys).each do |key|
-      latest_tag = newest_release_tag_in_an_array(potential_applicable_release_tags[key])
-      next if latest_tag.nil? # Otherwise, we have a valid tag, record it
-
-      released_hash[key] = { 'release' => latest_tag.release }
-    end
-    released_hash
-  end
-
-  # create hash structure from cocina administrative release tags, aggregates all releases for a specific target into an array of hashes
-  # e.g. {"Searchworks"=>[#<Cocina::Models::ReleaseTag "what"=>"self", "who"=>"cspitzer", "when"=>2021-02-18 21:46:36 UTC, "release"=>true>]}
-  def release_tags_by_project
-    cocina_object.administrative.releaseTags.group_by(&:to)
   end
 
   private
 
-  # Take an item and get all of its release tags and all tags on collections it is a member of it
-  # @return [Hash] a hash of all tags
-  def release_tags_for_item_and_all_governing_sets
-    return_tags = release_tags_by_project # this objects initial release tags
-
-    return return_tags unless cocina_object.dro? # no need to continue if this is a collection, since they don't nest anymore
-
-    # now go through any collections it is a member of and add them
-    cocina_object.structural.isMemberOf.each do |collection_druid|
-      service = self.class.new(CocinaObjectStore.find(collection_druid))
-      return_tags = combine_two_release_tag_hashes(return_tags, service.release_tags_by_project)
-    end
-    return_tags
+  def collection_tags
+    collections.flat_map { |collection| collection.administrative.releaseTags }.select { |tag| tag.what == 'collection' }
   end
 
-  # Take a hash of tags as obtained via release_tags method and returns the newest tag for each namespace
-  # @param tags [Hash] a hash of tags obtained via release_tags method or matching format
-  # @return [Hash] a hash of latest tags for each to value
-  def newest_release_tag(tags)
-    tags.transform_values { |val| newest_release_tag_in_an_array(val) }
+  def item_tags
+    cocina_object.administrative.releaseTags
   end
 
-  # Take a hash of tags as obtained via release_tags method and returns all self tags
-  # @param tags [Hash] a hash of tags obtained via release_tags method or matching format
-  # @return [Hash] a hash of self tags for each to value
-  def self_release_tags(tags)
-    tags_for_what_value(tags, 'self')
-  end
+  def collections
+    return [] unless cocina_object.dro?
 
-  # Take a hash of tags and return all tags with the matching what target
-  # @param tags [Hash] a hash of tags obtained via release_tags method or matching format
-  # @param what_target [String] the target for the 'what' key, self or collection
-  # @return [Hash] a hash of self tags for each to value
-  def tags_for_what_value(tags, what_target)
-    tags.transform_values do |tag_list|
-      tag_list.select { |tag| tag.what.casecmp?(what_target) }.presence
-    end.compact
+    cocina_object.structural.isMemberOf.map { |druid| CocinaObjectStore.find(druid) }
   end
-
-  # Take two hashes of tags and combine them, will not overwrite but will enforce uniqueness of the tags
-  # @param hash_one [Hash<String,Array<Cocina::Models::ReleaseTag>>] a hash of tags obtained via release_tags_by_project method or matching format
-  # @param hash_two [Hash<String,Array<Cocina::Models::ReleaseTag>>] a hash of tags obtained via release_tags_by_project method or matching format
-  # @return [Hash] the combined hash with uniquiness enforced
-  def combine_two_release_tag_hashes(hash_one, hash_two)
-    hash_two.each do |key, hash_two_value|
-      hash_one[key] = (hash_one.fetch(key, []) + hash_two_value).uniq
-    end
-    hash_one
-  end
-
-  # Takes an array of release tags and returns the most recent one
-  # @param array_of_tags [Array] an array of hashes, each hash a release tag
-  # @return [Hash] the most recent tag
-  def newest_release_tag_in_an_array(array_of_tags)
-    latest_tag_in_array = array_of_tags[0] || {}
-    array_of_tags.each do |tag|
-      latest_tag_in_array = tag if tag.date.utc > latest_tag_in_array.date.utc
-    end
-    latest_tag_in_array
-  end
-
-  attr_reader :cocina_object
 end

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -99,8 +99,10 @@ RSpec.describe 'Display metadata' do
       allow(SolrService.instance).to receive(:conn).and_return(solr_client)
 
       allow(ReleaseTags).to receive(:for).and_return(
-        'SearchWorks' => { 'release' => true },
-        'elsewhere' => { 'release' => false }
+        [
+          Cocina::Models::ReleaseTag.new(to: 'SearchWorks', release: true),
+          Cocina::Models::ReleaseTag.new(to: 'elsewhere', release: false)
+        ]
       )
       allow(Time).to receive(:now).and_return(now)
       allow_any_instance_of(PublishedRelationshipsFilter).to receive(:xml).and_return(relationships_xml)

--- a/spec/services/catalog/folio_writer_spec.rb
+++ b/spec/services/catalog/folio_writer_spec.rb
@@ -71,13 +71,13 @@ RSpec.describe Catalog::FolioWriter do
 
   describe '.save' do
     let(:cocina_object) { build(:dro, id: druid).new(identification:) }
-    let(:release_data) { { 'Searchworks' => { 'release' => true } } }
+    let(:release_data) { true }
     let(:hrid) { 'a8832162' }
 
     before do
       allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
       allow(FolioClient).to receive(:edit_marc_json).and_yield(folio_response_json)
-      allow(ReleaseTags).to receive(:for).and_return(release_data)
+      allow(ReleaseTags).to receive(:released_to_searchworks?).and_return(release_data)
     end
 
     context 'when a single catalog record has been released to Searchworks' do
@@ -158,18 +158,8 @@ RSpec.describe Catalog::FolioWriter do
         }
       end
 
-      context 'when explicitly not released' do
-        let(:release_data) { { 'Searchworks' => { 'release' => false } } }
-
-        it 'updates the MARC record and does not include the 856' do
-          folio_writer.save
-          expect(FolioClient).to have_received(:edit_marc_json).with(hrid:)
-          expect(folio_response_json).to eq(unreleased_marc_json)
-        end
-      end
-
-      context 'when implicitly not released' do
-        let(:release_data) { {} }
+      context 'when not released' do
+        let(:release_data) { false }
 
         it 'updates the MARC record and does not include the 856' do
           folio_writer.save

--- a/spec/services/catalog/symphony_writer_spec.rb
+++ b/spec/services/catalog/symphony_writer_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe Catalog::SymphonyWriter do
     end
 
     let(:cocina_object) { build(:dro, id: druid).new(identification:) }
-    let(:release_data) { { 'Searchworks' => { 'release' => true } } }
+    let(:release_data) { true }
 
     before do
       Settings.release.symphony_path = "#{fixtures}/sdr_purl"
-      allow(ReleaseTags).to receive(:for).and_return(release_data)
+      allow(ReleaseTags).to receive(:released_to_searchworks?).and_return(release_data)
     end
 
     after do
@@ -83,7 +83,7 @@ RSpec.describe Catalog::SymphonyWriter do
         }
       end
 
-      let(:release_data) { {} }
+      let(:release_data) { false }
 
       let(:marc856_file) do
         "8832162\tbc123dg9393\t"

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -147,15 +147,11 @@ RSpec.describe Publish::MetadataTransferService do
           expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(cocina_object)
         end
 
-        let(:release_tags) do
-          { 'Searchworks' => { 'release' => true }, 'Some_special_place' => { 'release' => true } }
-        end
-
         let(:access) { { view: 'citation-only', download: 'none' } }
 
         it 'identityMetadta, contentMetadata, rightsMetadata, generated dublin core, and public xml' do
           service.publish
-          expect(Publish::PublicXmlService).to have_received(:new).with(public_cocina: Cocina::Models::DRO, released_for: release_tags, thumbnail_service:)
+          expect(Publish::PublicXmlService).to have_received(:new).with(public_cocina: Cocina::Models::DRO, thumbnail_service:)
           expect(Publish::PublicDescMetadataService).to have_received(:new).with(Cocina::Models::DRO)
         end
       end


### PR DESCRIPTION

## Why was this change made? 🤔
The public cocina release tags will only contain the latest release tag for each project (same as the public XML)


## How was this change tested? 🤨
- [x] CI
- [x] stage


