### PR TITLE
Fix test to call #exist correctly with the database id

### DIFF
--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe CocinaObjectStore do
 
     it 'destroys the object' do
       described_class.destroy(dro.external_identifier)
-      expect(Dro).not_to exist(dro.external_identifier)
+      expect(Dro).not_to exist(dro.id)
       expect(Notifications::ObjectDeleted).to have_received(:publish)
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

This test was passing all the time as it wasn't actually testing anything.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



