### PR TITLE
Update reports to use RepositoryObject (1)

### DIFF
--- a/app/reports/contributor_identifiers.rb
+++ b/app/reports/contributor_identifiers.rb
@@ -7,12 +7,13 @@ class ContributorIdentifiers
   def self.report
     puts "item_druid,collection_druid,catalogRecordId,identifier\n"
 
-    Dro.where("jsonb_path_exists(description, '$.contributor.identifier.value')").find_each do |dro|
+    RepositoryObject.dros.where(head_version: "jsonb_path_exists(description, '$.contributor.identifier.value')").find_each do |dro|
       druid = dro.external_identifier
-      collection = dro.structural['isMemberOf'].first
-      catalog_record_id = dro.identification['catalogLinks'].first&.fetch('catalogRecordId')
+      head_version = dro.head_version
+      collection = head_version.structural['isMemberOf'].first
+      catalog_record_id = head_version.identification['catalogLinks'].first&.fetch('catalogRecordId')
 
-      dro.description.fetch('contributor').map do |contributor|
+      head_version.description.fetch('contributor').map do |contributor|
         contributor['identifier'].map do |identifier|
           puts "#{druid},#{collection},#{catalog_record_id},#{identifier['value']}\n"
         end

--- a/app/reports/descendant_source_code_no_uri.rb
+++ b/app/reports/descendant_source_code_no_uri.rb
@@ -36,7 +36,7 @@ class DescendantSourceCodeNoUri
 
     sql_result_rows.map do |row|
       collection_druid = row['collection_druid']
-      collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version.label
+      collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
 
       [
         row['item_druid'],

--- a/app/reports/descendant_source_code_no_uri.rb
+++ b/app/reports/descendant_source_code_no_uri.rb
@@ -36,7 +36,7 @@ class DescendantSourceCodeNoUri
 
     sql_result_rows.map do |row|
       collection_druid = row['collection_druid']
-      collection_name = Collection.find_by(external_identifier: collection_druid)&.label
+      collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version.label
 
       [
         row['item_druid'],

--- a/app/reports/descriptive_shape.rb
+++ b/app/reports/descriptive_shape.rb
@@ -44,14 +44,14 @@ class DescriptiveShape
   end
 
   def report
-    Dro.find_each do |obj|
-      has_catalog_link = obj.identification['catalogLinks'].present?
+    RepositoryObject.dros.find_each do |obj|
+      has_catalog_link = obj.head_version.identification['catalogLinks'].present?
 
       next if @catalog == 'none' && has_catalog_link
 
       next if @catalog == 'only' && !has_catalog_link
 
-      trace(obj.description)
+      trace(obj.head_version.description)
     end
     output
   end

--- a/app/reports/events_multiple_date_types.rb
+++ b/app/reports/events_multiple_date_types.rb
@@ -23,9 +23,9 @@ class EventsMultipleDateTypes
            ro.external_identifier,
            jsonb_path_query(rov.identification, '$.catalogLinks[*] ? (@.catalog == "folio").catalogRecordId') ->> 0 as catalogRecordId,
            jsonb_path_query(rov.structural, '$.isMemberOf') ->> 0 as collection_id
-           FROM repository_objects ro, repository_oobject_versions rov WHERE
-           rov.id = rov.head_version_id
-           jsonb_path_exists(rov.description, '#{EVENT_WITH_TYPED_DATE_JSONB_PATH}')
+           FROM repository_objects AS ro, repository_object_versions AS rov
+           WHERE rov.id = ro.head_version_id
+           AND jsonb_path_exists(rov.description, '#{EVENT_WITH_TYPED_DATE_JSONB_PATH}')
   SQL
 
   def self.report

--- a/app/reports/events_multiple_date_types.rb
+++ b/app/reports/events_multiple_date_types.rb
@@ -19,12 +19,13 @@ class EventsMultipleDateTypes
   EVENT_WITH_TYPED_DATE_JSONB_PATH = 'strict $.event.**.date.**.type'
 
   SQL = <<~SQL.squish.freeze
-    SELECT jsonb_path_query(description, '#{EVENT_JSONB_PATH}') ->> 0 as event,
-           external_identifier,
-           jsonb_path_query(identification, '$.catalogLinks[*] ? (@.catalog == "folio").catalogRecordId') ->> 0 as catalogRecordId,
-           jsonb_path_query(structural, '$.isMemberOf') ->> 0 as collection_id
-           FROM "dros" WHERE
-           jsonb_path_exists(description, '#{EVENT_WITH_TYPED_DATE_JSONB_PATH}')
+    SELECT jsonb_path_query(rov.description, '#{EVENT_JSONB_PATH}') ->> 0 as event,
+           ro.external_identifier,
+           jsonb_path_query(rov.identification, '$.catalogLinks[*] ? (@.catalog == "folio").catalogRecordId') ->> 0 as catalogRecordId,
+           jsonb_path_query(rov.structural, '$.isMemberOf') ->> 0 as collection_id
+           FROM repository_objects ro, repository_oobject_versions rov WHERE
+           rov.id = rov.head_version_id
+           jsonb_path_exists(rov.description, '#{EVENT_WITH_TYPED_DATE_JSONB_PATH}')
   SQL
 
   def self.report

--- a/app/reports/file_counts.rb
+++ b/app/reports/file_counts.rb
@@ -19,8 +19,8 @@ class FileCounts
           '$.contains[*].structural.contains[*].filename'
         )
       ) AS count
-    FROM repository_objects ro, repository_object_versions rov
-    WHERE ro.object_type = "dro" and rov.id = ro.head_version_id
+    FROM repository_objects AS ro, repository_object_versions AS rov
+    WHERE ro.object_type = 'dro' AND rov.id = ro.head_version_id
     ORDER BY count DESC
   SQL
 

--- a/app/reports/file_counts.rb
+++ b/app/reports/file_counts.rb
@@ -11,15 +11,16 @@
 #
 class FileCounts
   SQL = <<~SQL.squish.freeze
-    SELECT DISTINCT(external_identifier),
-      content_type,
+    SELECT DISTINCT(ro.external_identifier),
+      rov.content_type,
       JSONB_ARRAY_LENGTH(
         JSONB_PATH_QUERY_ARRAY(
-          structural,
+          rov.structural,
           '$.contains[*].structural.contains[*].filename'
         )
       ) AS count
-    FROM dros
+    FROM repository_objects ro, repository_object_versions rov
+    WHERE ro.object_type = "dro" and rov.id = ro.head_version_id
     ORDER BY count DESC
   SQL
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #4913 

- [x] contributors_identifiers: Updated to query `RepositoryObject.dros`
- [x] descendant_source_code_no_uri: Updated SQL to query repository_objects and repository_object_versions
- [x] descriptive_shape: Updated to query `RepositoryObject.dros`
- [x] events_multiple_date_types: Updated SQL to query repository_objects and repository_object_versions
- [x] export_cocina_from_druid_list: no need to update as it queries CocinaObjectStore directly.
- [x] file_counts: Updated SQL to query repository_objects and repository_object_versions

## How was this change tested? 🤨

I ran each report on stage without error

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



