### PR TITLE
Update UserVersion validation to check closed_at datetime

### DIFF
--- a/app/models/repository_object_version.rb
+++ b/app/models/repository_object_version.rb
@@ -66,6 +66,14 @@ class RepositoryObjectVersion < ApplicationRecord
     }.compact
   end
 
+  def closed?
+    closed_at.present?
+  end
+
+  def open?
+    !closed?
+  end
+
   private
 
   def update_object_source_id

--- a/app/models/user_version.rb
+++ b/app/models/user_version.rb
@@ -8,6 +8,6 @@ class UserVersion < ApplicationRecord
 
   def repository_object_version_is_closed
     # Validate that the repository object version is closed
-    errors.add(:repository_object_version, 'cannot set a user version to an open RepositoryObjectVersion') if repository_object_version.repository_object.open?
+    errors.add(:repository_object_version, 'cannot set a user version to an open RepositoryObjectVersion') if repository_object_version.open?
   end
 end

--- a/spec/models/repository_object_version_spec.rb
+++ b/spec/models/repository_object_version_spec.rb
@@ -305,4 +305,48 @@ RSpec.describe RepositoryObjectVersion do
       end
     end
   end
+
+  describe '.closed?' do
+    context 'when closed_at is nil' do
+      it 'returns false' do
+        expect(repository_object_version.closed?).to be false
+      end
+    end
+
+    context 'when closed_at is present' do
+      let(:attrs) do
+        {
+          version: 1,
+          version_description: 'My new version',
+          closed_at: Time.current
+        }
+      end
+
+      it 'returns true when closed_at is present' do
+        expect(repository_object_version.closed?).to be true
+      end
+    end
+  end
+
+  describe '.open?' do
+    context 'when closed_at is nil' do
+      it 'returns true when closed_at is nil' do
+        expect(repository_object_version.open?).to be true
+      end
+    end
+
+    context 'when closed_at is present' do
+      let(:attrs) do
+        {
+          version: 1,
+          version_description: 'My new version',
+          closed_at: Time.current
+        }
+      end
+
+      it 'returns false when closed_at is present' do
+        expect(repository_object_version.open?).to be false
+      end
+    end
+  end
 end

--- a/spec/models/user_version_spec.rb
+++ b/spec/models/user_version_spec.rb
@@ -18,8 +18,12 @@ RSpec.describe UserVersion do
     subject(:user_verison) { build(:user_version, repository_object_version:) }
 
     context 'when the repository object version is closed' do
-      before do
-        allow(repository_object).to receive(:open?).and_return(false)
+      let(:attrs) do
+        {
+          version: 1,
+          version_description: 'My new version',
+          closed_at: Time.current
+        }
       end
 
       it { is_expected.to be_valid }


### PR DESCRIPTION
## Why was this change made? 🤔

Update the validation to check `closed_at` on the RepositoryObjectVersion instead of the status of the parent RepositoryObject.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



