### PR TITLE
Make tests less flaky, less noisy, and faster

### DIFF
--- a/app/services/member_service.rb
+++ b/app/services/member_service.rb
@@ -31,7 +31,7 @@ class MemberService
     return members unless exclude_opened
 
     members.reject do |member|
-      workflow_client.active_lifecycle(druid: member.external_identifier, milestone_name: 'opened', version: member.version.to_s).present?
+      workflow_client.active_lifecycle(druid: member.external_identifier, milestone_name: 'opened', version: member.version).present?
     end
   end
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,4 +1,4 @@
 catalog:
   folio:
     max_lookup_tries: 3
-    sleep_seconds: 1
+    sleep_seconds: 0

--- a/spec/services/catalog/folio_writer_spec.rb
+++ b/spec/services/catalog/folio_writer_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Catalog::FolioWriter do
 
   let(:druid) { 'druid:bc123dg9393' }
   let(:bare_druid) { druid.delete_prefix('druid:') }
-
   let(:marc_856_data) do
     {
       indicators: '41',
@@ -20,7 +19,6 @@ RSpec.describe Catalog::FolioWriter do
       ]
     }
   end
-
   let(:folio_response_json) do
     { parsedRecordId: '1ab23862-46db-4da9-af5b-633adbf5f90f',
       fields:
@@ -36,7 +34,6 @@ RSpec.describe Catalog::FolioWriter do
         updateDate: '2023-02-14T10:39:19.642Z'
       } }.deep_stringify_keys
   end
-
   let(:updated_marc_json) do
     { parsedRecordId: '1ab23862-46db-4da9-af5b-633adbf5f90f',
       fields:
@@ -54,7 +51,6 @@ RSpec.describe Catalog::FolioWriter do
         updateDate: '2023-02-14T10:39:19.642Z'
       } }.deep_stringify_keys
   end
-
   let(:source_record) do
     { fields: [
       { '001': 'a666' },
@@ -67,7 +63,6 @@ RSpec.describe Catalog::FolioWriter do
                              { x: 'rights:world' }] } }
     ] }.deep_stringify_keys
   end
-
   let(:instance_record) do
     {
       id: 'db80714e-398c-56f5-b228-7ad0874107cf',
@@ -79,7 +74,6 @@ RSpec.describe Catalog::FolioWriter do
       }]
     }.deep_stringify_keys
   end
-
   let(:instance_record_unreleased) do
     {
       id: 'db80714e-398c-56f5-b228-7ad0874107cf',
@@ -88,7 +82,6 @@ RSpec.describe Catalog::FolioWriter do
       electronicAccess: []
     }.deep_stringify_keys
   end
-
   let(:unreleased_marc_json) do
     { parsedRecordId: '1ab23862-46db-4da9-af5b-633adbf5f90f',
       fields:

--- a/spec/services/cleanup_service_spec.rb
+++ b/spec/services/cleanup_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe CleanupService do
       end
 
       it 'backups, cleans up content, and delete workflows' do
-        described_class.stop_accessioning(druid)
+        expect { described_class.stop_accessioning(druid) }.to output.to_stdout
         expect(described_class).to have_received(:backup_content_by_druid).once.with(druid)
         expect(described_class).to have_received(:cleanup_by_druid).once.with(druid)
         expect(described_class).to have_received(:delete_accessioning_workflows).once.with(druid, version)
@@ -88,7 +88,7 @@ RSpec.describe CleanupService do
 
       context 'when dryrun' do
         it 'does nothing' do
-          described_class.stop_accessioning(druid, dryrun: true)
+          expect { described_class.stop_accessioning(druid, dryrun: true) }.to output.to_stdout
           expect(described_class).not_to have_received(:backup_content_by_druid)
           expect(described_class).not_to have_received(:cleanup_by_druid)
           expect(described_class).not_to have_received(:delete_accessioning_workflows)
@@ -104,7 +104,7 @@ RSpec.describe CleanupService do
       end
 
       it 'backups, cleans up content, and delete workflows' do
-        described_class.stop_accessioning(druid)
+        expect { described_class.stop_accessioning(druid) }.to output.to_stdout
         expect(described_class).to have_received(:backup_content_by_druid).once.with(druid)
         expect(described_class).to have_received(:cleanup_by_druid).once.with(druid)
         expect(described_class).to have_received(:delete_accessioning_workflows).once.with(druid, version)

--- a/spec/services/member_service_spec.rb
+++ b/spec/services/member_service_spec.rb
@@ -37,12 +37,20 @@ RSpec.describe MemberService do
       let(:exclude_opened) { true }
 
       before do
-        allow(workflow_client).to receive(:active_lifecycle).and_return(true, false)
+        allow(workflow_client).to receive(:active_lifecycle).with(
+          druid: dro1.external_identifier,
+          milestone_name: 'opened',
+          version: 1
+        ).and_return(true)
+        allow(workflow_client).to receive(:active_lifecycle).with(
+          druid: dro2.external_identifier,
+          milestone_name: 'opened',
+          version: 1
+        ).and_return(false)
       end
 
       it 'returns members' do
         expect(members).to eq [dro2.external_identifier]
-        expect(workflow_client).to have_received(:active_lifecycle).with(druid: dro1.external_identifier, milestone_name: 'opened', version: dro1.version.to_s)
       end
     end
 
@@ -56,8 +64,6 @@ RSpec.describe MemberService do
 
       it 'returns members' do
         expect(members).to eq [dro1.external_identifier]
-        expect(workflow_client).to have_received(:lifecycle).with(druid: dro1.external_identifier, milestone_name: 'published', version: dro1.version).once
-        expect(workflow_client).to have_received(:lifecycle).with(druid: dro2.external_identifier, milestone_name: 'published', version: dro2.version).once
       end
     end
   end


### PR DESCRIPTION
# Why was this change made?

Developer happiness and efficiency: while working on #4956, I found flaky tests, noisy tests, and some slow ones. I decided to try improving all of these. This commit includes those changes.

# How was this change tested?

- [x] CI
- [x] ran `rspec` 10-15 times in a row with random seeds and saw zero failures and zero noisy test output
