### PR TITLE
Return a 422 if release tags are being requested for an APO

### DIFF
--- a/app/controllers/release_tags_controller.rb
+++ b/app/controllers/release_tags_controller.rb
@@ -9,6 +9,12 @@ class ReleaseTagsController < ApplicationController
   end
 
   def index
+    if @cocina_object.admin_policy?
+      return json_api_error(status: :unprocessable_entity,
+                            title: 'Not a Collection or DRO',
+                            message: 'Only Collection or DROs can have release tags.')
+    end
+
     render json: ReleaseTagService.item_tags(cocina_object: @cocina_object)
   end
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -655,6 +655,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ReleaseTag'
+        '422':
+          description: Unprocessable entity.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
       parameters:
         - name: object_id
           in: path

--- a/spec/requests/release_tags_spec.rb
+++ b/spec/requests/release_tags_spec.rb
@@ -25,19 +25,33 @@ RSpec.describe 'Operations on release tags' do
   end
 
   describe '#index' do
-    let(:cocina_object) do
-      build(:dro, id: druid).new(
-        administrative: {
-          hasAdminPolicy: 'druid:hy787xj5878',
-          releaseTags: [tag]
-        }
-      )
+    context 'when a DRO' do
+      let(:cocina_object) do
+        build(:dro, id: druid).new(
+          administrative: {
+            hasAdminPolicy: 'druid:hy787xj5878',
+            releaseTags: [tag]
+          }
+        )
+      end
+
+      it 'returns the release tags' do
+        get "/v1/objects/#{druid}/release_tags", headers: auth_headers
+
+        expect(response.parsed_body).to contain_exactly(tag.to_h.stringify_keys)
+      end
     end
 
-    it 'returns the latest version for an object' do
-      get "/v1/objects/#{druid}/release_tags", headers: auth_headers
+    context 'when an AdminPolicy' do
+      let(:cocina_object) do
+        build(:admin_policy, id: druid)
+      end
 
-      expect(response.parsed_body).to contain_exactly(tag.to_h.stringify_keys)
+      it 'returns unprocessable entity' do
+        get "/v1/objects/#{druid}/release_tags", headers: auth_headers
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
     end
   end
 


### PR DESCRIPTION
closes #4767

## Why was this change made? 🤔
API hygiene.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

