### PR TITLE
Add folio_client legacy_auth setting

### DIFF
--- a/config/initializers/folio_client.rb
+++ b/config/initializers/folio_client.rb
@@ -5,7 +5,9 @@ begin
   FolioClient.configure(
     url: Settings.catalog.folio.okapi.url,
     login_params: {
-      username: Settings.catalog.folio.okapi.username, password: Settings.catalog.folio.okapi.password
+      username: Settings.catalog.folio.okapi.username,
+      password: Settings.catalog.folio.okapi.password,
+      legacy_auth: Settings.catalog.folio.okapi.legacy_auth
     },
     okapi_headers: {
       'X-Okapi-Tenant': Settings.catalog.folio.tenant_id,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -95,6 +95,7 @@ catalog:
       url: "https://okapi-dev.example.com"
       username: "app_sdr"
       password: "supersecret"
+      legacy_auth: true
     tenant_id: "example_tenant"
     max_lookup_tries: 5
     sleep_seconds: 10


### PR DESCRIPTION
## Why was this change made? 🤔
Allows us to use different versions of FOLIO auth until we're upgraded to Poppy in late March. 

## How was this change tested? 🤨
Deployed to QA and integration tests.
