### PR TITLE
Updated docker compose

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,6 +323,8 @@ GEM
       net-protocol
     net-ssh (7.2.3)
     nio4r (2.7.1)
+    nokogiri (1.16.4-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.16.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.4-x86_64-darwin)
@@ -562,6 +564,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  aarch64-linux-musl
   arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20

--- a/README.md
+++ b/README.md
@@ -89,10 +89,6 @@ docker push suldlss/dor-services-app:latest
 
 ### Without Docker
 
-First you'll need to setup configuration files to connect to a valid Fedora and SOLR instance.  See the "config/settings.yml" file for a template.  Create a folder called "config/settings" and then copy that settings.yml file and rename it for the environment you wish to setup (e.g. "config/settings/development.local.yml").
-
-Edit this file to add the appropriate URLs.  You may also need certs to talk to actual Fedora servers.  Once you have this file in place, you can start your Rails server or console in development mode:
-
 To spin up a local rails console:
 
   `bundle exec rails c`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
-version: '3.6'
-
 services:
   web:
     build: .
     volumes:
       - ./:/app
     working_dir: /app
+    platform: linux/amd64
     depends_on:
       - solr
       - suri
@@ -35,6 +34,7 @@ services:
     volumes:
       - ./:/app
     working_dir: /app
+    platform: linux/amd64
     command: bundle exec sidekiq
     depends_on:
       - redis
@@ -46,18 +46,19 @@ services:
       SETTINGS__SURI__URL: http://suri:3000
       SETTINGS__WORKFLOW_URL: http://workflow:3000
   redis:
-    image: redis:4
+    image: redis
     ports:
       - 6379:6379
   solr:
-    image: solr:slim
+    image: solr:8.11.2
     volumes:
       - ./solr_conf/conf/:/myconfig
     command: solr-create -c dorservices -d /myconfig
     ports:
-      - 8984:8983
+      - 8983:8983
   suri:
     image: suldlss/suri-rails:latest
+    platform: linux/amd64
     ports:
       - 3002:3000
     depends_on:
@@ -70,6 +71,7 @@ services:
       DATABASE_PORT: 5432
   workflow:
     image: suldlss/workflow-server:latest
+    platform: linux/amd64
     depends_on:
       - db
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - ./solr_conf/conf/:/myconfig
     command: solr-create -c dorservices -d /myconfig
     ports:
-      - 8983:8983
+      - 8984:8983
   suri:
     image: suldlss/suri-rails:latest
     platform: linux/amd64


### PR DESCRIPTION
## Why was this change made? 🤔
Update container definitions for a future use case that could make use of them (e.g. integration testing of indexing). This would be an alternative approach to https://github.com/sul-dlss/dor-services-app/pull/4934 which removes all container definitions except for the db. 

However, I'm not sure how to test that the container configurations are correct. They come up, but I'm not sure beyond that. 

## How was this change tested? 🤨
All containers come up locally. 



