### PR TITLE
spawn jobs for released members

### DIFF
--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -14,7 +14,7 @@ class PublishJob < ApplicationJob
     begin
       cocina_object = CocinaObjectStore.find(druid)
 
-      Publish::MetadataTransferService.publish(cocina_object)
+      Publish::MetadataTransferService.publish(cocina_object, workflow:)
       EventFactory.create(druid:, event_type: 'publishing_complete', data: { background_job_result_id: background_job_result.id })
     end
 

--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -51,7 +51,7 @@ module Publish
       Array.wrap(
         MemberService.for(cocina_object.externalIdentifier, exclude_opened: true, only_published: true)
       ).each do |member|
-        self.class.publish(CocinaObjectStore.find(member['id']))
+        PublishJob.set(queue: :publish_low).perform_later(druid: member['id'], background_job_result: BackgroundJobResult.create)
       end
     end
 

--- a/spec/jobs/publish_job_spec.rb
+++ b/spec/jobs/publish_job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PublishJob do
     end
 
     it 'invokes the Publish::MetadataTransferService' do
-      expect(Publish::MetadataTransferService).to have_received(:publish).with(item).once
+      expect(Publish::MetadataTransferService).to have_received(:publish).with(item, workflow:).once
     end
 
     it 'marks the job as complete' do

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -244,9 +244,15 @@ RSpec.describe Publish::MetadataTransferService do
       allow(described_class).to receive(:new).and_return(service)
     end
 
-    it 'calls publish on a new instance' do
+    it 'calls publish on a new instance with the default workflow' do
       described_class.publish(cocina_object)
       expect(described_class).to have_received(:new).with(cocina_object, workflow: 'accessionWF')
+      expect(service).to have_received(:publish)
+    end
+
+    it 'calls publish on a new instance with a specific workflow' do
+      described_class.publish(cocina_object, workflow: 'releaseWF')
+      expect(described_class).to have_received(:new).with(cocina_object, workflow: 'releaseWF')
       expect(service).to have_received(:publish)
     end
   end

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -236,4 +236,18 @@ RSpec.describe Publish::MetadataTransferService do
       expect(File.read(file_path)).to eq('<xml/>')
     end
   end
+
+  describe '.publish' do
+    let(:service) { instance_double(described_class, publish: nil) }
+
+    before do
+      allow(described_class).to receive(:new).and_return(service)
+    end
+
+    it 'calls publish on a new instance' do
+      described_class.publish(cocina_object)
+      expect(described_class).to have_received(:new).with(cocina_object, workflow: 'accessionWF')
+      expect(service).to have_received(:publish)
+    end
+  end
 end

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Publish::MetadataTransferService do
   let(:druid) { 'bc123df4567' }
   let(:access) { {} }
+  let(:workflow) { 'accessionWF' }
   let(:cocina_object) do
     build(:dro, id: "druid:#{druid}").new(
       access:,
@@ -32,7 +33,7 @@ RSpec.describe Publish::MetadataTransferService do
   end
   let(:cocina_collection) { build(:collection, id: 'druid:xh235dd9059') }
   let(:thumbnail_service) { ThumbnailService.new(cocina_object) }
-  let(:service) { described_class.new(cocina_object) }
+  let(:service) { described_class.new(cocina_object, workflow:) }
 
   describe '#publish' do
     before do
@@ -82,14 +83,14 @@ RSpec.describe Publish::MetadataTransferService do
         allow_any_instance_of(described_class).to receive(:publish_notify_on_success)
         allow(MemberService).to receive(:for).and_return({ 'id' => member_druid })
         allow(CocinaObjectStore).to receive(:find).with(member_druid).and_return(member_item)
-        allow(described_class).to receive(:new).with(cocina_object).and_call_original
+        allow(described_class).to receive(:new).with(cocina_object, workflow:).and_call_original
         allow(PublishJob).to receive(:set).with(queue: :publish_low).and_return(fake_publish_job)
       end
 
       it 'republishes member items' do
         service.publish
         expect(MemberService).to have_received(:for).once
-        expect(fake_publish_job).to have_received(:perform_later).once.with(druid: member_druid, background_job_result: BackgroundJobResult.last)
+        expect(fake_publish_job).to have_received(:perform_later).once.with(druid: member_druid, background_job_result: BackgroundJobResult.last, workflow:)
       end
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

fixes sul-dlss/argo#3972

I believe this should spawn a series of independent publish jobs for each member of a collection, setting them to the low priority queue, instead of trying to iterate and re-publish each collection member as part of the collection publishing.  This should allow the collection publish itself to complete quickly, while the collection members publish over time as the jobs complete.

~~HOLD - tested on stage and need to pass in the workflow param...fixing PR now~~

## How was this change tested? 🤨

Updated the test
Tested on stage with a large collection and watched jobs spawn and re-publish happen