### PR TITLE
Removes reading and writing of release tags to cocina.

### DIFF
--- a/app/services/release_tag_service.rb
+++ b/app/services/release_tag_service.rb
@@ -21,20 +21,11 @@ class ReleaseTagService
                       .find { |tag| tag.to.casecmp?('Searchworks') }&.release || false
   end
 
-  # Creates ReleaseTag model objects if and only if there are existing ReleaseTag model objects for the item.
-  # For now it continues to add release tags to the Cocina
-  # The effect of this will be that ReleaseTag model objects will only be created for items that have been migrated.
+  # Creates ReleaseTag model objects.
   # @param cocina_object [Cocina::Models::DRO, Cocina::Models::Collection] the object to add to
   # @param [Cocina::Models::ReleaseTag] tag
   def self.create(cocina_object:, tag:)
-    druid = cocina_object.externalIdentifier
-    ReleaseTag.from_cocina(druid:, tag:).save! if ReleaseTag.exists?(druid:)
-    updated_object = cocina_object.new(
-      administrative: cocina_object.administrative.new(
-        releaseTags: Array(cocina_object.administrative.releaseTags) + [tag]
-      )
-    )
-    CocinaObjectStore.store(updated_object, skip_lock: true)
+    ReleaseTag.from_cocina(druid: cocina_object.externalIdentifier, tag:).save!
   end
 
   def initialize(cocina_object)
@@ -57,20 +48,7 @@ class ReleaseTagService
   private
 
   def tags_for(druid)
-    release_tags = ReleaseTag.where(druid:).to_a
-    # If this object's release tags haven't been migrated to ReleaseTag model objects, get from cocina.
-    return tags_from_cocina(druid) if release_tags.empty?
-
-    release_tags.map(&:to_cocina)
-  end
-
-  def tags_from_cocina(druid)
-    from_cocina_object = if cocina_object.externalIdentifier == druid
-                           cocina_object
-                         else
-                           CocinaObjectStore.find(druid)
-                         end
-    from_cocina_object.administrative.releaseTags
+    ReleaseTag.where(druid:).map(&:to_cocina)
   end
 
   def collection_tags

--- a/spec/requests/release_tags_spec.rb
+++ b/spec/requests/release_tags_spec.rb
@@ -27,12 +27,11 @@ RSpec.describe 'Operations on release tags' do
   describe '#index' do
     context 'when a DRO' do
       let(:cocina_object) do
-        build(:dro, id: druid).new(
-          administrative: {
-            hasAdminPolicy: 'druid:hy787xj5878',
-            releaseTags: [tag]
-          }
-        )
+        build(:dro, id: druid)
+      end
+
+      before do
+        ReleaseTag.from_cocina(druid:, tag:).save!
       end
 
       it 'returns the release tags' do

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -11,23 +11,7 @@ RSpec.describe Publish::MetadataTransferService do
       access:,
       structural: { contains: [], isMemberOf: ['druid:xh235dd9059'] },
       administrative: {
-        hasAdminPolicy: 'druid:fg890hx1234',
-        releaseTags: [
-          {
-            who: 'dhartwig',
-            what: 'collection',
-            date: '2019-01-18T17:03:35.000+00:00',
-            to: 'Searchworks',
-            release: true
-          },
-          {
-            who: 'dhartwig',
-            what: 'collection',
-            date: '2020-01-18T17:03:35.000+00:00',
-            to: 'Some_special_place',
-            release: true
-          }
-        ]
+        hasAdminPolicy: 'druid:fg890hx1234'
       }
     )
   end
@@ -56,23 +40,7 @@ RSpec.describe Publish::MetadataTransferService do
           access: { view: 'world' },
           structural: { contains: [], isMemberOf: ['druid:xh235dd9059'] },
           administrative: {
-            hasAdminPolicy: 'druid:fg890hx1234',
-            releaseTags: [
-              {
-                who: 'dhartwig',
-                what: 'collection',
-                date: '2019-01-18T17:03:35.000+00:00',
-                to: 'Searchworks',
-                release: true
-              },
-              {
-                who: 'dhartwig',
-                what: 'collection',
-                date: '2020-01-18T17:03:35.000+00:00',
-                to: 'Some_special_place',
-                release: true
-              }
-            ]
+            hasAdminPolicy: 'druid:fg890hx1234'
           }
         )
       end
@@ -150,7 +118,7 @@ RSpec.describe Publish::MetadataTransferService do
 
         let(:access) { { view: 'citation-only', download: 'none' } }
 
-        it 'identityMetadta, contentMetadata, rightsMetadata, generated dublin core, and public xml' do
+        it 'identityMetadata, contentMetadata, rightsMetadata, generated dublin core, and public xml' do
           service.publish
           expect(Publish::PublicXmlService).to have_received(:new).with(public_cocina: Cocina::Models::DRO, thumbnail_service:)
           expect(Publish::PublicDescMetadataService).to have_received(:new).with(Cocina::Models::DRO)

--- a/spec/services/release_tag_service_spec.rb
+++ b/spec/services/release_tag_service_spec.rb
@@ -105,7 +105,6 @@ RSpec.describe ReleaseTagService do
       before do
         create(:release_tag, druid:, released_to: 'Searchworks', release: true)
       end
-      # let(:release_data) { [{ to: 'Searchworks', release: true }] }
 
       it { is_expected.to be true }
     end
@@ -182,26 +181,8 @@ RSpec.describe ReleaseTagService do
       allow(CocinaObjectStore).to receive(:store)
     end
 
-    context 'when ReleaseTag objects already exist for this item' do
-      before do
-        create(:release_tag, druid:)
-      end
-
-      it 'adds another release tag and records to the cocina' do
-        expect { create_tag }.to change { ReleaseTag.where(druid:).count }.by(1)
-        expect(CocinaObjectStore).to have_received(:store) do |dro|
-          expect(dro.administrative.releaseTags.size).to eq 4
-        end
-      end
-    end
-
-    context 'when no ReleaseTag objects exist for this item' do
-      it 'records to the cocina and adds no ReleaseTag' do
-        expect { create_tag }.not_to(change { ReleaseTag.where(druid:).count })
-        expect(CocinaObjectStore).to have_received(:store) do |dro|
-          expect(dro.administrative.releaseTags.size).to eq 4
-        end
-      end
+    it 'adds another release tag and' do
+      expect { create_tag }.to change { ReleaseTag.where(druid:).count }.by(1)
     end
   end
 
@@ -214,26 +195,6 @@ RSpec.describe ReleaseTagService do
       it 'returns release tags from the ReleaseTag objects' do
         expect(releases).to eq [
           release_tag.to_cocina
-        ]
-      end
-    end
-
-    context 'when no ReleaseTag objects exist for this item' do
-      let(:cocina_release_tags) do
-        [
-          {
-            who: 'carrickr',
-            what: 'collection',
-            date: '2015-01-06T23:33:47.000+00:00',
-            to: 'Revs',
-            release: true
-          }
-        ]
-      end
-
-      it 'returns release tags from the cocina object' do
-        expect(releases).to eq [
-          Cocina::Models::ReleaseTag.new(to: 'Revs', release: true, date: '2015-01-06T23:33:47Z', who: 'carrickr', what: 'collection')
         ]
       end
     end


### PR DESCRIPTION
closes #4757

## Why was this change made? 🤔
Release tags are now modeled in database.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

