### PR TITLE
do not update publish step in workflow service when pubishing items in collection

### DIFF
--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -53,7 +53,7 @@ module Publish
       Array.wrap(
         MemberService.for(cocina_object.externalIdentifier, exclude_opened: true, only_published: true)
       ).each do |member|
-        PublishJob.set(queue: :publish_low).perform_later(druid: member['id'], background_job_result: BackgroundJobResult.create, workflow:)
+        PublishJob.set(queue: :publish_low).perform_later(druid: member['id'], background_job_result: BackgroundJobResult.create, workflow:, log_success: false)
       end
     end
 

--- a/spec/jobs/publish_job_spec.rb
+++ b/spec/jobs/publish_job_spec.rb
@@ -41,6 +41,32 @@ RSpec.describe PublishJob do
       expect(LogSuccessJob).to have_received(:perform_later)
         .with(druid:, background_job_result: result, workflow: 'accessionWF', workflow_process: 'publish')
     end
+
+    context 'when log_success is set to false' do
+      subject(:perform) do
+        described_class.perform_now(druid:, background_job_result: result, workflow:, log_success: false)
+      end
+
+      it 'does not mark the job as complete' do
+        expect(EventFactory).to have_received(:create)
+
+        expect(LogSuccessJob).not_to have_received(:perform_later)
+          .with(druid:, background_job_result: result, workflow: 'accessionWF', workflow_process: 'publish')
+      end
+    end
+
+    context 'when log_success is set to true' do
+      subject(:perform) do
+        described_class.perform_now(druid:, background_job_result: result, workflow:, log_success: true)
+      end
+
+      it 'mark the job as complete' do
+        expect(EventFactory).to have_received(:create)
+
+        expect(LogSuccessJob).to have_received(:perform_later)
+          .with(druid:, background_job_result: result, workflow: 'accessionWF', workflow_process: 'publish')
+      end
+    end
   end
 
   context 'when fails dark validation', skip: 'turned off while preassembly could not make valid dark objects; see https://github.com/sul-dlss/dor-services-app/issues/4366' do

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Publish::MetadataTransferService do
       it 'republishes member items' do
         service.publish
         expect(MemberService).to have_received(:for).once
-        expect(fake_publish_job).to have_received(:perform_later).once.with(druid: member_druid, background_job_result: BackgroundJobResult.last, workflow:)
+        expect(fake_publish_job).to have_received(:perform_later).once.with(druid: member_druid, background_job_result: BackgroundJobResult.last, workflow:, log_success: false)
       end
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #4511: when re-publishing all items as part of a collection publish (which can happen during collection release), we do *not* need to update a workflow step when done.  The fact that a publish occurs is already noted in the Event history, and attempting to update a workflow step can cause errors such as this: https://app.honeybadger.io/projects/50568/faults/58644364  This occurs when the publish occurs for items that were never released, as part of a collection release (which triggers all member items to be published as well).  Currently we try to notify the workflow service that the `release-publish` step is completed, which is both unnecessary (as the publish step was not triggered by a workflow in that object) and will cause problems if that particular item has never been through releaseWF before.

This code simply short-circuits this workflow update when an item publish occurs as part as a collection publish (as opposed to when it is triggered from a workflow in that item itself).

## How was this change tested? 🤨

Updated specs, and on -stage too.