### PR TITLE
Queries ReleaseTag model objects from ReleaseTags service.

### DIFF
--- a/app/models/release_tag.rb
+++ b/app/models/release_tag.rb
@@ -10,4 +10,14 @@ class ReleaseTag < ApplicationRecord
     attributes[:created_at] = attributes.delete(:date)
     new(attributes)
   end
+
+  def to_cocina
+    Cocina::Models::ReleaseTag.new(
+      to: released_to,
+      release:,
+      date: created_at.iso8601,
+      who:,
+      what:
+    )
+  end
 end

--- a/app/services/release_tags.rb
+++ b/app/services/release_tags.rb
@@ -53,7 +53,11 @@ class ReleaseTags
   end
 
   def item_tags
-    cocina_object.administrative.releaseTags
+    release_tags = ReleaseTag.where(druid: cocina_object.externalIdentifier).to_a
+    # If this object's release tags haven't been migrated to ReleaseTag model objects, get from cocina.
+    return cocina_object.administrative.releaseTags if release_tags.empty?
+
+    release_tags.map(&:to_cocina)
   end
 
   private

--- a/spec/services/release_tags_spec.rb
+++ b/spec/services/release_tags_spec.rb
@@ -232,4 +232,28 @@ RSpec.describe ReleaseTags do
       end
     end
   end
+
+  describe '.item_tags' do
+    subject(:releases) { described_class.item_tags(cocina_object:) }
+
+    context 'when ReleaseTag objects exist for this item' do
+      let!(:release_tag) { create(:release_tag) }
+
+      it 'returns release tags from the ReleaseTag objects' do
+        expect(releases).to eq [
+          release_tag.to_cocina
+        ]
+      end
+    end
+
+    context 'when no ReleaseTag objects exist for this item' do
+      it 'returns release tags from the cocina object' do
+        expect(releases).to eq [
+          Cocina::Models::ReleaseTag.new(to: 'Revs', release: true, date: '2015-01-06T23:33:47Z', who: 'carrickr', what: 'collection'),
+          Cocina::Models::ReleaseTag.new(to: 'Revs', release: true, date: '2015-01-06T23:33:54Z', who: 'carrickr', what: 'self'),
+          Cocina::Models::ReleaseTag.new(to: 'Revs', release: false, date: '2015-01-06T23:40:01Z', who: 'carrickr', what: 'self')
+        ]
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes #4738

## Why was this change made? 🤔
To phase in use of ReleaseTag model objects as release tags are migrated to the db.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

