### PR TITLE
Handle cocina validation errors when refreshing metadata from API.

### DIFF
--- a/app/controllers/metadata_refresh_controller.rb
+++ b/app/controllers/metadata_refresh_controller.rb
@@ -19,5 +19,7 @@ class MetadataRefreshController < ApplicationController
   rescue Catalog::MarcService::MarcServiceError => e
     Honeybadger.notify(e)
     json_api_error(status: :internal_server_error, message: e.message)
+  rescue Cocina::Models::ValidationError => e
+    json_api_error(status: :unprocessable_entity, title: 'Cocina validation error', message: e.message)
   end
 end


### PR DESCRIPTION
refs https://github.com/sul-dlss/argo/issues/4326

## Why was this change made? 🤔
So that a more informative message can be provided to Argo users.


## How was this change tested? 🤨

Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



