### PR TITLE
Add report for events with displayLabel but no folio HRID

### DIFF
--- a/app/reports/property_events_with_display_label.rb
+++ b/app/reports/property_events_with_display_label.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Generate a report of DROs that have at leaste one event with a displayLabel
+#
+# bin/rails r -e production "PropertyEventsWithDisplayLabel.report"
+#
+class PropertyEventsWithDisplayLabel
+  def self.report
+    puts 'purl,title,collection name,APO'
+
+    Dro.where("jsonb_path_exists(description, '$.event.displayLabel')").find_each do |dro|
+      purl = dro.description['purl']
+      collection = dro.structural['isMemberOf'].first
+      collection_name = Collection.find_by(external_identifier: collection)&.label
+      next if dro.identification['catalogLinks'].pluck('catalog').include? 'folio'
+
+      puts "#{purl},#{dro.label},#{collection_name},#{dro.administrative['hasAdminPolicy']}\n"
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #4619 

Ran against production using [the cocina-models instrucitons](https://github.com/sul-dlss/cocina-models#running-reports-in-dsa) and verified the data through a cursory spot check that that showed the cocina data matches the selection criteria of at least one event WITH a displayLabel and does not include a folio HRID.

There are 563554 records in production matching this case.

Example data:

```
https://purl.stanford.edu/kk202jh4049,Interview with Stefania Moroianu,In Transit: An Oral History Project about Crossing Borders,druid:yf767bj4831
https://purl.stanford.edu/fp590fv0002,Interview with Megha Parwani,In Transit: An Oral History Project about Crossing Borders,druid:yf767bj4831
https://purl.stanford.edu/kp438vz9202,Interview with Anita Too,In Transit: An Oral History Project about Crossing Borders,druid:yf767bj4831
https://purl.stanford.edu/ff182kf4183,Interview with Gaeun Kim,Stanford Historical Society Oral History Program interviews, 1999-2012,druid:yf767bj4831
https://purl.stanford.edu/mk853tm4512,Interview with Anastasia Lyulina,Stanford Historical Society Oral History Program interviews, 1999-2012,druid:yf767bj4831
https://purl.stanford.edu/tf787ns0771,Interview with Stefania Moroianu,Stanford Historical Society Oral History Program interviews, 1999-2012,druid:yf767bj4831
https://purl.stanford.edu/tn647jf4277,Interview with Megha Parwani,Stanford Historical Society Oral History Program interviews, 1999-2012,druid:yf767bj4831
https://purl.stanford.edu/hs378vm2864,Interview with Anita Too,Stanford Historical Society Oral History Program interviews, 1999-2012,druid:yf767bj4831
https://purl.stanford.edu/by888sj5596,William H. Durham Oral History,Stanford Historical Society Oral History Program interviews, 1999-2012,druid:yf767bj4831
https://purl.stanford.edu/gh498sx1638,William H. Durham Oral History,Stanford Historical Society Oral History Program interviews, 1999-2012,druid:yf767bj4831
```

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



