### PR TITLE
stop pinning stanford-mods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,8 @@ gem 'mais_orcid_client'
 gem 'marc'
 gem 'moab-versioning', '~> 6.0', require: 'moab/stanford'
 gem 'preservation-client', '~> 6.0'
+gem 'stanford-mods'
 gem 'sul_orcid_client', '~> 0.3'
-# Pinning stanford-mods since >=3 breaks dor-services.
-gem 'stanford-mods', '~> 2.6'
 
 # Ruby general dependencies
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,8 +313,8 @@ GEM
       json
       nokogiri
       nokogiri-happymapper
-    mods (2.4.1)
-      edtf
+    mods (3.0.4)
+      edtf (~> 3.0)
       iso-639
       nokogiri (>= 1.6.6)
       nom-xml (~> 1.0)
@@ -548,9 +548,9 @@ GEM
       net-scp (>= 1.1.2)
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
-    stanford-mods (2.6.4)
+    stanford-mods (3.3.9)
       activesupport
-      mods (~> 2.2)
+      mods (~> 3.0, >= 3.0.4)
     stringio (3.1.0)
     strings-ansi (0.2.0)
     sul_orcid_client (0.4.1)
@@ -662,7 +662,7 @@ DEPENDENCIES
   sidekiq (~> 7.0)
   simplecov
   sneakers (~> 2.11)
-  stanford-mods (~> 2.6)
+  stanford-mods
   sul_orcid_client (~> 0.3)
   tty-progressbar
   uuidtools (~> 2.1.4)


### PR DESCRIPTION
## Why was this change made? 🤔

Based on the comment, I suspect we could have stopped pinning this gem when we stopped using the dor-services gem.

I'm also hopeful this will resolve the HB errors with the rolling indexer

## How was this change tested? 🤨

specs, integration tests in stage.





