### PR TITLE
Stop using cocina object when only version and druid needed

### DIFF
--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -2,7 +2,6 @@
 
 # Handles API routes for managing the DOR workspace
 class WorkspacesController < ApplicationController
-  before_action :load_cocina_object, only: [:reset]
   before_action :check_cocina_object_exists, only: %i[create]
 
   rescue_from(DruidTools::SameContentExistsError, DruidTools::DifferentContentExistsError) do |e|
@@ -25,7 +24,8 @@ class WorkspacesController < ApplicationController
   # Once an object has been transferred to preservation, reset the workspace by
   # renaming the druid-tree to a versioned directory and removing the export directory
   def reset
-    ResetWorkspaceJob.perform_later(druid: params[:object_id], version: @cocina_object.version)
+    version = CocinaObjectStore.version(params[:object_id])
+    ResetWorkspaceJob.perform_later(druid: params[:object_id], version:)
     head :no_content
   end
 

--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -80,6 +80,14 @@ class CocinaObjectStore
     end
   end
 
+  # Retrieves the version of a Cocina object from the datastore.
+  # @param [String] druid
+  # @return [Integer] version
+  # @raise [CocinaObjectNotFoundError] raised when the requested Cocina object is not found.
+  def self.version(druid)
+    new.version(druid)
+  end
+
   # @return [Cocina::Models::DROWithMetadata,Cocina::Models::CollectionWithMetadata,Cocina::Models::AdminPolicyWithMetadata]
   def find(druid)
     ar_to_cocina_find(druid)
@@ -111,6 +119,15 @@ class CocinaObjectStore
   # This is only public for migration use.
   def ar_exists?(druid)
     Dro.exists?(external_identifier: druid) || Collection.exists?(external_identifier: druid) || AdminPolicy.exists?(external_identifier: druid)
+  end
+
+  def version(druid)
+    ar_cocina_object = Dro.select(:version).find_by(external_identifier: druid) ||
+                       AdminPolicy.select(:version).find_by(external_identifier: druid) ||
+                       Collection.select(:version).find_by(external_identifier: druid)
+
+    ar_cocina_object&.version ||
+      raise(CocinaObjectNotFoundError.new("Couldn't find object with 'external_identifier'=#{druid}", druid))
   end
 
   def destroy(druid)

--- a/app/services/constituent_service.rb
+++ b/app/services/constituent_service.rb
@@ -29,10 +29,10 @@ class ConstituentService
     return errors if errors.any?
 
     # Make sure the virtual object is open before making modifications
-    updated_virtual_object = if VersionService.open?(virtual_object)
+    updated_virtual_object = if VersionService.open?(druid: virtual_object.externalIdentifier, version: virtual_object.version)
                                virtual_object
                              else
-                               VersionService.open(virtual_object,
+                               VersionService.open(cocina_object: virtual_object,
                                                    description: VERSION_DESCRIPTION,
                                                    significance: VERSION_SIGNIFICANCE,
                                                    event_factory:)
@@ -40,7 +40,7 @@ class ConstituentService
 
     updated_virtual_object = ResetContentMetadataService.reset(cocina_item: updated_virtual_object, constituent_druids:)
 
-    VersionService.close(updated_virtual_object,
+    VersionService.close(druid: updated_virtual_object.externalIdentifier, version: updated_virtual_object.version,
                          event_factory:)
 
     UpdateObjectService.update(updated_virtual_object)

--- a/app/services/embargo_release_service.rb
+++ b/app/services/embargo_release_service.rb
@@ -43,17 +43,17 @@ class EmbargoReleaseService
       return
     end
 
-    unless VersionService.can_open?(cocina_object)
+    unless VersionService.can_open?(druid: cocina_object.externalIdentifier, version: cocina_object.version)
       Rails.logger.warn("Skipping #{druid} - object is already open")
       return
     end
     Rails.logger.info("Releasing embargo for #{druid}")
 
-    updated_cocina_object = VersionService.open(cocina_object, description: 'embargo released', significance: 'admin')
+    updated_cocina_object = VersionService.open(cocina_object:, description: 'embargo released', significance: 'admin')
 
     updated_cocina_object = release_cocina_object(updated_cocina_object)
 
-    VersionService.close(updated_cocina_object)
+    VersionService.close(druid: updated_cocina_object.externalIdentifier, version: updated_cocina_object.version)
 
     EventFactory.create(druid:, event_type: 'embargo_released', data: {})
 

--- a/bin/migrate-cocina
+++ b/bin/migrate-cocina
@@ -62,12 +62,12 @@ end
 def perform_version(cocina_object:, version_description:)
   version_open_params = { significance: 'admin', description: version_description }
   # if this is an existing versionable object, open and close it, which will start accessionWF
-  if VersionService.can_open?(cocina_object)
-    opened_cocina_object = VersionService.open(cocina_object, **version_open_params)
-    VersionService.close(opened_cocina_object)
+  if VersionService.can_open?(druid: cocina_object.externalIdentifier, version: cocina_object.version)
+    opened_cocina_object = VersionService.open(cocina_object:, **version_open_params)
+    VersionService.close(druid: opened_cocina_object.externalIdentifier, version: opened_cocina_object.version)
   # if this is an existing accessioned object that is currently open, just close it
   else
-    VersionService.close(cocina_object, **version_open_params)
+    VersionService.close(druid: cocina_object.externalIdentifier, version: cocina_object.version, **version_open_params)
   end
 end
 
@@ -80,7 +80,7 @@ def perform_migrate(migrator_class:, obj:, mode:)
   migrator.migrate
   updated_cocina_object = obj.to_cocina_with_metadata # This validates the cocina object
   Cocina::ObjectValidator.validate(updated_cocina_object) # This validation is performed by UpdateObjectService.
-  raise 'Cannot version' if migrator.version? && !(VersionService.can_open?(updated_cocina_object) || VersionService.open?(updated_cocina_object))
+  raise 'Cannot version' if migrator.version? && !(VersionService.can_open?(druid: updated_cocina_object.externalIdentifier, version: updated_cocina_object.version) || VersionService.open?(druid: updated_cocina_object.externalIdentifier, version: updated_cocina_object.version))
 
   if mode == :migrate
     updated_cocina_object = UpdateObjectService.update(updated_cocina_object)

--- a/spec/requests/authorization_spec.rb
+++ b/spec/requests/authorization_spec.rb
@@ -3,10 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Authorization' do
-  let(:cocina_object) { instance_double(Cocina::Models::DRO, version: 5) }
-
   before do
-    allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
+    allow(CocinaObjectStore).to receive(:version).and_return(5)
     allow(Honeybadger).to receive(:notify)
     allow(Honeybadger).to receive(:context)
   end

--- a/spec/requests/reset_workspace_spec.rb
+++ b/spec/requests/reset_workspace_spec.rb
@@ -3,11 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Reset workspace' do
-  let(:cocina_object) { instance_double(Cocina::Models::DRO, version: 2) }
   let(:druid) { 'druid:bb222cc3333' }
 
   before do
-    allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
+    allow(CocinaObjectStore).to receive(:version).and_return(2)
     allow(ResetWorkspaceJob).to receive(:perform_later)
   end
 

--- a/spec/requests/start_accession_spec.rb
+++ b/spec/requests/start_accession_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
            params:,
            headers: { 'Authorization' => "Bearer #{jwt}" })
       expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, default_start_accession_workflow, version: '2')
-      expect(VersionService).to have_received(:open).with(cocina_object, **params)
-      expect(VersionService).to have_received(:close).with(updated_cocina_object, **close_params)
+      expect(VersionService).to have_received(:open).with(cocina_object:, **params)
+      expect(VersionService).to have_received(:close).with(druid:, version: 2, **close_params)
     end
 
     it 'can override the default workflow' do
@@ -84,8 +84,8 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
            params: params.merge(workflow: 'accessionWF'),
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'accessionWF', version: '2')
-      expect(VersionService).to have_received(:open).with(cocina_object, **params)
-      expect(VersionService).to have_received(:close).with(updated_cocina_object, **close_params)
+      expect(VersionService).to have_received(:open).with(cocina_object:, **params)
+      expect(VersionService).to have_received(:close).with(druid:, version: 2, **close_params)
     end
   end
 
@@ -101,7 +101,7 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
       expect(response).to have_http_status(:success)
       expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, default_start_accession_workflow, version: '1')
       expect(VersionService).not_to have_received(:open)
-      expect(VersionService).to have_received(:close).with(cocina_object, **close_params)
+      expect(VersionService).to have_received(:close).with(druid:, version: 1, **close_params)
     end
   end
 

--- a/spec/requests/versions_spec.rb
+++ b/spec/requests/versions_spec.rb
@@ -3,11 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe 'Operations regarding object versions' do
-  let(:cocina_object) { build(:dro) }
+  let(:cocina_object) { build(:dro, id: druid) }
 
   let(:date) { Time.zone.now }
 
   let(:lock) { 'abc123' }
+
+  let(:druid) { 'druid:mx123qw2323' }
 
   let(:cocina_object_with_metadata) do
     Cocina::Models.with_metadata(cocina_object, lock, created: date, modified: date)
@@ -16,7 +18,7 @@ RSpec.describe 'Operations regarding object versions' do
   let(:version) { 1 }
 
   before do
-    allow(CocinaObjectStore).to receive(:find).and_return(cocina_object_with_metadata)
+    allow(CocinaObjectStore).to receive_messages(find: cocina_object_with_metadata, version:)
   end
 
   describe '/versions/current' do
@@ -50,7 +52,7 @@ RSpec.describe 'Operations regarding object versions' do
         expect(response).to have_http_status :ok
         expect(response.body).to match(/version 1 closed/)
         expect(VersionService).to have_received(:close)
-          .with(cocina_object_with_metadata,
+          .with(druid:, version:,
                 **close_params)
       end
     end
@@ -101,7 +103,7 @@ RSpec.describe 'Operations regarding object versions' do
         expect(response.headers['Last-Modified']).to end_with 'GMT'
         expect(response.headers['X-Created-At']).to end_with 'GMT'
         expect(response.headers['ETag']).to match(%r{W/".+"})
-        expect(VersionService).to have_received(:open).with(cocina_object_with_metadata, **open_params)
+        expect(VersionService).to have_received(:open).with(cocina_object: cocina_object_with_metadata, **open_params)
       end
     end
 

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -39,6 +39,38 @@ RSpec.describe CocinaObjectStore do
     end
   end
 
+  describe '#version' do
+    context 'when object is not found in datastore' do
+      it 'raises' do
+        expect { store.version('druid:bc123df4567') }.to raise_error(CocinaObjectStore::CocinaObjectNotFoundError)
+      end
+    end
+
+    context 'when object is a DRO' do
+      let(:ar_cocina_object) { create(:ar_dro, version: 5) }
+
+      it 'returns version' do
+        expect(store.version(ar_cocina_object.external_identifier)).to eq(5)
+      end
+    end
+
+    context 'when object is an AdminPolicy' do
+      let(:ar_cocina_object) { create(:ar_admin_policy, version: 2) }
+
+      it 'returns version' do
+        expect(store.version(ar_cocina_object.external_identifier)).to eq(2)
+      end
+    end
+
+    context 'when object is a Collection' do
+      let(:ar_cocina_object) { create(:ar_collection, version: 4) }
+
+      it 'returns version' do
+        expect(store.version(ar_cocina_object.external_identifier)).to eq(4)
+      end
+    end
+  end
+
   describe '#find_by_source_id' do
     context 'when object is not found in datastore' do
       it 'raises' do

--- a/spec/services/constituent_service_spec.rb
+++ b/spec/services/constituent_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ConstituentService do
 
       it 'opens virtual object for versioning' do
         service.add(constituent_druids:)
-        expect(VersionService).to have_received(:open).with(virtual_object,
+        expect(VersionService).to have_received(:open).with(cocina_object: virtual_object,
                                                             description: ConstituentService::VERSION_DESCRIPTION,
                                                             significance: ConstituentService::VERSION_SIGNIFICANCE,
                                                             event_factory:)
@@ -58,7 +58,7 @@ RSpec.describe ConstituentService do
 
     it 'closes open version' do
       service.add(constituent_druids:)
-      expect(VersionService).to have_received(:close).with(virtual_object, event_factory:)
+      expect(VersionService).to have_received(:close).with(druid: virtual_object.externalIdentifier, version: virtual_object.version, event_factory:)
     end
 
     it 'indexes virtual object synchronously' do

--- a/spec/services/embargo_release_service_spec.rb
+++ b/spec/services/embargo_release_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe EmbargoReleaseService do
 
     let(:open_cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, version: 2) }
 
-    let(:released_cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, version: 2) }
+    let(:released_cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, version: 3) }
 
     let(:workflow_client) { instance_double(Dor::Workflow::Client, lifecycle: accessioned?) }
 
@@ -50,7 +50,7 @@ RSpec.describe EmbargoReleaseService do
       it 'skips' do
         service.release
         expect(Rails.logger).to have_received(:warn).with("Skipping #{druid} - object is already open")
-        expect(VersionService).to have_received(:can_open?).with(cocina_object)
+        expect(VersionService).to have_received(:can_open?).with(druid:, version: 1)
         expect(VersionService).not_to have_received(:open)
       end
     end
@@ -58,9 +58,9 @@ RSpec.describe EmbargoReleaseService do
     context 'when not open' do
       it 'lifts embargo' do
         service.release
-        expect(VersionService).to have_received(:open).with(cocina_object, description: 'embargo released', significance: 'admin')
+        expect(VersionService).to have_received(:open).with(cocina_object:, description: 'embargo released', significance: 'admin')
         expect(service).to have_received(:release_cocina_object).with(open_cocina_object)
-        expect(VersionService).to have_received(:close).with(released_cocina_object)
+        expect(VersionService).to have_received(:close).with(druid:, version: 3)
         expect(EventFactory).to have_received(:create).with(druid:, event_type: 'embargo_released', data: {})
         expect(Notifications::EmbargoLifted).to have_received(:publish).with(model: released_cocina_object)
       end

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe VersionService do
     end
 
     it 'creates a new service instance and sends #open_for_versioning?' do
-      described_class.open?(cocina_object)
+      described_class.open?(druid:, version:)
       expect(instance).to have_received(:open_for_versioning?).once
     end
   end
@@ -32,13 +32,13 @@ RSpec.describe VersionService do
     end
 
     it 'creates a new service instance and sends #accessioning?' do
-      described_class.in_accessioning?(cocina_object)
+      described_class.in_accessioning?(druid:, version:)
       expect(instance).to have_received(:accessioning?).once
     end
   end
 
   describe '.open' do
-    subject(:open) { described_class.open(cocina_object, significance: 'major', description: 'same as it ever was', opening_user_name: 'sunetid', event_factory:) }
+    subject(:open) { described_class.open(cocina_object:, significance: 'major', description: 'same as it ever was', opening_user_name: 'sunetid', event_factory:) }
 
     let(:workflow_client) do
       instance_double(Dor::Workflow::Client,
@@ -101,7 +101,7 @@ RSpec.describe VersionService do
     end
 
     context 'when a new version cannot be opened' do
-      let(:instance) { described_class.new(cocina_object) }
+      let(:instance) { described_class.new(druid:, version:) }
 
       before do
         allow(instance).to receive(:ensure_openable!).and_raise(VersionService::VersioningError, 'Object net yet accessioned')
@@ -133,7 +133,7 @@ RSpec.describe VersionService do
   end
 
   describe '.can_open?' do
-    subject(:can_open?) { described_class.can_open?(cocina_object) }
+    subject(:can_open?) { described_class.can_open?(druid:, version:) }
 
     before do
       allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
@@ -204,7 +204,7 @@ RSpec.describe VersionService do
 
   describe '.close' do
     subject(:close) do
-      described_class.close(cocina_object,
+      described_class.close(druid:, version:,
                             description:,
                             significance:,
                             user_name: 'jcoyne',


### PR DESCRIPTION
## Why was this change made? 🤔
Avoid instantiating a cocina object when it isn't needed to increase performance.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, Integration

