### PR TITLE
Support skipping open check in UpdateObjectService.

### DIFF
--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -85,7 +85,8 @@ class VersionService
 
     update_cocina_object = cocina_object
 
-    update_cocina_object = UpdateObjectService.update(cocina_object.new(version: new_object_version.version)) if cocina_object.version != new_object_version.version
+    # Skipping open check since not yet opened.
+    update_cocina_object = UpdateObjectService.update(cocina_object.new(version: new_object_version.version), skip_open_check: true) if cocina_object.version != new_object_version.version
 
     workflow_client.create_workflow_by_name(druid, 'versioningWF', version: new_object_version.version.to_s)
 

--- a/bin/migrate-cocina
+++ b/bin/migrate-cocina
@@ -90,7 +90,7 @@ def perform_migrate(migrator_class:, obj:, mode:)
 
   ## Note: because we are now storing the cocina for every version we cannot remediate cocina breaking changes for a particular cocina version here.
   if mode == :migrate
-    updated_cocina_object = UpdateObjectService.update(updated_cocina_object)
+    updated_cocina_object = UpdateObjectService.update(updated_cocina_object, skip_open_check: !migrator.version?)
     Publish::MetadataTransferService.publish(updated_cocina_object) if migrator.publish?
     close_version(cocina_object: updated_cocina_object, version_description: migrator.version_description) unless updated_cocina_object.version == current_object_version
   end

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe VersionService do
         expect(Dro.find_by(external_identifier: druid).version).to eq 2
         expect(ObjectVersion.current_version(druid).version).to eq(2)
         expect(workflow_state_service).to have_received(:accessioned?)
-        expect(workflow_state_service).to have_received(:open?).twice
+        expect(workflow_state_service).to have_received(:open?).once
         expect(workflow_state_service).to have_received(:accessioning?)
         expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'versioningWF', version: '2')
 
@@ -71,7 +71,7 @@ RSpec.describe VersionService do
         expect(ObjectVersion.current_version(druid).version).to eq(2)
         expect(ObjectVersion).not_to have_received(:sync_then_increment_version)
         expect(workflow_state_service).to have_received(:accessioned?)
-        expect(workflow_state_service).to have_received(:open?).twice
+        expect(workflow_state_service).to have_received(:open?).once
         expect(workflow_state_service).to have_received(:accessioning?)
         expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'versioningWF', version: '2')
 


### PR DESCRIPTION
## Why was this change made? 🤔
* VersionService.open calls the UpdateObjectService as part of the opening operation. However, at that time the item is not yet opened.
* Migrator script uses UpdateObjectService in cases in which it is migrating without versioning.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



