### PR TITLE
Add solr docs to solr.

### DIFF
--- a/app/services/indexer.rb
+++ b/app/services/indexer.rb
@@ -5,13 +5,15 @@ class Indexer
   # @param [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata]
   # raises [DorIndexing::RepositoryError]
   def self.reindex(cocina_object:)
-    DorIndexing.build(
+    solr_doc = DorIndexing.build(
       cocina_with_metadata: cocina_object,
       workflow_client: WorkflowClientFactory.build,
       cocina_finder:,
       administrative_tags_finder:,
       release_tags_finder:
     )
+    solr.add(solr_doc)
+    solr.commit
   end
 
   # Repository implementations backed by ActiveRecord
@@ -34,4 +36,9 @@ class Indexer
       ReleaseTagService.item_tags(cocina_object: CocinaObjectStore.find(druid))
     end
   end
+
+  def self.solr
+    RSolr.connect(timeout: 120, open_timeout: 120, url: Settings.solr.url)
+  end
+  private_class_method :solr
 end

--- a/bin/rolling_index
+++ b/bin/rolling_index
@@ -41,7 +41,14 @@ Daemons.run_proc(
         Honeybadger.notify("Identifier isn't valid utf-8", { identifier:, bytes: identifier.unpack('C*') }) unless doc['id'].valid_encoding?
         begin
           cocina_object = CocinaObjectStore.find(identifier)
-          Indexer.reindex(cocina_object:)
+          # This returns a Solr doc hash
+          DorIndexing.build(
+            cocina_with_metadata: cocina_object,
+            workflow_client: WorkflowClientFactory.build,
+            cocina_finder: Indexer.cocina_finder,
+            administrative_tags_finder: Indexer.administrative_tags_finder,
+            release_tags_finder: Indexer.release_tags_finder
+          )
         rescue CocinaObjectStore::CocinaObjectNotFoundError
           Honeybadger.notify('Rolling indexer cannot reindex since not found.', { druid: identifier })
           # Clean up cruft in QA and stage

--- a/spec/services/indexer_spec.rb
+++ b/spec/services/indexer_spec.rb
@@ -6,9 +6,13 @@ RSpec.describe Indexer do
   let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid) }
   let(:druid) { 'druid:bc123df4567' }
 
+  let(:solr_doc) { instance_double(Hash) }
+  let(:solr) { instance_double(RSolr::Client, add: nil, commit: nil) }
+
   describe '#reindex' do
     before do
-      allow(DorIndexing).to receive(:build)
+      allow(DorIndexing).to receive(:build).and_return(solr_doc)
+      allow(RSolr).to receive(:connect).and_return(solr)
     end
 
     it 'reindexes the object' do
@@ -20,6 +24,8 @@ RSpec.describe Indexer do
         administrative_tags_finder: Proc,
         release_tags_finder: Proc
       )
+      expect(solr).to have_received(:add).with(solr_doc)
+      expect(solr).to have_received(:commit)
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔
I goofed and mistakingly thought that DorIndexing.build submitted to solr, whereas it just builds the solr doc.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, stage

