### PR TITLE
Changes reset workspace to a job.

### DIFF
--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -24,11 +24,7 @@ class WorkspacesController < ApplicationController
   # Once an object has been transferred to preservation, reset the workspace by
   # renaming the druid-tree to a versioned directory and removing the export directory
   def reset
-    ResetWorkspaceService.reset(druid: params[:object_id], version: @cocina_object.version)
-    head :no_content
-  rescue ResetWorkspaceService::DirectoryAlreadyExists
-    # We're trapping errors and doing nothing, because the belief is that these indicate
-    # this API has already been called and completed.
+    ResetWorkspaceJob.perform_later(druid: params[:object_id], version: @cocina_object.version)
     head :no_content
   end
 

--- a/app/jobs/reset_workspace_job.rb
+++ b/app/jobs/reset_workspace_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Invokes the ResetWorkspaceService
+class ResetWorkspaceJob < ApplicationJob
+  queue_as :low
+
+  # @param [String] druid the identifier of the object to be reset
+  # @param [Integer] version the version of the object to be reset
+  def perform(druid:, version:)
+    ResetWorkspaceService.reset(druid:, version:)
+  rescue ResetWorkspaceService::DirectoryAlreadyExists
+    # We're trapping errors and doing nothing, because the belief is that these indicate
+    # this API has already been called and completed.
+  end
+end

--- a/spec/jobs/reset_workspace_job_spec.rb
+++ b/spec/jobs/reset_workspace_job_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ResetWorkspaceJob do
+  subject(:perform) do
+    described_class.perform_now(druid:, version:)
+  end
+
+  let(:druid) { 'druid:mk420bs7601' }
+  let(:version) { 1 }
+
+  context 'with no errors' do
+    before do
+      allow(ResetWorkspaceService).to receive(:reset)
+    end
+
+    it 'invokes the ResetService' do
+      perform
+      expect(ResetWorkspaceService).to have_received(:reset).with(druid:, version:).once
+    end
+  end
+
+  context 'with ResetWorkspaceService::DirectoryAlreadyExists' do
+    before do
+      allow(ResetWorkspaceService).to receive(:reset).and_raise(ResetWorkspaceService::DirectoryAlreadyExists)
+    end
+
+    it 'ignores' do
+      perform
+      expect(ResetWorkspaceService).to have_received(:reset).with(druid:, version:).once
+    end
+  end
+end

--- a/spec/requests/reset_workspace_spec.rb
+++ b/spec/requests/reset_workspace_spec.rb
@@ -8,28 +8,13 @@ RSpec.describe 'Reset workspace' do
 
   before do
     allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
+    allow(ResetWorkspaceJob).to receive(:perform_later)
   end
 
   context 'when the request is succcessful' do
-    before do
-      allow(ResetWorkspaceService).to receive(:reset)
-    end
-
     it 'is successful' do
       post "/v1/objects/#{druid}/workspace/reset", headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(ResetWorkspaceService).to have_received(:reset).with(druid:, version: 2)
-      expect(response).to be_no_content
-    end
-  end
-
-  context 'when an archive directory exists' do
-    before do
-      allow(ResetWorkspaceService).to receive(:reset)
-        .and_raise(ResetWorkspaceService::DirectoryAlreadyExists.new('dir already exists'))
-    end
-
-    it 'returns nothing' do
-      post "/v1/objects/#{druid}/workspace/reset", headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(ResetWorkspaceJob).to have_received(:perform_later).with(druid:, version: 2)
       expect(response).to be_no_content
     end
   end


### PR DESCRIPTION
closes #1039

## Why was this change made? 🤔
So avoid timeouts when service is slow to complete.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, infra integration
