### PR TITLE
Stop transfering mods to purl on publish

### DIFF
--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -34,7 +34,6 @@ module Publish
                                              thumbnail_service: @thumbnail_service)
       transfer_to_document_store(public_cocina.to_json, 'cocina.json')
       transfer_to_document_store(public_nokogiri.to_xml, 'public')
-      transfer_to_document_store(PublicDescMetadataService.new(public_cocina).to_xml, 'mods')
     end
 
     # Clear out the document cache for this item

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -112,7 +112,6 @@ RSpec.describe Publish::MetadataTransferService do
         before do
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/{"cocinaVersion"/, 'cocina.json')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<publicObject/, 'public')
-          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<mods:mods/, 'mods')
           expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(cocina_object)
         end
 
@@ -121,7 +120,6 @@ RSpec.describe Publish::MetadataTransferService do
         it 'identityMetadata, contentMetadata, rightsMetadata, generated dublin core, and public xml' do
           service.publish
           expect(Publish::PublicXmlService).to have_received(:new).with(public_cocina: Cocina::Models::DRO, thumbnail_service:)
-          expect(Publish::PublicDescMetadataService).to have_received(:new).with(Cocina::Models::DRO)
         end
       end
 
@@ -135,7 +133,6 @@ RSpec.describe Publish::MetadataTransferService do
         before do
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/{"cocinaVersion"/, 'cocina.json')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<publicObject/, 'public')
-          expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<mods:mods/, 'mods')
           expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(cocina_object)
           expect_any_instance_of(described_class).to receive(:republish_members!).with(no_args)
         end


### PR DESCRIPTION

## Why was this change made? 🤔

Purl no longer uses a standalone mods file. It gets the data from the mods within public xml.

See https://github.com/sul-dlss/purl/pull/936


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



