### PR TITLE
Refactor WorkflowStateService#active_workflow_except_step?

### DIFF
--- a/app/services/workflow_state_service.rb
+++ b/app/services/workflow_state_service.rb
@@ -24,11 +24,11 @@ class WorkflowStateService
     # The exception is GIS workflows.
     # gisAssemblyWF kicks off the gisDeliveryWF, the last step of which is closing the version.
     # For these purposes, we'll be considering gisDeliveryWF as an assemblyWF.
-    active_workflow_except_step?(workflow: 'assemblyWF', process: 'accessioning-initiate') \
-      || active_workflow_except_step?(workflow: 'wasCrawlPreassemblyWF', process: 'end-was-crawl-preassembly') \
-      || active_workflow_except_step?(workflow: 'wasSeedPreassemblyWF', process: 'end-was-seed-preassembly') \
-      || active_workflow_except_step?(workflow: 'gisDeliveryWF', process: 'start-accession-workflow') \
-      || active_workflow?(workflow: 'gisAssemblyWF')
+    active_workflow_except_step?(workflow: 'assemblyWF', process: 'accessioning-initiate') ||
+      active_workflow_except_step?(workflow: 'wasCrawlPreassemblyWF', process: 'end-was-crawl-preassembly') ||
+      active_workflow_except_step?(workflow: 'wasSeedPreassemblyWF', process: 'end-was-seed-preassembly') ||
+      active_workflow_except_step?(workflow: 'gisDeliveryWF', process: 'start-accession-workflow') ||
+      active_workflow?(workflow: 'gisAssemblyWF')
   end
 
   def open?
@@ -93,13 +93,7 @@ class WorkflowStateService
     # Is there a workflow for the current version? If not, then it can't be active.
     return false unless workflow_response.active_for?(version:)
 
-    incomplete_processes = workflow_response.incomplete_processes_for(version:)
-    # There is a workflow with no incomplete processes, so not active.
-    return false if incomplete_processes.empty?
-    # There is a workflow whose only incomplete process is the one that is excluded, so considering not active.
-    return false if incomplete_processes.size == 1 && incomplete_processes.first.name == process
-
-    # There is a workflow that has > 1 incomplete processes or the 1 incomplete process is not the excluded process.
-    true
+    # Does the active workflow contain any processes *other* than the one we're ignoring? If so, consider it active.
+    workflow_response.incomplete_processes_for(version:).any? { |step| step.name != process }
   end
 end

--- a/spec/services/workflow_state_service_spec.rb
+++ b/spec/services/workflow_state_service_spec.rb
@@ -3,15 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe WorkflowStateService do
-  subject(:service) { described_class.new(druid:, version:) }
+  subject(:workflow_state) { described_class.new(druid:, version:) }
 
   let(:druid) { 'druid:xz456jk0987' }
-
   let(:version) { 1 }
-
-  let(:workflow_client) do
-    instance_double(Dor::Workflow::Client)
-  end
+  let(:workflow_client) { instance_double(Dor::Workflow::Client) }
 
   before do
     allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
@@ -24,7 +20,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns true' do
-        expect(service.accessioned?).to be true
+        expect(workflow_state).to be_accessioned
         expect(workflow_client).to have_received(:lifecycle).with(druid:, milestone_name: 'accessioned')
       end
     end
@@ -35,7 +31,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns false' do
-        expect(service.accessioned?).to be false
+        expect(workflow_state).not_to be_accessioned
       end
     end
   end
@@ -47,7 +43,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns true' do
-        expect(service.open?).to be true
+        expect(workflow_state).to be_open
         expect(workflow_client).to have_received(:active_lifecycle).with(druid:, milestone_name: 'submitted', version: '1')
         expect(workflow_client).to have_received(:lifecycle).with(druid:, milestone_name: 'accessioned')
       end
@@ -59,7 +55,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns false' do
-        expect(service.open?).to be false
+        expect(workflow_state).not_to be_open
       end
     end
 
@@ -69,13 +65,12 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns false' do
-        expect(service.open?).to be false
+        expect(workflow_state).not_to be_open
       end
     end
 
     context 'when > version 1 and there is an active versionWF' do
       let(:version) { 2 }
-
       let(:workflow_response) { instance_double(Dor::Workflow::Response::Workflow, active_for?: true, complete_for?: false) }
 
       before do
@@ -83,14 +78,13 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns true' do
-        expect(service.open?).to be true
+        expect(workflow_state).to be_open
         expect(workflow_client).to have_received(:workflow).with(pid: druid, workflow_name: 'versioningWF')
       end
     end
 
     context 'when > version 1 and there is not an active versionWF' do
       let(:version) { 2 }
-
       let(:workflow_response) { instance_double(Dor::Workflow::Response::Workflow, active_for?: true, complete_for?: true) }
 
       before do
@@ -98,7 +92,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns false' do
-        expect(service.open?).to be false
+        expect(workflow_state).not_to be_open
       end
     end
   end
@@ -110,7 +104,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns true' do
-        expect(service.active_version_wf?).to be true
+        expect(workflow_state).to be_active_version_wf
         expect(workflow_client).to have_received(:active_lifecycle).with(druid:, milestone_name: 'opened', version: '1')
       end
     end
@@ -121,7 +115,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns false' do
-        expect(service.active_version_wf?).to be false
+        expect(workflow_state).not_to be_active_version_wf
       end
     end
   end
@@ -133,7 +127,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns true' do
-        expect(service.accessioning?).to be true
+        expect(workflow_state).to be_accessioning
         expect(workflow_client).to have_received(:active_lifecycle).with(druid:, milestone_name: 'submitted', version: '1')
       end
     end
@@ -144,7 +138,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns false' do
-        expect(service.accessioning?).to be false
+        expect(workflow_state).not_to be_accessioning
       end
     end
   end
@@ -155,8 +149,7 @@ RSpec.describe WorkflowStateService do
     let(:was_seed_preassembly_wf_response) { instance_double(Dor::Workflow::Response::Workflow, active_for?: false) }
     let(:gis_delivery_wf_response) { instance_double(Dor::Workflow::Response::Workflow, active_for?: false) }
     let(:gis_assembly_wf_response) { instance_double(Dor::Workflow::Response::Workflow, active_for?: false) }
-
-    let(:process) { instance_double(Dor::Workflow::Response::Process) }
+    let(:process) { instance_double(Dor::Workflow::Response::Process, name: 'arbitrary') }
 
     before do
       allow(workflow_client).to receive(:workflow).with(pid: druid, workflow_name: 'assemblyWF').and_return(assembly_wf_response)
@@ -172,7 +165,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns true' do
-        expect(service.assembling?).to be true
+        expect(workflow_state).to be_assembling
       end
     end
 
@@ -182,7 +175,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns true' do
-        expect(service.assembling?).to be true
+        expect(workflow_state).to be_assembling
       end
     end
 
@@ -192,7 +185,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns true' do
-        expect(service.assembling?).to be true
+        expect(workflow_state).to be_assembling
       end
     end
 
@@ -202,7 +195,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns true' do
-        expect(service.assembling?).to be true
+        expect(workflow_state).to be_assembling
       end
     end
 
@@ -214,7 +207,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns true' do
-        expect(service.assembling?).to be true
+        expect(workflow_state).to be_assembling
       end
     end
 
@@ -224,7 +217,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns true' do
-        expect(service.assembling?).to be true
+        expect(workflow_state).to be_assembling
       end
     end
 
@@ -242,7 +235,7 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns false' do
-        expect(service.assembling?).to be false
+        expect(workflow_state).not_to be_assembling
       end
     end
 
@@ -255,13 +248,13 @@ RSpec.describe WorkflowStateService do
       end
 
       it 'returns false' do
-        expect(service.assembling?).to be false
+        expect(workflow_state).not_to be_assembling
       end
     end
 
     context 'when there are no assembly workflows' do
       it 'returns false' do
-        expect(service.assembling?).to be false
+        expect(workflow_state).not_to be_assembling
       end
     end
   end


### PR DESCRIPTION
# Why was this change made?

This commit is a set of small refactoring around the workflow state service, including:

* Place the `||` operator at the end of the line so we don't need to rely on commented-out newlines
* Streamline the logic & comments for determining if *only* the exceptional step is running in a WF
* Use predicate matchers in spec

# How was this change tested?

CI
