### PR TITLE
increase sidekiq latency threshold and put in config

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -57,7 +57,7 @@ end
 
 OkComputer::Registry.register 'version', CustomAppVersionCheck.new
 OkComputer::Registry.register 'external-symphony', SymphonyCheck.new(format(Settings.catalog.symphony.base_url + Settings.catalog.symphony.marcxml_path, catkey: 12345))
-OkComputer::Registry.register 'background_jobs', OkComputer::SidekiqLatencyCheck.new('default', 25)
+OkComputer::Registry.register 'background_jobs', OkComputer::SidekiqLatencyCheck.new('default', Settings.sidekiq.latency_threshold)
 OkComputer::Registry.register 'feature-tables-have-data', TablesHaveDataCheck.new
 
 if Settings.rabbitmq.enabled

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -112,6 +112,11 @@ datacite:
   prefix: '10.80343'
   host: fake.datacite.example.com
 
+sidekiq:
+  latency_threshold: 900 # number of seconds above which okcomputer check for sidekiq latency fails
+                         # latency is expected to be temporarily big if lots of content is accessioned all at once
+                         # see https://github.com/sidekiq/sidekiq/wiki/Monitoring#monitoring-queue-latency
+
 honeybadger_checkins:
   embargo_release: foo
   missing_druids: bar


### PR DESCRIPTION
## Why was this change made? 🤔

Sidekiq latency can grow large if a lot of content is accessioned all at once (as the queue will grow faster than it's being worked on for a while).  This is OK and we don't need to be alerted, so increase the failure level much higher (to 15 minutes).  Also put in config so we can adjust easily and per environment if needed.
