### PR TITLE
Update opened version not head version of repository object

### DIFF
--- a/app/services/update_object_service.rb
+++ b/app/services/update_object_service.rb
@@ -37,7 +37,7 @@ class UpdateObjectService
     cocina_object_without_metadata = Cocina::Models.without_metadata(cocina_object)
 
     # TODO: after migration to RepositoryObject we can remove these nil checks
-    RepositoryObject.find_by(external_identifier: druid)&.head_version&.update!(RepositoryObjectVersion.to_model_hash(cocina_object_without_metadata))
+    RepositoryObject.find_by(external_identifier: druid)&.update_opened_version_from(cocina_object: cocina_object_without_metadata)
 
     event_factory.create(druid:, event_type: 'update', data: { success: true, request: cocina_object_without_metadata.to_h })
 

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -4,6 +4,12 @@
 class VersionService
   class VersioningError < StandardError; end
 
+  # @param [String] druid of the item
+  # @param [Integer] version of the item
+  def self.open?(...)
+    WorkflowStateService.new(...).open?
+  end
+
   # @param [Cocina::Models::DRO,Cocina::Models::Collection] cocina_object the item being acted upon
   # @param [String] description set description of version change
   # @param [String] opening_user_name add opening username to the events datastream

--- a/spec/services/update_object_service_spec.rb
+++ b/spec/services/update_object_service_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe UpdateObjectService do
           it 'saves to datastore' do
             expect(store.update).to be_a Cocina::Models::DROWithMetadata
             expect(Dro.find_by(external_identifier: ar_cocina_object.external_identifier).label).to eq('new label')
-            expect(repo_object.reload.head_version.label).to eq 'new label'
+            expect(repo_object.reload.opened_version.label).to eq 'new label'
           end
         end
       end

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -4,13 +4,9 @@ require 'rails_helper'
 
 RSpec.describe VersionService do
   let(:druid) { 'druid:xz456jk0987' }
-
   let(:cocina_object) { create(:ar_dro, external_identifier: druid).to_cocina_with_metadata }
-
   let(:version) { 1 }
-
   let(:event_factory) { class_double(EventFactory, create: true) }
-
   let(:workflow_state_service) { instance_double(WorkflowStateService) }
 
   before do
@@ -47,7 +43,7 @@ RSpec.describe VersionService do
         expect(Dro.find_by(external_identifier: druid).version).to eq 2
         expect(ObjectVersion.current_version(druid).version).to eq(2)
         expect(workflow_state_service).to have_received(:accessioned?)
-        expect(workflow_state_service).to have_received(:open?)
+        expect(workflow_state_service).to have_received(:open?).twice
         expect(workflow_state_service).to have_received(:accessioning?)
         expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'versioningWF', version: '2')
 
@@ -75,7 +71,7 @@ RSpec.describe VersionService do
         expect(ObjectVersion.current_version(druid).version).to eq(2)
         expect(ObjectVersion).not_to have_received(:sync_then_increment_version)
         expect(workflow_state_service).to have_received(:accessioned?)
-        expect(workflow_state_service).to have_received(:open?)
+        expect(workflow_state_service).to have_received(:open?).twice
         expect(workflow_state_service).to have_received(:accessioning?)
         expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'versioningWF', version: '2')
 


### PR DESCRIPTION
Follows #4854

# Why was this change made?

- Update opened version not head version of repository object
- Fix build in `main`

# How was this change tested?

CI
