### PR TITLE
allow accessioning start call to start gisAssemblyWF

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -173,6 +173,7 @@ paths:
             enum:
               - accessionWF
               - assemblyWF
+              - gisAssemblyWF
         - name: significance
           in: query
           description: the significance of the version change (if versioning is needed)


### PR DESCRIPTION
## Why was this change made? 🤔

Part of https://github.com/sul-dlss/pre-assembly/issues/1397 and https://github.com/sul-dlss/pre-assembly/issues/1403 --- to start GIS Objects accessioning, we need to start `gisAssemblyWF` with the API call to DSA, and this is currently not possible as it violates this constraint.


## How was this change tested? 🤨

Will deploy to stage