### PR TITLE
Use lightweight, AR-backed repository callables for indexing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 7.1.0'
 # DLSS/domain-specific dependencies
 gem 'cocina-models', '~> 0.95.0'
 gem 'datacite', '~> 0.3.0'
-gem 'dor_indexing', '~> 1.3'
+gem 'dor_indexing', '~> 2.0'
 gem 'dor-workflow-client', '~> 7.0'
 gem 'druid-tools', '~> 2.2'
 gem 'folio_client', '~> 0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       faraday-retry (~> 2.0)
       nokogiri (~> 1.6)
       zeitwerk (~> 2.1)
-    dor_indexing (1.4.1)
+    dor_indexing (2.0.1)
       activesupport
       cocina-models (~> 0.95.1)
       dor-workflow-client (~> 7.0)
@@ -589,7 +589,7 @@ DEPENDENCIES
   diffy
   dlss-capistrano
   dor-workflow-client (~> 7.0)
-  dor_indexing (~> 1.3)
+  dor_indexing (~> 2.0)
   druid-tools (~> 2.2)
   dry-monads
   edtf (~> 3.0)

--- a/bin/rolling_index
+++ b/bin/rolling_index
@@ -7,16 +7,24 @@ require 'parallel'
 
 QUERY = { q: '*:*', sort: 'timestamp asc', fl: 'id,timestamp', rows: Settings.rolling_indexer.query_size }.freeze
 
-# Cocina Repository implementation backed by ActiveRecord
-class CocinaRepository
-  def find(druid)
+# Repository implementations backed by ActiveRecord
+def administrative_tags_finder
+  lambda do |druid|
+    AdministrativeTags.for(identifier: druid)
+  end
+end
+
+def cocina_finder
+  lambda do |druid|
     CocinaObjectStore.find(druid)
   rescue CocinaObjectStore::CocinaObjectStoreError => e
-    raise DorIndexing::CocinaRepository::RepositoryError, e.message
+    raise DorIndexing::RepositoryError, e.message
   end
+end
 
-  def administrative_tags(druid)
-    AdministrativeTags.for(identifier: druid)
+def release_tags_finder
+  lambda do |druid|
+    ReleaseTags.item_tags(cocina_object: CocinaObjectStore.find(druid))
   end
 end
 
@@ -55,14 +63,20 @@ Daemons.run_proc(
         begin
           cocina_obj = CocinaObjectStore.find(identifier)
           # This returns a Solr doc hash
-          DorIndexing.build(cocina_with_metadata: cocina_obj, workflow_client: WorkflowClientFactory.build, cocina_repository: CocinaRepository.new)
+          DorIndexing.build(
+            cocina_with_metadata: cocina_obj,
+            workflow_client: WorkflowClientFactory.build,
+            cocina_finder:,
+            administrative_tags_finder:,
+            release_tags_finder:
+          )
         rescue CocinaObjectStore::CocinaObjectNotFoundError
           Honeybadger.notify('Rolling indexer cannot reindex since not found.', { druid: identifier })
           # Clean up cruft in QA and stage
           Indexer.delete(solr: solr_conn, identifier:) if DELETE_ENVS.include?(ENV['HONEYBADGER_ENV'])
           # Return `nil`, which is compacted, so the Solr add isn't grumpy
           nil
-        rescue DorIndexing::CocinaRepository::RepositoryError
+        rescue DorIndexing::RepositoryError
           Honeybadger.notify('Unexpected response from Dor Services App.', { druid: identifier })
           # Return `nil`, which is compacted, so the Solr add isn't grumpy
           nil


### PR DESCRIPTION
# Why was this change made?

To avoid using DSC from within DSA. An alternative to https://github.com/sul-dlss/dor-services-app/pull/4752 that depends on https://github.com/sul-dlss/dor_indexing/pull/48

# How was this change tested?

CI
