### PR TITLE
Make update_marc_record a job

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -131,7 +131,7 @@ class ObjectsController < ApplicationController
   # Called by common-accessioning
   def update_marc_record
     result = BackgroundJobResult.create
-    UpdateMarcJob.perform_later(Cocina::Models.without_metadata(@cocina_object).to_json, background_job_result: result)
+    UpdateMarcJob.perform_later(druid: params[:id], background_job_result: result)
     head :accepted
   end
 

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -128,9 +128,11 @@ class ObjectsController < ApplicationController
     head :accepted, location: result
   end
 
+  # Called by common-accessioning
   def update_marc_record
-    Catalog::UpdateMarc856RecordService.update(@cocina_object, thumbnail_service: ThumbnailService.new(@cocina_object))
-    head :created
+    result = BackgroundJobResult.create
+    UpdateMarcJob.perform_later(Cocina::Models.without_metadata(@cocina_object).to_json, background_job_result: result)
+    head :accepted
   end
 
   # Called by the robots.

--- a/app/jobs/update_marc_job.rb
+++ b/app/jobs/update_marc_job.rb
@@ -6,9 +6,8 @@ class UpdateMarcJob < ApplicationJob
   queue_as :update_marc
 
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
-  def perform(cocina_item_json, background_job_result:)
-    cocina_item = Cocina::Models.build(JSON.parse(cocina_item_json))
-    druid = cocina_item.externalIdentifier
+  def perform(druid:, background_job_result:)
+    cocina_item = CocinaObjectStore.find(druid)
     workflow = 'releaseWF'
     workflow_process = 'update-marc'
     background_job_result.processing!

--- a/app/jobs/update_marc_job.rb
+++ b/app/jobs/update_marc_job.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Add/remove a PURL from a catalog record
+# releaseWF uses this step.
+class UpdateMarcJob < ApplicationJob
+  queue_as :update_marc
+
+  # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
+  def perform(cocina_item_json, background_job_result:)
+    cocina_item = Cocina::Models.build(JSON.parse(cocina_item_json))
+    druid = cocina_item.externalIdentifier
+    workflow = 'releaseWF'
+    workflow_process = 'update-marc'
+    background_job_result.processing!
+
+    begin
+      Catalog::UpdateMarc856RecordService.update(cocina_item, thumbnail_service: ThumbnailService.new(cocina_item))
+    rescue StandardError => e
+      Honeybadger.notify(
+        'Error updating Folio record',
+        error_message: e.message,
+        context: {
+          druid: cocina_item.externalIdentifier
+        }
+      )
+      return LogFailureJob.perform_later(druid:,
+                                         background_job_result:,
+                                         workflow: 'releaseWF',
+                                         workflow_process: 'update-marc',
+                                         output: { errors: [{ title: 'Update MARC error', detail: e.message }] })
+    end
+
+    LogSuccessJob.perform_later(druid:,
+                                background_job_result:,
+                                workflow:,
+                                workflow_process:)
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -108,6 +108,8 @@ catalog:
       username: "app_sdr"
       password: "supersecret"
     tenant_id: "example_tenant"
+    max_lookup_tries: 5
+    sleep_seconds: 10
 
 datacite:
   prefix: '10.80343'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,4 @@
+catalog:
+  folio:
+    max_lookup_tries: 3
+    sleep_seconds: 1

--- a/spec/jobs/update_marc_job_spec.rb
+++ b/spec/jobs/update_marc_job_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UpdateMarcJob do
+  subject(:perform) do
+    described_class.perform_now(cocina_object.to_json, background_job_result: result)
+  end
+
+  let(:result) { create(:background_job_result) }
+  let(:cocina_object) { build(:dro, id: druid) }
+  let(:druid) { 'druid:mx123qw2323' }
+
+  before do
+    allow(result).to receive(:processing!)
+  end
+
+  context 'with no errors' do
+    before do
+      allow(Catalog::UpdateMarc856RecordService).to receive(:update)
+      allow(LogSuccessJob).to receive(:perform_later)
+      perform
+    end
+
+    it 'marks the job as processing' do
+      expect(result).to have_received(:processing!).once
+    end
+
+    it 'invokes the UpdateMarc856RecordService' do
+      expect(Catalog::UpdateMarc856RecordService).to have_received(:update).once
+    end
+
+    it 'marks the job as complete' do
+      expect(LogSuccessJob).to have_received(:perform_later)
+        .with(druid:, background_job_result: result, workflow: 'releaseWF', workflow_process: 'update-marc')
+    end
+  end
+
+  context 'with errors' do
+    before do
+      allow(Catalog::UpdateMarc856RecordService).to receive(:update).and_raise(StandardError, 'FOLIO update not completed.')
+      allow(LogFailureJob).to receive(:perform_later)
+      perform
+    end
+
+    it 'logs failure' do
+      expect(LogFailureJob).to have_received(:perform_later)
+        .with(druid:,
+              background_job_result: result,
+              workflow: 'releaseWF',
+              workflow_process: 'update-marc',
+              output: { errors: [{ title: 'Update MARC error', detail: 'FOLIO update not completed.' }] })
+    end
+  end
+end

--- a/spec/jobs/update_marc_job_spec.rb
+++ b/spec/jobs/update_marc_job_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe UpdateMarcJob do
   subject(:perform) do
-    described_class.perform_now(cocina_object.to_json, background_job_result: result)
+    described_class.perform_now(druid:, background_job_result: result)
   end
 
   let(:result) { create(:background_job_result) }
@@ -12,6 +12,7 @@ RSpec.describe UpdateMarcJob do
   let(:druid) { 'druid:mx123qw2323' }
 
   before do
+    allow(CocinaObjectStore).to receive(:find).with(druid).and_return(cocina_object)
     allow(result).to receive(:processing!)
   end
 

--- a/spec/requests/update_marc_record_spec.rb
+++ b/spec/requests/update_marc_record_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe 'Update MARC record' do
   end
 
   context 'when the request is successful' do
-    it 'returns a 201 response' do
+    it 'returns a 202 response' do
       post "/v1/objects/#{druid}/update_marc_record", headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(response).to have_http_status(:created)
+      expect(response).to have_http_status(:accepted)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #4454 to update FOLIO marc record 856 fields in the releaseWF, without concurrent updates. Will require deploying along with puppet and shared_configs PRs. 

Do not merge until coordinated with related shared_configs, common_accessioning, puppet PR reviews.

## How was this change tested? 🤨
Tested in QA with 100 druids released to same FOLIO record.
