### PR TITLE
Index locally on object create.

### DIFF
--- a/app/services/create_object_service.rb
+++ b/app/services/create_object_service.rb
@@ -47,6 +47,7 @@ class CreateObjectService
 
     # Broadcast this to a topic
     Notifications::ObjectCreated.publish(model: cocina_object_with_metadata)
+    Indexer.reindex(cocina_object: cocina_object_with_metadata)
     cocina_object_with_metadata
   end
 

--- a/app/services/ur_admin_policy_factory.rb
+++ b/app/services/ur_admin_policy_factory.rb
@@ -25,6 +25,6 @@ class UrAdminPolicyFactory
     )
 
     cocina_object_with_metadata = CocinaObjectStore.store(admin_policy_cocina, skip_lock: true)
-    Notifications::ObjectCreated.publish(model: cocina_object_with_metadata)
+    Indexer.reindex(cocina_object: cocina_object_with_metadata)
   end
 end

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Create object' do
   before do
     allow(SuriService).to receive(:mint_id).and_return(druid)
     allow_any_instance_of(CocinaObjectStore).to receive(:find).with('druid:dd999df4567').and_return(minimal_cocina_admin_policy)
-    stub_request(:put, 'https://dor-indexing-app.example.edu/dor/reindex_from_cocina')
+    allow(Indexer).to receive(:reindex)
   end
 
   context 'when the folio instance hrid is provided and save is successful' do

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'Create object' do
   before do
     allow(SuriService).to receive(:mint_id).and_return(druid)
     allow(Catalog::MarcService).to receive(:new).and_return(marc_service)
+    allow(Indexer).to receive(:reindex)
   end
 
   context 'when a DRO is provided' do

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe CocinaObjectStore do
       before do
         allow(Settings.ur_admin_policy).to receive(:druid).and_return('druid:bc123df4567')
         allow(Settings.enabled_features).to receive(:create_ur_admin_policy).and_return(true)
+        allow(Indexer).to receive(:reindex)
       end
 
       it 'bootstraps' do

--- a/spec/services/create_object_service_spec.rb
+++ b/spec/services/create_object_service_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe CreateObjectService do
     before do
       allow(Cocina::ObjectValidator).to receive(:validate)
       allow(Notifications::ObjectCreated).to receive(:publish)
+      allow(Indexer).to receive(:reindex)
       allow(store).to receive(:merge_access_for).and_return(requested_cocina_object)
       allow(store).to receive(:add_project_tag)
       allow(SuriService).to receive(:mint_id).and_return(druid)
@@ -49,6 +50,7 @@ RSpec.describe CreateObjectService do
         end.to change(Dro, :count).by(1).and change(RepositoryObject, :count).by(1)
 
         expect(Notifications::ObjectCreated).to have_received(:publish)
+        expect(Indexer).to have_received(:reindex)
         expect(Cocina::ObjectValidator).to have_received(:validate).with(requested_cocina_object)
         expect(store).to have_received(:merge_access_for).with(requested_cocina_object)
         expect(store).to have_received(:add_project_tag).with(druid, requested_cocina_object)
@@ -66,6 +68,7 @@ RSpec.describe CreateObjectService do
           expect(store.create(requested_cocina_object)).to be_a Cocina::Models::CollectionWithMetadata
         end.to change(Collection, :count).by(1)
         expect(Notifications::ObjectCreated).to have_received(:publish)
+        expect(Indexer).to have_received(:reindex)
         expect(Cocina::ObjectValidator).to have_received(:validate).with(requested_cocina_object)
         expect(store).to have_received(:merge_access_for).with(requested_cocina_object)
         expect(store).to have_received(:add_project_tag).with(druid, requested_cocina_object)

--- a/spec/services/ur_admin_policy_factory_spec.rb
+++ b/spec/services/ur_admin_policy_factory_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe UrAdminPolicyFactory do
   let(:druid) { Settings.ur_admin_policy.druid }
 
   before do
-    allow(Notifications::ObjectCreated).to receive(:publish)
+    allow(Indexer).to receive(:reindex)
   end
 
   it 'creates the Ur-AdminPolicy' do
     expect(AdminPolicy.exists?(external_identifier: druid)).to be false
     policy
     expect(AdminPolicy.exists?(external_identifier: druid)).to be true
-    expect(Notifications::ObjectCreated).to have_received(:publish)
+    expect(Indexer).to have_received(:reindex)
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
So that DIA can be sunset.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, integration test

