### PR TITLE
Destroy UserVersions before destroying RepositoryObjectVersion

### DIFF
--- a/app/models/repository_object_version.rb
+++ b/app/models/repository_object_version.rb
@@ -3,7 +3,7 @@
 # Models a repository object as it looked at a particular version.
 class RepositoryObjectVersion < ApplicationRecord
   belongs_to :repository_object
-  has_many :user_versions, dependent: :restrict_with_error
+  has_many :user_versions, dependent: :destroy
 
   has_one :head_version_of, class_name: 'RepositoryObject', inverse_of: :head_version, dependent: nil
   scope :in_virtual_objects, ->(member_druid) { where("structural #> '{hasMemberOrders,0}' -> 'members' ? :druid", druid: member_druid) }


### PR DESCRIPTION
## Why was this change made? 🤔

When we destroy a RepositoryObjectVersion we also want all of it's UserVersions to be destroyed at the same time.
Fixes #4939 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



