### PR TITLE
Normalize administrative tag labels to remove leading/trailing whitespace

### DIFF
--- a/app/models/administrative_tag.rb
+++ b/app/models/administrative_tag.rb
@@ -2,7 +2,5 @@
 
 # Administrative tags for an object
 class AdministrativeTag < ApplicationRecord
-  VALID_TAG_PATTERN = /\A.+( : .+)+\z/
-
   belongs_to :tag_label
 end

--- a/app/models/tag_label.rb
+++ b/app/models/tag_label.rb
@@ -3,14 +3,12 @@
 # This stores the tag text. This text could be applied to more than one object by an AdministrativeTag
 class TagLabel < ApplicationRecord
   VALID_TAG_PATTERN = /\A.+( : .+)+\z/
-  has_many :administrative_tags, dependent: :destroy
 
-  # rubocop:disable Rails/I18nLocaleTexts
+  has_many :administrative_tags, dependent: :destroy
+  normalizes :tag, with: ->(tag) { tag.squish }
+  scope :project, -> { where('tag like ?', 'Project : %') }
   validates :tag, format: {
     with: VALID_TAG_PATTERN,
-    message: 'must be a series of 2 or more strings delimited with space-padded colons, e.g., "Registered By : mjgiarlo : now"'
+    message: 'must be a series of 2 or more strings delimited with space-padded colons, e.g., "Registered By : mjgiarlo : now"' # rubocop:disable Rails/I18nLocaleTexts
   }
-  # rubocop:enable Rails/I18nLocaleTexts
-
-  scope :project, -> { where('tag like ?', 'Project : %') }
 end

--- a/spec/models/tag_label_spec.rb
+++ b/spec/models/tag_label_spec.rb
@@ -5,18 +5,48 @@ require 'rails_helper'
 RSpec.describe TagLabel do
   describe 'tag format validation' do
     context 'with invalid values' do
-      ['Configured With', 'Registered By:mjg'].each do |tag_string|
-        subject(:tag) { described_class.new(tag: tag_string) }
+      ['Configured With', 'Registered By:mjg'].each do |tag|
+        subject(:label) { described_class.new(tag:) }
 
         it { is_expected.not_to be_valid }
       end
     end
 
     context 'with valid values' do
-      ['Registered By : mjgiarlo', 'Process : Content Type : Map'].each do |tag_string|
-        subject(:tag) { described_class.new(tag: tag_string) }
+      ['Registered By : mjgiarlo', 'Process : Content Type : Map'].each do |tag|
+        subject(:label) { described_class.new(tag:) }
 
         it { is_expected.to be_valid }
+      end
+    end
+  end
+
+  describe 'tag format normalization' do
+    subject(:label) { described_class.new(tag:) }
+
+    let(:expected_tag) { 'Registered By : mjgiarlo' }
+
+    context 'with leading whitespace' do
+      let(:tag) { '   Registered By : mjgiarlo' }
+
+      it 'removes leading whitespace' do
+        expect(label.tag).to eq(expected_tag)
+      end
+    end
+
+    context 'with trailing whitespace' do
+      let(:tag) { 'Registered By : mjgiarlo   ' }
+
+      it 'removes trailing whitespace' do
+        expect(label.tag).to eq(expected_tag)
+      end
+    end
+
+    context 'without leading and trailing whitespace' do
+      let(:tag) { 'Registered By : mjgiarlo' }
+
+      it 'leaves the tag as is' do
+        expect(label.tag).to eq(expected_tag)
       end
     end
   end


### PR DESCRIPTION
# Why was this change made?

Fixes sul-dlss/argo#4327

The regular expression used in the DSA codebase and at the API layer (as expressed in `openapi.yml`) allows the user to enter both leading and trailing whitespace for administrative tags, and we don't want this whitespace persisted. The solution in this commit adds normalization at the DB model layer, removing the bad whitespace.

I opted for this solution over a validation-based solution (tightening the various regular expressions) because that may make remediation of currently persisted bad data harder.

We could consider a follow-up step that tweaks the regexes, but also, that's arguably of limited value once this commit is merged and bad data is remediated. Why? More work than it's worth, because we'd likely want to couple that change with user messaging to give them more guidance about how to enter a valid admin tag.

# How was this change tested?

CI
