### PR TITLE
Adds purl fetcher client.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'marc'
 gem 'marc-vocab', '~> 0.3.0' # for indexing
 gem 'moab-versioning', '~> 6.0', require: 'moab/stanford'
 gem 'preservation-client', '~> 6.0'
+gem 'purl_fetcher-client', '~> 1.2.0'
 gem 'stanford-mods' # for indexing
 gem 'sul_orcid_client', '~> 0.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,6 +362,9 @@ GEM
     public_suffix (5.0.5)
     puma (6.4.2)
       nio4r (~> 2.0)
+    purl_fetcher-client (1.2.0)
+      activesupport
+      faraday (~> 2.1)
     racc (1.7.3)
     rack (3.0.10)
     rack-console (1.4.0)
@@ -607,6 +610,7 @@ DEPENDENCIES
   preservation-client (~> 6.0)
   propshaft
   puma (~> 6.0)
+  purl_fetcher-client (~> 1.2.0)
   rack-console
   rails (~> 7.1.0)
   retries

--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -74,20 +74,14 @@ module Publish
     # When publishing a PURL, we notify purl-fetcher of changes.
     #
     def publish_notify_on_success(public_cocina)
-      Faraday.post(purl_services_url, public_cocina.to_json, { 'Content-Type' => 'application/json' })
+      PurlFetcher::Client::LegacyPublish.publish(cocina: public_cocina)
     end
 
     ##
     # When deleting a PURL, we notify purl-fetcher of changes.
     #
     def publish_delete_on_success
-      Faraday.delete(purl_services_url)
-    end
-
-    def purl_services_url
-      raise 'You have not configured purl-fetcher (Settings.purl_fetcher.url).' unless Settings.purl_fetcher.url
-
-      "#{Settings.purl_fetcher.url}/purls/#{cocina_object.externalIdentifier.delete_prefix('druid:')}"
+      PurlFetcher::Client::Unpublish.unpublish(druid: cocina_object.externalIdentifier)
     end
   end
 end

--- a/config/initializers/purl_fetcher_client.rb
+++ b/config/initializers/purl_fetcher_client.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+PurlFetcher::Client.configure(url: Settings.purl_fetcher.url, token: Settings.purl_fetcher.token)


### PR DESCRIPTION
closes #4958

## Why was this change made? 🤔
Cleaner / easier integration with purl fetcher.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, integration test.

