### PR TITLE
Add feature flag when creating RepositoryObjects.

### DIFF
--- a/app/services/create_object_service.rb
+++ b/app/services/create_object_service.rb
@@ -37,7 +37,7 @@ class CreateObjectService
     cocina_object = cocina_from_request(updated_cocina_request_object, druid, assign_doi)
     cocina_object = assign_doi(cocina_object) if assign_doi
     cocina_object_with_metadata = CocinaObjectStore.store(cocina_object, skip_lock: true)
-    RepositoryObject.create_from(cocina_object:)
+    RepositoryObject.create_from(cocina_object:) if Settings.enabled_features.repository_object_create
 
     add_project_tag(druid, cocina_request_object)
     # This creates version 1 (Initial Version)

--- a/spec/services/create_object_service_spec.rb
+++ b/spec/services/create_object_service_spec.rb
@@ -26,8 +26,22 @@ RSpec.describe CreateObjectService do
       allow(Catalog::MarcService).to receive(:new).and_return(marc_service)
     end
 
+    context 'when a DRO and repository_object_feature_flag is not set' do
+      let(:requested_cocina_object) { build(:request_dro) }
+
+      it 'does not create a RepositoryObject' do
+        expect do
+          expect(store.create(requested_cocina_object)).to be_a Cocina::Models::DROWithMetadata
+        end.to change(Dro, :count).by(1).and not_change(RepositoryObject, :count)
+      end
+    end
+
     context 'when a DRO' do
       let(:requested_cocina_object) { build(:request_dro) }
+
+      before do
+        allow(Settings.enabled_features).to receive(:repository_object_create).and_return(true)
+      end
 
       it 'persists it' do
         expect do


### PR DESCRIPTION
## Why was this change made? 🤔
So that RepositoryObjects are only created in environments where so configured.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit


