### PR TITLE
Compare cocina without metadata when testing legacy against Repositor…

### DIFF
--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -97,7 +97,7 @@ class CocinaObjectStore
       return cocina unless Settings.enabled_features.repository_object_test
 
       legacy = ar_find(druid).to_cocina_with_metadata
-      return cocina if legacy == cocina
+      return cocina if Cocina::Models.without_metadata(legacy) == Cocina::Models.without_metadata(cocina)
 
       Honeybadger.notify('Comparison of RepositoryObject with legacy object failed.', context: { druid: })
       return legacy

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -86,6 +86,10 @@ RSpec.describe CocinaObjectStore do
       context 'when objects match' do
         let(:version_attributes) { RepositoryObjectVersion.to_model_hash(ar_cocina_object.to_cocina) }
 
+        before do
+          repo_object.head_version.update!(updated_at: 1.day.ago)
+        end
+
         it "doesn't report a diff" do
           expect(store.find(repo_object.external_identifier)).to be_instance_of(Cocina::Models::DROWithMetadata)
           expect(Honeybadger).not_to have_received(:notify)


### PR DESCRIPTION
…yObjects.

closes #4865

## Why was this change made? 🤔
So that the comparison works correctly and we can audit new vs legacy model objects.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit


