### PR TITLE
Apply feature flag to retrieve_version_from_preservation

### DIFF
--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -85,7 +85,7 @@ class VersionService
   # @raise [Preservation::Client::Error] if bad response from preservation catalog.
   def can_open?(assume_accessioned: false)
     ensure_openable!(assume_accessioned:)
-    retrieve_version_from_preservation
+    retrieve_version_from_preservation if Settings.version_service.sync_with_preservation
     true
   rescue VersionService::VersioningError
     false


### PR DESCRIPTION
## Why was this change made? 🤔
So retrieve_version_from_preservation can be disabled so that that can_open? can be called from an Argo integration test.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



