### PR TITLE
Handle error for Folio OKComputer check.

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -29,6 +29,9 @@ class FolioCheck < OkComputer::Check
     else
       mark_message 'folio disabled'
     end
+  rescue StandardError => e
+    mark_failure
+    "#{e.class.name} received: #{e.message}."
   end
 end
 


### PR DESCRIPTION
## Why was this change made? 🤔
So that don't throw an error when Folio is down.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

QA, stage

