### PR TITLE
update to cocina-models 0.91.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.91.1)
+    cocina-models (0.91.2)
       activesupport
       deprecation
       dry-struct (~> 1.0)


### PR DESCRIPTION
## Why was this change made? 🤔

To allow dor_indexing_app to use stanford-mods, a small, backwards compatible change was made to cocina-models in PR sul-dlss/cocina-models/pull/625

## How was this change tested? 🤨

CI

I will run integration tests after all the cocina-models downstream updates are done


