### PR TITLE
bump cocina-models version to get new field for file types, update openapi.yml and tests accordingly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'rails', '~> 7.1.0'
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.91.0'
+gem 'cocina-models', '~> 0.92.0'
 gem 'datacite', '~> 0.3.0'
 gem 'dor-workflow-client', '~> 5.0'
 gem 'druid-tools', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,13 +113,14 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.91.4)
+    cocina-models (0.92.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       edtf
       equivalent-xml
+      i18n
       jsonpath
       nokogiri
       openapi3_parser
@@ -580,7 +581,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.91.0)
+  cocina-models (~> 0.92.0)
   committee
   config
   datacite (~> 0.3.0)

--- a/openapi.yml
+++ b/openapi.yml
@@ -2183,6 +2183,9 @@ components:
         hasMimeType:
           description: MIME Type of the File.
           type: string
+        languageTag:
+          description: "BCP 47 language tag: https://www.rfc-editor.org/rfc/rfc4646.txt -- other applications (like media players) expect language codes of this format, see e.g. https://videojs.com/guides/text-tracks/#srclang"
+          type: string
         use:
           description: Use for the File.
           type: string
@@ -2894,6 +2897,8 @@ components:
         version:
           type: integer
         hasMimeType:
+          type: string
+        languageTag:
           type: string
         externalIdentifier:
           type: string

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -245,6 +245,7 @@ RSpec.describe 'Create object' do
           'filename' => '00001.html',
           'label' => '00001.html',
           'hasMimeType' => 'text/html',
+          'languageTag' => 'lou-US',
           'use' => 'transcription',
           'administrative' => {
             'publish' => false,
@@ -365,6 +366,7 @@ RSpec.describe 'Create object' do
                     filename: '00001.html',
                     version: 1,
                     hasMimeType: 'text/html',
+                    languageTag: 'lou-US',
                     use: 'transcription',
                     hasMessageDigests: [
                       {

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -305,6 +305,7 @@ RSpec.describe 'Update object' do
           'filename' => '00001.html',
           'label' => '00001.html',
           'hasMimeType' => 'text/html',
+          'languageTag' => 'aqp-Latn-US',
           'use' => 'transcription',
           'administrative' => {
             'publish' => false,
@@ -462,6 +463,7 @@ RSpec.describe 'Update object' do
                       filename: '00001.html',
                       version: 1,
                       hasMimeType: 'text/html',
+                      languageTag: 'aqp-Latn-US',
                       use: 'transcription',
                       hasMessageDigests: [
                         {


### PR DESCRIPTION
## Why was this change made? 🤔

connects to sul-dlss/cocina-models#637 and sul-dlss/cocina-models#640

## How was this change tested? 🤨

unit tests

will run integration tests on QA or stage once all the SDR apps have been updated (i.e. DSA updated to latest cocina-models in this PR, sdr-api updated to latest cocina-models in [related PR](https://github.com/sul-dlss/sdr-api/pull/628), and access-update-scripts `cocina_level2_prs.rb` has been run)

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



