### PR TITLE
Unpin committee

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'stanford-mods', '~> 2.6'
 # Ruby general dependencies
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'bunny', '~> 2.17' # Send messages to RabbitMQ
-gem 'committee', '~> 4.4' # validates Open API spec (OAS)
+gem 'committee' # validates Open API spec (OAS)
 gem 'config'
 gem 'dry-monads'
 gem 'edtf', '~> 3.0' # used for metadata reports

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -527,7 +527,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-shared_configs
   cocina-models (~> 0.90.0)
-  committee (~> 4.4)
+  committee
   config
   datacite (~> 0.3.0)
   diffy


### PR DESCRIPTION
## Why was this change made? 🤔
To match other apps and allow committee to be updated to 5 with new cocina models gem.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



