### PR TITLE
[Report] cocina json for druid list

### DIFF
--- a/app/reports/export_cocina_from_druid_list.rb
+++ b/app/reports/export_cocina_from_druid_list.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# Given a list of druids, dump the cocina as line delimited JSON to stdout.
+#
+# Invoke via:
+# bin/rails r -e production "ExportCocinaFromDruidList.report(druid_list_filename: '/my/druid_list.txt')"
+#
+# * The input druid list should have one druid per line, namespaced (i.e. with the 'druid:' prefix).
+# * druid_list_filename should be the full path.  There won't be shell expansion, so e.g. "~" for home dir won't work.
+# * The output will be sent to stdout.
+#   * You probably want to redirect the output to a file.
+#   * If you have a large druid list, as this report is meant to handle, you also may want to stream the output through
+#     gzip, instead of to a raw .jsonl file.  e.g.:
+#     bin/rails r -e production "ExportCocinaFromDruidList.report(druid_list_filename: '/my/druid_list.txt')" | gzip > druid_list.cocina.`date -Iseconds`.jsonl.gz
+#     * You can page through it with zless, or search it with zgrep, if you want to do some basic viewing without unzipping it.
+#     * 'zcat myoutputfile.jsonl.gz | wc -l' is quick way to make sure the gzip output contains the expected number of records (can throw errors if output still being written)
+#
+# Meant for running exports that might be too large for Argo's ExportCocinaJsonJob, good for running in screen:
+# * all status related output is logged; report output goes to stdout for redirection to a file as desired by the caller
+# * reads the input file one line at a time without loading the whole thing; only keeps one output row in memory at a time
+class ExportCocinaFromDruidList
+  def self.report(...)
+    new(...).report
+  end
+
+  def initialize(druid_list_filename:)
+    @druid_list_filename = druid_list_filename
+  end
+
+  attr_reader :druid_list_filename
+
+  def report
+    raise "Input file missing: #{druid_list_filename}" unless File.exist?(druid_list_filename)
+
+    logger.info("Dumping cocina for '#{druid_list_filename}' to stdout")
+
+    logger.info("#{druid_list_filename} contains #{num_input_lines} entries")
+
+    num_processed = 0
+    File.foreach(druid_list_filename) do |raw_line|
+      num_processed += 1
+
+      druid = raw_line.chomp
+      if druid.empty? || !DruidTools::Druid.valid?(druid, true)
+        logger.warn("'#{druid}' is not actually a valid druid, skipping")
+        next
+      end
+
+      # The :lock field is unnecessary for this report, since we won't be using this cocina for editing and
+      # pushing updates back to DB.
+      # This produces output equivalent to taking cocina_object.to_json and manually removing the lock field
+      # from that string.
+      cocina_object_json = CocinaObjectStore.find(druid).to_h.except(:lock).to_json
+
+      output_record_line(cocina_object_json)
+
+      log_progress(num_processed)
+    rescue StandardError => e
+      logger.error("Unexpected error trying to output cocina for druid: #{e}")
+    end
+
+    logger.info("Dumped cocina for '#{druid_list_filename}' to stdout")
+  end
+
+  private
+
+  def logger
+    @logger ||= Logger.new(Rails.root.join('log', "#{self.class.name}.log"))
+  end
+
+  def num_input_lines
+    @num_input_lines ||= `wc -l #{druid_list_filename}`.match(/(\d+)/).captures.first.to_i
+  end
+
+  def progress_notification_chunk_size
+    @progress_notification_chunk_size ||= num_input_lines / 10
+  end
+
+  def log_progress(num_processed)
+    return unless (num_processed % progress_notification_chunk_size).zero?
+
+    logger.info("processed #{num_processed} input lines of #{num_input_lines} (#{num_processed.to_f / num_input_lines} percent complete)")
+  end
+
+  def output_record_line(str)
+    puts "#{str}\n"
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

fixes #4782 (in combo with the requested report output, see [comment with output location](https://github.com/sul-dlss/dor-services-app/issues/4782#issuecomment-2043841313))

## How was this change tested? 🤨

manually running the report for ticket, as well as running it over a small test file that had a mix of good findable druids, blank lines, and invalid druids.  also some local testing using `FactoryBot` created `Dro`s when i was re-working the implementation.

examples from dev laptop testing:
```
% bin/rails r "ExportCocinaFromDruidList.report(druid_list_filename: 'test_druids.txt')" | gzip > test_druids.cocina.`date -Iseconds`.jsonl.gz
% zless test_druids.cocina.2024-04-05T00:45:41-07:00.jsonl.gz
{"cocinaVersion":"0.96.0","type":"https://cocina.sul.stanford.edu/models/book","externalIdentifier":"druid:zv000sf0000","label":"Test DRO","version":1,"access":{"view":"world","download":"world","controlledDigitalLending":false},"administrative":{"hasAdminPolicy":"druid:hy787xj5878","releaseTags":[]},"description":{"title":[{"structuredValue":[],"parallelValue":[],"groupedValue":[],"value":"Test DRO","identifier":[],"note":[],"appliesTo":[]}],"contributor":[],"event":[],"form":[],"geographic":[],"language":[],"note":[],"identifier":[],"subject":[],"relatedResource":[],"marcEncodedData":[],"purl":"https://purl.stanford.edu/zv000sf0000"},"identification":{"catalogLinks":[],"sourceId":"googlebooks:d1"},"structural":{"contains":[{"type":"https://cocina.sul.stanford.edu/models/resources/file","externalIdentifier":"https://cocina.sul.stanford.edu/fileSet/123-456-789","label":"Page 1","version":1,"structural":{"contains":[{"type":"https://cocina.sul.stanford.edu/models/file","externalIdentifier":"https://cocina.sul.stanford.edu/file/123-456-789","label":"00001.html","filename":"00001.html","size":0,"version":1,"hasMimeType":"text/html","use":"transcription","hasMessageDigests":[{"type":"sha1","digest":"cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7"},{"type":"md5","digest":"e6d52da47a5ade91ae31227b978fb023"}],"access":{"view":"dark","download":"none","controlledDigitalLending":false},"administrative":{"publish":false,"sdrPreserve":true,"shelve":false}}]}}],"hasMemberOrders":[],"isMemberOf":[]},"created":"2024-04-05T07:05:20.000+00:00","modified":"2024-04-05T07:05:20.000+00:00"}
{"cocinaVersion":"0.96.0","type":"https://cocina.sul.stanford.edu/models/book","externalIdentifier":"druid:hv000xs0001","label":"Test DRO","version":1,"access":{"view":"world","download":"world","controlledDigitalLending":false},"administrative":{"hasAdminPolicy":"druid:hy787xj5878","releaseTags":[]},"description":{"title":[{"structuredValue":[],"parallelValue":[],"groupedValue":[],"value":"Test DRO","identifier":[],"note":[],"appliesTo":[]}],"contributor":[],"event":[],"form":[],"geographic":[],"language":[],"note":[],"identifier":[],"subject":[],"relatedResource":[],"marcEncodedData":[],"purl":"https://purl.stanford.edu/hv000xs0001"},"identification":{"catalogLinks":[],"sourceId":"googlebooks:d2"},"structural":{"contains":[{"type":"https://cocina.sul.stanford.edu/models/resources/file","externalIdentifier":"https://cocina.sul.stanford.edu/fileSet/123-456-789","label":"Page 1","version":1,"structural":{"contains":[{"type":"https://cocina.sul.stanford.edu/models/file","externalIdentifier":"https://cocina.sul.stanford.edu/file/123-456-789","label":"00001.html","filename":"00001.html","size":0,"version":1,"hasMimeType":"text/html","use":"transcription","hasMessageDigests":[{"type":"sha1","digest":"cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7"},{"type":"md5","digest":"e6d52da47a5ade91ae31227b978fb023"}],"access":{"view":"dark","download":"none","controlledDigitalLending":false},"administrative":{"publish":false,"sdrPreserve":true,"shelve":false}}]}}],"hasMemberOrders":[],"isMemberOf":[]},"created":"2024-04-05T07:05:22.000+00:00","modified":"2024-04-05T07:05:22.000+00:00"}
{"cocinaVersion":"0.96.0","type":"https://cocina.sul.stanford.edu/models/book","externalIdentifier":"druid:qg000jh0002","label":"Test DRO","version":1,"access":{"view":"world","download":"world","controlledDigitalLending":false},"administrative":{"hasAdminPolicy":"druid:hy787xj5878","releaseTags":[]},"description":{"title":[{"structuredValue":[],"parallelValue":[],"groupedValue":[],"value":"Test DRO","identifier":[],"note":[],"appliesTo":[]}],"contributor":[],"event":[],"form":[],"geographic":[],"language":[],"note":[],"identifier":[],"subject":[],"relatedResource":[],"marcEncodedData":[],"purl":"https://purl.stanford.edu/qg000jh0002"},"identification":{"catalogLinks":[],"sourceId":"googlebooks:d3"},"structural":{"contains":[{"type":"https://cocina.sul.stanford.edu/models/resources/file","externalIdentifier":"https://cocina.sul.stanford.edu/fileSet/123-456-789","label":"Page 1","version":1,"structural":{"contains":[{"type":"https://cocina.sul.stanford.edu/models/file","externalIdentifier":"https://cocina.sul.stanford.edu/file/123-456-789","label":"00001.html","filename":"00001.html","size":0,"version":1,"hasMimeType":"text/html","use":"transcription","hasMessageDigests":[{"type":"sha1","digest":"cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7"},{"type":"md5","digest":"e6d52da47a5ade91ae31227b978fb023"}],"access":{"view":"dark","download":"none","controlledDigitalLending":false},"administrative":{"publish":false,"sdrPreserve":true,"shelve":false}}]}}],"hasMemberOrders":[],"isMemberOf":[]},"created":"2024-04-05T07:05:23.000+00:00","modified":"2024-04-05T07:05:23.000+00:00"}
{"cocinaVersion":"0.96.0","type":"https://cocina.sul.stanford.edu/models/book","externalIdentifier":"druid:xj000fb0003","label":"Test DRO","version":1,"access":{"view":"world","download":"world","controlledDigitalLending":false},"administrative":{"hasAdminPolicy":"druid:hy787xj5878","releaseTags":[]},"description":{"title":[{"structuredValue":[],"parallelValue":[],"groupedValue":[],"value":"Test DRO","identifier":[],"note":[],"appliesTo":[]}],"contributor":[],"event":[],"form":[],"geographic":[],"language":[],"note":[],"identifier":[],"subject":[],"relatedResource":[],"marcEncodedData":[],"purl":"https://purl.stanford.edu/xj000fb0003"},"identification":{"catalogLinks":[],"sourceId":"googlebooks:d4"},"structural":{"contains":[{"type":"https://cocina.sul.stanford.edu/models/resources/file","externalIdentifier":"https://cocina.sul.stanford.edu/fileSet/123-456-789","label":"Page 1","version":1,"structural":{"contains":[{"type":"https://cocina.sul.stanford.edu/models/file","externalIdentifier":"https://cocina.sul.stanford.edu/file/123-456-789","label":"00001.html","filename":"00001.html","size":0,"version":1,"hasMimeType":"text/html","use":"transcription","hasMessageDigests":[{"type":"sha1","digest":"cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7"},{"type":"md5","digest":"e6d52da47a5ade91ae31227b978fb023"}],"access":{"view":"dark","download":"none","controlledDigitalLending":false},"administrative":{"publish":false,"sdrPreserve":true,"shelve":false}}]}}],"hasMemberOrders":[],"isMemberOf":[]},"created":"2024-04-05T07:05:24.000+00:00","modified":"2024-04-05T07:05:24.000+00:00"}
{"cocinaVersion":"0.96.0","type":"https://cocina.sul.stanford.edu/models/book","externalIdentifier":"druid:vq000xf0006","label":"Test DRO","version":1,"access":{"view":"world","download":"world","controlledDigitalLending":false},"administrative":{"hasAdminPolicy":"druid:hy787xj5878","releaseTags":[]},"description":{"title":[{"structuredValue":[],"parallelValue":[],"groupedValue":[],"value":"Test DRO","identifier":[],"note":[],"appliesTo":[]}],"contributor":[],"event":[],"form":[],"geographic":[],"language":[],"note":[],"identifier":[],"subject":[],"relatedResource":[],"marcEncodedData":[],"purl":"https://purl.stanford.edu/vq000xf0006"},"identification":{"catalogLinks":[],"sourceId":"googlebooks:d5"},"structural":{"contains":[{"type":"https://cocina.sul.stanford.edu/models/resources/file","externalIdentifier":"https://cocina.sul.stanford.edu/fileSet/123-456-789","label":"Page 1","version":1,"structural":{"contains":[{"type":"https://cocina.sul.stanford.edu/models/file","externalIdentifier":"https://cocina.sul.stanford.edu/file/123-456-789","label":"00001.html","filename":"00001.html","size":0,"version":1,"hasMimeType":"text/html","use":"transcription","hasMessageDigests":[{"type":"sha1","digest":"cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7"},{"type":"md5","digest":"e6d52da47a5ade91ae31227b978fb023"}],"access":{"view":"dark","download":"none","controlledDigitalLending":false},"administrative":{"publish":false,"sdrPreserve":true,"shelve":false}}]}}],"hasMemberOrders":[],"isMemberOf":[]},"created":"2024-04-05T07:06:02.000+00:00","modified":"2024-04-05T07:06:02.000+00:00"}
```

```
% cat log/ExportCocinaFromDruidList.log
I, [2024-04-05T00:45:46.970725 #13463]  INFO -- : Dumping cocina for 'test_druids.txt' to stdout
I, [2024-04-05T00:45:46.989834 #13463]  INFO -- : test_druids.txt contains 12 entries
W, [2024-04-05T00:45:46.990047 #13463]  WARN -- : '' is not actually a valid druid, skipping
I, [2024-04-05T00:45:47.341933 #13463]  INFO -- : processed 2 input lines of 12 (0.16666666666666666 percent complete)
W, [2024-04-05T00:45:47.342025 #13463]  WARN -- : '' is not actually a valid druid, skipping
I, [2024-04-05T00:45:47.345902 #13463]  INFO -- : processed 4 input lines of 12 (0.3333333333333333 percent complete)
W, [2024-04-05T00:45:47.345973 #13463]  WARN -- : '' is not actually a valid druid, skipping
I, [2024-04-05T00:45:47.349686 #13463]  INFO -- : processed 6 input lines of 12 (0.5 percent complete)
W, [2024-04-05T00:45:47.349790 #13463]  WARN -- : 'foooobaarbaaaaz' is not actually a valid druid, skipping
I, [2024-04-05T00:45:47.353378 #13463]  INFO -- : processed 8 input lines of 12 (0.6666666666666666 percent complete)
W, [2024-04-05T00:45:47.353447 #13463]  WARN -- : '' is not actually a valid druid, skipping
I, [2024-04-05T00:45:47.356753 #13463]  INFO -- : processed 10 input lines of 12 (0.8333333333333334 percent complete)
W, [2024-04-05T00:45:47.356820 #13463]  WARN -- : '' is not actually a valid druid, skipping
W, [2024-04-05T00:45:47.356905 #13463]  WARN -- : '' is not actually a valid druid, skipping
I, [2024-04-05T00:45:47.356990 #13463]  INFO -- : Dumped cocina for 'test_druids.txt' to stdout
```

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



