### PR TITLE
Delete ReleaseTag model objects when deleting an item.

### DIFF
--- a/app/services/delete_service.rb
+++ b/app/services/delete_service.rb
@@ -54,6 +54,7 @@ class DeleteService
     AdministrativeTags.destroy_all(identifier: druid)
     ObjectVersion.where(druid:).destroy_all
     Event.where(druid:).destroy_all
+    ReleaseTag.where(druid:).destroy_all
   end
 
   def druid

--- a/spec/services/delete_service_spec.rb
+++ b/spec/services/delete_service_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe DeleteService do
       AdministrativeTags.create(identifier: druid, tags: ['test : tag'])
       Event.create!(druid:, event_type: 'version_close', data: { version: '4' })
       ObjectVersion.create(druid:, version: 4, tag: '4.0.0', description: 'Version 4.0.0')
+      ReleaseTag.create(druid:, who: 'bergeraj', what: 'self', released_to: 'Searchworks', release: true)
     end
 
     it 'deletes from datastore and Solr' do
@@ -78,6 +79,7 @@ RSpec.describe DeleteService do
       expect(AdministrativeTags.for(identifier: druid)).to be_empty
       expect(Event.exists?(druid:)).to be(false)
       expect(ObjectVersion.exists?(druid:)).to be(false)
+      expect(ReleaseTag.exists?(druid:)).to be(false)
     end
   end
 end


### PR DESCRIPTION
closes #4740

## Why was this change made? 🤔
Cleanup, similar to other active record models.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

