### PR TITLE
[Hold] Report on cocina contributors and form where there is a missing value

### DIFF
--- a/app/reports/contributor_without_name_dros.rb
+++ b/app/reports/contributor_without_name_dros.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Report on contributors with no name value that have role information
+
+# Invoke via:
+# bin/rails r -e production "ContributorWithoutNameDros.report"
+class ContributorWithoutNameDros
+  # NOTE: Prefer strict JSON querying over lax when using the `.**` operator, per
+  #       https://www.postgresql.org/docs/14/functions-json.html#STRICT-AND-LAX-MODES
+  #
+  # > The .** accessor can lead to surprising results when using the lax mode.
+  # > ... This happens because the .** accessor selects both the segments array
+  # > and each of its elements, while the .HR accessor automatically unwraps
+  # > arrays when using the lax mode. To avoid surprising results, we recommend
+  # > using the .** accessor only in the strict mode.
+  JSONB_PATH = 'strict $.**.contributor.**.name[*] ? (!(exists(@.value))) ? ((exists(@.role.code)) || (exists(@.role.value)) || (exists(@.role.uri)))'
+  SQL = <<~SQL.squish.freeze
+    SELECT dros.external_identifier as item_druid,
+           desc_value->'role'->'code' as role_code,
+           desc_value->'role'->'value' as role_value,
+           desc_value->'role'->'uri' as role_uri,
+           desc_value->'value' as name_value,
+           jsonb_path_query(dros.structural, '$.isMemberOf') ->> 0 as collection_druid,
+           jsonb_path_query(identification, '$.catalogLinks[*] ? (@.catalog == "symphony").catalogRecordId') ->> 0 as catalog_record_id
+           FROM "dros",
+           jsonb_path_query(dros.description, '#{JSONB_PATH}') desc_value
+           WHERE
+           jsonb_path_exists(dros.description, '#{JSONB_PATH}')
+  SQL
+
+  def self.report
+    puts "item_druid,catalog_record_id,collection_druid,collection_name,name_value,role_code,role_value,role_uri\n"
+    rows(SQL).compact.each { |row| puts row }
+  end
+
+  def self.rows(sql_query)
+    sql_result_rows = ActiveRecord::Base.connection.execute(sql_query).to_a
+
+    sql_result_rows.map do |row|
+      collection_druid = row['collection_druid']
+      collection_name = Collection.find_by(external_identifier: collection_druid)&.label
+
+      [
+        row['item_druid'],
+        row['catalog_record_id'],
+        collection_druid,
+        "\"#{collection_name}\"",
+        row['name_value'],
+        row['role_code'],
+        row['role_value'],
+        row['role_uri']
+      ].join(',')
+    end
+  end
+end

--- a/app/reports/form_without_value_collections.rb
+++ b/app/reports/form_without_value_collections.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Report on form with no value that have source and/or type information
+
+# Invoke via:
+# bin/rails r -e production "FormWithoutValueCollections.report"
+class FormWithoutValueCollections
+  # NOTE: Prefer strict JSON querying over lax when using the `.**` operator, per
+  #       https://www.postgresql.org/docs/14/functions-json.html#STRICT-AND-LAX-MODES
+  #
+  # > The .** accessor can lead to surprising results when using the lax mode.
+  # > ... This happens because the .** accessor selects both the segments array
+  # > and each of its elements, while the .HR accessor automatically unwraps
+  # > arrays when using the lax mode. To avoid surprising results, we recommend
+  # > using the .** accessor only in the strict mode.
+  JSONB_PATH = 'strict $.**.form.**.value[*] ? (!(exists(@.value))) ? ((exists(@.type)) || (exists(@.source.code)) || (exists(@.source.value)) || (exists(@.source.uri)))'
+  SQL = <<~SQL.squish.freeze
+    SELECT collections.external_identifier as collection_druid,
+           desc_value->'value' as form_value,
+           desc_value->'type' as form_type,
+           desc_value->'source'->'code' as source_code,
+           desc_value->'source'->'value' as source_value,
+           desc_value->'source'->'uri' as source_uri,
+           jsonb_path_query(identification, '$.catalogLinks[*] ? (@.catalog == "symphony").catalogRecordId') ->> 0 as catalog_record_id
+           FROM "collections",
+           jsonb_path_query(collections.description, '#{JSONB_PATH}') desc_value
+           WHERE
+           jsonb_path_exists(collections.description, '#{JSONB_PATH}')
+  SQL
+
+  def self.report
+    puts "collection_druid,catalog_record_id,collection_name,form_value,form_type,source_code,source_value,source_uri\n"
+    rows(SQL).compact.each { |row| puts row }
+  end
+
+  def self.rows(sql_query)
+    sql_result_rows = ActiveRecord::Base.connection.execute(sql_query).to_a
+
+    sql_result_rows.map do |row|
+      collection_name = Collection.find_by(external_identifier: collection_druid)&.label
+
+      [
+        collection_druid,
+        row['catalog_record_id'],
+        "\"#{collection_name}\"",
+        row['form_value'],
+        row['form_type'],
+        row['source_code'],
+        row['source_value'],
+        row['source_uri']
+      ].join(',')
+    end
+  end
+end

--- a/app/reports/form_without_value_dros.rb
+++ b/app/reports/form_without_value_dros.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Report on form with no value that have source and/or type information
+
+# Invoke via:
+# bin/rails r -e production "FormWithoutValueDros.report"
+class FormWithoutValueDros
+  # NOTE: Prefer strict JSON querying over lax when using the `.**` operator, per
+  #       https://www.postgresql.org/docs/14/functions-json.html#STRICT-AND-LAX-MODES
+  #
+  # > The .** accessor can lead to surprising results when using the lax mode.
+  # > ... This happens because the .** accessor selects both the segments array
+  # > and each of its elements, while the .HR accessor automatically unwraps
+  # > arrays when using the lax mode. To avoid surprising results, we recommend
+  # > using the .** accessor only in the strict mode.
+  JSONB_PATH = 'strict $.**.form.**.value[*] ? (!(exists(@.value))) ? ((exists(@.type)) || (exists(@.source.code)) || (exists(@.source.value)) || (exists(@.source.uri)))'
+  SQL = <<~SQL.squish.freeze
+    SELECT dros.external_identifier as item_druid,
+           desc_value->'value' as form_value,
+           desc_value->'type' as form_type,
+           desc_value->'source'->'code' as source_code,
+           desc_value->'source'->'value' as source_value,
+           desc_value->'source'->'uri' as source_uri,
+           jsonb_path_query(dros.structural, '$.isMemberOf') ->> 0 as collection_druid,
+           jsonb_path_query(identification, '$.catalogLinks[*] ? (@.catalog == "symphony").catalogRecordId') ->> 0 as catalog_record_id
+           FROM "dros",
+           jsonb_path_query(dros.description, '#{JSONB_PATH}') desc_value
+           WHERE
+           jsonb_path_exists(dros.description, '#{JSONB_PATH}')
+  SQL
+
+  def self.report
+    puts "item_druid,catalog_record_id,collection_druid,collection_name,form_value,form_type,source_code,source_value,source_uri\n"
+    rows(SQL).compact.each { |row| puts row }
+  end
+
+  def self.rows(sql_query)
+    sql_result_rows = ActiveRecord::Base.connection.execute(sql_query).to_a
+
+    sql_result_rows.map do |row|
+      collection_druid = row['collection_druid']
+      collection_name = Collection.find_by(external_identifier: collection_druid)&.label
+
+      [
+        row['item_druid'],
+        row['catalog_record_id'],
+        collection_druid,
+        "\"#{collection_name}\"",
+        row['form_value'],
+        row['form_type'],
+        row['source_code'],
+        row['source_value'],
+        row['source_uri']
+      ].join(',')
+    end
+  end
+end


### PR DESCRIPTION
Hold for confirmation that the reports are correct -- no such objects were found for dros or collections in prod, stage or qa!

## Why was this change made? 🤔

To find cocina for objects that have conditions that make them throw errors while indexing.

Fixes #4541 - descriptive.contributor which has role info but has no name.value
Fixes #4540 - descriptive.form which has source or type info but has no value.

sul-dlss/argo#4071 and sul-dlss/argo#4072 disallowed csv imports that would create such things, and sul-dlss/cocina-models#610 and sul-dlss/cocina-models#611 are to create cocina-models validations that prevent this at the cocina level.

## How was this change tested? 🤨

Ran the reports on sdr-deploy

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



