### PR TITLE
update to cocina-models 0.91.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.91.0)
+    cocina-models (0.91.1)
       activesupport
       deprecation
       dry-struct (~> 1.0)


### PR DESCRIPTION
## Why was this change made? 🤔

To allow dor_indexing_app to use stanford-mods, a small, backwards compatible change was made to cocina-models in PR sul-dlss/cocina-models/pull/623

## How was this change tested? 🤨

CI

I will run integration tests after all the cocina-models downstream updates are done

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



