### PR TITLE
Clean up RepositoryObject conditional code in CocinaObjectStore

### DIFF
--- a/app/models/repository_object.rb
+++ b/app/models/repository_object.rb
@@ -11,7 +11,7 @@ class RepositoryObject < ApplicationRecord
   class VersionAlreadyOpened < StandardError; end
   class VersionNotOpened < StandardError; end
 
-  has_many :versions, class_name: 'RepositoryObjectVersion', dependent: :destroy, inverse_of: 'repository_object'
+  has_many :versions, -> { order(version: :asc) }, class_name: 'RepositoryObjectVersion', dependent: :destroy, inverse_of: 'repository_object'
 
   belongs_to :head_version, class_name: 'RepositoryObjectVersion', optional: true
   belongs_to :last_closed_version, class_name: 'RepositoryObjectVersion', optional: true

--- a/app/services/ur_admin_policy_factory.rb
+++ b/app/services/ur_admin_policy_factory.rb
@@ -24,6 +24,7 @@ class UrAdminPolicyFactory
       }
     )
 
+    RepositoryObject.create_from(cocina_object: admin_policy_cocina)
     cocina_object_with_metadata = CocinaObjectStore.store(admin_policy_cocina, skip_lock: true)
     Indexer.reindex(cocina_object: cocina_object_with_metadata)
   end

--- a/spec/factories/repository_object_versions.rb
+++ b/spec/factories/repository_object_versions.rb
@@ -2,19 +2,100 @@
 
 FactoryBot.define do
   factory :repository_object_version do
+    transient do
+      external_identifier { generate(:unique_druid) }
+      is_member_of { [] }
+      source_id { "sul:#{SecureRandom.uuid}" }
+    end
     sequence(:version)
-    version_description { 'MyString' }
-    cocina_version { '0.5.0' }
-    content_type { 'MyString' }
-    label { 'MyString' }
-    access { '' }
-    administrative { '' }
-    description { '' }
-    identification { '' }
-    structural { '' }
-    geographic { '' }
+    version_description { 'Best version ever' }
+    cocina_version { Cocina::Models::VERSION }
+    content_type { Cocina::Models::ObjectType.book }
+    label { 'Test DRO' }
+    access do
+      { view: 'world', download: 'world' }
+    end
+    administrative do
+      { hasAdminPolicy: 'druid:hy787xj5878' }
+    end
+    description do
+      {
+        title: [{ value: label }],
+        purl: "https://purl.stanford.edu/#{external_identifier.delete_prefix('druid:')}"
+      }
+    end
+    identification do
+      { sourceId: source_id }
+    end
+    structural do
+      { contains: [
+        {
+          type: Cocina::Models::FileSetType.file,
+          externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/123-456-789', label: 'Page 1', version: 1,
+          structural: {
+            contains: [
+              {
+                type: Cocina::Models::ObjectType.file,
+                externalIdentifier: 'https://cocina.sul.stanford.edu/file/123-456-789',
+                label: '00001.html',
+                filename: '00001.html',
+                size: 0,
+                version: 1,
+                hasMimeType: 'text/html',
+                use: 'transcription',
+                hasMessageDigests: [
+                  {
+                    type: 'sha1', digest: 'cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7'
+                  }, {
+                    type: 'md5', digest: 'e6d52da47a5ade91ae31227b978fb023'
+                  }
+                ],
+                access: { view: 'dark' },
+                administrative: { publish: false, sdrPreserve: true, shelve: false }
+              }
+            ]
+          }
+        }
+      ] }.tap do |h|
+        h.merge!({ isMemberOf: is_member_of }) if is_member_of.present?
+      end
+    end
+    geographic { nil }
     created_at { Time.current }
     updated_at { Time.current }
     closed_at { nil }
+  end
+
+  trait :dro_repository_object_version do # rubocop:disable Lint/EmptyBlock
+  end
+
+  trait :admin_policy_repository_object_version do
+    transient do
+      access_template { { view: 'world', download: 'world' } }
+    end
+    label { 'Test Admin Policy' }
+    content_type { Cocina::Models::ObjectType.admin_policy }
+    administrative do
+      {
+        hasAdminPolicy: 'druid:hy787xj5878',
+        hasAgreement: 'druid:bb033gt0615',
+        accessTemplate: access_template
+      }
+    end
+    access { nil }
+    identification { nil }
+    structural { nil }
+  end
+
+  trait :collection_repository_object_version do
+    label { 'Test Collection' }
+    content_type { Cocina::Models::ObjectType.collection }
+    administrative do
+      { hasAdminPolicy: 'druid:hy787xj5878' }
+    end
+    access do
+      { view: 'world' }
+    end
+    structural { nil }
   end
 end

--- a/spec/factories/repository_objects.rb
+++ b/spec/factories/repository_objects.rb
@@ -2,15 +2,41 @@
 
 FactoryBot.define do
   factory :repository_object do
-    object_type { 'dro' }
+    object_type { :dro }
     external_identifier { generate(:unique_druid) }
     source_id { "sul:#{SecureRandom.uuid}" }
     lock { 'MyString' }
   end
 
+  trait :admin_policy do
+    object_type { :admin }
+  end
+
+  trait :collection do
+    object_type { :collection }
+  end
+
   trait :closed do
     after(:create) do |repo_object, _context|
       repo_object.close_version!
+    end
+  end
+
+  trait :with_repository_object_version do
+    transient do
+      repository_object_version { nil }
+      sequence(:version)
+    end
+    after(:create) do |repo_object, context|
+      repo_object_version = context.repository_object_version ||
+                            build(:repository_object_version, :"#{repo_object.object_type}_repository_object_version", external_identifier: repo_object.external_identifier, source_id: repo_object.source_id, version: context.version)
+      if (existing_repo_object_version = repo_object.versions.find_by(version: repo_object_version.version))
+        repo_object.update!(last_closed_version: nil, head_version: nil, opened_version: nil)
+        existing_repo_object_version.destroy!
+      end
+      repo_object_version.repository_object = repo_object
+      repo_object_version.save!
+      repo_object.update!(head_version: repo_object_version, opened_version: repo_object_version)
     end
   end
 end

--- a/spec/requests/find_object_spec.rb
+++ b/spec/requests/find_object_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 
 RSpec.describe 'Get the object' do
   context 'when the requested object is an item' do
-    let(:object) { create(:ar_dro) }
+    let(:object) { create(:repository_object, :with_repository_object_version) }
 
     it 'returns the object' do
-      get "/v1/objects/find?sourceId=#{object.identification['sourceId']}",
+      get "/v1/objects/find?sourceId=#{object.head_version.identification['sourceId']}",
           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to have_http_status(:ok)
       expect(response.headers['Last-Modified']).to end_with 'GMT'
@@ -18,10 +18,10 @@ RSpec.describe 'Get the object' do
   end
 
   context 'when the requested object is a collection' do
-    let(:object) { create(:ar_collection) }
+    let(:object) { create(:repository_object, :collection, :with_repository_object_version) }
 
     it 'returns the object' do
-      get "/v1/objects/find?sourceId=#{object.identification['sourceId']}",
+      get "/v1/objects/find?sourceId=#{object.head_version.identification['sourceId']}",
           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(object.external_identifier)
@@ -29,7 +29,7 @@ RSpec.describe 'Get the object' do
   end
 
   context 'when the requested object is not found' do
-    let(:object) { create(:ar_collection) }
+    let(:object) { create(:repository_object) }
 
     it 'returns not found' do
       get '/v1/objects/find?sourceId=sul:abc123',

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Get the object' do
 
   context 'when the requested object is an item' do
     let(:response_model) { response.parsed_body.deep_symbolize_keys }
-    let(:object) { create(:ar_dro, identification: { sourceId: 'googlebooks:d1' }) }
+    let(:object) { create(:repository_object, :with_repository_object_version, source_id: 'googlebooks:d1', version: 1) }
 
     context 'when the object exists with full metadata' do
       let(:expected) do
@@ -58,7 +58,7 @@ RSpec.describe 'Get the object' do
       end
 
       before do
-        object.update(
+        object.head_version.update(
           content_type: Cocina::Models::ObjectType.object,
           label: 'foo',
           version: 1,
@@ -113,28 +113,28 @@ RSpec.describe 'Get the object' do
 
     context 'when the object is a virtual object' do
       before do
-        object.update(structural: { hasMemberOrders: [{
-                        members: [
-                          'druid:kq126jw7402',
-                          'druid:cv761kr7119',
-                          'druid:kn300wd1779',
-                          'druid:rz617vr4473',
-                          'druid:sd322dt2118',
-                          'druid:hp623ch4433',
-                          'druid:sq217qj5005',
-                          'druid:vd823mb5658',
-                          'druid:zp230ft8517',
-                          'druid:xx933wk5286',
-                          'druid:qf828rv2163'
-                        ]
-                      }] })
+        object.head_version.update(structural: { hasMemberOrders: [{
+                                     members: [
+                                       'druid:kq126jw7402',
+                                       'druid:cv761kr7119',
+                                       'druid:kn300wd1779',
+                                       'druid:rz617vr4473',
+                                       'druid:sd322dt2118',
+                                       'druid:hp623ch4433',
+                                       'druid:sq217qj5005',
+                                       'druid:vd823mb5658',
+                                       'druid:zp230ft8517',
+                                       'druid:xx933wk5286',
+                                       'druid:qf828rv2163'
+                                     ]
+                                   }] })
       end
 
       it 'returns the object' do
         get "/v1/objects/#{druid}",
             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status(:ok)
-        expect(response.body).to equal_cocina_model(object.to_cocina)
+        expect(response.body).to equal_cocina_model(object.head_version.to_cocina)
       end
     end
 
@@ -168,48 +168,51 @@ RSpec.describe 'Get the object' do
   end
 
   context 'when the requested object is a collection' do
-    let(:object) { create(:ar_collection, label: 'foo') }
+    let(:object) { create(:repository_object, :collection, :with_repository_object_version) }
 
     it 'returns the object' do
       get "/v1/objects/#{druid}",
           headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to have_http_status(:ok)
-      expect(response.body).to equal_cocina_model(object.to_cocina)
+      expect(response.body).to equal_cocina_model(object.head_version.to_cocina)
     end
   end
 
   context 'when the requested object is an APO' do
-    let(:object) do
-      create(:ar_admin_policy, administrative: {
-               registrationWorkflow: %w[registrationWF goobiWF],
-               disseminationWorkflow: 'wasCrawlPreassemblyWF',
-               hasAdminPolicy: 'druid:bc123df4567',
-               hasAgreement: 'druid:bb008zm4587',
-               accessTemplate: {},
-               roles: [
-                 {
-                   'name' => 'dor-apo-manager',
-                   'members' => [
-                     {
-                       'type' => 'workgroup',
-                       'identifier' => 'sdr:psm-staff'
-                     },
-                     {
-                       'type' => 'workgroup',
-                       'identifier' => 'sdr:developer'
-                     },
-                     {
-                       'type' => 'workgroup',
-                       'identifier' => 'sdr:metadata-staff'
-                     },
-                     {
-                       'type' => 'workgroup',
-                       'identifier' => 'sdr:admin-docs'
-                     }
-                   ]
-                 }
-               ]
-             })
+    let(:druid) { 'druid:mf309wt4240' }
+
+    before do
+      repository_object_version = build(:repository_object_version, :admin_policy_repository_object_version, external_identifier: druid, version: 1, administrative: {
+                                          registrationWorkflow: %w[registrationWF goobiWF],
+                                          disseminationWorkflow: 'wasCrawlPreassemblyWF',
+                                          hasAdminPolicy: 'druid:bc123df4567',
+                                          hasAgreement: 'druid:bb008zm4587',
+                                          accessTemplate: {},
+                                          roles: [
+                                            {
+                                              'name' => 'dor-apo-manager',
+                                              'members' => [
+                                                {
+                                                  'type' => 'workgroup',
+                                                  'identifier' => 'sdr:psm-staff'
+                                                },
+                                                {
+                                                  'type' => 'workgroup',
+                                                  'identifier' => 'sdr:developer'
+                                                },
+                                                {
+                                                  'type' => 'workgroup',
+                                                  'identifier' => 'sdr:metadata-staff'
+                                                },
+                                                {
+                                                  'type' => 'workgroup',
+                                                  'identifier' => 'sdr:admin-docs'
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        })
+      create(:repository_object, :admin_policy, :with_repository_object_version, repository_object_version:, external_identifier: druid)
     end
 
     context 'when the object exists with all metadata' do

--- a/spec/requests/update_doi_metadata_spec.rb
+++ b/spec/requests/update_doi_metadata_spec.rb
@@ -3,12 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe 'Update DOI metadata' do
-  let(:druid) { object.external_identifier }
-  let(:object) do
-    create(:ar_dro, identification: {
-             doi: '10.80343/bc123df4567',
-             sourceId: "sul:#{rand(100000..9_999_999)}"
-           })
+  let(:druid) { 'druid:jh683dj3492' }
+  let!(:object) do
+    repository_object_version = build(:repository_object_version, external_identifier: druid, identification: {
+                                        doi: '10.80343/bc123df4567',
+                                        sourceId: "sul:#{rand(100000..9_999_999)}"
+                                      })
+    create(:repository_object, :with_repository_object_version, repository_object_version:, external_identifier: druid)
   end
 
   before do
@@ -22,7 +23,7 @@ RSpec.describe 'Update DOI metadata' do
 
     context 'when the item meets the required preconditions' do
       before do
-        object.update(
+        object.head_version.update(
           description: {
             title: [{ value: 'Test obj' }],
             purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}",

--- a/spec/requests/update_orcid_work_spec.rb
+++ b/spec/requests/update_orcid_work_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Update Orcid work' do
   let(:druid) { object.external_identifier }
   let(:object) do
-    create(:ar_dro)
+    create(:repository_object, :with_repository_object_version)
   end
 
   before do

--- a/spec/requests/versions_inventory_spec.rb
+++ b/spec/requests/versions_inventory_spec.rb
@@ -5,29 +5,27 @@ require 'rails_helper'
 RSpec.describe 'Release tags' do
   let(:druid) { 'druid:mx123qw2323' }
 
-  context 'with a RepositoryObject' do
-    let(:repository_object) { build(:repository_object, **attrs) }
+  let(:repository_object) { build(:repository_object, **attrs) }
 
-    let(:attrs) do
-      {
-        external_identifier: druid,
-        object_type: 'dro',
-        source_id: 'sul:dlss:testing'
-      }
-    end
+  let(:attrs) do
+    {
+      external_identifier: druid,
+      object_type: 'dro',
+      source_id: 'sul:dlss:testing'
+    }
+  end
 
-    before do
-      repository_object.save # we need at least one persisted version so we can run this test
-      repository_object.versions.create!(version: 2, version_description: 'draft')
-    end
+  before do
+    repository_object.save # we need at least one persisted version so we can run this test
+    repository_object.versions.create!(version: 2, version_description: 'draft')
+  end
 
-    it 'returns a 200' do
-      get "/v1/objects/#{druid}/versions",
-          headers: { 'Authorization' => "Bearer #{jwt}" }
+  it 'returns a 200' do
+    get "/v1/objects/#{druid}/versions",
+        headers: { 'Authorization' => "Bearer #{jwt}" }
 
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to eq '{"versions":[{"versionId":1,"message":"Initial version"},' \
-                                  '{"versionId":2,"message":"draft"}]}'
-    end
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to eq '{"versions":[{"versionId":1,"message":"Initial version"},' \
+                                '{"versionId":2,"message":"draft"}]}'
   end
 end

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -15,18 +15,18 @@ RSpec.describe CocinaObjectStore do
     end
 
     context 'when object is a DRO' do
-      let(:ar_cocina_object) { create(:ar_dro) }
+      let(:repository_object) { create(:repository_object, :with_repository_object_version) }
 
       it 'returns Cocina::Models::DROWithMetadata' do
-        expect(store.find(ar_cocina_object.external_identifier)).to be_instance_of(Cocina::Models::DROWithMetadata)
+        expect(store.find(repository_object.external_identifier)).to be_instance_of(Cocina::Models::DROWithMetadata)
       end
     end
 
     context 'when object is an AdminPolicy' do
-      let(:ar_cocina_object) { create(:ar_admin_policy) }
+      let(:repository_object) { create(:repository_object, :admin_policy, :with_repository_object_version) }
 
       it 'returns Cocina::Models::AdminPolicy' do
-        expect(store.find(ar_cocina_object.external_identifier)).to be_instance_of(Cocina::Models::AdminPolicyWithMetadata)
+        expect(store.find(repository_object.external_identifier)).to be_instance_of(Cocina::Models::AdminPolicyWithMetadata)
       end
     end
 
@@ -43,23 +43,10 @@ RSpec.describe CocinaObjectStore do
     end
 
     context 'when object is a Collection' do
-      let(:ar_cocina_object) { create(:ar_collection) }
+      let(:repository_object) { create(:repository_object, :collection, :with_repository_object_version) }
 
       it 'returns Cocina::Models::Collection' do
-        expect(store.find(ar_cocina_object.external_identifier)).to be_instance_of(Cocina::Models::CollectionWithMetadata)
-      end
-    end
-
-    context 'when object is a RepositoryObject' do
-      let(:version_attributes) { RepositoryObjectVersion.to_model_hash(build(:dro, id: repo_object.external_identifier)) }
-      let(:repo_object) { create(:repository_object) }
-
-      before do
-        repo_object.head_version.update!(version_attributes)
-      end
-
-      it 'returns Cocina::Models::DRO' do
-        expect(store.find(repo_object.external_identifier)).to be_instance_of(Cocina::Models::DROWithMetadata)
+        expect(store.find(repository_object.external_identifier)).to be_instance_of(Cocina::Models::CollectionWithMetadata)
       end
     end
   end
@@ -71,64 +58,19 @@ RSpec.describe CocinaObjectStore do
       end
     end
 
-    context 'when object is a DRO' do
-      let(:ar_cocina_object) { create(:ar_dro, version: 5) }
+    context 'when object is found in datastore' do
+      let(:repository_object) { create(:repository_object, :with_repository_object_version, version: 5) }
 
       it 'returns version' do
-        expect(store.version(ar_cocina_object.external_identifier)).to eq(5)
+        expect(store.version(repository_object.external_identifier)).to eq(5)
       end
-    end
-
-    context 'when object is an AdminPolicy' do
-      let(:ar_cocina_object) { create(:ar_admin_policy, version: 2) }
-
-      it 'returns version' do
-        expect(store.version(ar_cocina_object.external_identifier)).to eq(2)
-      end
-    end
-
-    context 'when object is a Collection' do
-      let(:ar_cocina_object) { create(:ar_collection, version: 4) }
-
-      it 'returns version' do
-        expect(store.version(ar_cocina_object.external_identifier)).to eq(4)
-      end
-    end
-
-    context "when repository_object_test is enabled and versions don't match" do
-      let(:ar_cocina_object) { create(:ar_dro, version: 5) }
-
-      before do
-        allow(Honeybadger).to receive(:notify)
-        create(:repository_object, external_identifier: ar_cocina_object.external_identifier)
-        allow(Settings.enabled_features).to receive(:repository_object_test).and_return true
-      end
-
-      it 'returns old version and logs to Honeybadger' do
-        expect(store.version(ar_cocina_object.external_identifier)).to eq(5)
-        expect(Honeybadger).to have_received(:notify)
-          .with("Version from RepositoryObjectVersion doesn't match version in legacy store.",
-                context: { druid: ar_cocina_object.external_identifier, version_from_repository_object: 1, version_from_ar_cocina_object: 5 })
-      end
-    end
-
-    context 'when RepositoryObject is found' do
-      subject { store.version(repository_object.external_identifier) }
-
-      let(:repository_object) { create(:repository_object) }
-
-      before do
-        create(:ar_dro, external_identifier: repository_object.external_identifier, version: 5)
-      end
-
-      it { is_expected.to eq 1 }
     end
   end
 
   describe '#find_by_source_id' do
     subject(:find_by_source) { store.find_by_source_id(source_id) }
 
-    let(:source_id) { ar_cocina_object.identification['sourceId'] }
+    let(:source_id) { repository_object.head_version.identification['sourceId'] }
 
     context 'when object is not found in datastore' do
       let(:source_id) { 'sul:abc123' }
@@ -138,104 +80,29 @@ RSpec.describe CocinaObjectStore do
       end
     end
 
-    context 'when object is a DRO' do
-      let(:ar_cocina_object) { create(:ar_dro) }
+    context 'when object is found in datastore' do
+      let(:repository_object) { create(:repository_object, :with_repository_object_version) }
 
       it 'returns Cocina::Models::DROWithMetadata' do
-        expect(find_by_source).to be_instance_of(Cocina::Models::DROWithMetadata)
-      end
-    end
-
-    context 'when object is a Collection' do
-      let(:ar_cocina_object) { create(:ar_collection) }
-
-      it 'returns Cocina::Models::Collection' do
-        expect(find_by_source).to be_instance_of(Cocina::Models::CollectionWithMetadata)
-      end
-    end
-
-    context 'when object is a RepositoryObject' do
-      let(:version_attributes) { RepositoryObjectVersion.to_model_hash(build(:dro, id: repo_object.external_identifier)) }
-      let(:repo_object) { create(:repository_object) }
-      let(:source_id) { repo_object.head_version.identification['sourceId'] }
-
-      before do
-        repo_object.head_version.update!(version_attributes)
-      end
-
-      it 'returns Cocina::Models::DRO' do
         expect(find_by_source).to be_instance_of(Cocina::Models::DROWithMetadata)
       end
     end
   end
 
   describe '#exists?' do
-    context 'when repository_object is false' do
-      context 'when object is not found in datastore' do
-        it 'returns false' do
-          expect(store.exists?('druid:bc123df4567')).to be(false)
-        end
-      end
+    subject { store.exists?(druid) }
 
-      context 'when type is specified and object is found in datastore' do
-        let(:ar_cocina_object) { create(:ar_dro) }
+    context 'when the object is found in the datastore' do
+      let(:druid) { repository_object.external_identifier }
+      let(:repository_object) { create(:repository_object, :with_repository_object_version) }
 
-        it 'returns true' do
-          expect(store.exists?(ar_cocina_object.external_identifier, type: CocinaObjectStore::DRO)).to be(true)
-        end
-      end
-
-      context 'when type is specified and object is found in datastore but different type' do
-        let(:ar_cocina_object) { create(:ar_dro) }
-
-        it 'returns false' do
-          expect(store.exists?(ar_cocina_object.external_identifier, type: [CocinaObjectStore::COLLECTION, CocinaObjectStore::ADMIN_POLICY])).to be(false)
-        end
-      end
-
-      context 'when object is a DRO' do
-        let(:ar_cocina_object) { create(:ar_dro) }
-
-        it 'returns true' do
-          expect(store.exists?(ar_cocina_object.external_identifier)).to be(true)
-        end
-      end
-
-      context 'when object is an AdminPolicy' do
-        let(:ar_cocina_object) { create(:ar_admin_policy) }
-
-        it 'returns true' do
-          expect(store.exists?(ar_cocina_object.external_identifier)).to be(true)
-        end
-      end
-
-      context 'when object is a Collection' do
-        let(:ar_cocina_object) { create(:ar_collection) }
-
-        it 'returns true' do
-          expect(store.exists?(ar_cocina_object.external_identifier)).to be(true)
-        end
-      end
+      it { is_expected.to be true }
     end
 
-    context 'when repository_object_find is true' do
-      subject { store.exists?(druid) }
+    context 'when the object is not found in then datastore' do
+      let(:druid) { 'druid:bc123df4567' }
 
-      before do
-        allow(Settings.enabled_features).to receive(:repository_object_find).and_return(true)
-      end
-
-      context 'when the item exists' do
-        let(:druid) { create(:repository_object).external_identifier }
-
-        it { is_expected.to be true }
-      end
-
-      context "when the item doesn't exist" do
-        let(:druid) { 'druid:bc123df4567' }
-
-        it { is_expected.to be false }
-      end
+      it { is_expected.to be false }
     end
   end
 
@@ -246,27 +113,11 @@ RSpec.describe CocinaObjectStore do
       end
     end
 
-    context 'when object is a DRO' do
-      let(:ar_cocina_object) { create(:ar_dro) }
+    context 'when object is found in datastore' do
+      let(:repository_object) { create(:repository_object, :with_repository_object_version) }
 
       it 'returns true' do
-        expect(store.exists!(ar_cocina_object.external_identifier)).to be(true)
-      end
-    end
-
-    context 'when object is an AdminPolicy' do
-      let(:ar_cocina_object) { create(:ar_admin_policy) }
-
-      it 'returns true' do
-        expect(store.exists!(ar_cocina_object.external_identifier)).to be(true)
-      end
-    end
-
-    context 'when object is a Collection' do
-      let(:ar_cocina_object) { create(:ar_collection) }
-
-      it 'returns true' do
-        expect(store.exists!(ar_cocina_object.external_identifier)).to be(true)
+        expect(store.exists!(repository_object.external_identifier)).to be(true)
       end
     end
   end

--- a/spec/services/create_object_service_spec.rb
+++ b/spec/services/create_object_service_spec.rb
@@ -27,16 +27,6 @@ RSpec.describe CreateObjectService do
       allow(Catalog::MarcService).to receive(:new).and_return(marc_service)
     end
 
-    context 'when a DRO and repository_object_feature_flag is not set' do
-      let(:requested_cocina_object) { build(:request_dro) }
-
-      it 'does not create a RepositoryObject' do
-        expect do
-          expect(store.create(requested_cocina_object)).to be_a Cocina::Models::DROWithMetadata
-        end.to change(Dro, :count).by(1).and not_change(RepositoryObject, :count)
-      end
-    end
-
     context 'when a DRO' do
       let(:requested_cocina_object) { build(:request_dro) }
 

--- a/spec/services/thumbnail_service_spec.rb
+++ b/spec/services/thumbnail_service_spec.rb
@@ -65,64 +65,64 @@ RSpec.describe ThumbnailService do
       end
 
       context 'when an externalFile image resource is the only image' do
+        let(:druid) { 'druid:cg767mn6478' }
         let(:member_object) do
-          create(
-            :ar_dro,
-            external_identifier: 'druid:cg767mn6478',
-            structural: {
-              contains: [
-                {
-                  type: Cocina::Models::FileSetType.image,
-                  externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/cg767mn6478-2064a12c-c97f-4c66-85eb-1693fd5ae56f',
-                  label: 'Object 1',
-                  version: 1,
-                  structural: {
-                    contains: [
-                      {
-                        type: Cocina::Models::ObjectType.file,
-                        externalIdentifier: 'https://cocina.sul.stanford.edu/file/cg767mn6478-2064a12c-c97f-4c66-85eb-1693fd5ae56f/2542A.tiff',
-                        label: '2542A.tiff',
-                        filename: '2542A.tiff',
-                        hasMimeType: 'image/tiff',
-                        size: 3_182_927,
-                        version: 1,
-                        access: {
-                          view: 'world',
-                          download: 'none'
-                        },
-                        administrative: {
-                          publish: false,
-                          sdrPreserve: true,
-                          shelve: false
-                        },
-                        hasMessageDigests: []
-                      },
-                      {
-                        type: Cocina::Models::ObjectType.file,
-                        externalIdentifier: 'https://cocina.sul.stanford.edu/file/cg767mn6478-2064a12c-c97f-4c66-85eb-1693fd5ae56f/2542A.jp2',
-                        label: '2542A.jp2',
-                        filename: '2542A.jp2',
-                        hasMimeType: 'image/jp2',
-                        size: 11_043,
-                        version: 1,
-                        access: {
-                          view: 'world',
-                          download: 'none'
-                        },
-                        administrative: {
-                          publish: true,
-                          sdrPreserve: false,
-                          shelve: true
-                        },
-                        hasMessageDigests: []
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          )
+          repository_object_version = build(:repository_object_version, external_identifier: druid,
+                                                                        structural: {
+                                                                          contains: [
+                                                                            {
+                                                                              type: Cocina::Models::FileSetType.image,
+                                                                              externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/cg767mn6478-2064a12c-c97f-4c66-85eb-1693fd5ae56f',
+                                                                              label: 'Object 1',
+                                                                              version: 1,
+                                                                              structural: {
+                                                                                contains: [
+                                                                                  {
+                                                                                    type: Cocina::Models::ObjectType.file,
+                                                                                    externalIdentifier: 'https://cocina.sul.stanford.edu/file/cg767mn6478-2064a12c-c97f-4c66-85eb-1693fd5ae56f/2542A.tiff',
+                                                                                    label: '2542A.tiff',
+                                                                                    filename: '2542A.tiff',
+                                                                                    hasMimeType: 'image/tiff',
+                                                                                    size: 3_182_927,
+                                                                                    version: 1,
+                                                                                    access: {
+                                                                                      view: 'world',
+                                                                                      download: 'none'
+                                                                                    },
+                                                                                    administrative: {
+                                                                                      publish: false,
+                                                                                      sdrPreserve: true,
+                                                                                      shelve: false
+                                                                                    },
+                                                                                    hasMessageDigests: []
+                                                                                  },
+                                                                                  {
+                                                                                    type: Cocina::Models::ObjectType.file,
+                                                                                    externalIdentifier: 'https://cocina.sul.stanford.edu/file/cg767mn6478-2064a12c-c97f-4c66-85eb-1693fd5ae56f/2542A.jp2',
+                                                                                    label: '2542A.jp2',
+                                                                                    filename: '2542A.jp2',
+                                                                                    hasMimeType: 'image/jp2',
+                                                                                    size: 11_043,
+                                                                                    version: 1,
+                                                                                    access: {
+                                                                                      view: 'world',
+                                                                                      download: 'none'
+                                                                                    },
+                                                                                    administrative: {
+                                                                                      publish: true,
+                                                                                      sdrPreserve: false,
+                                                                                      shelve: true
+                                                                                    },
+                                                                                    hasMessageDigests: []
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          ]
+                                                                        })
+          create(:repository_object, :with_repository_object_version, repository_object_version:, external_identifier: druid)
         end
+
         let(:structural) do
           {
             hasMemberOrders: [{

--- a/spec/services/update_object_service_spec.rb
+++ b/spec/services/update_object_service_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe UpdateObjectService do
   include Dry::Monads[:result]
   let(:store) { described_class.new(cocina_object:, skip_lock: true, skip_open_check: false) }
   let(:open) { true }
+  let(:druid) { 'druid:zr174jb7823' }
+  let!(:repository_object) { create(:repository_object, :with_repository_object_version, external_identifier: druid, version: 1) }
 
   describe '#update' do
     before do
@@ -15,17 +17,17 @@ RSpec.describe UpdateObjectService do
     end
 
     context 'when object is a DRO' do
-      context 'when skipping lock (e.g., for a create)' do
+      context 'when skipping lock' do
         let(:cocina_object) do
           Cocina::Models::DRO.new({
                                     cocinaVersion: '0.0.1',
-                                    externalIdentifier: 'druid:xz456jk0987',
+                                    externalIdentifier: druid,
                                     type: Cocina::Models::ObjectType.book,
-                                    label: 'Test DRO',
+                                    label: 'Changed Test DRO',
                                     version: 1,
                                     description: {
-                                      title: [{ value: 'Test DRO' }],
-                                      purl: 'https://purl.stanford.edu/xz456jk0987'
+                                      title: [{ value: 'Changed Test DRO' }],
+                                      purl: 'https://purl.stanford.edu/zr174jb7823'
                                     },
                                     access: { view: 'world', download: 'world' },
                                     administrative: { hasAdminPolicy: 'druid:hy787xj5878' },
@@ -35,69 +37,45 @@ RSpec.describe UpdateObjectService do
         end
 
         it 'saves to datastore' do
-          expect(Dro.find_by(external_identifier: cocina_object.externalIdentifier)).to be_nil
           expect(store.update).to be_a Cocina::Models::DROWithMetadata
-          expect(Dro.find_by(external_identifier: cocina_object.externalIdentifier)).not_to be_nil
+          expect(repository_object.reload.head_version.label).to eq 'Changed Test DRO'
         end
       end
 
       context 'when checking lock succeeds' do
         let(:store) { described_class.new(cocina_object:, skip_lock: false, skip_open_check: false) }
 
-        let(:ar_cocina_object) { create(:ar_dro) }
-        let(:lock) { "#{ar_cocina_object.external_identifier}=0" }
+        let(:lock) { "#{druid}=0" }
 
         let(:cocina_object) do
-          Cocina::Models.with_metadata(ar_cocina_object.to_cocina, lock, created: ar_cocina_object.created_at.utc, modified: ar_cocina_object.updated_at.utc)
+          Cocina::Models.with_metadata(repository_object.head_version.to_cocina, lock, created: repository_object.created_at.utc, modified: repository_object.updated_at.utc)
                         .new(label: 'new label')
         end
 
-        context "when RepositoryObject doesn't exist" do
-          it 'saves to datastore' do
-            expect(store.update).to be_a Cocina::Models::DROWithMetadata
-            expect(Dro.find_by(external_identifier: ar_cocina_object.external_identifier).label).to eq('new label')
-          end
+        before do
+          create(:ar_dro, external_identifier: druid)
         end
 
-        context 'when RepositoryObject exists' do
-          let!(:repo_object) do
-            create(:repository_object, external_identifier: ar_cocina_object.external_identifier)
-          end
-
-          it 'saves to datastore' do
-            expect(store.update).to be_a Cocina::Models::DROWithMetadata
-            expect(Dro.find_by(external_identifier: ar_cocina_object.external_identifier).label).to eq('new label')
-            expect(repo_object.reload.opened_version.label).to eq 'new label'
-          end
-        end
-
-        context 'when repository_object_test is enabled' do
-          before do
-            create(:repository_object, external_identifier: ar_cocina_object.external_identifier)
-            allow(Settings.enabled_features).to receive(:repository_object_test).and_return(true)
-            allow(Honeybadger).to receive(:notify)
-          end
-
-          it 'does not notify' do
-            expect(store.update).to be_a Cocina::Models::DROWithMetadata
-            expect(Honeybadger).not_to have_received(:notify)
-          end
+        it 'saves to datastore' do
+          expect(store.update).to be_a Cocina::Models::DROWithMetadata
+          expect(repository_object.reload.opened_version.label).to eq 'new label'
         end
       end
 
       context 'when checking lock fails' do
         let(:store) { described_class.new(cocina_object:, skip_lock: false, skip_open_check: false) }
-        let!(:ar_cocina_object) { create(:ar_dro) }
         let(:lock) { '64e8320d19d62ddb73c501276c5655cf' }
 
         let(:cocina_object) do
-          Cocina::Models.with_metadata(ar_cocina_object.to_cocina, lock, created: ar_cocina_object.updated_at.utc, modified: ar_cocina_object.updated_at.utc)
+          Cocina::Models.with_metadata(repository_object.head_version.to_cocina, lock, created: repository_object.created_at.utc, modified: repository_object.updated_at.utc)
                         .new(label: 'new label')
         end
 
+        before do
+          create(:ar_dro, external_identifier: druid)
+        end
+
         it 'saves to datastore' do
-          ar_cocina_object.label = 'someone else changed this label'
-          ar_cocina_object.save!
           expect { store.update }.to raise_error(CocinaObjectStore::StaleLockError)
         end
       end
@@ -106,22 +84,22 @@ RSpec.describe UpdateObjectService do
         let(:open) { false }
         let(:store) { described_class.new(cocina_object:, skip_lock: false, skip_open_check: false) }
 
-        let(:ar_cocina_object) { create(:ar_dro) }
-        let(:lock) { "#{ar_cocina_object.external_identifier}=0" }
+        let(:lock) { "#{druid}=0" }
 
         let(:cocina_object) do
-          Cocina::Models.with_metadata(ar_cocina_object.to_cocina, lock, created: ar_cocina_object.created_at.utc, modified: ar_cocina_object.updated_at.utc)
+          Cocina::Models.with_metadata(repository_object.head_version.to_cocina, lock, created: repository_object.created_at.utc, modified: repository_object.updated_at.utc)
                         .new(label: 'new label')
         end
 
         before do
           allow(Honeybadger).to receive(:notify)
+          create(:ar_dro, external_identifier: druid)
         end
 
         it 'notifies honeybadger' do
           expect(store.update).to be_a Cocina::Models::DROWithMetadata
           expect(Honeybadger).to have_received(:notify).with('Updating repository item without an open version',
-                                                             context: { druid: ar_cocina_object.external_identifier, version: 1 })
+                                                             context: { druid:, version: 1 })
         end
       end
 
@@ -198,15 +176,17 @@ RSpec.describe UpdateObjectService do
     end
 
     context 'when object is a Collection' do
+      let!(:repository_object) { create(:repository_object, :collection, :with_repository_object_version, external_identifier: druid, version: 1) }
+
       let(:cocina_object) do
         Cocina::Models::Collection.new({
                                          cocinaVersion: '0.0.1',
-                                         externalIdentifier: 'druid:hp308wm0436',
+                                         externalIdentifier: druid,
                                          type: Cocina::Models::ObjectType.collection,
                                          label: 'Test Collection',
                                          description: {
                                            title: [{ value: 'Updated title' }],
-                                           purl: 'https://purl.stanford.edu/hp308wm0436'
+                                           purl: 'https://purl.stanford.edu/zr174jb7823'
                                          },
                                          version: 1,
                                          access: { view: 'world' },
@@ -218,21 +198,12 @@ RSpec.describe UpdateObjectService do
       end
 
       before do
-        # Create a existing record with a different title
-        CocinaObjectStore.store(cocina_object.new(
-                                  description: {
-                                    title: [{ value: 'Original title' }],
-                                    purl: 'https://purl.stanford.edu/hp308wm0436'
-                                  }
-                                ), skip_lock: true)
-
         allow(PublishItemsModifiedJob).to receive(:perform_later)
       end
 
       it 'saves to datastore' do
         expect(store.update).to be_a Cocina::Models::CollectionWithMetadata
-        updated_row = Collection.find_by(external_identifier: cocina_object.externalIdentifier)
-        expect(updated_row.to_cocina.description.title.first.value).to eq 'Updated title'
+        expect(repository_object.reload.head_version.to_cocina.description.title.first.value).to eq 'Updated title'
         expect(PublishItemsModifiedJob).to have_received(:perform_later)
       end
     end
@@ -244,16 +215,10 @@ RSpec.describe UpdateObjectService do
 
       before do
         # Create a existing record without a source id
-        CocinaObjectStore.store(cocina_object.new(identification: {}), skip_lock: true)
+        create(:repository_object, :collection, :with_repository_object_version, external_identifier: cocina_object.externalIdentifier)
 
         # Create a duplicate record with the same sourceId
-        CocinaObjectStore.store(cocina_object.new(
-                                  externalIdentifier: 'druid:dd645sg2172',
-                                  description: {
-                                    title: [{ value: 'Test Collection' }],
-                                    purl: 'https://purl.stanford.edu/dd645sg2172'
-                                  }
-                                ), skip_lock: true)
+        create(:repository_object, :collection, :with_repository_object_version, external_identifier: 'druid:dd645sg2172', source_id: cocina_object.identification.sourceId)
 
         allow(PublishItemsModifiedJob).to receive(:perform_later)
       end


### PR DESCRIPTION
refs #4940 

## Why was this change made? 🤔
Continue migration to RepositoryObjects.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



