### PR TITLE
use dor_indexing v1.2.0 and cocina-models 0.94.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.94.0)
+    cocina-models (0.94.2)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -170,8 +170,9 @@ GEM
       faraday-retry (~> 2.0)
       nokogiri (~> 1.6)
       zeitwerk (~> 2.1)
-    dor_indexing (1.1.1)
-      cocina-models (~> 0.94.0)
+    dor_indexing (1.2.0)
+      cocina-models (~> 0.94.1)
+      dor-workflow-client (~> 7.0)
       honeybadger
       marc-vocab (~> 0.3.0)
       solrizer


### PR DESCRIPTION
## Why was this change made? 🤔

To get new title indexing in dor_indexing gem 1.2.0, which uses new methods in cocina-models 0.94.2 - used in rolling (re)indexer.

## How was this change tested? 🤨

CI is enough - we're just indexing a few new title fields.



