### PR TITLE
require ReleaseTag "what" attribute as part of cocina-models upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /postgres-data
 
 config/certs
+.byebug_history
 .rvmrc
 .ruby-*
 coverage/*

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'rails', '~> 7.1.0'
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.95.0'
+gem 'cocina-models', '~> 0.96.0'
 gem 'datacite', '~> 0.3.0'
-gem 'dor_indexing', '~> 2.0'
+gem 'dor_indexing', '~> 2.1'
 gem 'dor-workflow-client', '~> 7.0'
 gem 'druid-tools', '~> 2.2'
 gem 'folio_client', '~> 0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.95.1)
+    cocina-models (0.96.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -171,9 +171,9 @@ GEM
       faraday-retry (~> 2.0)
       nokogiri (~> 1.6)
       zeitwerk (~> 2.1)
-    dor_indexing (2.0.1)
+    dor_indexing (2.1.0)
       activesupport
-      cocina-models (~> 0.95.1)
+      cocina-models (~> 0.96.0)
       dor-workflow-client (~> 7.0)
       honeybadger
       marc-vocab (~> 0.3.0)
@@ -580,7 +580,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.95.0)
+  cocina-models (~> 0.96.0)
   committee
   config
   daemons
@@ -589,7 +589,7 @@ DEPENDENCIES
   diffy
   dlss-capistrano
   dor-workflow-client (~> 7.0)
-  dor_indexing (~> 2.0)
+  dor_indexing (~> 2.1)
   druid-tools (~> 2.2)
   dry-monads
   edtf (~> 3.0)

--- a/openapi.yml
+++ b/openapi.yml
@@ -2688,6 +2688,7 @@ components:
       additionalProperties: true
       required:
         - release
+        - what
       properties:
         who:
           description: Who did this release

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -286,8 +286,8 @@ RSpec.describe Publish::PublicXmlService do
           build(:dro, id: 'druid:bc123df4567').new(description:, administrative: {
                                                      hasAdminPolicy: 'druid:qv648vd4392',
                                                      releaseTags: [
-                                                       { to: 'Searchworks', release: true, date: '2015-10-23T21:49:29.000+00:00' },
-                                                       { to: 'PURL sitemap', release: true, date: '2015-10-23T21:49:29.000+00:00' }
+                                                       { to: 'Searchworks', release: true, date: '2015-10-23T21:49:29.000+00:00', what: 'self' },
+                                                       { to: 'PURL sitemap', release: true, date: '2015-10-23T21:49:29.000+00:00', what: 'self' }
                                                      ]
                                                    })
         end
@@ -308,9 +308,9 @@ RSpec.describe Publish::PublicXmlService do
           build(:dro, id: 'druid:bc123df4567').new(description:, administrative: {
                                                      hasAdminPolicy: 'druid:qv648vd4392',
                                                      releaseTags: [
-                                                       { to: 'Searchworks', release: false, date: '2015-10-23T21:49:29.000+00:00' },
-                                                       { to: 'Searchworks', release: true, date: '2018-10-23T21:49:29.000+00:00' },
-                                                       { to: 'Some_special_place', release: true, date: '2015-10-23T21:49:29.000+00:00' }
+                                                       { to: 'Searchworks', release: false, date: '2015-10-23T21:49:29.000+00:00', what: 'self' },
+                                                       { to: 'Searchworks', release: true, date: '2018-10-23T21:49:29.000+00:00', what: 'self' },
+                                                       { to: 'Some_special_place', release: true, date: '2015-10-23T21:49:29.000+00:00', what: 'self' }
                                                      ]
                                                    })
         end


### PR DESCRIPTION
## Why was this change made? 🤔

related:
* update dor_indexing gem
* fix tests to provide value for previously optional release tag field
* require 'csv' in a file that uses `CSV.parse` (`registration_csv_converter_spec.rb` started failing without this change)

opportunistic touchup: add `.byebug_history` to `.gitignore`.

goes with https://github.com/sul-dlss/cocina-models/pull/697


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



