### PR TITLE
Add report for objects with multiple events but no folio hrid

### DIFF
--- a/app/reports/property_multiple_events.rb
+++ b/app/reports/property_multiple_events.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Generate a report of DROs that have mutiple events but no folio HRID
+#
+# bin/rails r -e production "PropertyMultipleEvents.report"
+#
+class PropertyMultipleEvents
+  # find events in cocina objects
+  EVENT_JSONB_PATH = '$.event[*] ? (@ != null)'
+  PURL_JSONB_PATH = 'strict $.purl'
+
+  SQL = <<~SQL.squish.freeze
+    SELECT jsonb_path_query(description, '#{PURL_JSONB_PATH}') ->> 0 as purl,
+           external_identifier,
+           label,
+           jsonb_path_query(structural, '$.isMemberOf') ->> 0 as collection_id,
+           jsonb_path_query(administrative, '$.hasAdminPolicy') ->> 0 as apo
+           FROM "dros" WHERE
+           jsonb_array_length(jsonb_path_query_array(description, '#{EVENT_JSONB_PATH}')) > 1
+           AND NOT jsonb_path_exists(dros.identification, '$.catalogLinks[*] ? (@.catalog == "folio").catalogRecordId')
+  SQL
+
+  def self.report
+    puts 'purl,title,collection name,APO'
+
+    result_rows(SQL).compact.each { |row| puts row }
+  end
+
+  def self.result_rows(sql)
+    ActiveRecord::Base
+      .connection
+      .execute(sql)
+      .to_a
+      .group_by { |row| row['external_identifier'] }
+      .map do |_id, rows|
+        collection_druid = rows.first['collection_id']
+        collection_name = Collection.find_by(external_identifier: collection_druid)&.label
+
+        [
+          rows.first['purl'],
+          rows.first['label'],
+          "\"#{collection_name}\"",
+          rows.first['apo']
+        ].join(',')
+      end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #4618 

Ran in qa and verified the results match the selection criteria:
```
purl,title,collection name,APO
https://sul-purl-stage.stanford.edu/fc661cd6790,SUL Logo for Fenugreek Leaf Curry Leaves,"Fenugreek Leaf Curry Leaves",druid:zx485kb6348
https://sul-purl-stage.stanford.edu/gw372yy8196,SUL Logo for Arrowroot Curry Leaves,"Arrowroot Curry Leaves",druid:zx485kb6348
https://sul-purl-stage.stanford.edu/tv885tb9774,SUL Logo for Mint Cashews,"Mint Cashews",druid:zx485kb6348
https://sul-purl-stage.stanford.edu/ft059yx6058,SUL Logo for Tandoori Mix Coconut Water,"Tandoori Mix Coconut Water",druid:zx485kb6348
https://sul-purl-stage.stanford.edu/wx441ty6154,SUL Logo for Cayenne Pepper Peppercorns,"Cayenne Pepper Peppercorns",druid:zx485kb6348
```


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



