### PR TITLE
Remove unnecessary sass dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,8 +66,8 @@ end
 
 group :development do
   gem 'graphiql-rails' # GraphQL IDE
+  gem 'propshaft' # for GraphiQL
   gem 'puma', '~> 6.0' # app server for dev
-  gem 'sass-rails' # for GraphiQL
 end
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,6 @@ GEM
       net-http
     faraday-retry (2.2.1)
       faraday (~> 2.0)
-    ffi (1.16.3)
     folio_client (0.16.0)
       activesupport (>= 4.2, < 8)
       dry-monads
@@ -353,6 +352,11 @@ GEM
       faraday (~> 2.0)
       moab-versioning (>= 5.0.0, < 7)
       zeitwerk (~> 2.1)
+    propshaft (0.8.0)
+      actionpack (>= 7.0.0)
+      activesupport (>= 7.0.0)
+      rack
+      railties (>= 7.0.0)
     psych (5.1.2)
       stringio
     public_suffix (5.0.5)
@@ -471,16 +475,6 @@ GEM
       rubocop (~> 1.40)
     ruby-cache (0.3.0)
     ruby-progressbar (1.13.0)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     scrub_rb (1.0.1)
     serverengine (2.1.1)
       sigdump (~> 0.2.2)
@@ -509,13 +503,6 @@ GEM
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
-    sprockets (4.2.1)
-      concurrent-ruby (~> 1.0)
-      rack (>= 2.2.4, < 4)
-    sprockets-rails (3.4.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      sprockets (>= 3.0.0)
     sshkit (1.22.1)
       base64
       mutex_m
@@ -539,7 +526,6 @@ GEM
       diff-lcs
       patience_diff
     thor (1.3.1)
-    tilt (2.3.0)
     timeout (0.4.1)
     tty-cursor (0.7.1)
     tty-progressbar (0.18.2)
@@ -617,6 +603,7 @@ DEPENDENCIES
   parallel
   pg
   preservation-client (~> 6.0)
+  propshaft
   puma (~> 6.0)
   rack-console
   rails (~> 7.1.0)
@@ -630,7 +617,6 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   ruby-cache (~> 0.3.0)
-  sass-rails
   sidekiq (~> 7.0)
   simplecov
   sneakers (~> 2.11)

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,8 +14,6 @@ require 'action_controller/railtie'
 # require "action_text/engine"
 require 'action_view/railtie'
 # require "action_cable/engine"
-# Needed to run Graphiql in development.
-require 'sprockets/railtie' if Rails.env.development?
 # require 'rails/test_unit/railtie'
 require 'active_support'
 require 'active_support/core_ext/integer/time'


### PR DESCRIPTION


## Why was this change made? 🤔
Graphqli needs sprockets or propshaft. There is no sass dependency


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



