### PR TITLE
bugfix bin/validate-cocina

### DIFF
--- a/bin/validate-cocina
+++ b/bin/validate-cocina
@@ -66,7 +66,11 @@ def validate(clazz, sample_size, processes)
       Cocina::Models::Mapping::ToMods::Description.transform(cocina_obj.description, cocina_obj.externalIdentifier)
       [obj.external_identifier, nil]
     rescue StandardError => e
-      collection = obj.structural['isMemberOf'].join(' ')
+      collection = if obj.is_a?(Dro)
+                     obj.structural['isMemberOf'].join(' ')
+                   else
+                     ''
+                   end
       [obj.external_identifier, clazz.name, collection, e.message]
     end
   end.flatten(1)


### PR DESCRIPTION
## Why was this change made? 🤔
Collections don't have structural, so only grab the collection for DROs.

## How was this change tested? 🤨
Ran `bin/validate-cocina` with invalid collections and the script doesn't blow up anymore. Also confirmed the collection is being captured for DROs. 


