### PR TITLE
Avoid deprecation warning with clear_active_connections

### DIFF
--- a/app/jobs/shelve_job.rb
+++ b/app/jobs/shelve_job.rb
@@ -16,7 +16,7 @@ class ShelveJob < ApplicationJob
 
       # Shelving can take a long time and can cause the database connections to get stale.
       # So reset to avoid: ActiveRecord::StatementInvalid: PG::ConnectionBad: PQconsumeInput() could not receive data from server: Connection timed out : BEGIN
-      ActiveRecord::Base.clear_active_connections!
+      ActiveRecord::Base.connection_handler.clear_active_connections!
       EventFactory.create(druid:, event_type: 'shelving_complete', data: { background_job_result_id: background_job_result.id })
     rescue ShelvableFilesStager::FileNotFound => e
       return LogFailureJob.perform_later(druid:,


### PR DESCRIPTION
## Why was this change made? 🤔
```
DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_active_connections! is deprecated. Please call the method directly on the connection handler; for example: `ActiveRecord::Base.connection_handler.clear_active_connections!`. (called from perform at /Users/jcoyne85/workspace/sul-dlss/dor-services-app/app/jobs/shelve_job.rb:19)
```



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



