### PR TITLE
Bump lograge to 0.14.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,7 +261,7 @@ GEM
       multi_json
     jwt (2.7.1)
     language_server-protocol (3.17.0.3)
-    lograge (0.13.0)
+    lograge (0.14.0)
       actionpack (>= 4)
       activesupport (>= 4)
       railties (>= 4)


### PR DESCRIPTION
# Why was this change made?

This helps when lograge has to deal with deprecations, which is currently causing HB exceptions due to a changed Rails API.

Fewer HB exceptions that aren't meaningful is a good thing.

# How was this change tested?

CI
