### PR TITLE
Change assembling check in VersionService.

### DIFF
--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -165,7 +165,7 @@ class VersionService
 
   private
 
-  delegate :active_assembly_wf?, :accessioning?, :open?, to: :workflow_state_service
+  delegate :assembling?, :accessioning?, :open?, to: :workflow_state_service
 
   def workflow_client
     @workflow_client ||= WorkflowClientFactory.build
@@ -177,7 +177,7 @@ class VersionService
 
   def ensure_closeable!
     raise VersionService::VersioningError, "Trying to close version #{version} on #{druid} which is not opened for versioning" unless open?
-    raise VersionService::VersioningError, "Trying to close version #{version} on #{druid} which has active assemblyWF" if active_assembly_wf?
+    raise VersionService::VersioningError, "Trying to close version #{version} on #{druid} which has active assemblyWF" if assembling?
     raise VersionService::VersioningError, "accessionWF already created for versioned object #{druid}" if accessioning?
   end
 end

--- a/app/services/workflow_state_service.rb
+++ b/app/services/workflow_state_service.rb
@@ -46,15 +46,6 @@ class WorkflowStateService
     false
   end
 
-  def active_assembly_wf?
-    # This is the last step of the assemblyWF
-    accessioning_initiate_status = workflow_client.workflow_status(druid:,
-                                                                   workflow: 'assemblyWF',
-                                                                   process: 'accessioning-initiate')
-    # If the last step is "waiting", this implies the assemblyWF is running
-    accessioning_initiate_status == 'waiting'
-  end
-
   def active_version_wf?
     return true if workflow_client.active_lifecycle(druid:, milestone_name: 'opened', version: version.to_s)
 

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe VersionService do
 
     context 'when description and user_name are passed in' do
       before do
-        allow(workflow_state_service).to receive_messages(open?: true, accessioning?: false, active_assembly_wf?: false)
+        allow(workflow_state_service).to receive_messages(open?: true, accessioning?: false, assembling?: false)
       end
 
       it 'sets description and an event' do
@@ -262,7 +262,7 @@ RSpec.describe VersionService do
       let(:start_accession) { false }
 
       before do
-        allow(workflow_state_service).to receive_messages(open?: true, accessioning?: false, active_assembly_wf?: false)
+        allow(workflow_state_service).to receive_messages(open?: true, accessioning?: false, assembling?: false)
       end
 
       it 'passes the correct value of create_accession_wf' do
@@ -286,7 +286,7 @@ RSpec.describe VersionService do
 
     context 'when the object has an active accesssionWF' do
       before do
-        allow(workflow_state_service).to receive_messages(active_assembly_wf?: false, open?: true, accessioning?: true)
+        allow(workflow_state_service).to receive_messages(assembling?: false, open?: true, accessioning?: true)
       end
 
       it 'raises an exception' do
@@ -296,24 +296,24 @@ RSpec.describe VersionService do
 
     context 'when the object has an active assemblyWF' do
       before do
-        allow(workflow_state_service).to receive_messages(active_assembly_wf?: true, open?: true)
+        allow(workflow_state_service).to receive_messages(assembling?: true, open?: true)
       end
 
       it 'raises an exception' do
         expect { close }.to raise_error(VersionService::VersioningError, "Trying to close version 2 on #{druid} which has active assemblyWF")
-        expect(workflow_state_service).to have_received(:active_assembly_wf?)
+        expect(workflow_state_service).to have_received(:assembling?)
       end
     end
 
     context 'when the object has no assemblyWF' do
       before do
-        allow(workflow_state_service).to receive_messages(active_assembly_wf?: false, open?: true, accessioning?: false)
+        allow(workflow_state_service).to receive_messages(assembling?: false, open?: true, accessioning?: false)
       end
 
       it 'creates the accessioningWF' do
         close
         expect(repository_object.reload.last_closed_version).to be_present
-        expect(workflow_state_service).to have_received(:active_assembly_wf?)
+        expect(workflow_state_service).to have_received(:assembling?)
         expect(workflow_client).to have_received(:close_version).with(druid:, version: '2', create_accession_wf: true)
       end
     end
@@ -322,7 +322,7 @@ RSpec.describe VersionService do
       let(:description) { nil }
 
       before do
-        allow(workflow_state_service).to receive_messages(active_assembly_wf?: false, open?: true, accessioning?: false)
+        allow(workflow_state_service).to receive_messages(assembling?: false, open?: true, accessioning?: false)
       end
 
       it 'closes the object version using existing signficance and description' do
@@ -340,12 +340,12 @@ RSpec.describe VersionService do
       let(:repository_object) { nil }
 
       before do
-        allow(workflow_state_service).to receive_messages(active_assembly_wf?: false, open?: true, accessioning?: false)
+        allow(workflow_state_service).to receive_messages(assembling?: false, open?: true, accessioning?: false)
       end
 
       it 'closes the version' do
         close
-        expect(workflow_state_service).to have_received(:active_assembly_wf?)
+        expect(workflow_state_service).to have_received(:assembling?)
         expect(workflow_client).to have_received(:close_version).with(druid:, version: '2', create_accession_wf: true)
       end
     end
@@ -360,7 +360,7 @@ RSpec.describe VersionService do
 
     context 'when cloaseable' do
       before do
-        allow(workflow_state_service).to receive_messages(open?: true, accessioning?: false, active_assembly_wf?: false)
+        allow(workflow_state_service).to receive_messages(open?: true, accessioning?: false, assembling?: false)
       end
 
       it 'returns true' do
@@ -380,7 +380,7 @@ RSpec.describe VersionService do
 
     context 'when the object has an active accesssionWF' do
       before do
-        allow(workflow_state_service).to receive_messages(active_assembly_wf?: false, open?: true, accessioning?: true)
+        allow(workflow_state_service).to receive_messages(assembling?: false, open?: true, accessioning?: true)
       end
 
       it 'returns false' do
@@ -390,7 +390,7 @@ RSpec.describe VersionService do
 
     context 'when the object has an active assemblyWF' do
       before do
-        allow(workflow_state_service).to receive_messages(active_assembly_wf?: true, open?: true)
+        allow(workflow_state_service).to receive_messages(assembling?: true, open?: true)
       end
 
       it 'returns false' do

--- a/spec/services/workflow_state_service_spec.rb
+++ b/spec/services/workflow_state_service_spec.rb
@@ -149,29 +149,6 @@ RSpec.describe WorkflowStateService do
     end
   end
 
-  describe '.active_assembly_wf?' do
-    context 'when there is an active assemblyWF' do
-      before do
-        allow(workflow_client).to receive(:workflow_status).and_return('waiting')
-      end
-
-      it 'returns true' do
-        expect(service.active_assembly_wf?).to be true
-        expect(workflow_client).to have_received(:workflow_status).with(druid:, workflow: 'assemblyWF', process: 'accessioning-initiate')
-      end
-    end
-
-    context 'when there is not an active assemblyWF' do
-      before do
-        allow(workflow_client).to receive(:workflow_status).and_return('completed')
-      end
-
-      it 'returns false' do
-        expect(service.active_assembly_wf?).to be false
-      end
-    end
-  end
-
   describe '.assembling?' do
     let(:response_without_workflow) { instance_double(Dor::Workflow::Response::Workflow, active_for?: false) }
     let(:response_with_complete_workflow) { instance_double(Dor::Workflow::Response::Workflow, active_for?: true, complete_for?: true) }


### PR DESCRIPTION
closes #4842

## Why was this change made? 🤔
Any assembly workflow should prevent closing since an assembly workflow might change the cocina / files.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

