### PR TITLE
Encapsulate checking that AdminPolicy exists behind CocinaObjectStore.

### DIFF
--- a/app/services/create_object_service.rb
+++ b/app/services/create_object_service.rb
@@ -57,7 +57,7 @@ class CreateObjectService
   def ensure_ur_admin_policy_exists(cocina_object)
     return unless Settings.enabled_features.create_ur_admin_policy && cocina_object.administrative.hasAdminPolicy == Settings.ur_admin_policy.druid
 
-    AdminPolicy.exists?(external_identifier: Settings.ur_admin_policy.druid) || UrAdminPolicyFactory.create
+    CocinaObjectStore.exists?(Settings.ur_admin_policy.druid, type: CocinaObjectStore::ADMIN_POLICY) || UrAdminPolicyFactory.create
   end
 
   # Merge the rights, use statement, license and copyright statement from the

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -113,6 +113,22 @@ RSpec.describe CocinaObjectStore do
       end
     end
 
+    context 'when type is specified and object is found in datastore' do
+      let(:ar_cocina_object) { create(:ar_dro) }
+
+      it 'returns true' do
+        expect(store.exists?(ar_cocina_object.external_identifier, type: CocinaObjectStore::DRO)).to be(true)
+      end
+    end
+
+    context 'when type is specified and object is found in datastore but different type' do
+      let(:ar_cocina_object) { create(:ar_dro) }
+
+      it 'returns false' do
+        expect(store.exists?(ar_cocina_object.external_identifier, type: [CocinaObjectStore::COLLECTION, CocinaObjectStore::ADMIN_POLICY])).to be(false)
+      end
+    end
+
     context 'when object is a DRO' do
       let(:ar_cocina_object) { create(:ar_dro) }
 


### PR DESCRIPTION
closes #4772

## Why was this change made? 🤔
So that direct use of active record is encapsulated.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

