### PR TITLE
send either catkey or folio_instance_hrid to goobi depending on what is active

### DIFF
--- a/app/services/goobi_service.rb
+++ b/app/services/goobi_service.rb
@@ -71,7 +71,7 @@ class GoobiService
             <title>#{title_or_label.encode(xml: :text)}</title>
             <contentType>#{content_type}</contentType>
             <project>#{project_name.encode(xml: :text)}</project>
-            <catkey>#{catkey}</catkey>
+            <catkey>#{catalog_id}</catkey>
             <barcode>#{barcode}</barcode>
             <collectionId>#{collection_id}</collectionId>
             <collectionName>#{collection_name.encode(xml: :text)}</collectionName>
@@ -102,8 +102,12 @@ class GoobiService
     Settings.goobi.default_goobi_workflow_name
   end
 
-  def catkey
-    cocina_obj.identification&.catalogLinks&.filter { |link| link.catalog == 'symphony' }&.first&.catalogRecordId
+  def catalog_id
+    cocina_obj.identification&.catalogLinks&.filter { |link| link.catalog == catalog_id_type }&.first&.catalogRecordId
+  end
+
+  def catalog_id_type
+    Settings.enabled_features.read_folio ? 'folio' : 'symphony'
   end
 
   def barcode

--- a/spec/services/goobi_service_spec.rb
+++ b/spec/services/goobi_service_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe GoobiService do
             catalog: 'symphony',
             catalogRecordId: '11403803',
             refresh: true
+          },
+          {
+            catalog: 'folio',
+            catalogRecordId: 'a11403803',
+            refresh: true
           }
         ],
         sourceId: 'some:source_id'
@@ -230,96 +235,127 @@ RSpec.describe GoobiService do
       allow(AdministrativeTags).to receive(:for).and_return(tags)
     end
 
-    context 'without ocr tag present' do
-      let(:tags) { ['DPG : Workflow : book_workflow & stuff', 'Process : Content Type : Book', 'LAB : MAPS'] }
+    context 'when folio enabled' do
+      before { allow(Settings.enabled_features).to receive(:read_folio).and_return(true) }
 
-      it 'creates the correct xml request' do
-        expect(xml_request).to be_equivalent_to <<-XML
-          <stanfordCreationRequest>
-            <objectId>#{druid}</objectId>
-            <objectType>item</objectType>
-            <sourceID>some:source_id</sourceID>
-            <title>Object Title &amp; A Special character</title>
-            <contentType>Book (ltr)</contentType>
-            <project>Project Name</project>
-            <catkey>11403803</catkey>
-            <barcode>#{barcode}</barcode>
-            <collectionId>druid:oo000oo0001</collectionId>
-            <collectionName>collection name</collectionName>
-            <sdrWorkflow>#{Settings.goobi.dpg_workflow_name}</sdrWorkflow>
-            <goobiWorkflow>goobi_workflow</goobiWorkflow>
-            <ocr>false</ocr>
-            <tags>
-                <tag name="DPG" value="Workflow : book_workflow &amp; stuff"/>
-                <tag name="Process" value="Content Type : Book"/>
-                <tag name="LAB" value="MAPS"/>
-            </tags>
-          </stanfordCreationRequest>
-        XML
-      end
-    end
+      context 'without ocr tag present' do
+        let(:tags) { ['DPG : Workflow : book_workflow & stuff', 'Process : Content Type : Book', 'LAB : MAPS'] }
 
-    context 'with ocr tag present' do
-      let(:tags) { ['DPG : Workflow : book_workflow', 'DPG : OCR : TRUE'] }
-
-      it 'creates the correct xml request' do
-        expect(xml_request).to be_equivalent_to <<-XML
-          <stanfordCreationRequest>
-            <objectId>#{druid}</objectId>
-            <objectType>item</objectType>
-            <sourceID>some:source_id</sourceID>
-            <title>Object Title &amp; A Special character</title>
-            <contentType>Book (ltr)</contentType>
-            <project>Project Name</project>
-            <catkey>11403803</catkey>
-            <barcode>#{barcode}</barcode>
-            <collectionId>druid:oo000oo0001</collectionId>
-            <collectionName>collection name</collectionName>
-            <sdrWorkflow>#{Settings.goobi.dpg_workflow_name}</sdrWorkflow>
-            <goobiWorkflow>goobi_workflow</goobiWorkflow>
-            <ocr>true</ocr>
-            <tags>
-                <tag name="DPG" value="Workflow : book_workflow"/>
-                <tag name="DPG" value="OCR : TRUE"/>
-            </tags>
-          </stanfordCreationRequest>
-        XML
-      end
-    end
-
-    context 'with no tags present' do
-      let(:tags) { [] }
-
-      let(:description) do
-        {
-          title: [
-            {
-              value: 'Constituent label & A Special character'
-            }
-          ],
-          purl: Purl.for(druid:)
-        }
+        it 'creates the correct xml request with folio instance hrid' do
+          expect(xml_request).to be_equivalent_to <<-XML
+            <stanfordCreationRequest>
+              <objectId>#{druid}</objectId>
+              <objectType>item</objectType>
+              <sourceID>some:source_id</sourceID>
+              <title>Object Title &amp; A Special character</title>
+              <contentType>Book (ltr)</contentType>
+              <project>Project Name</project>
+              <catkey>a11403803</catkey>
+              <barcode>#{barcode}</barcode>
+              <collectionId>druid:oo000oo0001</collectionId>
+              <collectionName>collection name</collectionName>
+              <sdrWorkflow>#{Settings.goobi.dpg_workflow_name}</sdrWorkflow>
+              <goobiWorkflow>goobi_workflow</goobiWorkflow>
+              <ocr>false</ocr>
+              <tags>
+                  <tag name="DPG" value="Workflow : book_workflow &amp; stuff"/>
+                  <tag name="Process" value="Content Type : Book"/>
+                  <tag name="LAB" value="MAPS"/>
+              </tags>
+            </stanfordCreationRequest>
+          XML
+        end
       end
 
-      it 'creates the correct xml request when MODs title exists with a special character' do
-        expect(xml_request).to be_equivalent_to <<-XML
-          <stanfordCreationRequest>
-            <objectId>#{druid}</objectId>
-            <objectType>item</objectType>
-            <sourceID>some:source_id</sourceID>
-            <title>Constituent label &amp; A Special character</title>
-            <contentType>Book (ltr)</contentType>
-            <project>Project Name</project>
-            <catkey>11403803</catkey>
-            <barcode>#{barcode}</barcode>
-            <collectionId>druid:oo000oo0001</collectionId>
-            <collectionName>collection name</collectionName>
-            <sdrWorkflow>#{Settings.goobi.dpg_workflow_name}</sdrWorkflow>
-            <goobiWorkflow>goobi_workflow</goobiWorkflow>
-            <ocr>false</ocr>
-            <tags></tags>
-          </stanfordCreationRequest>
-        XML
+      context 'with ocr tag present' do
+        let(:tags) { ['DPG : Workflow : book_workflow', 'DPG : OCR : TRUE'] }
+
+        it 'creates the correct xml request' do
+          expect(xml_request).to be_equivalent_to <<-XML
+            <stanfordCreationRequest>
+              <objectId>#{druid}</objectId>
+              <objectType>item</objectType>
+              <sourceID>some:source_id</sourceID>
+              <title>Object Title &amp; A Special character</title>
+              <contentType>Book (ltr)</contentType>
+              <project>Project Name</project>
+              <catkey>a11403803</catkey>
+              <barcode>#{barcode}</barcode>
+              <collectionId>druid:oo000oo0001</collectionId>
+              <collectionName>collection name</collectionName>
+              <sdrWorkflow>#{Settings.goobi.dpg_workflow_name}</sdrWorkflow>
+              <goobiWorkflow>goobi_workflow</goobiWorkflow>
+              <ocr>true</ocr>
+              <tags>
+                  <tag name="DPG" value="Workflow : book_workflow"/>
+                  <tag name="DPG" value="OCR : TRUE"/>
+              </tags>
+            </stanfordCreationRequest>
+          XML
+        end
+      end
+
+      context 'with no tags present' do
+        let(:tags) { [] }
+
+        let(:description) do
+          {
+            title: [
+              {
+                value: 'Constituent label & A Special character'
+              }
+            ],
+            purl: Purl.for(druid:)
+          }
+        end
+
+        it 'creates the correct xml request when MODs title exists with a special character' do
+          expect(xml_request).to be_equivalent_to <<-XML
+            <stanfordCreationRequest>
+              <objectId>#{druid}</objectId>
+              <objectType>item</objectType>
+              <sourceID>some:source_id</sourceID>
+              <title>Constituent label &amp; A Special character</title>
+              <contentType>Book (ltr)</contentType>
+              <project>Project Name</project>
+              <catkey>a11403803</catkey>
+              <barcode>#{barcode}</barcode>
+              <collectionId>druid:oo000oo0001</collectionId>
+              <collectionName>collection name</collectionName>
+              <sdrWorkflow>#{Settings.goobi.dpg_workflow_name}</sdrWorkflow>
+              <goobiWorkflow>goobi_workflow</goobiWorkflow>
+              <ocr>false</ocr>
+              <tags></tags>
+            </stanfordCreationRequest>
+          XML
+        end
+      end
+
+      context 'when symphony enabled' do
+        before { allow(Settings.enabled_features).to receive(:read_folio).and_return(false) }
+
+        let(:tags) { [] }
+
+        it 'creates the correct xml request with symphony catkey' do
+          expect(xml_request).to be_equivalent_to <<-XML
+            <stanfordCreationRequest>
+              <objectId>#{druid}</objectId>
+              <objectType>item</objectType>
+              <sourceID>some:source_id</sourceID>
+              <title>Object Title &amp; A Special character</title>
+              <contentType>Book (ltr)</contentType>
+              <project>Project Name</project>
+              <catkey>11403803</catkey>
+              <barcode>#{barcode}</barcode>
+              <collectionId>druid:oo000oo0001</collectionId>
+              <collectionName>collection name</collectionName>
+              <sdrWorkflow>#{Settings.goobi.dpg_workflow_name}</sdrWorkflow>
+              <goobiWorkflow>goobi_workflow</goobiWorkflow>
+              <ocr>false</ocr>
+              <tags></tags>
+            </stanfordCreationRequest>
+          XML
+        end
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Part of #4549 

When we switch to Folio, we will want to send folio_instance_hrids to the Goobi system instead of catkeys.  Thus the XML we construct needs to use our ILS feature flag to decide what to send.

Note that the name of the XML element we send to Goobi will continue to be "catkey", as changing this will require a code change on the Goobi end (which is out of our control and which the contractor would have to complete).

Two notes:
- The call that Goobi makes at the end of the process is not affected by the ILS change, as it is simply a call to start accessioning to the `/v1/objects/druid:DRUID_HERE/accession` endpoint of DSA.  There is no reference to catkey at all at this point. See https://github.com/sul-dlss/DevOpsDocs/blob/master/projects/goobi/operations-concerns.md for more details.
- We should verify on QA or stage that we are allowed to send folio formatted IDs to Goobi without an issue (e.g. "a1234" or "in1234").  We need to verify their code accepts non numeric characters in the "catkey" field in the XML we send.

## How was this change tested? 🤨

- Added a new unit test.
- Deployed to QA (which has folio turned on) and verified that I was able to register a new object with a folio instance HRID ("a12345"), and see this sent over to Goobi.  It is still labeled as "catkey" in the Goobi UI (to be expected), but the value was sent correctly, shows correctly, and didn't cause any errors (see screenshot below).  Object: https://argo-qa.stanford.edu/view/druid:xw490jn2818 and you can find it in Goobi stage (which is what DSA/Argo QA is connected to) by searching for the druid. https://goobi-stage-a.stanford.edu/goobi/uii/process_all.xhtml?dswid=5693

![Screen Shot 2023-08-16 at 3 32 03 PM](https://github.com/sul-dlss/dor-services-app/assets/47137/ecef467e-08f8-49b9-9835-42456810eb38)


