### PR TITLE
explicitly enable upcoming committee default

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -52,6 +52,7 @@ module DorServices
       Committee::Middleware::RequestValidation,
       schema_path: 'openapi.yml',
       strict: true,
+      strict_reference_validation: true,
       error_class: JSONAPIError,
       accept_request_filter: accept_proc,
       parse_response_by_content_type: false,
@@ -63,6 +64,7 @@ module DorServices
       config.middleware.use(
         Committee::Middleware::ResponseValidation,
         schema_path: 'openapi.yml',
+        strict_reference_validation: true,
         parse_response_by_content_type: true,
         query_hash_key: 'rack.request.query_hash',
         raise: true,


### PR DESCRIPTION
## Why was this change made? 🤔

set `strict_reference_validation` to `true` on `RequestValidation` and `ResponseValidation` to silence deprecation warning


## How was this change tested? 🤨

CI

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



