### PR TITLE
Pin rails to minor.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-gem 'rails', '~> 7.0'
+gem 'rails', '~> 7.1.0'
 
 # DLSS/domain-specific dependencies
 gem 'cocina-models', '~> 0.91.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -613,7 +613,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 6.0)
   rack-console
-  rails (~> 7.0)
+  rails (~> 7.1.0)
   retries
   rsolr
   rspec-rails


### PR DESCRIPTION
## Why was this change made? 🤔
Consistency with other apps and for rails, minor is too major for a dependency update.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



