### PR TITLE
Add committee configuration to remove warnings.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -52,7 +52,8 @@ module DorServices
       error_class: JSONAPIError,
       accept_request_filter: accept_proc,
       parse_response_by_content_type: false,
-      query_hash_key: 'action_dispatch.request.query_parameters'
+      query_hash_key: 'action_dispatch.request.query_parameters',
+      parameter_overwite_by_rails_rule: false
     )
     # Ensure we are passing back valid responses when running tests
     if Rails.env.test?
@@ -61,7 +62,8 @@ module DorServices
         schema_path: 'openapi.yml',
         parse_response_by_content_type: true,
         query_hash_key: 'rack.request.query_hash',
-        raise: true
+        raise: true,
+        parameter_overwite_by_rails_rule: false
       )
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔
Avoid future committee configuration problems.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Before:
```
bundle exec rspec spec/requests/authorization_spec.rb
[DEPRECATION] Committee: please set parameter_overwite_by_rails_rule = false because we'll change default value to "true" in next major version.
[DEPRECATION] Committee: please set parameter_overwite_by_rails_rule = false because we'll change default value to "true" in next major version.
```

After:
```
bundle exec rspec spec/requests/authorization_spec.rb
```


