### PR TITLE
Remove skipped tests that are no longer applicable.

### DIFF
--- a/spec/jobs/publish_job_spec.rb
+++ b/spec/jobs/publish_job_spec.rb
@@ -68,27 +68,4 @@ RSpec.describe PublishJob do
       end
     end
   end
-
-  context 'when fails dark validation', skip: 'turned off while preassembly could not make valid dark objects; see https://github.com/sul-dlss/dor-services-app/issues/4366' do
-    let(:valid) { false }
-    let(:invalid_filenames) { ['foo.txt', 'bar.txt'] }
-
-    before do
-      allow(LogFailureJob).to receive(:perform_later)
-      perform
-    end
-
-    it 'marks the job as processing' do
-      expect(result).to have_received(:processing!).once
-    end
-
-    it 'marks the job as complete' do
-      expect(LogFailureJob).to have_received(:perform_later)
-        .with(druid:,
-              background_job_result: result,
-              workflow: 'accessionWF',
-              workflow_process: 'publish',
-              output: { errors: [{ detail: 'Not all files have dark access and/or are unshelved when item access is dark: ["foo.txt", "bar.txt"]', title: 'Access mismatch' }] })
-    end
-  end
 end

--- a/spec/jobs/shelve_job_spec.rb
+++ b/spec/jobs/shelve_job_spec.rb
@@ -62,24 +62,4 @@ RSpec.describe ShelveJob do
               output: { errors: [{ detail: error_message, title: 'Unable to shelve files' }] })
     end
   end
-
-  context 'when fails dark validation', skip: 'turned off while preassembly could not make valid dark objects; see https://github.com/sul-dlss/dor-services-app/issues/4366' do
-    let(:valid) { false }
-    let(:invalid_filenames) { ['foo.txt', 'bar.txt'] }
-
-    before do
-      allow(LogFailureJob).to receive(:perform_later)
-    end
-
-    it 'marks the job as errored' do
-      perform
-      expect(result).to have_received(:processing!).once
-      expect(LogFailureJob).to have_received(:perform_later)
-        .with(druid:,
-              background_job_result: result,
-              workflow: 'accessionWF',
-              workflow_process: 'shelve',
-              output: { errors: [{ detail: 'Not all files have dark access and/or are unshelved when item access is dark: ["foo.txt", "bar.txt"]', title: 'Access mismatch' }] })
-    end
-  end
 end


### PR DESCRIPTION
closes #4366

## Why was this change made? 🤔
Dark is validated by cocina models, so no need to do so in shelve or publish jobs. That makes these tests unnecessary.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



