### PR TITLE
Update accessioning endpoint for correctly versioning.

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -150,14 +150,14 @@ paths:
     post:
       tags:
         - objects
-      summary: Start accessioning or re-accession an object to DOR
+      summary: Start an assembly workflow, optionally opening a version
       description: ''
       operationId: 'objects#accession'
       responses:
         '201':
-          description: Accessioning/re-accessioning started
+          description: Workflow started
         '409':
-          description: Unable to start accessioning because accessioning has already been started.
+          description: Unable to open version.
       parameters:
         - name: id
           in: path
@@ -173,7 +173,6 @@ paths:
             type: string
             default: assemblyWF
             enum:
-              - accessionWF
               - assemblyWF
               - gisAssemblyWF
         - name: description


### PR DESCRIPTION
closes #4830

## Why was this change made? 🤔
This existing endpoint was doing crazy versioning. It should be just be opening a version if needed.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, integration test.

