### PR TITLE
Remove bogus linked_files entries from deploy config

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -38,7 +38,7 @@ set :log_level, :info
 # set :keep_releases, 5
 
 set :linked_dirs, %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle config/certs config/settings)
-set :linked_files, %w(config/secrets.yml config/honeybadger.yml config/newrelic.yml config/database.yml)
+set :linked_files, %w(config/honeybadger.yml config/database.yml)
 
 # Namespace crontab entries by application and stage
 set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }


### PR DESCRIPTION
These are no longer in shared_configs.
