### PR TITLE
bump dor_indexing gem to v1.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,12 +171,12 @@ GEM
       faraday-retry (~> 2.0)
       nokogiri (~> 1.6)
       zeitwerk (~> 2.1)
-    dor_indexing (1.3.1)
+    dor_indexing (1.4.0)
+      activesupport
       cocina-models (~> 0.95.0)
       dor-workflow-client (~> 7.0)
       honeybadger
       marc-vocab (~> 0.3.0)
-      solrizer
       stanford-mods
       zeitwerk
     drb (2.2.0)
@@ -260,7 +260,7 @@ GEM
     graphql (2.2.8)
     hashdiff (1.1.0)
     hashie (5.0.0)
-    honeybadger (5.4.1)
+    honeybadger (5.5.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     i18n (1.14.1)
@@ -529,10 +529,6 @@ GEM
       rake (~> 12.3)
       serverengine (~> 2.1.0)
       thor
-    solrizer (4.1.0)
-      activesupport
-      nokogiri
-      xml-simple
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
@@ -593,8 +589,6 @@ GEM
     websocket-extensions (0.1.5)
     whenever (1.0.0)
       chronic (>= 0.6.3)
-    xml-simple (1.1.9)
-      rexml
     zeitwerk (2.6.13)
 
 PLATFORMS


### PR DESCRIPTION
## Why was this change made? 🤔

Update dor_indexing_gem to v1.4.0 to start indexing to new replacement fields (see https://github.com/sul-dlss/dor_indexing/releases/tag/v1.4.0)

## How was this change tested? 🤨

deployed to stage and ran integration tests.


