### PR TITLE
Refactors logic for getting release tags for items and collections. F…

### DIFF
--- a/app/services/registration_csv_converter.rb
+++ b/app/services/registration_csv_converter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'csv'
+
 # Convert CSV to JSON for registration
 class RegistrationCsvConverter
   include Dry::Monads[:result]

--- a/spec/services/release_tags_spec.rb
+++ b/spec/services/release_tags_spec.rb
@@ -5,143 +5,95 @@ require 'rails_helper'
 RSpec.describe ReleaseTags do
   let(:releases) { described_class.new(cocina_object) }
   let(:cocina_object) do
-    build(:dro, id: druid, collection_ids: [collection_druid]).new(
+    build(:dro, id: druid, collection_ids:).new(
       administrative: {
         hasAdminPolicy: apo_id,
-        releaseTags: [
-          {
-            who: 'carrickr',
-            what: 'collection',
-            date: '2015-01-06T23:33:47.000+00:00',
-            to: 'Revs',
-            release: true
-          },
-          {
-            who: 'carrickr',
-            what: 'self',
-            date: '2015-01-06T23:33:54.000+00:00',
-            to: 'Revs',
-            release: true
-          },
-          {
-            who: 'carrickr',
-            what: 'self',
-            date: '2015-01-06T23:40:01.000+00:00',
-            to: 'Revs',
-            release: false
-          }
-        ]
+        releaseTags: cocina_release_tags
       }
     )
   end
   let(:apo_id) { 'druid:qv648vd4392' }
   let(:collection_druid) { 'druid:xh235dd9059' }
   let(:druid) { 'druid:bb004bn8654' }
+  let(:cocina_release_tags) { [] }
+  let(:collection_ids) { [] }
 
   describe '.for_public_metadata' do
     subject(:releases) { described_class.for_public_metadata(cocina_object:) }
 
-    context 'when item has a self tag' do
-      let(:cocina_object) do
-        build(:dro).new(
-          administrative: {
-            hasAdminPolicy: 'druid:fg890hx1234',
-            releaseTags: [
-              {
-                who: 'dhartwig',
-                what: 'collection',
-                date: '2019-01-18T17:03:35.000+00:00',
-                to: 'Searchworks',
-                release: true
-              }
-            ]
-          }
-        )
-      end
+    context 'when item has self tags' do
+      let!(:searchworks_self_release_tag) { create(:release_tag, druid:, released_to: 'Searchworks', what: 'self') }
+      let!(:earthworks_self_release_tag) { create(:release_tag, druid:, released_to: 'Earthworks', what: 'self') }
 
       it 'returns the list of release tags' do
         expect(releases).to eq [
-          Cocina::Models::ReleaseTag.new(to: 'Searchworks', release: true, date: '2019-01-18T17:03:35Z', who: 'dhartwig', what: 'collection')
+          searchworks_self_release_tag.to_cocina,
+          earthworks_self_release_tag.to_cocina
         ]
       end
     end
 
-    context 'when collection has a self tag' do
-      let(:collection_druid) { 'druid:xh235dd9059' }
-
-      let(:cocina_object) do
-        build(:dro).new(structural: {
-                          isMemberOf: [collection_druid]
-                        })
-      end
-
-      let(:collection_object) do
-        build(:collection, id: collection_druid).new(administrative: {
-                                                       hasAdminPolicy: apo_id,
-                                                       releaseTags: [
-                                                         {
-                                                           who: 'dhartwig',
-                                                           what: 'self',
-                                                           date: '2019-01-18T17:03:35.000+00:00',
-                                                           to: 'Searchworks',
-                                                           release: true
-                                                         }
-                                                       ]
-                                                     })
-      end
+    context 'when item has multiple self tags' do
+      let!(:self_release_tag) { create(:release_tag, druid:, released_to: 'Searchworks', what: 'self') }
 
       before do
-        allow(CocinaObjectStore).to receive(:find).with(collection_druid).and_return(collection_object)
+        create(:release_tag, druid:, released_to: 'Searchworks', what: 'self', created_at: 1.day.ago)
       end
 
-      it { is_expected.to be_empty }
-    end
-
-    context 'when collection has a collection tag and the item has a self tag' do
-      let(:collection_druid) { 'druid:xh235dd9059' }
-
-      let(:cocina_object) do
-        build(:dro).new(structural: {
-                          isMemberOf: [collection_druid]
-                        },
-                        administrative: {
-                          hasAdminPolicy: apo_id,
-                          releaseTags: [
-                            {
-                              who: 'dhartwig',
-                              what: 'self',
-                              date: '2019-01-18T17:03:35.000+00:00',
-                              to: 'Earthworks',
-                              release: true
-                            }
-                          ]
-                        })
-      end
-
-      let(:collection_object) do
-        build(:collection, id: collection_druid).new(administrative: {
-                                                       hasAdminPolicy: apo_id,
-                                                       releaseTags: [
-                                                         {
-                                                           who: 'dhartwig',
-                                                           what: 'collection',
-                                                           date: '2019-01-18T17:03:35.000+00:00',
-                                                           to: 'Searchworks',
-                                                           release: true
-                                                         }
-                                                       ]
-                                                     })
-      end
-
-      before do
-        allow(CocinaObjectStore).to receive(:find).with(collection_druid).and_return(collection_object)
-      end
-
-      it 'returns the tags from collections and the item' do
+      it 'returns the most recent tag' do
         expect(releases).to eq [
-          Cocina::Models::ReleaseTag.new(to: 'Earthworks', release: true, date: '2019-01-18T17:03:35Z', who: 'dhartwig', what: 'self'),
-          Cocina::Models::ReleaseTag.new(to: 'Searchworks', release: true, date: '2019-01-18T17:03:35Z', who: 'dhartwig', what: 'collection')
+          self_release_tag.to_cocina
         ]
+      end
+    end
+
+    context 'when a collection has a self tag' do
+      let(:collection_ids) { [collection_druid] }
+
+      before do
+        create(:release_tag, druid: collection_druid, released_to: 'Searchworks', what: 'self')
+      end
+
+      it 'ignores the collection self tag' do
+        expect(releases).to eq []
+      end
+    end
+
+    context 'when a collection has a collection tag' do
+      let(:collection_ids) { [collection_druid] }
+
+      let!(:collection_release_tag) { create(:release_tag, druid: collection_druid, released_to: 'Searchworks', what: 'collection') }
+
+      it 'returns the collection tag' do
+        expect(releases).to eq [collection_release_tag.to_cocina]
+      end
+    end
+
+    context 'when a collection has a collection tag (created first) and the item has a self tag' do
+      let(:collection_ids) { [collection_druid] }
+
+      let!(:self_release_tag) { create(:release_tag, druid:, released_to: 'Searchworks', what: 'self') }
+
+      before do
+        create(:release_tag, druid: collection_druid, released_to: 'Searchworks', what: 'collection', created_at: 1.day.ago)
+      end
+
+      it 'prioritizes the item self tag' do
+        expect(releases).to eq [self_release_tag.to_cocina]
+      end
+    end
+
+    context 'when a collection has a collection tag and the item has a self tag (created first)' do
+      let(:collection_ids) { [collection_druid] }
+
+      let!(:self_release_tag) { create(:release_tag, druid:, released_to: 'Searchworks', what: 'self', created_at: 1.day.ago) }
+
+      before do
+        create(:release_tag, druid: collection_druid, released_to: 'Searchworks', what: 'collection')
+      end
+
+      it 'prioritizes the item self tag' do
+        expect(releases).to eq [self_release_tag.to_cocina]
       end
     end
   end
@@ -149,53 +101,47 @@ RSpec.describe ReleaseTags do
   describe '.released_to_searchworks?' do
     subject { described_class.released_to_searchworks?(cocina_object:) }
 
-    let(:cocina_object) do
-      build(:dro).new(
-        administrative: {
-          hasAdminPolicy: apo_id,
-          releaseTags: release_data
-        }
-      )
-    end
-
     context 'when release_data tag has release to=Searchworks and value is true' do
-      let(:release_data) { [{ to: 'Searchworks', release: true }] }
+      before do
+        create(:release_tag, druid:, released_to: 'Searchworks', release: true)
+      end
+      # let(:release_data) { [{ to: 'Searchworks', release: true }] }
 
       it { is_expected.to be true }
     end
 
     context 'when release_data tag has release to=searchworks (all lowercase) and value is true' do
-      let(:release_data) { [{ to: 'searchworks', release: true }] }
+      before do
+        create(:release_tag, druid:, released_to: 'searchworks', release: true)
+      end
 
       it { is_expected.to be true }
     end
 
-    context 'when release_data tag has release to=SearchWorks (camcelcase) and value is true' do
-      let(:release_data) { [{ to: 'SearchWorks', release: true }] }
+    context 'when release_data tag has release to=SearchWorks (camelcase) and value is true' do
+      before do
+        create(:release_tag, druid:, released_to: 'SearchWorks', release: true)
+      end
 
       it { is_expected.to be true }
     end
 
     context 'when release_data tag has release to=Searchworks and value is false' do
-      let(:release_data) { [{ to: 'Searchworks', release: false }] }
-
-      it { is_expected.to be false }
-    end
-
-    context 'when release_data tag has release to=Searchworks but no specified release value' do
-      let(:release_data) { [{ to: 'Searchworks' }] }
+      before do
+        create(:release_tag, druid:, released_to: 'Searchworks', release: false)
+      end
 
       it { is_expected.to be false }
     end
 
     context 'when there are no release tags at all' do
-      let(:release_data) { [] }
-
       it { is_expected.to be false }
     end
 
     context 'when there are non searchworks related release tags' do
-      let(:release_data) { [{ to: 'Revs', release: true }] }
+      before do
+        create(:release_tag, druid:, released_to: 'Revs', release: true)
+      end
 
       it { is_expected.to be false }
     end
@@ -205,6 +151,32 @@ RSpec.describe ReleaseTags do
     subject(:create_tag) { described_class.create(cocina_object:, tag:) }
 
     let(:tag) { Cocina::Models::ReleaseTag.new(to: 'Earthworks', what: 'self', who: 'cathy', date: 2.days.ago.iso8601) }
+
+    let(:cocina_release_tags) do
+      [
+        {
+          who: 'carrickr',
+          what: 'collection',
+          date: '2015-01-06T23:33:47.000+00:00',
+          to: 'Revs',
+          release: true
+        },
+        {
+          who: 'carrickr',
+          what: 'self',
+          date: '2015-01-06T23:33:54.000+00:00',
+          to: 'Revs',
+          release: true
+        },
+        {
+          who: 'carrickr',
+          what: 'self',
+          date: '2015-01-06T23:40:01.000+00:00',
+          to: 'Revs',
+          release: false
+        }
+      ]
+    end
 
     before do
       allow(CocinaObjectStore).to receive(:store)
@@ -247,11 +219,21 @@ RSpec.describe ReleaseTags do
     end
 
     context 'when no ReleaseTag objects exist for this item' do
+      let(:cocina_release_tags) do
+        [
+          {
+            who: 'carrickr',
+            what: 'collection',
+            date: '2015-01-06T23:33:47.000+00:00',
+            to: 'Revs',
+            release: true
+          }
+        ]
+      end
+
       it 'returns release tags from the cocina object' do
         expect(releases).to eq [
-          Cocina::Models::ReleaseTag.new(to: 'Revs', release: true, date: '2015-01-06T23:33:47Z', who: 'carrickr', what: 'collection'),
-          Cocina::Models::ReleaseTag.new(to: 'Revs', release: true, date: '2015-01-06T23:33:54Z', who: 'carrickr', what: 'self'),
-          Cocina::Models::ReleaseTag.new(to: 'Revs', release: false, date: '2015-01-06T23:40:01Z', who: 'carrickr', what: 'self')
+          Cocina::Models::ReleaseTag.new(to: 'Revs', release: true, date: '2015-01-06T23:33:47Z', who: 'carrickr', what: 'collection')
         ]
       end
     end


### PR DESCRIPTION
…ixes logic for getting release tags for public metadata.

closes #4764
closes #4765
:

## Why was this change made? 🤔
Fixes for release tags.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

