### PR TITLE
Add language to the public xml content-metadata section

### DIFF
--- a/app/services/cocina/to_xml/content_metadata_generator.rb
+++ b/app/services/cocina/to_xml/content_metadata_generator.rb
@@ -83,6 +83,7 @@ module Cocina
           file_node['shelve'] = shelve_attr(cocina_file)
           file_node['preserve'] = preserve_attr(cocina_file)
           file_node['role'] = cocina_file.use if cocina_file.use
+          file_node['language'] = cocina_file.languageTag if cocina_file.languageTag
           Array(cocina_file.hasMessageDigests).each do |message_digest|
             file_node.add_child(create_checksum_node(message_digest.type, message_digest.digest))
           end

--- a/spec/services/cocina/to_xml/content_metadata_generator_spec.rb
+++ b/spec/services/cocina/to_xml/content_metadata_generator_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Cocina::ToXml::ContentMetadataGenerator do
       'hasMimeType' => 'text/html',
       'use' => 'transcription',
       'size' => 997,
+      'languageTag' => 'en',
       'administrative' => {
         'publish' => false,
         'sdrPreserve' => true,
@@ -209,7 +210,7 @@ RSpec.describe Cocina::ToXml::ContentMetadataGenerator do
           <bookData readingOrder="rtl" />
           <resource id="https://cocina.sul.stanford.edu/fileSet/bc123df5678-123-456-789" sequence="1" type="page">
             <label>Page 1</label>
-            <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription">
+            <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription" language="en">
               <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
               <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
             </file>
@@ -239,7 +240,7 @@ RSpec.describe Cocina::ToXml::ContentMetadataGenerator do
         <contentMetadata objectId="druid:bc123df5678" type="image">
           <resource id="https://cocina.sul.stanford.edu/fileSet/bc123df5678-123-456-789" sequence="1" type="file">
             <label>Page 1</label>
-            <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription">
+            <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription" language="en">
               <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
               <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
             </file>
@@ -264,7 +265,7 @@ RSpec.describe Cocina::ToXml::ContentMetadataGenerator do
         <contentMetadata objectId="druid:bc123df5678" type="image">
           <resource id="https://cocina.sul.stanford.edu/fileSet/bc123df5678-123-456-789" sequence="1" type="file">
             <label>Page 1</label>
-            <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription">
+            <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription" language="en">
               <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
               <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
             </file>
@@ -424,7 +425,7 @@ RSpec.describe Cocina::ToXml::ContentMetadataGenerator do
         <contentMetadata objectId="druid:bc123df5678" type="document">
           <resource id="https://cocina.sul.stanford.edu/fileSet/bc123df5678-123-456-789" sequence="1" type="file">
             <label>Page 1</label>
-            <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription">
+            <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription" language="en">
               <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
               <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
             </file>
@@ -709,7 +710,7 @@ RSpec.describe Cocina::ToXml::ContentMetadataGenerator do
         <contentMetadata objectId="druid:bc123df5678" type="book">
           <resource id="https://cocina.sul.stanford.edu/fileSet/bc123df5678-012-345-678" sequence="1" type="file">
             <label>Page 1</label>
-            <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription">
+            <file id="00001.html" mimetype="text/html" size="997" preserve="yes" publish="no" shelve="no" role="transcription" language="en">
               <checksum type="sha1">cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7</checksum>
               <checksum type="md5">e6d52da47a5ade91ae31227b978fb023</checksum>
             </file>


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #4641 

Note that `languageTag` is already available in the public JSON, see: https://sul-purl-stage.stanford.edu/wm783fb6812.json


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



