### PR TITLE
Move label building from PublicXmlService to PublicCocinaService

### DIFF
--- a/app/services/publish/public_cocina_service.rb
+++ b/app/services/publish/public_cocina_service.rb
@@ -11,14 +11,16 @@ module Publish
       @cocina = cocina
     end
 
+    # update the label to match what is in the description.title (used by sul-embed and searchworks_traject_indexer (via PublicXmlService))
     # remove any file that is not published
     # remove any file_set that doesn't have at least one published file
     # remove partOfProject (similar to how we remove tags from identityMetadata)
     def build
+      label = Cocina::Models::Builders::TitleBuilder.build(cocina.description.title)
       if cocina.dro?
-        cocina.new(structural: build_structural, administrative: build_administrative)
+        cocina.new(label:, structural: build_structural, administrative: build_administrative)
       elsif cocina.collection?
-        cocina.new(administrative: build_administrative)
+        cocina.new(label:, administrative: build_administrative)
       else
         raise "unexpected call to PublicCocinaService.build for #{cocina.externalIdentifier}"
       end

--- a/app/services/publish/public_xml_service.rb
+++ b/app/services/publish/public_xml_service.rb
@@ -75,7 +75,7 @@ module Publish
 
     # catkeys are used by PURL
     # objectType is used by purl-fetcher
-    # objectLabel is used by https://github.com/sul-dlss/searchworks_traject_indexer/blob/b5ed9906a5a0130eca5e68fbb0e8633bdbe6ffd6/lib/sdr_stuff.rb#L54
+    # objectLabel is used by https://github.com/sul-dlss/searchworks_traject_indexer/blob/72195e34e364fb2c191c40b23fe51679746f6419/lib/public_xml_record.rb#L34
     # Barcode and sourceId are used by the CdlController in Stacks https://github.com/sul-dlss/stacks/blame/master/app/controllers/cdl_controller.rb#L121
     def public_identity_metadata
       nodes = catalog_record_ids(SYMPHONY).map { |catkey| "  <otherId name=\"catkey\">#{catkey}</otherId>" }
@@ -87,7 +87,7 @@ module Publish
         <<~XML
           <identityMetadata>
             <objectType>#{public_cocina.collection? ? 'collection' : 'item'}</objectType>
-            <objectLabel>#{Cocina::Models::Builders::TitleBuilder.build(public_cocina.description.title)}</objectLabel>
+            <objectLabel>#{public_cocina.label}</objectLabel>
             #{nodes.join("\n")}
           </identityMetadata>
         XML

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Publish::MetadataTransferService do
         before do
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/{"cocinaVersion"/, 'cocina.json')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<publicObject/, 'public')
-          expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(cocina_object)
+          expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(Cocina::Models::DRO)
         end
 
         let(:access) { { view: 'citation-only', download: 'none' } }
@@ -133,7 +133,7 @@ RSpec.describe Publish::MetadataTransferService do
         before do
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/{"cocinaVersion"/, 'cocina.json')
           expect_any_instance_of(described_class).to receive(:transfer_to_document_store).with(/<publicObject/, 'public')
-          expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(cocina_object)
+          expect_any_instance_of(described_class).to receive(:publish_notify_on_success).with(Cocina::Models::Collection)
           expect_any_instance_of(described_class).to receive(:republish_members!).with(no_args)
         end
 

--- a/spec/services/publish/public_cocina_service_spec.rb
+++ b/spec/services/publish/public_cocina_service_spec.rb
@@ -15,8 +15,14 @@ RSpec.describe Publish::PublicCocinaService do
 
   context 'with a DRO' do
     let(:publish_files) { false }
+    let(:druid) { 'druid:bc123df4567' }
+
     let(:cocina_object) do
-      build(:dro).new(
+      build(:dro, id: druid).new(
+        description: {
+          title: [{ value: 'Constituent label &amp; A Special character' }],
+          purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
+        },
         structural: {
           contains: [
             {
@@ -122,6 +128,10 @@ RSpec.describe Publish::PublicCocinaService do
           hasMemberOrders: [{ viewingDirection: 'left-to-right' }]
         }
       )
+    end
+
+    it 'updates the label' do
+      expect(create.label).to eq 'Constituent label &amp; A Special character'
     end
 
     context 'when there are no published files' do

--- a/spec/services/publish/public_xml_service_spec.rb
+++ b/spec/services/publish/public_xml_service_spec.rb
@@ -10,12 +10,6 @@ RSpec.describe Publish::PublicXmlService do
 
   let(:thumbnail_service) { ThumbnailService.new(public_cocina) }
 
-  let(:description) do
-    {
-      title: [{ value: 'Constituent label &amp; A Special character' }],
-      purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
-    }
-  end
   let(:structural) do
     {
       contains: [{
@@ -71,7 +65,7 @@ RSpec.describe Publish::PublicXmlService do
 
     context 'when there are no release tags' do
       let(:public_cocina) do
-        build(:dro, id: druid).new(description:)
+        build(:dro, id: druid)
       end
 
       it 'does not include a releaseData element and any info in identityMetadata' do
@@ -124,8 +118,7 @@ RSpec.describe Publish::PublicXmlService do
 
     context 'produces xml with' do
       let(:public_cocina) do
-        build(:dro, id: druid).new(
-          description:,
+        build(:dro, id: druid, label: 'Constituent label &amp; A Special character').new(
           structural:,
           identification: {
             barcode: '36105132211504',
@@ -277,7 +270,7 @@ RSpec.describe Publish::PublicXmlService do
 
       context 'when no thumb is present' do
         let(:public_cocina) do
-          build(:dro, id: druid).new(description:)
+          build(:dro, id: druid)
         end
 
         it 'does not add a thumb node' do
@@ -293,7 +286,7 @@ RSpec.describe Publish::PublicXmlService do
 
       context 'when there are single release tags per target' do
         let(:public_cocina) do
-          build(:dro, id: druid).new(description:, administrative:)
+          build(:dro, id: druid).new(administrative:)
         end
 
         let(:administrative) do
@@ -320,7 +313,7 @@ RSpec.describe Publish::PublicXmlService do
 
     context 'with a collection' do
       let(:public_cocina) do
-        build(:collection, id: druid).new(description:)
+        build(:collection, id: druid, label: 'Constituent label &amp; A Special character')
       end
 
       it 'publishes the expected datastreams' do
@@ -343,7 +336,7 @@ RSpec.describe Publish::PublicXmlService do
 
       context 'when there are release tags' do
         let(:public_cocina) do
-          build(:collection, id: druid).new(description:, administrative:)
+          build(:collection, id: druid).new(administrative:)
         end
 
         let(:administrative) do
@@ -371,7 +364,7 @@ RSpec.describe Publish::PublicXmlService do
     context 'with external references' do
       let(:druid) { 'druid:hj097bm8879' }
       let(:public_cocina) do
-        build(:dro, id: druid, type: Cocina::Models::ObjectType.map).new(description:, structural:)
+        build(:dro, id: druid, type: Cocina::Models::ObjectType.map).new(structural:)
       end
       let(:structural) do
         {


### PR DESCRIPTION


## Why was this change made? 🤔

This will allow us to power the access systems, which rely on the label, from cocina.  Since the public xml is derived from the public cocina, this is no longer needed in the PublicXmlService

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



