### PR TITLE
Add collection to validate-cocina CSV

### DIFF
--- a/bin/validate-cocina
+++ b/bin/validate-cocina
@@ -66,7 +66,8 @@ def validate(clazz, sample_size, processes)
       Cocina::Models::Mapping::ToMods::Description.transform(cocina_obj.description, cocina_obj.externalIdentifier)
       [obj.external_identifier, nil]
     rescue StandardError => e
-      [obj.external_identifier, clazz.name, e.message]
+      collection = obj.structural['isMemberOf'].join(' ')
+      [obj.external_identifier, clazz.name, collection, e.message]
     end
   end.flatten(1)
 end
@@ -75,8 +76,8 @@ results = validate(Dro, options[:sample],
                    options[:processes]) + validate(Collection, options[:sample], options[:processes]) + validate(AdminPolicy, options[:sample], options[:processes])
 
 CSV.open('validate-cocina.csv', 'w') do |writer|
-  writer << %w[druid type message]
-  results.each do |(druid, class_name, error)|
-    writer << [druid, class_name, error] if error
+  writer << %w[druid type collection message]
+  results.each do |(druid, class_name, collection, error)|
+    writer << [druid, class_name, collection, error] if error
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Get more info to help metadata remediators. 

## How was this change tested? 🤨
Ran on prod with a cocina-models branch that would produce validation errors and fill a report. 

Sample rows from report:
```
druid,type,collection,message
druid:bc675gs0465,Dro,"","Multiple value, groupedValue, structuredValue, and parallelValue in description: note1, note2, note3"
druid:dq023sp1654,Dro,druid:qp986cj5218,"Multiple value, groupedValue, structuredValue, and parallelValue in description: event1.date1"
druid:dq375wm0695,Dro,"","Multiple value, groupedValue, structuredValue, and parallelValue in description: note1, note2, note3"
druid:fs229nd6736,Dro,druid:qp986cj5218,"Multiple value, groupedValue, structuredValue, and parallelValue in description: event1.date1"
```

