### PR TITLE
Add catalog limits

### DIFF
--- a/app/reports/descriptive_shape.rb
+++ b/app/reports/descriptive_shape.rb
@@ -32,17 +32,34 @@
 # .title[].structuredValue[].value,344
 # ...
 #
+# Optionally you can limit the analysis to records that have links to the
+# catalog with:
+#
+# bin/rails r -e production "DescriptiveShape.report(catalog: 'only')"
+#
+# Similarly you can limit to objects that have no link to the catalog with:
+#
+# bin/rails r -e production "DescriptiveShape.report(catalog: 'none')"
+#
 class DescriptiveShape
-  def self.report
-    new.report
+  def self.report(catalog_only: false, catalog: 'all')
+    @catalog = catalog
+    new(catalog).report
   end
 
-  def initialize
+  def initialize(catalog)
+    @catalog = catalog
     @shape = Hash.new(0)
   end
 
   def report
     Dro.find_each do |obj|
+      has_catalog_link = obj.identification['catalogLinks'].present?
+
+      next if @catalog == 'none' && has_catalog_link
+
+      next if @catalog == 'only' && !has_catalog_link
+
       trace(obj.description)
     end
     output


### PR DESCRIPTION
## Why was this change made? 🤔

This commit includes options for generating stats for Cocina objects
that have links to the catalog, or don't have links to the catalog. This
is to try to help see how the metadata changes based on whether it was
derived from MARC or not.

This was accidentally not committed before because it was hacked on live
over on the sdr-infra server (sorry!)

## How was this change tested? 🤨

The report was run on sdr-infra, I think? It was a while ago...
