### PR TITLE
Persist content type for admin policies.

### DIFF
--- a/app/models/repository_object_version.rb
+++ b/app/models/repository_object_version.rb
@@ -22,14 +22,11 @@ class RepositoryObjectVersion < ApplicationRecord
       .except(:externalIdentifier, :version)
       .tap do |object_hash|
       object_hash[:cocina_version] = object_hash.delete(:cocinaVersion)
+      object_hash[:content_type] = object_hash.delete(:type)
       case cocina_object
       when Cocina::Models::DRO
-        object_hash[:content_type] = object_hash.delete(:type)
         object_hash[:geographic] ||= nil
-      when Cocina::Models::Collection
-        object_hash[:content_type] = object_hash.delete(:type)
       when Cocina::Models::AdminPolicy
-        object_hash.delete(:type)
         object_hash[:description] ||= nil
       end
     end

--- a/spec/models/repository_object_version_spec.rb
+++ b/spec/models/repository_object_version_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe RepositoryObjectVersion do
       it { is_expected.not_to include(:externalIdentifier) }
       it { is_expected.not_to include(:version) }
       it { is_expected.to include(cocina_version: Cocina::Models::VERSION) }
-      it { is_expected.not_to include(:content_type) }
+      it { is_expected.to include(content_type: Cocina::Models::ObjectType.admin_policy) }
       it { is_expected.to include(description: hash_including(:title)) }
 
       context 'with no description' do


### PR DESCRIPTION
closes #4767

## Why was this change made? 🤔
So that RepositoryObjectVersions for APOs can be deserialized to cocina models.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

