### PR TITLE
Adds default order for release tags.

### DIFF
--- a/app/models/release_tag.rb
+++ b/app/models/release_tag.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
+# Model for release tags, which indicate that an item or collection should be released.
 class ReleaseTag < ApplicationRecord
+  default_scope { order(created_at: :asc) }
 end

--- a/spec/models/release_tag_spec.rb
+++ b/spec/models/release_tag_spec.rb
@@ -3,5 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe ReleaseTag do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'default_scope' do
+    let!(:release_tag1) { create(:release_tag, created_at: Time.zone.now) }
+    let!(:release_tag2) { create(:release_tag, created_at: 1.day.ago) }
+
+    it 'orders by created_at' do
+      expect(described_class.all).to eq([release_tag2, release_tag1])
+    end
+  end
 end


### PR DESCRIPTION
closes #4736

## Why was this change made? 🤔
To ensure that ordering correct when querying release tags.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

