### PR TITLE
No longer update marc 856 from ConstituentService.

### DIFF
--- a/app/services/constituent_service.rb
+++ b/app/services/constituent_service.rb
@@ -72,10 +72,6 @@ class ConstituentService
     constituent_druids.each do |constituent_druid|
       cocina_item = CocinaObjectStore.find(constituent_druid)
       Publish::MetadataTransferService.publish(cocina_item)
-
-      next unless cocina_item.identification&.catalogLinks&.any? { |link| link.catalog == 'symphony' }
-
-      Catalog::UpdateMarc856RecordService.update(cocina_item, thumbnail_service: ThumbnailService.new(cocina_item))
     end
   end
 end

--- a/spec/services/constituent_service_spec.rb
+++ b/spec/services/constituent_service_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe ConstituentService do
       allow(CocinaObjectStore).to receive(:find).and_return(mock_item)
       allow(SynchronousIndexer).to receive(:reindex_remotely_from_cocina)
       allow(Publish::MetadataTransferService).to receive(:publish)
-      allow(Catalog::UpdateMarc856RecordService).to receive(:update)
     end
 
     context 'when one or more items are not combinable' do
@@ -70,16 +69,6 @@ RSpec.describe ConstituentService do
       service.add(constituent_druids:)
       expect(CocinaObjectStore).to have_received(:find).exactly(constituent_druids.count).times
       expect(Publish::MetadataTransferService).to have_received(:publish).exactly(constituent_druids.count).times
-      expect(Catalog::UpdateMarc856RecordService).not_to have_received(:update)
-    end
-
-    context 'when constituents have catkeys' do
-      let(:mock_item) { build(:dro, catkeys: ['12345']) }
-
-      it 'updates MARC' do
-        service.add(constituent_druids:)
-        expect(Catalog::UpdateMarc856RecordService).to have_received(:update).exactly(constituent_druids.count).times
-      end
     end
 
     it 'returns nil' do


### PR DESCRIPTION
closes #4548

## Why was this change made? 🤔
See ticket.


## How was this change tested? 🤨

Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



