### PR TITLE
Add a report for descriptive metadata

### DIFF
--- a/app/reports/descriptive_shape.rb
+++ b/app/reports/descriptive_shape.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Generate a report on the "shape" of Cocina descriptive metadata:
+#
+# bin/rails r -e production "DescriptiveShape.report"
+#
+# This will output a CSV file of JSON paths that contain a string or number value:
+#
+# path,count
+# .purl,4452
+# .title[].value,4321
+# .form[].type,2163
+# .form[].value,1810
+# .form[].source.value,1358
+# .note[].value,1319
+# .event[].date[].type,825
+# .event[].date[].encoding.code,629
+# .event[].date[].qualifier,2
+# .event[].date[].structuredValue[].type,18
+# .event[].date[].structuredValue[].value,18
+# .event[].note[].type,219
+# .event[].note[].value,219
+# .event[].note[].source.value,203
+# .event[].location[].code,204
+# .event[].location[].source.code,204
+# .event[].date[].value,816
+# .event[].location[].value,196
+# .title[].note[].type,161
+# .title[].note[].value,155
+# .title[].status,178
+# .title[].structuredValue[].type,344
+# .title[].structuredValue[].value,344
+# ...
+#
+# The results will also be written as descriptive-shape.json
+#
+class DescriptiveShape
+  def self.report
+    new.report
+  end
+
+  def initialize
+    @shape = Hash.new(0)
+  end
+
+  def report
+    Dro.find_each do |obj|
+      trace(obj.description)
+    end
+
+    save
+    output
+  end
+
+  private
+
+  def trace(obj, path = '')
+    case obj
+    when Array
+      trace_array(obj, path)
+    when Hash
+      trace_hash(obj, path)
+    else
+      @shape[path] += 1
+    end
+  end
+
+  def trace_array(obj, path)
+    obj.each do |item|
+      trace(item, "#{path}[]")
+    end
+  end
+
+  def trace_hash(obj, path)
+    obj.each do |key, value|
+      trace(value, "#{path}.#{key}")
+    end
+  end
+
+  def save
+    File.write('descriptive-shape.json', JSON.pretty_generate(@shape))
+  end
+
+  def output
+    puts 'path,count'
+    @shape.each do |path, count|
+      puts "#{path},#{count}"
+    end
+  end
+end

--- a/app/reports/descriptive_shape.rb
+++ b/app/reports/descriptive_shape.rb
@@ -32,8 +32,6 @@
 # .title[].structuredValue[].value,344
 # ...
 #
-# The results will also be written as descriptive-shape.json
-#
 class DescriptiveShape
   def self.report
     new.report
@@ -47,8 +45,6 @@ class DescriptiveShape
     Dro.find_each do |obj|
       trace(obj.description)
     end
-
-    save
     output
   end
 
@@ -75,10 +71,6 @@ class DescriptiveShape
     obj.each do |key, value|
       trace(value, "#{path}.#{key}")
     end
-  end
-
-  def save
-    File.write('descriptive-shape.json', JSON.pretty_generate(@shape))
   end
 
   def output


### PR DESCRIPTION
## Why was this change made? 🤔

Generate a report of the shape of JSON in descriptive metadata. The shape is represented as a set of JSON paths which have either a string or number value, and the number of times they appear in the data:

```csv
path,count
.purl,4452
.title[].value,4321
.form[].type,2163
.form[].value,1810
.form[].source.value,1358
.note[].value,1319
.event[].date[].type,825
.event[].date[].encoding.code,629
.event[].date[].qualifier,2
.event[].date[].structuredValue[].type,18
.event[].date[].structuredValue[].value,18
```

The hope is that it might help in evaluating how we might want to further normalize and constrain descriptive metadata so that it is easier to edit.

## How was this change tested? 🤨

Using sdr-infra.stanford.edu against QA (running now on Prod).

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



