### PR TITLE
Parallelize rolling index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'jsonpath', '~> 1.1' # used for metadata reports
 gem 'jwt' # json web token
 gem 'lograge'
 gem 'okcomputer'
-gem 'parallel' # used for validating cocina tools
+gem 'parallel' # used for validating cocina tools and for rolling indexer
 gem 'pg'
 gem 'retries' # for Goobi
 gem 'rsolr'

--- a/bin/rolling_index
+++ b/bin/rolling_index
@@ -48,7 +48,7 @@ Daemons.run_proc(
     batches = response_docs.each_slice(Settings.rolling_indexer.batch_size)
     batches.each.with_index do |batch, _index|
       batch_start_time = Time.zone.now
-      solr_docs = Parallel.filter_map(batch, in_processes: Settings.rolling_index.num_parallel_processes) do |doc|
+      solr_docs = Parallel.filter_map(batch, in_processes: Settings.rolling_indexer.num_parallel_processes) do |doc|
         identifier = doc['id'].scrub('')
         # Occasionally, we've seen invalid bytes in the identifier, so try to catch those:
         Honeybadger.notify("Identifier isn't valid utf-8", { identifier:, bytes: identifier.unpack('C*') }) unless doc['id'].valid_encoding?

--- a/bin/rolling_index
+++ b/bin/rolling_index
@@ -3,6 +3,7 @@
 
 require_relative '../config/environment'
 require 'daemons'
+require 'parallel'
 
 QUERY = { q: '*:*', sort: 'timestamp asc', fl: 'id,timestamp', rows: Settings.rolling_indexer.query_size }.freeze
 
@@ -47,13 +48,13 @@ Daemons.run_proc(
     batches = response_docs.each_slice(Settings.rolling_indexer.batch_size)
     batches.each.with_index do |batch, _index|
       batch_start_time = Time.zone.now
-      solr_docs = batch.filter_map do |doc|
+      solr_docs = Parallel.filter_map(batch, in_processes: Settings.rolling_index.num_parallel_processes) do |doc|
         identifier = doc['id'].scrub('')
         # Occasionally, we've seen invalid bytes in the identifier, so try to catch those:
         Honeybadger.notify("Identifier isn't valid utf-8", { identifier:, bytes: identifier.unpack('C*') }) unless doc['id'].valid_encoding?
         begin
-          # This returns a Solr doc hash
           cocina_obj = CocinaObjectStore.find(identifier)
+          # This returns a Solr doc hash
           DorIndexing.build(cocina_with_metadata: cocina_obj, workflow_client: WorkflowClientFactory.build, cocina_repository: CocinaRepository.new)
         rescue CocinaObjectStore::CocinaObjectNotFoundError
           Honeybadger.notify('Rolling indexer cannot reindex since not found.', { druid: identifier })

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -131,7 +131,9 @@ rolling_indexer:
   # number of docs to send to Solr in a batch
   batch_size: 5
   # avoid overloading DSA for other work (seconds)
-  pause_time_between_docs: 0.1
+  pause_time_between_docs: 0.05
+  # number of parallel processes to build solr docs from cocina
+  num_parallel_processes: 1
   # a little more than softCommit max time is desired (a Solr 'add' with commitWithin does a softCommit) (seconds)
   # see solrconfig.xml for softCommit max time
   pause_for_solr: 61


### PR DESCRIPTION
## Why was this change made? 🤔

To instrument a way to speed up (or slow down) the rolling_indexer at will.   This will help us shepherd indexing changes through quickly, or to slow down the rolling_indexer due to heavy DSA usage by some other project.

Fixes #4687

## How was this change tested? 🤨

I ran it on qa with parallel value of 2 and of 1.
