### PR TITLE
bump cocina-models version to get latest model validation changes, update openapi.yml accordingly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'rails', '~> 7.1.0'
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.92.0'
+gem 'cocina-models', '~> 0.93.0'
 gem 'datacite', '~> 0.3.0'
 gem 'dor-workflow-client', '~> 5.0'
 gem 'druid-tools', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.92.0)
+    cocina-models (0.93.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -581,7 +581,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.92.0)
+  cocina-models (~> 0.93.0)
   committee
   config
   datacite (~> 0.3.0)

--- a/openapi.yml
+++ b/openapi.yml
@@ -2184,11 +2184,9 @@ components:
           description: MIME Type of the File.
           type: string
         languageTag:
-          description: "BCP 47 language tag: https://www.rfc-editor.org/rfc/rfc4646.txt -- other applications (like media players) expect language codes of this format, see e.g. https://videojs.com/guides/text-tracks/#srclang"
-          type: string
+          $ref: '#/components/schemas/LanguageTag'
         use:
-          description: Use for the File.
-          type: string
+          $ref: '#/components/schemas/FileUse'
         hasMessageDigests:
           type: array
           items:
@@ -2283,6 +2281,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/File'
+    FileUse:
+      description: Use for the File.
+      type: string
+      nullable: true
     FolioCatalogLink:
       description: A linkage between an object and a Folio catalog record
       type: object
@@ -2411,6 +2413,10 @@ components:
         valueLanguage:
           # description: present for mapping to additional schemas in the future and for consistency but not otherwise used
           $ref: "#/components/schemas/DescriptiveValueLanguage"
+    LanguageTag:
+      description: "BCP 47 language tag: https://www.rfc-editor.org/rfc/rfc4646.txt -- other applications (like media players) expect language codes of this format, see e.g. https://videojs.com/guides/text-tracks/#srclang"
+      type: string
+      nullable: true
     License:
       description: The license governing reuse of the DRO. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
       type: string
@@ -2899,11 +2905,11 @@ components:
         hasMimeType:
           type: string
         languageTag:
-          type: string
+          $ref: '#/components/schemas/LanguageTag'
         externalIdentifier:
           type: string
         use:
-          type: string
+          $ref: '#/components/schemas/FileUse'
         hasMessageDigests:
           type: array
           items:


### PR DESCRIPTION
## Why was this change made? 🤔

better validation for langauge tags, nilable language tags and use fields, stricter description validation

https://github.com/sul-dlss/cocina-models/releases/tag/v0.93.0

## How was this change tested? 🤨

unit tests

will run integration tests on QA or stage once all the SDR apps have been updated (i.e. DSA updated to latest cocina-models in this PR, sdr-api updated to latest cocina-models in [related PR](https://github.com/sul-dlss/sdr-api/pull/630), and access-update-scripts `cocina_level2_prs.rb` has been run)

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



