### PR TITLE
Mark workflow step completed after actually performing reset workspace.

### DIFF
--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -24,9 +24,10 @@ class WorkspacesController < ApplicationController
   # Once an object has been transferred to preservation, reset the workspace by
   # renaming the druid-tree to a versioned directory and removing the export directory
   def reset
+    result = BackgroundJobResult.create
     version = CocinaObjectStore.version(params[:object_id])
-    ResetWorkspaceJob.perform_later(druid: params[:object_id], version:)
-    head :no_content
+    ResetWorkspaceJob.set(queue: params['lane-id']).perform_later(druid: params[:object_id], version:, background_job_result: result, workflow: params[:workflow])
+    head :created, location: result
   end
 
   private

--- a/app/jobs/reset_workspace_job.rb
+++ b/app/jobs/reset_workspace_job.rb
@@ -2,14 +2,33 @@
 
 # Invokes the ResetWorkspaceService
 class ResetWorkspaceJob < ApplicationJob
-  queue_as :low
+  queue_as :default
+
+  WORKFLOW_PROCESS = 'reset-workspace'
 
   # @param [String] druid the identifier of the object to be reset
   # @param [Integer] version the version of the object to be reset
-  def perform(druid:, version:)
-    ResetWorkspaceService.reset(druid:, version:)
-  rescue ResetWorkspaceService::DirectoryAlreadyExists
-    # We're trapping errors and doing nothing, because the belief is that these indicate
-    # this API has already been called and completed.
+  # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
+  # @param [String] workflow Which workflow should this be reported to?
+  def perform(druid:, version:, background_job_result:, workflow:)
+    background_job_result.processing!
+
+    begin
+      ResetWorkspaceService.reset(druid:, version:)
+    rescue ResetWorkspaceService::DirectoryAlreadyExists
+      # We're trapping errors and doing nothing, because the belief is that these indicate
+      # this API has already been called and completed.
+    rescue StandardError => e
+      return LogFailureJob.perform_later(druid:,
+                                         background_job_result:,
+                                         workflow:,
+                                         workflow_process: WORKFLOW_PROCESS,
+                                         output: { errors: [{ title: 'Unable to reset workspace', detail: e.message }] })
+    end
+
+    LogSuccessJob.perform_later(druid:,
+                                workflow:,
+                                background_job_result:,
+                                workflow_process: WORKFLOW_PROCESS)
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -712,6 +712,24 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
+        - name: workflow
+          in: query
+          description: which workflow should this be reported to
+          schema:
+            type: string
+            enum:
+              - accessionWF
+              - releaseWF
+          example: releaseWF
+        - name: lane-id
+          in: query
+          description: Lane for prioritizing the work
+          schema:
+            type: string
+            enum:
+              - 'default'
+              - 'low'
+            default: 'default'
     post:
       tags:
         - workspaces
@@ -745,6 +763,24 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
+        - name: workflow
+          in: query
+          description: which workflow should this be reported to
+          schema:
+            type: string
+            enum:
+              - accessionWF
+              - releaseWF
+          example: releaseWF
+        - name: lane-id
+          in: query
+          description: Lane for prioritizing the work
+          schema:
+            type: string
+            enum:
+              - 'default'
+              - 'low'
+            default: 'default'
   '/v1/objects/{object_id}/shelve':
     post:
       tags:

--- a/spec/jobs/reset_workspace_job_spec.rb
+++ b/spec/jobs/reset_workspace_job_spec.rb
@@ -4,20 +4,30 @@ require 'rails_helper'
 
 RSpec.describe ResetWorkspaceJob do
   subject(:perform) do
-    described_class.perform_now(druid:, version:)
+    described_class.perform_now(druid:, version:, background_job_result: result, workflow:)
   end
 
   let(:druid) { 'druid:mk420bs7601' }
   let(:version) { 1 }
+  let(:result) { create(:background_job_result) }
+  let(:workflow) { 'accessionWF' }
+
+  before do
+    allow(result).to receive(:processing!)
+    allow(LogSuccessJob).to receive(:perform_later)
+  end
 
   context 'with no errors' do
     before do
       allow(ResetWorkspaceService).to receive(:reset)
     end
 
-    it 'invokes the ResetService' do
+    it 'invokes the ResetService and logs success' do
       perform
+      expect(result).to have_received(:processing!).once
       expect(ResetWorkspaceService).to have_received(:reset).with(druid:, version:).once
+      expect(LogSuccessJob).to have_received(:perform_later)
+        .with(druid:, background_job_result: result, workflow: 'accessionWF', workflow_process: 'reset-workspace')
     end
   end
 
@@ -26,9 +36,26 @@ RSpec.describe ResetWorkspaceJob do
       allow(ResetWorkspaceService).to receive(:reset).and_raise(ResetWorkspaceService::DirectoryAlreadyExists)
     end
 
-    it 'ignores' do
+    it 'ignores and logs success' do
       perform
       expect(ResetWorkspaceService).to have_received(:reset).with(druid:, version:).once
+      expect(LogSuccessJob).to have_received(:perform_later)
+        .with(druid:, background_job_result: result, workflow: 'accessionWF', workflow_process: 'reset-workspace')
+    end
+  end
+
+  context 'when an error' do
+    before do
+      allow(ResetWorkspaceService).to receive(:reset).and_raise('Grrrr')
+      allow(LogFailureJob).to receive(:perform_later)
+    end
+
+    it 'logs failure' do
+      perform
+      expect(ResetWorkspaceService).to have_received(:reset).with(druid:, version:).once
+      expect(LogFailureJob).to have_received(:perform_later)
+        .with(druid:, background_job_result: result, workflow: 'accessionWF', workflow_process: 'reset-workspace',
+              output: { errors: [{ detail: 'Grrrr', title: 'Unable to reset workspace' }] })
     end
   end
 end

--- a/spec/requests/reset_workspace_spec.rb
+++ b/spec/requests/reset_workspace_spec.rb
@@ -4,17 +4,21 @@ require 'rails_helper'
 
 RSpec.describe 'Reset workspace' do
   let(:druid) { 'druid:bb222cc3333' }
+  let(:job) { class_double(ResetWorkspaceJob, perform_later: nil) }
 
   before do
     allow(CocinaObjectStore).to receive(:version).and_return(2)
-    allow(ResetWorkspaceJob).to receive(:perform_later)
+    allow(ResetWorkspaceJob).to receive(:set).and_return(job)
   end
 
   context 'when the request is succcessful' do
     it 'is successful' do
-      post "/v1/objects/#{druid}/workspace/reset", headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(ResetWorkspaceJob).to have_received(:perform_later).with(druid:, version: 2)
-      expect(response).to be_no_content
+      post "/v1/objects/#{druid}/workspace/reset?workflow=accessionWF&lane-id=low",
+           headers: { 'Authorization' => "Bearer #{jwt}" }
+      expect(ResetWorkspaceJob).to have_received(:set).with(queue: 'low')
+      expect(job).to have_received(:perform_later)
+        .with(druid:, version: 2, background_job_result: BackgroundJobResult, workflow: 'accessionWF')
+      expect(response).to have_http_status(:created)
     end
   end
 end


### PR DESCRIPTION
closes #4634

## Why was this change made? 🤔

The reset_workspace step processing is done here in DSA by a job class, so that job class should updated the workflow status to "completed" ... since it is doing the work!

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, stage

