### PR TITLE
[HOLD] only add last releaseTag to a collection object in public XML

### DIFF
--- a/app/services/publish/public_cocina_service.rb
+++ b/app/services/publish/public_cocina_service.rb
@@ -15,12 +15,13 @@ module Publish
     # remove any file_set that doesn't have at least one published file
     # remove partOfProject (similar to how we remove tags from identityMetadata)
     def build
-      return cocina unless cocina.dro? || cocina.collection?
-
-      return cocina.new(administrative: build_administrative) if cocina.collection?
-
-      cocina.new(structural: build_structural,
-                 administrative: build_administrative)
+      if cocina.dro?
+        cocina.new(structural: build_structural, administrative: build_administrative)
+      elsif cocina.collection?
+        cocina.new(administrative: build_administrative)
+      else
+        cocina
+      end
     end
 
     private

--- a/app/services/publish/public_cocina_service.rb
+++ b/app/services/publish/public_cocina_service.rb
@@ -20,7 +20,7 @@ module Publish
       elsif cocina.collection?
         cocina.new(administrative: build_administrative)
       else
-        cocina
+        raise "unexpected call to PublicCocinaService.build for #{cocina.externalIdentifier}"
       end
     end
 

--- a/app/services/publish/public_cocina_service.rb
+++ b/app/services/publish/public_cocina_service.rb
@@ -15,7 +15,9 @@ module Publish
     # remove any file_set that doesn't have at least one published file
     # remove partOfProject (similar to how we remove tags from identityMetadata)
     def build
-      return cocina unless cocina.dro?
+      return cocina unless cocina.dro? || cocina.collection?
+
+      return cocina.new(administrative: build_administrative) if cocina.collection?
 
       cocina.new(structural: build_structural,
                  administrative: build_administrative)

--- a/spec/services/publish/public_cocina_service_spec.rb
+++ b/spec/services/publish/public_cocina_service_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 RSpec.describe Publish::PublicCocinaService do
   subject(:json) { JSON.parse(create.to_json) }
 
-  let(:create) { described_class.create(cocina_item) }
+  let(:create) { described_class.create(cocina_object) }
 
-  let(:cocina_item) do
+  let(:cocina_object) do
     build(:dro).new(
       structural: {
         contains: [
@@ -118,5 +118,15 @@ RSpec.describe Publish::PublicCocinaService do
 
   it 'discards the non-published filesets and files' do
     expect(json.dig('structural', 'contains').size).to eq 0
+  end
+
+  context 'with an admin_policy' do
+    let(:cocina_object) do
+      build(:admin_policy, id: 'druid:bc123df4567')
+    end
+
+    it 'throws an exception' do
+      expect { create }.to raise_error(RuntimeError, 'unexpected call to PublicCocinaService.build for druid:bc123df4567')
+    end
   end
 end

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Publish::PublicXmlService do
       end
     end
 
-    context 'with an problematic location code' do
+    context 'with a problematic location code' do
       let(:cocina_object) do
         build(:dro, id: 'druid:bc123df4567').new(
           access: {
@@ -281,13 +281,13 @@ RSpec.describe Publish::PublicXmlService do
         expect(ng_xml.at_xpath('/publicObject/thumb').to_xml).to be_equivalent_to('<thumb>bc123df4567/wt183gy6220_00_0001.jp2</thumb>')
       end
 
-      context 'when there are release tags' do
+      context 'when there are single release tags per target' do
         let(:cocina_object) do
           build(:dro, id: 'druid:bc123df4567').new(description:, administrative: {
                                                      hasAdminPolicy: 'druid:qv648vd4392',
                                                      releaseTags: [
-                                                       { to: 'Searchworks', release: true },
-                                                       { to: 'Some_special_place', release: true }
+                                                       { to: 'Searchworks', release: true, date: '2015-10-23T21:49:29.000+00:00' },
+                                                       { to: 'Some_special_place', release: true, date: '2015-10-23T21:49:29.000+00:00' }
                                                      ]
                                                    })
         end
@@ -298,6 +298,30 @@ RSpec.describe Publish::PublicXmlService do
 
         it 'includes releaseData element from release tags' do
           releases = ng_xml.xpath('/publicObject/releaseData/release')
+          expect(releases.map(&:inner_text)).to eq %w[true true]
+          expect(releases.pluck('to')).to eq %w[Searchworks Some_special_place]
+        end
+      end
+
+      context 'when there are multiple release tags per target' do
+        let(:cocina_object) do
+          build(:dro, id: 'druid:bc123df4567').new(description:, administrative: {
+                                                     hasAdminPolicy: 'druid:qv648vd4392',
+                                                     releaseTags: [
+                                                       { to: 'Searchworks', release: false, date: '2015-10-23T21:49:29.000+00:00' },
+                                                       { to: 'Searchworks', release: true, date: '2018-10-23T21:49:29.000+00:00' },
+                                                       { to: 'Some_special_place', release: true, date: '2015-10-23T21:49:29.000+00:00' }
+                                                     ]
+                                                   })
+        end
+
+        it 'does not include this release data in identityMetadata' do
+          expect(ng_xml.at_xpath('/publicObject/identityMetadata/release')).to be_nil
+        end
+
+        it 'includes only the latest releaseData element from release tags for each target' do
+          releases = ng_xml.xpath('/publicObject/releaseData/release')
+          expect(releases.size).to eq 2
           expect(releases.map(&:inner_text)).to eq %w[true true]
           expect(releases.pluck('to')).to eq %w[Searchworks Some_special_place]
         end
@@ -325,6 +349,52 @@ RSpec.describe Publish::PublicXmlService do
           </identityMetadata>
         XML
         expect(ng_xml.at_xpath('/publicObject/identityMetadata').to_xml).to be_equivalent_to expected
+      end
+
+      context 'when there are single release tags per target' do
+        let(:cocina_object) do
+          build(:collection, id: 'druid:bc123df4567').new(description:, administrative: {
+                                                            hasAdminPolicy: 'druid:qv648vd4392',
+                                                            releaseTags: [
+                                                              { to: 'Searchworks', what: 'collection', release: true, date: '2015-10-23T21:49:29.000+00:00' },
+                                                              { to: 'Some_special_place', what: 'collection', release: true, date: '2015-10-23T21:49:29.000+00:00' }
+                                                            ]
+                                                          })
+        end
+
+        it 'does not include this release data in identityMetadata' do
+          expect(ng_xml.at_xpath('/publicObject/identityMetadata/release')).to be_nil
+        end
+
+        it 'includes releaseData element from release tags' do
+          releases = ng_xml.xpath('/publicObject/releaseData/release')
+          expect(releases.map(&:inner_text)).to eq %w[true true]
+          expect(releases.pluck('to')).to eq %w[Searchworks Some_special_place]
+        end
+      end
+
+      context 'when there are multiple release tags per target' do
+        let(:cocina_object) do
+          build(:collection, id: 'druid:bc123df4567').new(description:, administrative: {
+                                                            hasAdminPolicy: 'druid:qv648vd4392',
+                                                            releaseTags: [
+                                                              { to: 'Searchworks', what: 'collection', release: false, date: '2015-10-23T21:49:29.000+00:00' },
+                                                              { to: 'Searchworks', what: 'collection', release: true, date: '2018-10-23T21:49:29.000+00:00' },
+                                                              { to: 'Some_special_place', what: 'collection', release: true, date: '2015-10-23T21:49:29.000+00:00' }
+                                                            ]
+                                                          })
+        end
+
+        it 'does not include this release data in identityMetadata' do
+          expect(ng_xml.at_xpath('/publicObject/identityMetadata/release')).to be_nil
+        end
+
+        it 'includes only the latest releaseData element from release tags for each target' do
+          releases = ng_xml.xpath('/publicObject/releaseData/release')
+          expect(releases.size).to eq 2
+          expect(releases.map(&:inner_text)).to eq %w[true true]
+          expect(releases.pluck('to')).to eq %w[Searchworks Some_special_place]
+        end
       end
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

[HOLD] to verify collection publishing works as expected (test in stage) and isn't missing additional info neded

Fixes #4515 - collection publishing should use same logic for building administrative public XML as we do for items

Question: previously we were just returning the entire collection cocina, which is different than we do for items.   Unclear if this approach is removing public XML data for collections that should otherwise be published (though all current tests pass still).

## How was this change tested? 🤨

Added unit tests