### PR TITLE
Removes checks from cleanup service.

### DIFF
--- a/app/services/cleanup_service.rb
+++ b/app/services/cleanup_service.rb
@@ -19,15 +19,6 @@ class CleanupService
     $stdout.puts '*** DRY RUN - NO ACTIONS WILL BE PERFORMED' if dryrun
     $stdout.puts "...object found is an item: version #{object.version}"
 
-    # Verify the current version has not made it to preservation by checking if it is openable:
-    # if it is, then it must have been sent to preservation and therefore we must stop.
-    raise "v#{object.version} of the object has already been sent to preservation: cannot proceed" if VersionService.can_open?(druid:, version: object.version)
-
-    # If `preservationIngestWF#complete-ingest` exists and is not completed, then a step in this workflow is likely in error
-    # (ie. preservation got part way and then failed) and we should stop, since extra remediation may be needed
-    ingest_complete = WorkflowClientFactory.build.workflow_status(druid:, workflow: 'preservationIngestWF', process: 'complete-ingest')
-    raise "v#{object.version} of the object has preservationIngestWF#complete-ingest not completed: cannot proceed" if ingest_complete.present? && ingest_complete != 'completed'
-
     $stdout.puts "...v#{object.version} of the object has not been sent to preservation"
 
     # backup folders

--- a/spec/services/cleanup_service_spec.rb
+++ b/spec/services/cleanup_service_spec.rb
@@ -111,32 +111,6 @@ RSpec.describe CleanupService do
       end
     end
 
-    context 'when object can be opened (i.e. already in perservation)' do
-      before { allow(VersionService).to receive_messages(can_open?: true) }
-
-      it 'raises an exception and stops' do
-        expect { described_class.stop_accessioning(druid) }.to raise_error StandardError
-        expect(described_class).not_to have_received(:backup_content_by_druid)
-        expect(described_class).not_to have_received(:cleanup_by_druid)
-        expect(described_class).not_to have_received(:delete_accessioning_workflows)
-      end
-    end
-
-    context 'when object cannot be opened but preservationIngestWF exists and is not complete (i.e. problem preserving)' do
-      before do
-        allow(VersionService).to receive_messages(can_open?: false)
-        allow(WorkflowClientFactory).to receive(:build).and_return(client)
-        allow(client).to receive(:workflow_status).with(druid:, workflow: 'preservationIngestWF', process: 'complete-ingest').and_return('waiting')
-      end
-
-      it 'raises an exception and stops' do
-        expect { described_class.stop_accessioning(druid) }.to raise_error StandardError
-        expect(described_class).not_to have_received(:backup_content_by_druid)
-        expect(described_class).not_to have_received(:cleanup_by_druid)
-        expect(described_class).not_to have_received(:delete_accessioning_workflows)
-      end
-    end
-
     context 'with bogus druid' do
       it 'raises an exception and stops' do
         expect { described_class.stop_accessioning('bogus') }.to raise_error StandardError


### PR DESCRIPTION
## Why was this change made? 🤔
The current checks were inaccurate. In discussion with @andrewjbtw we determined that since he would be the only one running this service and it will be revamped in forthcoming discard draft work it was easiest to just remove the checks.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

