### PR TITLE
Renames ReleaseTags service to ReleaseTagService.

### DIFF
--- a/app/controllers/release_tags_controller.rb
+++ b/app/controllers/release_tags_controller.rb
@@ -9,11 +9,11 @@ class ReleaseTagsController < ApplicationController
   end
 
   def index
-    render json: ReleaseTags.item_tags(cocina_object: @cocina_object)
+    render json: ReleaseTagService.item_tags(cocina_object: @cocina_object)
   end
 
   def create
-    ReleaseTags.create(cocina_object: @cocina_object, tag: new_tag)
+    ReleaseTagService.create(cocina_object: @cocina_object, tag: new_tag)
     head :created
   end
 

--- a/app/services/catalog/folio_writer.rb
+++ b/app/services/catalog/folio_writer.rb
@@ -49,11 +49,11 @@ module Catalog
     def update_current_ids(catalog_record_id:)
       FolioClient.edit_marc_json(hrid: catalog_record_id) do |marc_json|
         marc_json['fields'].reject! { |field| (field['tag'] == '856') && field['content'].include?(purl_no_protocol) }
-        marc_json['fields'] << marc_856_field if ReleaseTags.released_to_searchworks?(cocina_object:)
+        marc_json['fields'] << marc_856_field if ReleaseTagService.released_to_searchworks?(cocina_object:)
       end
 
       retry_lookup do
-        if ReleaseTags.released_to_searchworks?(cocina_object:)
+        if ReleaseTagService.released_to_searchworks?(cocina_object:)
           raise StandardError, 'No matching PURL found in instance record after update.' unless instance_has_purl?(catalog_record_id:)
 
           raise StandardError, 'No completely matching 856 found in source record after update.' unless updated?(catalog_record_id:)

--- a/app/services/catalog/marc_856_generator.rb
+++ b/app/services/catalog/marc_856_generator.rb
@@ -126,7 +126,7 @@ module Catalog
 
       collections.each do |collection_druid|
         collection = CocinaObjectStore.find(collection_druid)
-        next unless ReleaseTags.released_to_searchworks?(cocina_object: collection)
+        next unless ReleaseTagService.released_to_searchworks?(cocina_object: collection)
 
         catalog_link = collection.identification&.catalogLinks&.find { |link| link.catalog == catalog }
         collection_info << { code: 'x', value: "collection:#{collection.externalIdentifier.sub('druid:', '')}:#{catalog_link&.catalogRecordId}:#{Cocina::Models::Builders::TitleBuilder.build(collection.description.title)}" }

--- a/app/services/publish/public_cocina_service.rb
+++ b/app/services/publish/public_cocina_service.rb
@@ -33,7 +33,7 @@ module Publish
     def build_administrative
       Cocina::Models::Administrative.new(cocina.administrative.to_h
         .except(:partOfProject)
-        .merge(releaseTags: ReleaseTags.for_public_metadata(cocina_object: cocina)))
+        .merge(releaseTags: ReleaseTagService.for_public_metadata(cocina_object: cocina)))
     end
 
     def build_structural

--- a/app/services/release_tag_service.rb
+++ b/app/services/release_tag_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Shows and creates release tags. This replaces parts of https://github.com/sul-dlss/dor-services/blob/main/lib/dor/models/concerns/releaseable.rb
-class ReleaseTags
+class ReleaseTagService
   # Retrieve the release tags for an item and all the collections that it is a part of
   #
   # Determine projects in which an item is released

--- a/bin/rolling_index
+++ b/bin/rolling_index
@@ -24,7 +24,7 @@ end
 
 def release_tags_finder
   lambda do |druid|
-    ReleaseTags.item_tags(cocina_object: CocinaObjectStore.find(druid))
+    ReleaseTagService.item_tags(cocina_object: CocinaObjectStore.find(druid))
   end
 end
 

--- a/spec/services/catalog/folio_writer_spec.rb
+++ b/spec/services/catalog/folio_writer_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Catalog::FolioWriter do
     before do
       allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
       allow(FolioClient).to receive(:edit_marc_json).and_yield(folio_response_json)
-      allow(ReleaseTags).to receive(:released_to_searchworks?).and_return(release_data)
+      allow(ReleaseTagService).to receive(:released_to_searchworks?).and_return(release_data)
       allow(FolioClient).to receive_messages(fetch_instance_info: instance_record, fetch_marc_hash: source_record)
       allow(Honeybadger).to receive(:notify)
     end

--- a/spec/services/catalog/marc856_generator_spec.rb
+++ b/spec/services/catalog/marc856_generator_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Catalog::Marc856Generator do
   end
 
   before do
-    allow(ReleaseTags).to receive(:released_to_searchworks?).and_return(release_data)
+    allow(ReleaseTagService).to receive(:released_to_searchworks?).and_return(release_data)
   end
 
   describe '.create' do

--- a/spec/services/release_tag_service_spec.rb
+++ b/spec/services/release_tag_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ReleaseTags do
+RSpec.describe ReleaseTagService do
   let(:releases) { described_class.new(cocina_object) }
   let(:cocina_object) do
     build(:dro, id: druid, collection_ids:).new(


### PR DESCRIPTION
closes #4763

## Why was this change made? 🤔
Developer joy. Or at least less Developer confusion.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



