### PR TITLE
move backup_path to settings

### DIFF
--- a/app/services/cleanup_service.rb
+++ b/app/services/cleanup_service.rb
@@ -5,9 +5,8 @@ require 'pathname'
 # Remove all traces of the object's data files from the workspace and export areas
 class CleanupService
   # @param [String] druid The identifier for the object for which we will stop accessioning
-  # @param [String] backup_path The base directory to backup to
   # @param [boolean] dryrun if true, will just display output but not perform actions
-  def self.stop_accessioning(druid, backup_path, dryrun: false)
+  def self.stop_accessioning(druid, dryrun: false)
     # This will raise an exception if an invalid format (or no) druid is passed in
     druid_obj = DruidTools::Druid.new(druid)
 
@@ -33,7 +32,7 @@ class CleanupService
 
     # backup folders
     $stdout.puts '...backing up content folders'
-    backup_content_by_druid(druid, backup_path) unless dryrun
+    backup_content_by_druid(druid) unless dryrun
 
     # delete workspace folders
     $stdout.puts '...deleting content folders'
@@ -55,11 +54,10 @@ class CleanupService
   end
 
   # @param [String] druid The identifier for the object whose data is to be backed up
-  # @param [String] backup_path The base directory to backup to
-  def self.backup_content_by_druid(druid, backup_path)
-    backup_content(druid, Settings.cleanup.local_workspace_root, backup_path)
-    backup_content(druid, Settings.cleanup.local_assembly_root, backup_path)
-    backup_content(druid, Settings.cleanup.local_export_home, backup_path)
+  def self.backup_content_by_druid(druid)
+    backup_content(druid, Settings.cleanup.local_workspace_root, Settings.cleanup.local_backup_path)
+    backup_content(druid, Settings.cleanup.local_assembly_root, Settings.cleanup.local_backup_path)
+    backup_content(druid, Settings.cleanup.local_export_home, Settings.cleanup.local_backup_path)
   end
 
   # @param [String] druid The identifier for the object whose accessioning workflows should be deleted

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -76,6 +76,7 @@ cleanup:
   local_workspace_root: '/dor/workspace'
   local_assembly_root: '/dor/assembly'
   local_export_home: '/dor/export'
+  local_backup_path: /dor/stopped'
 
 dor:
   hmac_secret: 'my$ecretK3y'

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -13,7 +13,7 @@ namespace :cleanup do
     $stdout.puts "This will completely stop accessioning for #{druid}. Are you sure? [y/n]:"
     raise 'Aborting' unless $stdin.gets.chomp == 'y'
 
-    CleanupService.stop_accessioning(druid, '/dor/stopped', dryrun:)
+    CleanupService.stop_accessioning(druid, dryrun:)
   end
 
   # Stop accessioning in progress for multiple druids supplied in a CSV (one per line, no header)
@@ -33,10 +33,11 @@ namespace :cleanup do
 
     rows.each do |row|
       druid = row.first
+      $stdout.puts '====='
       $stdout.puts druid
 
       begin
-        CleanupService.stop_accessioning(druid, '/dor/stopped', dryrun:)
+        CleanupService.stop_accessioning(druid, dryrun:)
       rescue StandardError => e
         $stdout.puts "Error stopping accessioning for #{druid}: #{e.message} #{e.backtrace.join("\n")}"
       end


### PR DESCRIPTION
## Why was this change made? 🤔

Follow on from #4598 incorporating suggestions from John.

1. Moves the backup_path to settings to make it easily configurable and then stop passing it around as much
2. Add some additional output spacing

## How was this change tested? 🤨

Updates specs