### PR TITLE
Notify honeybadger when an update is issued on a non-opened object

### DIFF
--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe 'Update object' do
     allow(Cocina::ObjectValidator).to receive(:validate)
 
     allow(EventFactory).to receive(:create)
+    allow(VersionService).to receive(:open?).and_return(true)
   end
 
   it 'updates the object' do


### PR DESCRIPTION


## Why was this change made? 🤔

Fixes #4759

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



