### PR TITLE
descriptive_shape report: don't count empty values

### DIFF
--- a/app/reports/descriptive_shape.rb
+++ b/app/reports/descriptive_shape.rb
@@ -74,19 +74,19 @@ class DescriptiveShape
     when Hash
       trace_hash(obj, path)
     else
-      @shape[path] += 1
+      @shape[path] += 1 if obj.present?
     end
   end
 
   def trace_array(obj, path)
     obj.each do |item|
-      trace(item, "#{path}[]")
+      trace(item, "#{path}[]") if item.present?
     end
   end
 
   def trace_hash(obj, path)
     obj.each do |key, value|
-      trace(value, "#{path}.#{key}")
+      trace(value, "#{path}.#{key}") if value.present?
     end
   end
 

--- a/app/reports/descriptive_shape.rb
+++ b/app/reports/descriptive_shape.rb
@@ -42,8 +42,7 @@
 # bin/rails r -e production "DescriptiveShape.report(catalog: 'none')"
 #
 class DescriptiveShape
-  def self.report(catalog_only: false, catalog: 'all')
-    @catalog = catalog
+  def self.report(catalog: 'all')
     new(catalog).report
   end
 

--- a/app/reports/descriptive_shape.rb
+++ b/app/reports/descriptive_shape.rb
@@ -26,21 +26,13 @@
 # .event[].date[].value,816
 # .event[].location[].value,196
 # .title[].note[].type,161
-# .title[].note[].value,155
-# .title[].status,178
-# .title[].structuredValue[].type,344
-# .title[].structuredValue[].value,344
 # ...
 #
-# Optionally you can limit the analysis to records that have links to the
-# catalog with:
-#
-# bin/rails r -e production "DescriptiveShape.report(catalog: 'only')"
-#
-# Similarly you can limit to objects that have no link to the catalog with:
-#
-# bin/rails r -e production "DescriptiveShape.report(catalog: 'none')"
-#
+# Optionally you can limit the results:
+# - to records that have links to the catalog
+#     bin/rails r -e production "DescriptiveShape.report(catalog: 'only')"
+# - to records that have no link to the catalog with:
+#     bin/rails r -e production "DescriptiveShape.report(catalog: 'none')"
 class DescriptiveShape
   def self.report(catalog: 'all')
     new(catalog).report


### PR DESCRIPTION
## Why was this change made? 🤔

Because for these reports (to be used for visualizations), we don't want to count empty strings, empty arrays, or empty hashes.

Sample:

| Path  | count from  cocina-shape csv | count with this change | notes |
| ------------- | ------------- | ------------- | ------------- |
| .form[].type | 19134787  |  19149410 | bigger - more data now |
| .form[].value | 19154130  |  19169166 | bigger - more data now |
| .form[].source.code | 8047351  |  8040441 | smaller - showing the change here matters  |
| .form[].source.value | 6833221  |  6828312 | smaller |
| .note[].type | 5335050  |  5332403 | smaller |
| .note[].value | 13045378  |  13039404 | smaller |
| .note[].displayLabel | 4717437  |  4715473 | smaller |
| .note[].structuredValue[].value | 1801233  |  1797313 | smaller |

from:

```
ndushay@li-dl-7477-7cf5 cocina-shape (html-tweaks) $ head DescriptiveShape_no_empties.csv 
[DEPRECATION] Committee: please set parameter_overwite_by_rails_rule = false because we'll change default value to "true" in next major version.
path,count
.form[].type,19149410
.form[].value,19169166
.form[].source.code,8047351
.form[].source.value,6833221
.note[].type,5335050
.note[].value,13045378
.note[].displayLabel,4717437
.note[].structuredValue[].value,1801233
ndushay@li-dl-7477-7cf5 cocina-shape (html-tweaks) $ head data-all.csv 
path,count
.form[].type,19134787
.form[].value,19154130
.form[].source.code,8040441
.form[].source.value,6828312
.note[].type,5332403
.note[].value,13039404
.note[].displayLabel,4715473
.note[].structuredValue[].value,1797313
.purl,5201124
```


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



