### PR TITLE
Destroy the RepositoryObject when calling CocinaObjectStore#destroy

### DIFF
--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -142,7 +142,12 @@ class CocinaObjectStore
   def destroy(druid)
     cocina_object = CocinaObjectStore.find(druid)
 
-    ar_destroy(druid)
+    RepositoryObject.transaction do
+      # TODO: After migrating to RepositoryObjects, we can get rid of the nil check and use:
+      #   RepositoryObject.find_by!(external_identifier: druid).destroy
+      RepositoryObject.find_by(external_identifier: druid)&.destroy
+      ar_destroy(druid)
+    end
 
     Notifications::ObjectDeleted.publish(model: cocina_object, deleted_at: Time.zone.now)
   end

--- a/spec/factories/repository_object_versions.rb
+++ b/spec/factories/repository_object_versions.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :repository_object_version do
-    repository_object { nil }
     sequence(:version)
     version_description { 'MyString' }
     cocina_version { 1 }


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #4796 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



