### PR TITLE
Correctly rename file when shelving.

### DIFF
--- a/app/services/digital_stacks_service.rb
+++ b/app/services/digital_stacks_service.rb
@@ -62,7 +62,7 @@ class DigitalStacksService
   # @param [Moab::FileSignature] moab_signature The fixity values of the file
   # @return [Boolean] true if file renamed, false otherwise
   def self.rename_file(old_pathname, new_pathname, moab_signature)
-    if old_pathname.exist? && (old_pathname.size == moab_signature.size)
+    if old_pathname.exist? && (old_pathname.size == moab_signature.size.to_i)
       file_signature = Moab::FileSignature.new.signature_from_file(old_pathname)
       if file_signature == moab_signature
         new_pathname.parent.mkpath


### PR DESCRIPTION
closes https://github.com/sul-dlss/common-accessioning/issues/1107

## Why was this change made? 🤔

Renaming while shelving was failing because the rename process was comparing a size that was an integer against a size that was a string. See logging below:
```
I, [2023-10-04T06:09:00.274160 #686972]  INFO -- : [ActiveJob] [ShelveJob] [eb580e54-d70e-4fc9-a828-789ec32eb828] RENAME - Renaming 2 files in /stacks/mp/491/pr/4725
I, [2023-10-04T06:09:00.274555 #686972]  INFO -- : [ActiveJob] [ShelveJob] [eb580e54-d70e-4fc9-a828-789ec32eb828] RENAME - Renaming /stacks/mp/491/pr/4725/image.jpg to /stacks/mp/491/pr/4725/85a32f398e228e8228ad84422941110597e0d87a
I, [2023-10-04T06:09:00.286342 #686972]  INFO -- : [ActiveJob] [ShelveJob] [eb580e54-d70e-4fc9-a828-789ec32eb828] RENAME - /stacks/mp/491/pr/4725/image.jpg exists? true
I, [2023-10-04T06:09:00.286574 #686972]  INFO -- : [ActiveJob] [ShelveJob] [eb580e54-d70e-4fc9-a828-789ec32eb828] RENAME - /stacks/mp/491/pr/4725/image.jpg size 29634 Integer
I, [2023-10-04T06:09:00.286735 #686972]  INFO -- : [ActiveJob] [ShelveJob] [eb580e54-d70e-4fc9-a828-789ec32eb828] RENAME - /stacks/mp/491/pr/4725/image.jpg moab signature size 29634 String
I, [2023-10-04T06:09:00.286903 #686972]  INFO -- : [ActiveJob] [ShelveJob] [eb580e54-d70e-4fc9-a828-789ec32eb828] RENAME - /stacks/mp/491/pr/4725/image.jpg size? false
I, [2023-10-04T06:09:00.287171 #686972]  INFO -- : [ActiveJob] [ShelveJob] [eb580e54-d70e-4fc9-a828-789ec32eb828] RENAME - Renaming /stacks/mp/491/pr/4725/image.jp2 to /stacks/mp/491/pr/4725/e4d88f9a52d7688f71ee07c9186509bb0a64fa8d
I, [2023-10-04T06:09:00.288611 #686972]  INFO -- : [ActiveJob] [ShelveJob] [eb580e54-d70e-4fc9-a828-789ec32eb828] RENAME - /stacks/mp/491/pr/4725/image.jp2 exists? true
I, [2023-10-04T06:09:00.288814 #686972]  INFO -- : [ActiveJob] [ShelveJob] [eb580e54-d70e-4fc9-a828-789ec32eb828] RENAME - /stacks/mp/491/pr/4725/image.jp2 size 139970 Integer
I, [2023-10-04T06:09:00.288973 #686972]  INFO -- : [ActiveJob] [ShelveJob] [eb580e54-d70e-4fc9-a828-789ec32eb828] RENAME - /stacks/mp/491/pr/4725/image.jp2 moab signature size 139970 String
I, [2023-10-04T06:09:00.289175 #686972]  INFO -- : [ActiveJob] [ShelveJob] [eb580e54-d70e-4fc9-a828-789ec32eb828] RENAME - /stacks/mp/491/pr/4725/image.jp2 size? false
I, [2023-10-04T06:09:00.289449 #686972]  INFO -- : [ActiveJob] [ShelveJob] [eb580e54-d70e-4fc9-a828-789ec32eb828] RENAME - Renaming /stacks/mp/491/pr/4725/85a32f398e228e8228ad84422941110597e0d87a to /stacks/mp/491/pr/4725/image-move.jpg
I, [2023-10-04T06:09:00.289671 #686972]  INFO -- : [ActiveJob] [ShelveJob] [eb580e54-d70e-4fc9-a828-789ec32eb828] RENAME - /stacks/mp/491/pr/4725/85a32f398e228e8228ad84422941110597e0d87a exists? false
```


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

QA. I was unable to reproduce in unit tests (i.e., create a Moab::FileSignature with a string size.)

