### PR TITLE
remove some fedora cruft

### DIFF
--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -5,7 +5,7 @@
 class PublishJob < ApplicationJob
   queue_as :publish_default
 
-  # @param [String] druid the identifier of the fedora_item to be published
+  # @param [String] druid the identifier of the item to be published
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
   # @param [String] workflow Which workflow should this be reported to?
   def perform(druid:, background_job_result:, workflow:)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -45,7 +45,6 @@ version_service:
   sync_with_preservation: true
 
 # URLs
-fedora_url: 'https://user:password@fedora.example.com:1000/fedora'
 solr:
   select_path: 'select'
   timeout: 120

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,3 +1,2 @@
-fedora_url: http://fedoraAdmin:fedoraAdmin@localhost:8983/fedora
 solr:
   url: http://localhost:8984/solr/dorservices

--- a/spec/requests/administrative_tags_spec.rb
+++ b/spec/requests/administrative_tags_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Administrative tags' do
     context 'when item is not found' do
       before do
         allow(CocinaObjectStore).to receive(:find)
-          .and_raise(CocinaObjectStore::CocinaObjectNotFoundError, "Unable to find '#{druid}' in fedora. See logger for details.")
+          .and_raise(CocinaObjectStore::CocinaObjectNotFoundError, "Unable to find '#{druid}' in repository. See logger for details.")
       end
 
       it 'returns a 404' do
@@ -73,7 +73,7 @@ RSpec.describe 'Administrative tags' do
              params: %( {"administrative_tags":#{tags.to_json}} ),
              headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
         expect(response).to have_http_status(:not_found)
-        expect(response.body).to eq('Unable to find \'druid:mx123qw2323\' in fedora. See logger for details.')
+        expect(response.body).to eq('Unable to find \'druid:mx123qw2323\' in repository. See logger for details.')
         expect(Notifications::ObjectUpdated).not_to have_received(:publish)
       end
     end
@@ -151,7 +151,7 @@ RSpec.describe 'Administrative tags' do
     context 'when item is not found' do
       before do
         allow(CocinaObjectStore).to receive(:find)
-          .and_raise(CocinaObjectStore::CocinaObjectNotFoundError, "Unable to find '#{druid}' in fedora. See logger for details.")
+          .and_raise(CocinaObjectStore::CocinaObjectNotFoundError, "Unable to find '#{druid}' in repository. See logger for details.")
       end
 
       it 'returns a 404' do
@@ -159,7 +159,7 @@ RSpec.describe 'Administrative tags' do
             params: %( {"administrative_tag":"#{new_tag}"} ),
             headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
         expect(response).to have_http_status(:not_found)
-        expect(response.body).to eq('Unable to find \'druid:mx123qw2323\' in fedora. See logger for details.')
+        expect(response.body).to eq('Unable to find \'druid:mx123qw2323\' in repository. See logger for details.')
       end
     end
 
@@ -282,14 +282,14 @@ RSpec.describe 'Administrative tags' do
     context 'when item is not found' do
       before do
         allow(CocinaObjectStore).to receive(:find)
-          .and_raise(CocinaObjectStore::CocinaObjectNotFoundError, "Unable to find '#{druid}' in fedora. See logger for details.")
+          .and_raise(CocinaObjectStore::CocinaObjectNotFoundError, "Unable to find '#{druid}' in repository. See logger for details.")
       end
 
       it 'returns a 404' do
         delete "/v1/objects/#{druid}/administrative_tags/#{CGI.escape(tag)}",
                headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status(:not_found)
-        expect(response.body).to eq('Unable to find \'druid:mx123qw2323\' in fedora. See logger for details.')
+        expect(response.body).to eq('Unable to find \'druid:mx123qw2323\' in repository. See logger for details.')
       end
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

* remove obsolete `fedora_url` from config
* remove obsolete references to fedora from test error messages in specs
* remove obsolete fedora reference from `PublishJob#perform` param description


## How was this change tested? 🤨

unit tests

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



