### PR TITLE
Allow the release_tags API to show the public tags

### DIFF
--- a/app/controllers/release_tags_controller.rb
+++ b/app/controllers/release_tags_controller.rb
@@ -15,7 +15,7 @@ class ReleaseTagsController < ApplicationController
                             message: 'Only Collection or DROs can have release tags.')
     end
 
-    render json: ReleaseTagService.item_tags(cocina_object: @cocina_object)
+    render json: params[:public] ? ReleaseTagService.for_public_metadata(cocina_object: @cocina_object) : ReleaseTagService.item_tags(cocina_object: @cocina_object)
   end
 
   def create

--- a/openapi.yml
+++ b/openapi.yml
@@ -5,14 +5,14 @@ info:
   title: DOR Services API
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
 servers:
-  - url: 'https://dor-services-{env}.stanford.edu'
+  - url: "https://dor-services-{env}.stanford.edu"
     description: Production service
     variables:
       env:
         default: prod
-  - url: 'https://dor-services-{env}.stanford.edu'
+  - url: "https://dor-services-{env}.stanford.edu"
     description: Staging service
     variables:
       env:
@@ -41,34 +41,34 @@ paths:
     get:
       summary: A healthcheck endpoint
       responses:
-        '200':
+        "200":
           description: The status of the service
-  '/v1/background_job_results/{id}':
+  "/v1/background_job_results/{id}":
     get:
       tags:
         - jobs
       summary: View results of a background job
       description: Used to allow the application run long-running processes out of the request/response cycle
-      operationId: 'background_job_results#show'
+      operationId: "background_job_results#show"
       responses:
-        '200':
+        "200":
           description: The background job has completed
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BackgroundJobResultResponse'
-        '202':
+                $ref: "#/components/schemas/BackgroundJobResultResponse"
+        "202":
           description: The background job is pending or processing
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BackgroundJobResultResponse'
-        '404':
+                $ref: "#/components/schemas/BackgroundJobResultResponse"
+        "404":
           description: The background job with the given id was not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: id
           in: path
@@ -82,9 +82,9 @@ paths:
         - objects
       summary: Create a virtual object.
       description: Combines a virtual_object object with constituent objects to create an object like an Atlas (composed of several images)
-      operationId: 'virtual_objects#create'
+      operationId: "virtual_objects#create"
       responses:
-        '201':
+        "201":
           description: Virtual merge action started
           headers:
             location:
@@ -104,16 +104,16 @@ paths:
                   type: array
                   minItems: 1
                   items:
-                    $ref: '#/components/schemas/VirtualObjectRequest'
-  '/v1/objects/{id}/publish':
+                    $ref: "#/components/schemas/VirtualObjectRequest"
+  "/v1/objects/{id}/publish":
     post:
       tags:
         - objects
       summary: Publish object to PURL
-      description: ''
-      operationId: 'objects#publish'
+      description: ""
+      operationId: "objects#publish"
       responses:
-        '201':
+        "201":
           description: Publishing action started
           headers:
             location:
@@ -127,7 +127,7 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
         - name: workflow
           in: query
           description: which workflow should this be reported to
@@ -143,20 +143,20 @@ paths:
           schema:
             type: string
             enum:
-              - 'default'
-              - 'low'
-            default: 'default'
-  '/v1/objects/{id}/accession':
+              - "default"
+              - "low"
+            default: "default"
+  "/v1/objects/{id}/accession":
     post:
       tags:
         - objects
       summary: Start an assembly workflow, optionally opening a version
-      description: ''
-      operationId: 'objects#accession'
+      description: ""
+      operationId: "objects#accession"
       responses:
-        '201':
+        "201":
           description: Workflow started
-        '409':
+        "409":
           description: Unable to open version.
       parameters:
         - name: id
@@ -164,7 +164,7 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
         - name: workflow
           in: query
           description: which workflow should be started
@@ -181,23 +181,23 @@ paths:
           required: true
           schema:
             type: string
-          example: 'Re-accessioning this object'
+          example: "Re-accessioning this object"
         - name: opening_user_name
           in: query
           description: the username of the person creating the version (if versioning is needed)
           required: false
           schema:
             type: string
-          example: 'some_sunetid'
-  '/v1/objects/{id}/preserve':
+          example: "some_sunetid"
+  "/v1/objects/{id}/preserve":
     post:
       tags:
         - objects
       summary: Move an object to preservation
-      description: ''
-      operationId: 'objects#preserve'
+      description: ""
+      operationId: "objects#preserve"
       responses:
-        '201':
+        "201":
           description: Preservation action started
           headers:
             location:
@@ -211,25 +211,25 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
         - name: lane-id
           in: query
           description: Lane for prioritizing the work
           schema:
             type: string
             enum:
-              - 'default'
-              - 'low'
-            default: 'default'
-  '/v1/objects/{id}/update_marc_record':
+              - "default"
+              - "low"
+            default: "default"
+  "/v1/objects/{id}/update_marc_record":
     post:
       tags:
         - integrations
       summary: Update Symphony with a new marc record from DOR
-      description: ''
-      operationId: 'objects#update_marc_record'
+      description: ""
+      operationId: "objects#update_marc_record"
       responses:
-        '200':
+        "200":
           description: OK
       parameters:
         - name: id
@@ -237,16 +237,16 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
-  '/v1/objects/{id}/update_doi_metadata':
+            $ref: "#/components/schemas/Druid"
+  "/v1/objects/{id}/update_doi_metadata":
     post:
       tags:
         - integrations
       summary: Update Datacite DOI metadata
-      description: 'Starts a background job to do this, from DOI and metadata in the repository'
-      operationId: 'objects#update_doi_metadata'
+      description: "Starts a background job to do this, from DOI and metadata in the repository"
+      operationId: "objects#update_doi_metadata"
       responses:
-        '202':
+        "202":
           description: Accepted
       parameters:
         - name: id
@@ -254,16 +254,16 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
-  '/v1/objects/{id}/update_orcid_work':
+            $ref: "#/components/schemas/Druid"
+  "/v1/objects/{id}/update_orcid_work":
     post:
       tags:
         - integrations
       summary: Update Orcid Work
-      description: 'Starts a background job to do this, from metadata in the repository'
-      operationId: 'objects#update_orcid_work'
+      description: "Starts a background job to do this, from metadata in the repository"
+      operationId: "objects#update_orcid_work"
       responses:
-        '202':
+        "202":
           description: Accepted
       parameters:
         - name: id
@@ -271,16 +271,16 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
-  '/v1/objects/{id}/unpublish':
+            $ref: "#/components/schemas/Druid"
+  "/v1/objects/{id}/unpublish":
     post:
       tags:
         - objects
       summary: Unpublish an object from PURL
-      description: ''
-      operationId: 'objects#unpublish'
+      description: ""
+      operationId: "objects#unpublish"
       responses:
-        '201':
+        "201":
           description: Unpublish action started
           headers:
             location:
@@ -294,7 +294,7 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
         - name: workflow
           in: query
           description: which workflow should this be reported to
@@ -309,18 +309,18 @@ paths:
           schema:
             type: string
             enum:
-              - 'default'
-              - 'low'
-            default: 'default'
-  '/v1/objects/{id}/notify_goobi':
+              - "default"
+              - "low"
+            default: "default"
+  "/v1/objects/{id}/notify_goobi":
     post:
       tags:
         - integrations
       summary: Registers an object with the Goobi server
-      description: ''
-      operationId: 'objects#notify_goobi'
+      description: ""
+      operationId: "objects#notify_goobi"
       responses:
-        '200':
+        "200":
           description: OK
       parameters:
         - name: id
@@ -328,16 +328,16 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
-  '/v1/objects/{id}/reindex':
+            $ref: "#/components/schemas/Druid"
+  "/v1/objects/{id}/reindex":
     post:
       tags:
         - integrations
       summary: Reindex the object in Solr
-      description: ''
-      operationId: 'objects#reindex'
+      description: ""
+      operationId: "objects#reindex"
       responses:
-        '204':
+        "204":
           description: OK
       parameters:
         - name: id
@@ -345,70 +345,70 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
-  '/v1/objects/{object_id}/administrative_tags':
+            $ref: "#/components/schemas/Druid"
+  "/v1/objects/{object_id}/administrative_tags":
     get:
       tags:
         - tags
       summary: Show administrative tags for an object
-      description: ''
-      operationId: 'administrative_tags#show'
+      description: ""
+      operationId: "administrative_tags#show"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AdministrativeTag'
+                  $ref: "#/components/schemas/AdministrativeTag"
       parameters:
         - name: object_id
           in: path
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
     post:
       tags:
         - tags
       summary: Create (or replace) one or more administrative tags
-      description: ''
-      operationId: 'administrative_tags#create'
+      description: ""
+      operationId: "administrative_tags#create"
       responses:
-        '201':
+        "201":
           description: Created
-        '400':
+        "400":
           description: Bad request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '404':
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
           description: Object not found
           content:
             text/plain:
               schema:
                 type: string
-        '409':
+        "409":
           description: Request would result in a duplicate tag
           content:
             text/plain:
               schema:
                 type: string
-        '412':
+        "412":
           description: Provided ETag didn't match the previous version.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: object_id
           in: path
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
       requestBody:
         description: one or more administrative tags for an object
         content:
@@ -425,16 +425,16 @@ paths:
                   type: array
                   minItems: 1
                   items:
-                    $ref: '#/components/schemas/AdministrativeTag'
-  '/v1/administrative_tags/search':
+                    $ref: "#/components/schemas/AdministrativeTag"
+  "/v1/administrative_tags/search":
     get:
       tags:
         - tags
       summary: Search for existing tags
-      description: 'This is useful for doing autocomplete of tags in Argo'
-      operationId: 'administrative_tags#search'
+      description: "This is useful for doing autocomplete of tags in Argo"
+      operationId: "administrative_tags#search"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -449,23 +449,23 @@ paths:
           required: true
           schema:
             type: string
-  '/v1/objects/{object_id}/administrative_tags/{id}':
+  "/v1/objects/{object_id}/administrative_tags/{id}":
     delete:
       tags:
         - tags
       summary: Delete an administrative tag for an object
-      description: ''
-      operationId: 'administrative_tags#destroy'
+      description: ""
+      operationId: "administrative_tags#destroy"
       responses:
-        '204':
+        "204":
           description: Deleted
-        '400':
+        "400":
           description: Bad request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '404':
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
           description: Object or tag not found
           content:
             text/plain:
@@ -477,35 +477,35 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
         - name: id
           in: path
           description: ID of tag to remove
           required: true
           schema:
-            $ref: '#/components/schemas/AdministrativeTagEscaped'
+            $ref: "#/components/schemas/AdministrativeTagEscaped"
     put:
       tags:
         - tags
       summary: Update one administrative tag
-      description: ''
-      operationId: 'administrative_tags#update (PUT)'
+      description: ""
+      operationId: "administrative_tags#update (PUT)"
       responses:
-        '204':
+        "204":
           description: Updated
-        '400':
+        "400":
           description: Bad request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '404':
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
           description: Object or tag not found
           content:
             text/plain:
               schema:
                 type: string
-        '409':
+        "409":
           description: Request would result in a duplicate tag
           content:
             text/plain:
@@ -517,13 +517,13 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
         - name: id
           in: path
           description: ID of tag to replace
           required: true
           schema:
-            $ref: '#/components/schemas/AdministrativeTagEscaped'
+            $ref: "#/components/schemas/AdministrativeTagEscaped"
       requestBody:
         description: A replacement administrative tag
         content:
@@ -534,25 +534,25 @@ paths:
                 - administrative_tag
               properties:
                 administrative_tag:
-                  $ref: '#/components/schemas/AdministrativeTag'
+                  $ref: "#/components/schemas/AdministrativeTag"
     patch:
       tags:
         - tags
       summary: Update one administrative tag
-      description: ''
-      operationId: 'administrative_tags#update (PATCH)'
+      description: ""
+      operationId: "administrative_tags#update (PATCH)"
       responses:
-        '204':
+        "204":
           description: Updated
-        '400':
+        "400":
           description: Bad request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '404':
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
           description: Object or tag not found
-        '409':
+        "409":
           description: Request would result in a duplicate tag
       parameters:
         - name: object_id
@@ -560,13 +560,13 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
         - name: id
           in: path
           description: ID of tag to replace
           required: true
           schema:
-            $ref: '#/components/schemas/AdministrativeTagEscaped'
+            $ref: "#/components/schemas/AdministrativeTagEscaped"
       requestBody:
         description: A replacement administrative tag
         content:
@@ -577,32 +577,32 @@ paths:
                 - administrative_tag
               properties:
                 administrative_tag:
-                  $ref: '#/components/schemas/AdministrativeTag'
-  '/v1/objects/{id}/apply_admin_policy_defaults':
+                  $ref: "#/components/schemas/AdministrativeTag"
+  "/v1/objects/{id}/apply_admin_policy_defaults":
     post:
       tags:
         - objects
       summary: Applies the default values (copyright, use_statement, rights) from the admin policy
-      description: ''
-      operationId: 'admin_policy_defaults#apply'
+      description: ""
+      operationId: "admin_policy_defaults#apply"
       responses:
-        '200':
+        "200":
           description: OK
-        '400':
-          description: 'The object is not supported for inheritance of APO access defaults because its type is not supported'
+        "400":
+          description: "The object is not supported for inheritance of APO access defaults because its type is not supported"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '404':
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
           description: Not found
-        '422':
-          description: 'The object is in a state in which it cannot be modified: it must be either registered or opened for versioning'
+        "422":
+          description: "The object is in a state in which it cannot be modified: it must be either registered or opened for versioning"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
           description: Internal server error
       parameters:
         - name: id
@@ -610,78 +610,85 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
-  '/v1/objects/{id}/refresh_metadata':
+            $ref: "#/components/schemas/Druid"
+  "/v1/objects/{id}/refresh_metadata":
     post:
       tags:
         - integrations
       summary: Update object metadata with marc from Symphony
-      description: ''
-      operationId: 'metadata_refresh#refresh_metadata'
+      description: ""
+      operationId: "metadata_refresh#refresh_metadata"
       responses:
-        '200':
+        "200":
           description: OK
-        '400':
+        "400":
           description: Catkey not found in Symphony.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '422':
+                $ref: "#/components/schemas/ErrorResponse"
+        "422":
           description: Unprocessable entity.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
           description: Internal server error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: id
           in: path
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
-  '/v1/objects/{object_id}/release_tags':
+            $ref: "#/components/schemas/Druid"
+  "/v1/objects/{object_id}/release_tags":
     get:
       tags:
         - release_tags
       summary: The release tag log for this object
-      operationId: 'release_tags#index'
+      operationId: "release_tags#index"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ReleaseTag'
-        '422':
+                  $ref: "#/components/schemas/ReleaseTag"
+        "422":
           description: Unprocessable entity.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: object_id
           in: path
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
+        - name: public
+          in: query
+          description: Return all of the tags that apply to this object, from the collection and directly applied
+          required: false
+          schema:
+            type: boolean
+            default: false
     post:
       tags:
         - release_tags
       summary: Create a new release_tag for this object
-      description: ''
-      operationId: 'release_tag#create'
+      description: ""
+      operationId: "release_tag#create"
       responses:
-        '201':
+        "201":
           description: Created
       parameters:
         - name: object_id
@@ -689,22 +696,22 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
       requestBody:
         description: release tag to add to the system
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ReleaseTag'
-  '/v1/objects/{object_id}/query/collections':
+              $ref: "#/components/schemas/ReleaseTag"
+  "/v1/objects/{object_id}/query/collections":
     get:
       tags:
         - objects
       summary: List the collections that an object belongs to
-      description: ''
-      operationId: 'queries#collections'
+      description: ""
+      operationId: "queries#collections"
       responses:
-        '200':
+        "200":
           description: OK
       parameters:
         - name: object_id
@@ -712,19 +719,19 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
-  '/v1/objects/{object_id}/members':
+            $ref: "#/components/schemas/Druid"
+  "/v1/objects/{object_id}/members":
     get:
       tags:
         - objects
       summary: List the members of this collection
-      description: ''
-      operationId: 'members#index'
+      description: ""
+      operationId: "members#index"
       responses:
-        '200':
+        "200":
           description: OK
           content:
-            application/json:            
+            application/json:
               schema:
                 type: object
                 properties:
@@ -734,7 +741,7 @@ paths:
                       type: object
                       properties:
                         externalIdentifier:
-                          $ref: '#/components/schemas/Druid'
+                          $ref: "#/components/schemas/Druid"
                         version:
                           type: integer
       parameters:
@@ -743,30 +750,30 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
-  '/v1/objects/{object_id}/workspace':
+            $ref: "#/components/schemas/Druid"
+  "/v1/objects/{object_id}/workspace":
     delete:
       tags:
         - workspaces
       summary: Remove an object's workspace
-      description: ''
-      operationId: 'workspaces#destroy'
+      description: ""
+      operationId: "workspaces#destroy"
       responses:
-        '200':
+        "200":
           description: OK
-        '422':
+        "422":
           description: There was a problem removing the workspace.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: object_id
           in: path
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
         - name: workflow
           in: query
           description: which workflow should this be reported to
@@ -782,17 +789,17 @@ paths:
           schema:
             type: string
             enum:
-              - 'default'
-              - 'low'
-            default: 'default'
+              - "default"
+              - "low"
+            default: "default"
     post:
       tags:
         - workspaces
       summary: Create a workspace for an object
-      description: ''
-      operationId: 'workspaces#create'
+      description: ""
+      operationId: "workspaces#create"
       responses:
-        '200':
+        "200":
           description: OK
       parameters:
         - name: object_id
@@ -800,16 +807,16 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
-  '/v1/objects/{object_id}/workspace/reset':
+            $ref: "#/components/schemas/Druid"
+  "/v1/objects/{object_id}/workspace/reset":
     post:
       tags:
         - workspaces
       summary: Resets a workspace for an object
       description: After an object has been copied to preservation the workspace can be reset. This is called by the reset-workspace step of the accessionWF
-      operationId: 'workspaces#reset'
+      operationId: "workspaces#reset"
       responses:
-        '204':
+        "204":
           description: OK
       parameters:
         - name: object_id
@@ -817,7 +824,7 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
         - name: workflow
           in: query
           description: which workflow should this be reported to
@@ -833,18 +840,18 @@ paths:
           schema:
             type: string
             enum:
-              - 'default'
-              - 'low'
-            default: 'default'
-  '/v1/objects/{object_id}/shelve':
+              - "default"
+              - "low"
+            default: "default"
+  "/v1/objects/{object_id}/shelve":
     post:
       tags:
         - objects
       summary: Push the item to stacks
-      description: ''
-      operationId: 'shelves#create'
+      description: ""
+      operationId: "shelves#create"
       responses:
-        '201':
+        "201":
           description: Shelving action started
           headers:
             location:
@@ -852,59 +859,59 @@ paths:
               schema:
                 type: string
                 format: uri
-        '422':
-          description: 'The object you provided was not an item and could not be shelved'
+        "422":
+          description: "The object you provided was not an item and could not be shelved"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: object_id
           in: path
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
         - name: lane-id
           in: query
           description: Lane for prioritizing the work
           schema:
             type: string
             enum:
-              - 'default'
-              - 'low'
-            default: 'default'
-  '/v1/objects/{object_id}/events':
+              - "default"
+              - "low"
+            default: "default"
+  "/v1/objects/{object_id}/events":
     get:
       tags:
         - events
       summary: Return a list of events about this object
-      description: ''
-      operationId: 'events#index'
+      description: ""
+      operationId: "events#index"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ObjectEvent'
+                  $ref: "#/components/schemas/ObjectEvent"
       parameters:
         - name: object_id
           in: path
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
     post:
       tags:
         - events
       summary: Create an event about this object
-      description: ''
-      operationId: 'events#create'
+      description: ""
+      operationId: "events#create"
       responses:
-        '201':
+        "201":
           description: Created
       parameters:
         - name: object_id
@@ -912,22 +919,22 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
       requestBody:
         description: event to add to the system
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ObjectEvent'
-  '/v1/objects/{object_id}/versions/openable':
+              $ref: "#/components/schemas/ObjectEvent"
+  "/v1/objects/{object_id}/versions/openable":
     get:
       tags:
         - versions
       summary: Query to determine whether a version can be opened for this object
-      description: ''
-      operationId: 'versions#openable'
+      description: ""
+      operationId: "versions#openable"
       responses:
-        '200':
+        "200":
           description: OK
       parameters:
         - name: object_id
@@ -935,16 +942,16 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
-  '/v1/objects/{object_id}/versions/current':
+            $ref: "#/components/schemas/Druid"
+  "/v1/objects/{object_id}/versions/current":
     get:
       tags:
         - versions
       summary: Return the current version number for this object
-      description: ''
-      operationId: 'versions#current'
+      description: ""
+      operationId: "versions#current"
       responses:
-        '200':
+        "200":
           description: OK
       parameters:
         - name: object_id
@@ -952,38 +959,38 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
-  '/v1/objects/{object_id}/versions/status':
+            $ref: "#/components/schemas/Druid"
+  "/v1/objects/{object_id}/versions/status":
     get:
       tags:
         - versions
       summary: Return the status of the current version for this object
-      description: 'The status includes whether the version is open or closed and whether certain workflows are active'
-      operationId: 'versions#status'
+      description: "The status includes whether the version is open or closed and whether certain workflows are active"
+      operationId: "versions#status"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VersionStatus'
+                $ref: "#/components/schemas/VersionStatus"
       parameters:
         - name: object_id
           in: path
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
 
-  '/v1/objects/{object_id}/versions/current/close':
+  "/v1/objects/{object_id}/versions/current/close":
     post:
       tags:
         - versions
       summary: Close the currently open version for this object
-      description: ''
-      operationId: 'versions#close_current'
+      description: ""
+      operationId: "versions#close_current"
       responses:
-        '200':
+        "200":
           description: OK
       parameters:
         - name: object_id
@@ -991,7 +998,7 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
         - name: start_accession
           in: query
           schema:
@@ -1005,58 +1012,58 @@ paths:
           required: false
           schema:
             type: string
-            example: 'Re-accessioning this object'
+            example: "Re-accessioning this object"
         - name: user_name
           in: query
           description: the username of the person creating the version
           schema:
             type: string
-            example: 'some_sunetid'
+            example: "some_sunetid"
         - name: user_versions
           in: query
           description: Create, update, or do nothing with user versions on close
           schema:
             type: string
             enum:
-              - 'none'
-              - 'new'
-              - 'udpate'
-  '/v1/objects/{object_id}/versions':
+              - "none"
+              - "new"
+              - "udpate"
+  "/v1/objects/{object_id}/versions":
     get:
       tags:
         - versions
       summary: The version log for this object
-      operationId: 'versions#index'
+      operationId: "versions#index"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VersionLog'
+                $ref: "#/components/schemas/VersionLog"
       parameters:
         - name: object_id
           in: path
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
     post:
       tags:
         - versions
       summary: Open a new version for this object
-      description: ''
-      operationId: 'versions#create'
+      description: ""
+      operationId: "versions#create"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/DRO'
-                  - $ref: '#/components/schemas/Collection'
-                  - $ref: '#/components/schemas/AdminPolicy'
+                  - $ref: "#/components/schemas/DRO"
+                  - $ref: "#/components/schemas/Collection"
+                  - $ref: "#/components/schemas/AdminPolicy"
           headers:
             ETag:
               schema:
@@ -1073,14 +1080,14 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
         - name: description
           in: query
           description: short description for object version being opened
           required: true
           schema:
             type: string
-          example: 'Adding thumbnail'
+          example: "Adding thumbnail"
         - name: assume_accessioned
           in: query
           description: If true, does not check whether object has been accessioned
@@ -1094,7 +1101,7 @@ paths:
           required: false
           schema:
             type: string
-          example: 'some_sunetid'
+          example: "some_sunetid"
   /v1/objects:
     post:
       tags:
@@ -1106,7 +1113,7 @@ paths:
 
         Note that the 'source_id' property is required for items but not for
         collections.
-      operationId: 'objects#create'
+      operationId: "objects#create"
       parameters:
         - in: query
           name: assign_doi
@@ -1118,19 +1125,19 @@ paths:
           application/json:
             schema:
               oneOf:
-                - $ref: '#/components/schemas/RequestDRO'
-                - $ref: '#/components/schemas/RequestCollection'
-                - $ref: '#/components/schemas/RequestAdminPolicy'
+                - $ref: "#/components/schemas/RequestDRO"
+                - $ref: "#/components/schemas/RequestCollection"
+                - $ref: "#/components/schemas/RequestAdminPolicy"
       responses:
-        '201':
+        "201":
           description: OK
           content:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/DRO'
-                  - $ref: '#/components/schemas/Collection'
-                  - $ref: '#/components/schemas/AdminPolicy'
+                  - $ref: "#/components/schemas/DRO"
+                  - $ref: "#/components/schemas/Collection"
+                  - $ref: "#/components/schemas/AdminPolicy"
           headers:
             ETag:
               schema:
@@ -1141,69 +1148,69 @@ paths:
             X-Created-At:
               schema:
                 type: string
-        '400':
+        "400":
           description: Invalid DOR parameter
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '404':
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
           description: Object not found in DOR
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '409':
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
           description: Object with that sourceId already exists
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '422':
+                $ref: "#/components/schemas/ErrorResponse"
+        "422":
           description: Roundtrip validation has failed
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
           description: Server error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '502':
+                $ref: "#/components/schemas/ErrorResponse"
+        "502":
           description: Error connecting to Symphony
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '503':
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
           description: Service temporarily disabled
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
   /v1/objects/find:
     get:
       tags:
         - objects
       summary: Finds an object
-      operationId: 'objects#find'
+      operationId: "objects#find"
       parameters:
         - in: query
           name: sourceId
           required: true
           schema:
-            $ref: '#/components/schemas/SourceId'
+            $ref: "#/components/schemas/SourceId"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/DRO'
-                  - $ref: '#/components/schemas/Collection'
+                  - $ref: "#/components/schemas/DRO"
+                  - $ref: "#/components/schemas/Collection"
           headers:
             ETag:
               schema:
@@ -1214,13 +1221,13 @@ paths:
             X-Created-At:
               schema:
                 type: string
-        '404':
+        "404":
           description: Object not found in DOR
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-  '/v1/objects/{id}':
+                $ref: "#/components/schemas/ErrorResponse"
+  "/v1/objects/{id}":
     patch:
       tags:
         - objects
@@ -1232,14 +1239,14 @@ paths:
 
         Since we don't presently have a full mapping between cocina JSON and MODS,
         only the title can be updated in the descriptive metadata.
-      operationId: 'objects#update'
+      operationId: "objects#update"
       parameters:
         - name: id
           in: path
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
       requestBody:
         required: true
         content:
@@ -1247,19 +1254,19 @@ paths:
             # Note that additionalProperties needs to be set to true to allow id parameter.
             schema:
               oneOf:
-                - $ref: '#/components/schemas/DRO'
-                - $ref: '#/components/schemas/Collection'
-                - $ref: '#/components/schemas/AdminPolicy'
+                - $ref: "#/components/schemas/DRO"
+                - $ref: "#/components/schemas/Collection"
+                - $ref: "#/components/schemas/AdminPolicy"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/DRO'
-                  - $ref: '#/components/schemas/Collection'
-                  - $ref: '#/components/schemas/AdminPolicy'
+                  - $ref: "#/components/schemas/DRO"
+                  - $ref: "#/components/schemas/Collection"
+                  - $ref: "#/components/schemas/AdminPolicy"
           headers:
             ETag:
               schema:
@@ -1270,44 +1277,44 @@ paths:
             X-Created-At:
               schema:
                 type: string
-        '400':
+        "400":
           description: Invalid DOR parameter
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '404':
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
           description: Object not found in DOR
-        '409':
+        "409":
           description: Object with that sourceId already exists
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '412':
+                $ref: "#/components/schemas/ErrorResponse"
+        "412":
           description: Roundtrip validation has failed
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
           description: Server error
     get:
       tags:
         - objects
       summary: Retrieve the object COCINA metadata
-      description: 'Returns a JSON representation (not yet complete) of an object, collection or admin policy.'
-      operationId: 'objects#show'
+      description: "Returns a JSON representation (not yet complete) of an object, collection or admin policy."
+      operationId: "objects#show"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/DRO'
-                  - $ref: '#/components/schemas/Collection'
-                  - $ref: '#/components/schemas/AdminPolicy'
+                  - $ref: "#/components/schemas/DRO"
+                  - $ref: "#/components/schemas/Collection"
+                  - $ref: "#/components/schemas/AdminPolicy"
           headers:
             ETag:
               schema:
@@ -1318,41 +1325,41 @@ paths:
             X-Created-At:
               schema:
                 type: string
-        '304':
+        "304":
           description: No change. The client provided an ETag that matches the current state of the item.
-        '422':
+        "422":
           description: Unprocessable Entity
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
           description: Internal Server Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
       parameters:
         - name: id
           in: path
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
     delete:
       tags:
         - objects
       summary: Destroys the object
-      description: ''
-      operationId: 'objects#destroy'
+      description: ""
+      operationId: "objects#destroy"
       responses:
-        '201':
+        "201":
           description: Deleted
-        '400':
+        "400":
           description: Bad request
-        '404':
+        "404":
           description: Object or tag not found
-        '500':
+        "500":
           description: Internal Server Error
       parameters:
         - name: id
@@ -1360,7 +1367,7 @@ paths:
           description: ID of object
           required: true
           schema:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
         - name: user_name
           in: query
           description: Username of user requesting delete
@@ -1373,13 +1380,13 @@ components:
       type: object
       oneOf:
         # Being first, makes DarkAccess the default.
-        - $ref: '#/components/schemas/DarkAccess'
-        - $ref: '#/components/schemas/CitationOnlyAccess'
-        - $ref: '#/components/schemas/ControlledDigitalLendingAccess'
-        - $ref: '#/components/schemas/LocationBasedAccess'
-        - $ref: '#/components/schemas/LocationBasedDownloadAccess'
-        - $ref: '#/components/schemas/StanfordAccess'
-        - $ref: '#/components/schemas/WorldAccess'
+        - $ref: "#/components/schemas/DarkAccess"
+        - $ref: "#/components/schemas/CitationOnlyAccess"
+        - $ref: "#/components/schemas/ControlledDigitalLendingAccess"
+        - $ref: "#/components/schemas/LocationBasedAccess"
+        - $ref: "#/components/schemas/LocationBasedDownloadAccess"
+        - $ref: "#/components/schemas/StanfordAccess"
+        - $ref: "#/components/schemas/WorldAccess"
     AccessRole:
       description: Access role conferred by an AdminPolicy to objects within it. (used by Argo)
       type: object
@@ -1389,22 +1396,22 @@ components:
           description: Name of role
           type: string
           enum:
-            - 'dor-apo-depositor'
-            - 'dor-apo-manager'
-            - 'dor-apo-viewer'
-            - 'sdr-administrator'
-            - 'sdr-viewer'
-            - 'hydrus-collection-creator'
-            - 'hydrus-collection-manager'
-            - 'hydrus-collection-depositor'
-            - 'hydrus-collection-item-depositor'
-            - 'hydrus-collection-reviewer'
-            - 'hydrus-collection-viewer'
+            - "dor-apo-depositor"
+            - "dor-apo-manager"
+            - "dor-apo-viewer"
+            - "sdr-administrator"
+            - "sdr-viewer"
+            - "hydrus-collection-creator"
+            - "hydrus-collection-manager"
+            - "hydrus-collection-depositor"
+            - "hydrus-collection-item-depositor"
+            - "hydrus-collection-reviewer"
+            - "hydrus-collection-viewer"
         members:
           description: The users and groups that are members of the role
           type: array
           items:
-            $ref: '#/components/schemas/AccessRoleMember'
+            $ref: "#/components/schemas/AccessRoleMember"
       required:
         - members
         - name
@@ -1417,8 +1424,8 @@ components:
           description: Name of role
           type: string
           enum:
-            - 'sunetid'
-            - 'workgroup'
+            - "sunetid"
+            - "workgroup"
         identifier:
           type: string
       required:
@@ -1429,21 +1436,21 @@ components:
       additionalProperties: true
       properties:
         cocinaVersion:
-          $ref: '#/components/schemas/CocinaVersion'
+          $ref: "#/components/schemas/CocinaVersion"
         type:
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/admin_policy'
+            - "https://cocina.sul.stanford.edu/models/admin_policy"
         externalIdentifier:
-          $ref: '#/components/schemas/Druid'
+          $ref: "#/components/schemas/Druid"
         label:
           type: string
         version:
           type: integer
         administrative:
-          $ref: '#/components/schemas/AdminPolicyAdministrative'
+          $ref: "#/components/schemas/AdminPolicyAdministrative"
         description:
-          $ref: '#/components/schemas/Description'
+          $ref: "#/components/schemas/Description"
       required:
         - cocinaVersion
         - administrative
@@ -1456,26 +1463,26 @@ components:
       additionalProperties: false
       properties:
         hasAdminPolicy:
-          $ref: '#/components/schemas/Druid'
+          $ref: "#/components/schemas/Druid"
         releaseTags:
           description: Tags for release
           type: array
           items:
-            $ref: '#/components/schemas/ReleaseTag'
+            $ref: "#/components/schemas/ReleaseTag"
       required:
         - hasAdminPolicy
     AdminPolicyAccessTemplate:
-      description: 'Provides the template of access settings that is copied to the items governed by an AdminPolicy. This is almost the same as DROAccess, but it provides no defaults and has no embargo.'
+      description: "Provides the template of access settings that is copied to the items governed by an AdminPolicy. This is almost the same as DROAccess, but it provides no defaults and has no embargo."
       type: object
       additionalProperties: false
       oneOf:
-        - $ref: '#/components/schemas/DarkAccess'
-        - $ref: '#/components/schemas/CitationOnlyAccess'
-        - $ref: '#/components/schemas/ControlledDigitalLendingAccess'
-        - $ref: '#/components/schemas/LocationBasedAccess'
-        - $ref: '#/components/schemas/LocationBasedDownloadAccess'
-        - $ref: '#/components/schemas/StanfordAccess'
-        - $ref: '#/components/schemas/WorldAccess'
+        - $ref: "#/components/schemas/DarkAccess"
+        - $ref: "#/components/schemas/CitationOnlyAccess"
+        - $ref: "#/components/schemas/ControlledDigitalLendingAccess"
+        - $ref: "#/components/schemas/LocationBasedAccess"
+        - $ref: "#/components/schemas/LocationBasedDownloadAccess"
+        - $ref: "#/components/schemas/StanfordAccess"
+        - $ref: "#/components/schemas/WorldAccess"
       properties:
         copyright:
           $ref: "#/components/schemas/Copyright"
@@ -1489,7 +1496,7 @@ components:
       additionalProperties: false
       properties:
         accessTemplate:
-          $ref: '#/components/schemas/AdminPolicyAccessTemplate'
+          $ref: "#/components/schemas/AdminPolicyAccessTemplate"
         registrationWorkflow:
           description: When you register an item with this admin policy, these are the workflows that are available.
           type: array
@@ -1505,20 +1512,21 @@ components:
           items:
             type: string
         hasAdminPolicy:
-          $ref: '#/components/schemas/Druid'
+          $ref: "#/components/schemas/Druid"
         hasAgreement:
-          $ref: '#/components/schemas/Druid'
+          $ref: "#/components/schemas/Druid"
         roles:
           description: The access roles conferred by this AdminPolicy (used by Argo)
           type: array
           items:
-            $ref: '#/components/schemas/AccessRole'
+            $ref: "#/components/schemas/AccessRole"
       required:
         - hasAdminPolicy
         - hasAgreement
         - accessTemplate
     AppliesTo:
-      description: Property model for indicating the parts, aspects, or versions of the resource to which a
+      description:
+        Property model for indicating the parts, aspects, or versions of the resource to which a
         descriptive element is applicable.
       type: object
       additionalProperties: false
@@ -1528,27 +1536,27 @@ components:
           items:
             $ref: "#/components/schemas/DescriptiveBasicValue"
     Barcode:
-      description: 'A barcode'
+      description: "A barcode"
       oneOf:
-        - $ref: '#/components/schemas/BusinessBarcode'
-        - $ref: '#/components/schemas/LaneMedicalBarcode'
-        - $ref: '#/components/schemas/CatkeyBarcode'
-        - $ref: '#/components/schemas/StandardBarcode'
+        - $ref: "#/components/schemas/BusinessBarcode"
+        - $ref: "#/components/schemas/LaneMedicalBarcode"
+        - $ref: "#/components/schemas/CatkeyBarcode"
+        - $ref: "#/components/schemas/StandardBarcode"
     BusinessBarcode:
       description: The barcode associated with a business library DRO object, prefixed with 2050
       type: string
-      pattern: '^2050[0-9]{7}$'
-      example: '20503740296'
+      pattern: "^2050[0-9]{7}$"
+      example: "20503740296"
     CatalogLink:
-      description: 'A linkage between an object and a catalog record'
+      description: "A linkage between an object and a catalog record"
       oneOf:
-        - $ref: '#/components/schemas/FolioCatalogLink'
-        - $ref: '#/components/schemas/SymphonyCatalogLink'
+        - $ref: "#/components/schemas/FolioCatalogLink"
+        - $ref: "#/components/schemas/SymphonyCatalogLink"
     CatkeyBarcode:
       description: The barcode associated with a DRO object based on catkey, prefixed with a catkey followed by a hyphen
       type: string
-      pattern: '^[0-9]+-[0-9]+$'
-      example: '6772719-1001'
+      pattern: "^[0-9]+-[0-9]+$"
+      example: "6772719-1001"
     CitationOnlyAccess:
       type: object
       properties:
@@ -1561,7 +1569,7 @@ components:
           description: Download access level.
           type: string
           enum:
-            - 'none'
+            - "none"
         location:
           description: Not used for this access type, must be null.
           type: string
@@ -1580,25 +1588,25 @@ components:
       description: The version of Cocina with which this object conforms.
       type: string
       pattern: '^\d+\.\d+\.\d+$'
-      example: '1.2.3'
+      example: "1.2.3"
     Collection:
       description: A group of Digital Repository Objects that indicate some type of conceptual grouping within the domain that is worth reusing across the system.
       type: object
       additionalProperties: true
       properties:
         cocinaVersion:
-          $ref: '#/components/schemas/CocinaVersion'
+          $ref: "#/components/schemas/CocinaVersion"
         type:
           description: The content type of the Collection. Selected from an established set of values.
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/collection'
-            - 'https://cocina.sul.stanford.edu/models/curated-collection'
-            - 'https://cocina.sul.stanford.edu/models/user-collection'
-            - 'https://cocina.sul.stanford.edu/models/exhibit'
-            - 'https://cocina.sul.stanford.edu/models/series'
+            - "https://cocina.sul.stanford.edu/models/collection"
+            - "https://cocina.sul.stanford.edu/models/curated-collection"
+            - "https://cocina.sul.stanford.edu/models/user-collection"
+            - "https://cocina.sul.stanford.edu/models/exhibit"
+            - "https://cocina.sul.stanford.edu/models/series"
         externalIdentifier:
-          $ref: '#/components/schemas/Druid'
+          $ref: "#/components/schemas/Druid"
         label:
           description: Primary processing label (can be same as title) for a Collection.
           type: string
@@ -1606,13 +1614,13 @@ components:
           description: Version for the Collection within SDR.
           type: integer
         access:
-          $ref: '#/components/schemas/CollectionAccess'
+          $ref: "#/components/schemas/CollectionAccess"
         administrative:
-          $ref: '#/components/schemas/Administrative'
+          $ref: "#/components/schemas/Administrative"
         description:
-          $ref: '#/components/schemas/Description'
+          $ref: "#/components/schemas/Description"
         identification:
-          $ref: '#/components/schemas/CollectionIdentification'
+          $ref: "#/components/schemas/CollectionIdentification"
       required:
         - cocinaVersion
         - description
@@ -1632,9 +1640,9 @@ components:
           description: Access level
           type: string
           enum:
-            - 'world'
-            - 'dark'
-          default: 'dark'
+            - "world"
+            - "dark"
+          default: "dark"
         copyright:
           $ref: "#/components/schemas/Copyright"
         useAndReproductionStatement:
@@ -1648,11 +1656,12 @@ components:
         catalogLinks:
           type: array
           items:
-            $ref: '#/components/schemas/CatalogLink'
+            $ref: "#/components/schemas/CatalogLink"
         sourceId:
-          $ref: '#/components/schemas/SourceId'
+          $ref: "#/components/schemas/SourceId"
     Contributor:
-      description: Property model for describing agents contributing in some way to
+      description:
+        Property model for describing agents contributing in some way to
         the creation and history of the resource.
       type: object
       additionalProperties: false
@@ -1666,11 +1675,13 @@ components:
           description: Entity type of the contributor (person, organization, etc.). See https://github.com/sul-dlss/cocina-models/blob/main/docs/description_types.md for valid types.
           type: string
         status:
-          description: Status of the contributor relative to other parallel contributors
+          description:
+            Status of the contributor relative to other parallel contributors
             (e.g. the primary author among a group of contributors).
           type: string
         role:
-          description: Relationships of the contributor to the resource or to an event
+          description:
+            Relationships of the contributor to the resource or to an event
             in its history.
           type: array
           items:
@@ -1728,40 +1739,40 @@ components:
       description: A record identifier created in Folio
       type: string
       pattern: '^in\d+$'
-      example: 'in11403803'
+      example: "in11403803"
     DOI:
       description: Digital Object Identifier (https://www.doi.org)
       oneOf:
-        - $ref: '#/components/schemas/DoiPattern'
-        - $ref: '#/components/schemas/DoiExceptions'
+        - $ref: "#/components/schemas/DoiPattern"
+        - $ref: "#/components/schemas/DoiExceptions"
     DRO:
       description: Domain-defined abstraction of a 'work'. Digital Repository Objects' abstraction is describable for our domain’s purposes, i.e. for management needs within our system.
       type: object
       additionalProperties: true
       properties:
         cocinaVersion:
-          $ref: '#/components/schemas/CocinaVersion'
+          $ref: "#/components/schemas/CocinaVersion"
         type:
           description: The content type of the DRO. Selected from an established set of values.
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/object'
-            - 'https://cocina.sul.stanford.edu/models/3d'
-            - 'https://cocina.sul.stanford.edu/models/agreement'
-            - 'https://cocina.sul.stanford.edu/models/book'
-            - 'https://cocina.sul.stanford.edu/models/document'
-            - 'https://cocina.sul.stanford.edu/models/geo'
-            - 'https://cocina.sul.stanford.edu/models/image'
-            - 'https://cocina.sul.stanford.edu/models/page'
-            - 'https://cocina.sul.stanford.edu/models/photograph'
-            - 'https://cocina.sul.stanford.edu/models/manuscript'
-            - 'https://cocina.sul.stanford.edu/models/map'
-            - 'https://cocina.sul.stanford.edu/models/media'
-            - 'https://cocina.sul.stanford.edu/models/track'
-            - 'https://cocina.sul.stanford.edu/models/webarchive-binary'
-            - 'https://cocina.sul.stanford.edu/models/webarchive-seed'
+            - "https://cocina.sul.stanford.edu/models/object"
+            - "https://cocina.sul.stanford.edu/models/3d"
+            - "https://cocina.sul.stanford.edu/models/agreement"
+            - "https://cocina.sul.stanford.edu/models/book"
+            - "https://cocina.sul.stanford.edu/models/document"
+            - "https://cocina.sul.stanford.edu/models/geo"
+            - "https://cocina.sul.stanford.edu/models/image"
+            - "https://cocina.sul.stanford.edu/models/page"
+            - "https://cocina.sul.stanford.edu/models/photograph"
+            - "https://cocina.sul.stanford.edu/models/manuscript"
+            - "https://cocina.sul.stanford.edu/models/map"
+            - "https://cocina.sul.stanford.edu/models/media"
+            - "https://cocina.sul.stanford.edu/models/track"
+            - "https://cocina.sul.stanford.edu/models/webarchive-binary"
+            - "https://cocina.sul.stanford.edu/models/webarchive-seed"
         externalIdentifier:
-          $ref: '#/components/schemas/Druid'
+          $ref: "#/components/schemas/Druid"
         label:
           description: Primary processing label (can be same as title) for a DRO.
           type: string
@@ -1769,17 +1780,17 @@ components:
           description: Version for the DRO within SDR.
           type: integer
         access:
-          $ref: '#/components/schemas/DROAccess'
+          $ref: "#/components/schemas/DROAccess"
         administrative:
-          $ref: '#/components/schemas/Administrative'
+          $ref: "#/components/schemas/Administrative"
         description:
-          $ref: '#/components/schemas/Description'
+          $ref: "#/components/schemas/Description"
         identification:
-          $ref: '#/components/schemas/Identification'
+          $ref: "#/components/schemas/Identification"
         structural:
-          $ref: '#/components/schemas/DROStructural'
+          $ref: "#/components/schemas/DROStructural"
         geographic:
-          $ref: '#/components/schemas/Geographic'
+          $ref: "#/components/schemas/Geographic"
       required:
         - cocinaVersion
         - access
@@ -1801,7 +1812,7 @@ components:
             copyright:
               $ref: "#/components/schemas/Copyright"
             embargo:
-              $ref: '#/components/schemas/Embargo'
+              $ref: "#/components/schemas/Embargo"
             useAndReproductionStatement:
               $ref: "#/components/schemas/UseAndReproductionStatement"
             license:
@@ -1815,32 +1826,32 @@ components:
           description: Filesets that contain the digital representations (Files)
           type: array
           items:
-            $ref: '#/components/schemas/FileSet'
+            $ref: "#/components/schemas/FileSet"
         hasMemberOrders:
           description: Provided sequences or orderings of members, including some metadata about each sequence (i.e. sequence label, sequence type, if the sequence is primary, etc.).
           type: array
           items:
-            $ref: '#/components/schemas/Sequence'
+            $ref: "#/components/schemas/Sequence"
         isMemberOf:
           description: Collections that this DRO is a member of
           type: array
           items:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
     DarkAccess:
       type: object
       properties:
         view:
           description: Access level.
           type: string
-          default: 'dark'
+          default: "dark"
           enum:
             - dark
         download:
           description: Download access level.
           type: string
-          default: 'none'
+          default: "none"
           enum:
-            - 'none'
+            - "none"
         location:
           description: Not used for this access type, must be null.
           type: string
@@ -1952,7 +1963,7 @@ components:
             value:
               description: String or integer value of the descriptive element.
               oneOf:
-              - type: string
+                - type: string
               # Title note (nonsorting character count) was supposed to be able to accept an integer value,
               # but this triggered a bug in committee:
               # https://github.com/interagent/committee/issues/286
@@ -1961,7 +1972,8 @@ components:
               description: Type of value provided by the descriptive element. See https://github.com/sul-dlss/cocina-models/blob/main/docs/description_types.md for valid types.
               type: string
             status:
-              description: Status of the descriptive element value relative to other instances
+              description:
+                Status of the descriptive element value relative to other instances
                 of the element.
               type: string
             code:
@@ -1981,7 +1993,7 @@ components:
               description: Identifiers and URIs associated with the descriptive element.
               type: array
               items:
-                  $ref: "#/components/schemas/DescriptiveValue"
+                $ref: "#/components/schemas/DescriptiveValue"
             source:
               $ref: "#/components/schemas/Source"
             displayLabel:
@@ -2138,24 +2150,24 @@ components:
         - type: object
           properties:
             valueScript:
-              $ref: '#/components/schemas/Standard'
+              $ref: "#/components/schemas/Standard"
               # description: An alphabet or other notation used to represent a
               #   language or other symbolic system of the descriptive element value.
     DoiExceptions:
       type: string
       description: pre-existing Digital Object Identifiers (https://www.doi.org) not matching the pattern (case insensitive)
       pattern: '^10\.(25740\/([vV][aA]90-[cC][tT]15|[sS][yY][xX][aA]-[mM]256|12[qQ][fF]-5243|65[jJ]8-6114)|25936\/629[tT]-[bB][xX]79)$'
-      example: '10.25740/12qF-5243'
+      example: "10.25740/12qF-5243"
     DoiPattern:
       type: string
       description: Digital Object Identifier (https://www.doi.org) regex pattern
       # The prod and test prefixes are permitted
       pattern: '^10\.(25740|80343)\/[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
-      example: '10.25740/bc123df4567'
+      example: "10.25740/bc123df4567"
     Druid:
       type: string
-      pattern: '^druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
-      example: 'druid:bc123df4567'
+      pattern: "^druid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$"
+      example: "druid:bc123df4567"
     Embargo:
       type: object
       additionalProperties: false
@@ -2167,7 +2179,7 @@ components:
               description: Date when the Collection is released from an embargo.
               type: string
               format: date-time
-              example: '2029-06-22T07:00:00.000+00:00'
+              example: "2029-06-22T07:00:00.000+00:00"
             useAndReproductionStatement:
               $ref: "#/components/schemas/UseAndReproductionStatement"
           required:
@@ -2229,7 +2241,7 @@ components:
           description: The content type of the File.
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/file'
+            - "https://cocina.sul.stanford.edu/models/file"
         externalIdentifier:
           description: Identifier for the resource within the SDR architecture but outside of the repository. UUID. Constant across resource versions. What clients will use calling the repository.
           type: string
@@ -2249,19 +2261,19 @@ components:
           description: MIME Type of the File.
           type: string
         languageTag:
-          $ref: '#/components/schemas/LanguageTag'
+          $ref: "#/components/schemas/LanguageTag"
         use:
-          $ref: '#/components/schemas/FileUse'
+          $ref: "#/components/schemas/FileUse"
         hasMessageDigests:
           type: array
           items:
-            $ref: '#/components/schemas/MessageDigest'
+            $ref: "#/components/schemas/MessageDigest"
         access:
-          $ref: '#/components/schemas/FileAccess'
+          $ref: "#/components/schemas/FileAccess"
         administrative:
-          $ref: '#/components/schemas/FileAdministrative'
+          $ref: "#/components/schemas/FileAdministrative"
         presentation:
-          $ref: '#/components/schemas/Presentation'
+          $ref: "#/components/schemas/Presentation"
       required:
         - externalIdentifier
         - label
@@ -2277,12 +2289,12 @@ components:
       additionalProperties: false
       oneOf:
         # Being first, makes DarkAccess the default.
-        - $ref: '#/components/schemas/DarkAccess'
-        - $ref: '#/components/schemas/ControlledDigitalLendingAccess'
-        - $ref: '#/components/schemas/LocationBasedAccess'
-        - $ref: '#/components/schemas/LocationBasedDownloadAccess'
-        - $ref: '#/components/schemas/StanfordAccess'
-        - $ref: '#/components/schemas/WorldAccess'
+        - $ref: "#/components/schemas/DarkAccess"
+        - $ref: "#/components/schemas/ControlledDigitalLendingAccess"
+        - $ref: "#/components/schemas/LocationBasedAccess"
+        - $ref: "#/components/schemas/LocationBasedDownloadAccess"
+        - $ref: "#/components/schemas/StanfordAccess"
+        - $ref: "#/components/schemas/WorldAccess"
     FileAdministrative:
       type: object
       additionalProperties: false
@@ -2309,18 +2321,18 @@ components:
           description: The content type of the Fileset.
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/resources/audio'
-            - 'https://cocina.sul.stanford.edu/models/resources/attachment'
-            - 'https://cocina.sul.stanford.edu/models/resources/document'
-            - 'https://cocina.sul.stanford.edu/models/resources/file'
-            - 'https://cocina.sul.stanford.edu/models/resources/image'
-            - 'https://cocina.sul.stanford.edu/models/resources/media'
-            - 'https://cocina.sul.stanford.edu/models/resources/object'
-            - 'https://cocina.sul.stanford.edu/models/resources/page'
-            - 'https://cocina.sul.stanford.edu/models/resources/preview'
-            - 'https://cocina.sul.stanford.edu/models/resources/3d'
-            - 'https://cocina.sul.stanford.edu/models/resources/thumb'
-            - 'https://cocina.sul.stanford.edu/models/resources/video'
+            - "https://cocina.sul.stanford.edu/models/resources/audio"
+            - "https://cocina.sul.stanford.edu/models/resources/attachment"
+            - "https://cocina.sul.stanford.edu/models/resources/document"
+            - "https://cocina.sul.stanford.edu/models/resources/file"
+            - "https://cocina.sul.stanford.edu/models/resources/image"
+            - "https://cocina.sul.stanford.edu/models/resources/media"
+            - "https://cocina.sul.stanford.edu/models/resources/object"
+            - "https://cocina.sul.stanford.edu/models/resources/page"
+            - "https://cocina.sul.stanford.edu/models/resources/preview"
+            - "https://cocina.sul.stanford.edu/models/resources/3d"
+            - "https://cocina.sul.stanford.edu/models/resources/thumb"
+            - "https://cocina.sul.stanford.edu/models/resources/video"
         externalIdentifier:
           type: string
         label:
@@ -2330,7 +2342,7 @@ components:
           description: Version for the Fileset within SDR.
           type: integer
         structural:
-          $ref: '#/components/schemas/FileSetStructural'
+          $ref: "#/components/schemas/FileSetStructural"
       required:
         - externalIdentifier
         - label
@@ -2345,7 +2357,7 @@ components:
         contains:
           type: array
           items:
-            $ref: '#/components/schemas/File'
+            $ref: "#/components/schemas/File"
     FileUse:
       description: Use for the File.
       type: string
@@ -2363,7 +2375,8 @@ components:
             - previous folio
           example: folio
         refresh:
-          description: Only one of the catkeys should be designated for refreshing.
+          description:
+            Only one of the catkeys should be designated for refreshing.
             This means that this key is the one used to pull metadata from the catalog
             if there is more than one key present.
           type: boolean
@@ -2371,9 +2384,9 @@ components:
         catalogRecordId:
           description: Record identifier that is unique within the context of the linked record's catalog.
           oneOf:
-            - $ref: '#/components/schemas/MigratedFromSymphonyIdentifier'
-            - $ref: '#/components/schemas/MigratedFromVoyagerIdentifier'
-            - $ref: '#/components/schemas/CreatedInFolioIdentifier'
+            - $ref: "#/components/schemas/MigratedFromSymphonyIdentifier"
+            - $ref: "#/components/schemas/MigratedFromVoyagerIdentifier"
+            - $ref: "#/components/schemas/CreatedInFolioIdentifier"
       required:
         - catalog
         - catalogRecordId
@@ -2393,24 +2406,25 @@ components:
       additionalProperties: false
       properties:
         barcode:
-          $ref: '#/components/schemas/Barcode'
+          $ref: "#/components/schemas/Barcode"
         catalogLinks:
           type: array
           items:
-            $ref: '#/components/schemas/CatalogLink'
+            $ref: "#/components/schemas/CatalogLink"
         doi:
-          $ref: '#/components/schemas/DOI'
+          $ref: "#/components/schemas/DOI"
         sourceId:
-          $ref: '#/components/schemas/SourceId'
+          $ref: "#/components/schemas/SourceId"
       required:
         - sourceId
     LaneMedicalBarcode:
       description: The barcode associated with a Lane Medical Library DRO object, prefixed with 245
       type: string
-      pattern: '^245[0-9]{8}$'
-      example: '24503259768'
+      pattern: "^245[0-9]{8}$"
+      example: "24503259768"
     Language:
-      description: Languages, scripts, symbolic systems, and notations used in all
+      description:
+        Languages, scripts, symbolic systems, and notations used in all
         or part of a resource or its descriptive metadata.
       type: object
       additionalProperties: false
@@ -2447,7 +2461,7 @@ components:
           type: string
           description: present for mapping to additional schemas in the future and for consistency but not otherwise used
         script:
-          $ref: '#/components/schemas/DescriptiveValue'
+          $ref: "#/components/schemas/DescriptiveValue"
           # description: An alphabet or other notation used to represent a
           #   language or other symbolic system associated with the resource.
         source:
@@ -2487,36 +2501,36 @@ components:
       type: string
       nullable: true
       enum:
-        - 'https://www.gnu.org/licenses/agpl.txt'
-        - 'https://www.apache.org/licenses/LICENSE-2.0'
-        - 'https://opensource.org/licenses/BSD-2-Clause'
-        - 'https://opensource.org/licenses/BSD-3-Clause'
-        - 'https://creativecommons.org/licenses/by/4.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nc/4.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nd/4.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-sa/4.0/legalcode'
-        - 'https://creativecommons.org/publicdomain/zero/1.0/legalcode'
-        - 'https://opensource.org/licenses/cddl1'
-        - 'https://www.eclipse.org/legal/epl-2.0'
-        - 'https://www.gnu.org/licenses/gpl-3.0-standalone.html'
-        - 'https://www.isc.org/downloads/software-support-policy/isc-license/'
-        - 'https://www.gnu.org/licenses/lgpl-3.0-standalone.html'
-        - 'https://opensource.org/licenses/MIT'
-        - 'https://www.mozilla.org/MPL/2.0/'
-        - 'https://opendatacommons.org/licenses/by/1-0/'
-        - 'http://opendatacommons.org/licenses/odbl/1.0/' # Non cannonical, but in some of our data
-        - 'https://opendatacommons.org/licenses/odbl/1-0/'
-        - 'https://creativecommons.org/publicdomain/mark/1.0/'
-        - 'https://opendatacommons.org/licenses/pddl/1-0/'
-        - 'https://creativecommons.org/licenses/by/3.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-sa/3.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nd/3.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nc/3.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode'
-        - 'https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode'
-        - 'https://cocina.sul.stanford.edu/licenses/none' # Only used in some legacy ETDs and not actually permitted per the Project Chimera docs.
+        - "https://www.gnu.org/licenses/agpl.txt"
+        - "https://www.apache.org/licenses/LICENSE-2.0"
+        - "https://opensource.org/licenses/BSD-2-Clause"
+        - "https://opensource.org/licenses/BSD-3-Clause"
+        - "https://creativecommons.org/licenses/by/4.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nc/4.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
+        - "https://creativecommons.org/licenses/by-sa/4.0/legalcode"
+        - "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
+        - "https://opensource.org/licenses/cddl1"
+        - "https://www.eclipse.org/legal/epl-2.0"
+        - "https://www.gnu.org/licenses/gpl-3.0-standalone.html"
+        - "https://www.isc.org/downloads/software-support-policy/isc-license/"
+        - "https://www.gnu.org/licenses/lgpl-3.0-standalone.html"
+        - "https://opensource.org/licenses/MIT"
+        - "https://www.mozilla.org/MPL/2.0/"
+        - "https://opendatacommons.org/licenses/by/1-0/"
+        - "http://opendatacommons.org/licenses/odbl/1.0/" # Non cannonical, but in some of our data
+        - "https://opendatacommons.org/licenses/odbl/1-0/"
+        - "https://creativecommons.org/publicdomain/mark/1.0/"
+        - "https://opendatacommons.org/licenses/pddl/1-0/"
+        - "https://creativecommons.org/licenses/by/3.0/legalcode"
+        - "https://creativecommons.org/licenses/by-sa/3.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nd/3.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nc/3.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode"
+        - "https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"
+        - "https://cocina.sul.stanford.edu/licenses/none" # Only used in some legacy ETDs and not actually permitted per the Project Chimera docs.
     LocationBasedAccess:
       type: object
       properties:
@@ -2535,12 +2549,12 @@ components:
           description: If access or download is "location-based", which location should have access.
           type: string
           enum:
-            - 'spec'
-            - 'music'
-            - 'ars'
-            - 'art'
-            - 'hoover'
-            - 'm&m'
+            - "spec"
+            - "music"
+            - "ars"
+            - "art"
+            - "hoover"
+            - "m&m"
         controlledDigitalLending:
           type: boolean
           default: false
@@ -2568,12 +2582,12 @@ components:
           description: Which location should have download access.
           type: string
           enum:
-            - 'spec'
-            - 'music'
-            - 'ars'
-            - 'art'
-            - 'hoover'
-            - 'm&m'
+            - "spec"
+            - "music"
+            - "ars"
+            - "art"
+            - "hoover"
+            - "m&m"
         controlledDigitalLending:
           type: boolean
           default: false
@@ -2604,12 +2618,12 @@ components:
       description: A record identifier migrated from Symphony
       type: string
       pattern: '^a\d+$'
-      example: 'a11403803'
+      example: "a11403803"
     MigratedFromVoyagerIdentifier:
       description: A record identifier migrated from Voyager
       type: string
       pattern: '^L\d+$'
-      example: 'L11403803'
+      example: "L11403803"
     Presentation:
       description: Presentation data for the File.
       type: object
@@ -2647,7 +2661,8 @@ components:
           items:
             $ref: "#/components/schemas/DescriptiveValue"
         contributor:
-          description: Agents contributing in some way to the creation and history of the
+          description:
+            Agents contributing in some way to the creation and history of the
             related resource.
           type: array
           items:
@@ -2658,13 +2673,15 @@ components:
           items:
             $ref: "#/components/schemas/Event"
         form:
-          description: Characteristics of the related resource's physical, digital, and intellectual
+          description:
+            Characteristics of the related resource's physical, digital, and intellectual
             form and genre, and of its process of creation.
           type: array
           items:
             $ref: "#/components/schemas/DescriptiveValue"
         language:
-          description: Languages, scripts, symbolic systems, and notations used in all or
+          description:
+            Languages, scripts, symbolic systems, and notations used in all or
             part of a related resource.
           type: array
           items:
@@ -2739,11 +2756,11 @@ components:
       additionalProperties: false
       properties:
         cocinaVersion:
-          $ref: '#/components/schemas/CocinaVersion'
+          $ref: "#/components/schemas/CocinaVersion"
         type:
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/admin_policy'
+            - "https://cocina.sul.stanford.edu/models/admin_policy"
         label:
           type: string
         version:
@@ -2752,9 +2769,9 @@ components:
           enum:
             - 1
         administrative:
-          $ref: '#/components/schemas/AdminPolicyAdministrative'
+          $ref: "#/components/schemas/AdminPolicyAdministrative"
         description:
-          $ref: '#/components/schemas/RequestDescription'
+          $ref: "#/components/schemas/RequestDescription"
       required:
         - cocinaVersion
         - administrative
@@ -2779,15 +2796,15 @@ components:
       additionalProperties: true
       properties:
         cocinaVersion:
-          $ref: '#/components/schemas/CocinaVersion'
+          $ref: "#/components/schemas/CocinaVersion"
         type:
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/collection'
-            - 'https://cocina.sul.stanford.edu/models/curated-collection'
-            - 'https://cocina.sul.stanford.edu/models/user-collection'
-            - 'https://cocina.sul.stanford.edu/models/exhibit'
-            - 'https://cocina.sul.stanford.edu/models/series'
+            - "https://cocina.sul.stanford.edu/models/collection"
+            - "https://cocina.sul.stanford.edu/models/curated-collection"
+            - "https://cocina.sul.stanford.edu/models/user-collection"
+            - "https://cocina.sul.stanford.edu/models/exhibit"
+            - "https://cocina.sul.stanford.edu/models/series"
         label:
           type: string
         version:
@@ -2796,13 +2813,13 @@ components:
           enum:
             - 1
         access:
-          $ref: '#/components/schemas/CollectionAccess'
+          $ref: "#/components/schemas/CollectionAccess"
         administrative:
-          $ref: '#/components/schemas/RequestAdministrative'
+          $ref: "#/components/schemas/RequestAdministrative"
         description:
-          $ref: '#/components/schemas/RequestDescription'
+          $ref: "#/components/schemas/RequestDescription"
         identification:
-          $ref: '#/components/schemas/CollectionIdentification'
+          $ref: "#/components/schemas/CollectionIdentification"
       required:
         - cocinaVersion
         - access
@@ -2816,25 +2833,25 @@ components:
       additionalProperties: true
       properties:
         cocinaVersion:
-          $ref: '#/components/schemas/CocinaVersion'
+          $ref: "#/components/schemas/CocinaVersion"
         type:
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/object'
-            - 'https://cocina.sul.stanford.edu/models/3d'
-            - 'https://cocina.sul.stanford.edu/models/agreement'
-            - 'https://cocina.sul.stanford.edu/models/book'
-            - 'https://cocina.sul.stanford.edu/models/document'
-            - 'https://cocina.sul.stanford.edu/models/geo'
-            - 'https://cocina.sul.stanford.edu/models/image'
-            - 'https://cocina.sul.stanford.edu/models/page'
-            - 'https://cocina.sul.stanford.edu/models/photograph'
-            - 'https://cocina.sul.stanford.edu/models/manuscript'
-            - 'https://cocina.sul.stanford.edu/models/map'
-            - 'https://cocina.sul.stanford.edu/models/media'
-            - 'https://cocina.sul.stanford.edu/models/track'
-            - 'https://cocina.sul.stanford.edu/models/webarchive-binary'
-            - 'https://cocina.sul.stanford.edu/models/webarchive-seed'
+            - "https://cocina.sul.stanford.edu/models/object"
+            - "https://cocina.sul.stanford.edu/models/3d"
+            - "https://cocina.sul.stanford.edu/models/agreement"
+            - "https://cocina.sul.stanford.edu/models/book"
+            - "https://cocina.sul.stanford.edu/models/document"
+            - "https://cocina.sul.stanford.edu/models/geo"
+            - "https://cocina.sul.stanford.edu/models/image"
+            - "https://cocina.sul.stanford.edu/models/page"
+            - "https://cocina.sul.stanford.edu/models/photograph"
+            - "https://cocina.sul.stanford.edu/models/manuscript"
+            - "https://cocina.sul.stanford.edu/models/map"
+            - "https://cocina.sul.stanford.edu/models/media"
+            - "https://cocina.sul.stanford.edu/models/track"
+            - "https://cocina.sul.stanford.edu/models/webarchive-binary"
+            - "https://cocina.sul.stanford.edu/models/webarchive-seed"
         label:
           type: string
         version:
@@ -2843,17 +2860,17 @@ components:
           enum:
             - 1
         access:
-          $ref: '#/components/schemas/DROAccess'
+          $ref: "#/components/schemas/DROAccess"
         administrative:
-          $ref: '#/components/schemas/RequestAdministrative'
+          $ref: "#/components/schemas/RequestAdministrative"
         description:
-          $ref: '#/components/schemas/RequestDescription'
+          $ref: "#/components/schemas/RequestDescription"
         identification:
-          $ref: '#/components/schemas/RequestIdentification'
+          $ref: "#/components/schemas/RequestIdentification"
         structural:
-          $ref: '#/components/schemas/RequestDROStructural'
+          $ref: "#/components/schemas/RequestDROStructural"
         geographic:
-          $ref: '#/components/schemas/Geographic'
+          $ref: "#/components/schemas/Geographic"
       required:
         - cocinaVersion
         - administrative
@@ -2869,16 +2886,16 @@ components:
         contains:
           type: array
           items:
-            $ref: '#/components/schemas/RequestFileSet'
+            $ref: "#/components/schemas/RequestFileSet"
         hasMemberOrders:
           type: array
           items:
-            $ref: '#/components/schemas/Sequence'
+            $ref: "#/components/schemas/Sequence"
         isMemberOf:
           description: Collections that this DRO is a member of
           type: array
           items:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
     RequestDescription:
       description: Description that is included in a request to create a DRO. This is the same as a Description, except excludes PURL.
       type: object
@@ -2891,7 +2908,8 @@ components:
           items:
             $ref: "#/components/schemas/Title"
         contributor:
-          description: Agents contributing in some way to the creation and history of the
+          description:
+            Agents contributing in some way to the creation and history of the
             resource.
           type: array
           items:
@@ -2902,7 +2920,8 @@ components:
           items:
             $ref: "#/components/schemas/Event"
         form:
-          description: Characteristics of the resource's physical, digital, and intellectual
+          description:
+            Characteristics of the resource's physical, digital, and intellectual
             form and genre, and of its process of creation.
           type: array
           items:
@@ -2913,7 +2932,8 @@ components:
           items:
             $ref: "#/components/schemas/DescriptiveGeographicMetadata"
         language:
-          description: Languages, scripts, symbolic systems, and notations used in all or
+          description:
+            Languages, scripts, symbolic systems, and notations used in all or
             part of a resource.
           type: array
           items:
@@ -2959,7 +2979,7 @@ components:
         type:
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/file'
+            - "https://cocina.sul.stanford.edu/models/file"
         label:
           type: string
         filename:
@@ -2971,21 +2991,21 @@ components:
         hasMimeType:
           type: string
         languageTag:
-          $ref: '#/components/schemas/LanguageTag'
+          $ref: "#/components/schemas/LanguageTag"
         externalIdentifier:
           type: string
         use:
-          $ref: '#/components/schemas/FileUse'
+          $ref: "#/components/schemas/FileUse"
         hasMessageDigests:
           type: array
           items:
-            $ref: '#/components/schemas/MessageDigest'
+            $ref: "#/components/schemas/MessageDigest"
         access:
-          $ref: '#/components/schemas/FileAccess'
+          $ref: "#/components/schemas/FileAccess"
         administrative:
-          $ref: '#/components/schemas/FileAdministrative'
+          $ref: "#/components/schemas/FileAdministrative"
         presentation:
-          $ref: '#/components/schemas/Presentation'
+          $ref: "#/components/schemas/Presentation"
       required:
         - label
         - type
@@ -3001,24 +3021,24 @@ components:
         type:
           type: string
           enum:
-            - 'https://cocina.sul.stanford.edu/models/resources/audio'
-            - 'https://cocina.sul.stanford.edu/models/resources/attachment'
-            - 'https://cocina.sul.stanford.edu/models/resources/document'
-            - 'https://cocina.sul.stanford.edu/models/resources/file'
-            - 'https://cocina.sul.stanford.edu/models/resources/image'
-            - 'https://cocina.sul.stanford.edu/models/resources/media'
-            - 'https://cocina.sul.stanford.edu/models/resources/object'
-            - 'https://cocina.sul.stanford.edu/models/resources/page'
-            - 'https://cocina.sul.stanford.edu/models/resources/preview'
-            - 'https://cocina.sul.stanford.edu/models/resources/3d'
-            - 'https://cocina.sul.stanford.edu/models/resources/thumb'
-            - 'https://cocina.sul.stanford.edu/models/resources/video'
+            - "https://cocina.sul.stanford.edu/models/resources/audio"
+            - "https://cocina.sul.stanford.edu/models/resources/attachment"
+            - "https://cocina.sul.stanford.edu/models/resources/document"
+            - "https://cocina.sul.stanford.edu/models/resources/file"
+            - "https://cocina.sul.stanford.edu/models/resources/image"
+            - "https://cocina.sul.stanford.edu/models/resources/media"
+            - "https://cocina.sul.stanford.edu/models/resources/object"
+            - "https://cocina.sul.stanford.edu/models/resources/page"
+            - "https://cocina.sul.stanford.edu/models/resources/preview"
+            - "https://cocina.sul.stanford.edu/models/resources/3d"
+            - "https://cocina.sul.stanford.edu/models/resources/thumb"
+            - "https://cocina.sul.stanford.edu/models/resources/video"
         label:
           type: string
         version:
           type: integer
         structural:
-          $ref: '#/components/schemas/RequestFileSetStructural'
+          $ref: "#/components/schemas/RequestFileSetStructural"
       required:
         - label
         - type
@@ -3032,7 +3052,7 @@ components:
         contains:
           type: array
           items:
-            $ref: '#/components/schemas/RequestFile'
+            $ref: "#/components/schemas/RequestFile"
     RequestIdentification:
       # Doesn't permit a DOI because our DOIs all use the DRUID as part of the DOI.
       # You have to register the object in order to get the DRUID before you can mint a DOI
@@ -3041,13 +3061,13 @@ components:
       additionalProperties: false
       properties:
         barcode:
-          $ref: '#/components/schemas/Barcode'
+          $ref: "#/components/schemas/Barcode"
         catalogLinks:
           type: array
           items:
-            $ref: '#/components/schemas/CatalogLink'
+            $ref: "#/components/schemas/CatalogLink"
         sourceId:
-          $ref: '#/components/schemas/SourceId'
+          $ref: "#/components/schemas/SourceId"
       required:
         - sourceId
     Sequence:
@@ -3092,7 +3112,7 @@ components:
           type: string
     SourceId:
       type: string
-      pattern: '^.+:.+$'
+      pattern: "^.+:.+$"
       description: >
         Unique identifier in some other system. This is because a large proportion of what is deposited in SDR,
         historically and currently, are representations of objects that are also represented in other systems.
@@ -3100,9 +3120,10 @@ components:
         in systems that have their own identifiers. Similarly, books have barcodes, archival materials have collection numbers
         and physical locations, etc. The sourceId allows determining if an item has been deposited before and where to
         look for the original item if you're looking at its SDR representation. The format is: "namespace:identifier"
-      example: 'sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026'
+      example: "sul:PC0170_s3_Fiesta_Bowl_2012-01-02_210609_2026"
     Standard:
-      description: Property model for indicating the encoding, standard, or syntax
+      description:
+        Property model for indicating the encoding, standard, or syntax
         to which a value conforms (e.g. RDA).
       type: object
       additionalProperties: false
@@ -3131,8 +3152,8 @@ components:
       description: The standard barcode associated with a DRO object, prefixed with 36105
       type: string
       nullable: true
-      pattern: '^36105[0-9]{9}$'
-      example: '36105010362304'
+      pattern: "^36105[0-9]{9}$"
+      example: "36105010362304"
     StanfordAccess:
       type: object
       properties:
@@ -3173,7 +3194,8 @@ components:
             - previous symphony
           example: symphony
         refresh:
-          description: Only one of the catkeys should be designated for refreshing.
+          description:
+            Only one of the catkeys should be designated for refreshing.
             This means that this key is the one used to pull metadata from the catalog
             if there is more than one key present.
           type: boolean
@@ -3182,7 +3204,7 @@ components:
           description: Record identifier that is unique within the context of the linked record's catalog.
           type: string
           pattern: '^\d+$'
-          example: '11403803'
+          example: "11403803"
       required:
         - catalog
         - catalogRecordId
@@ -3244,17 +3266,17 @@ components:
         - download
     AdministrativeTag:
       type: string
-      pattern: '^.+( : .+)+$'
-      example: 'Foo : Bar : Baz'
+      pattern: "^.+( : .+)+$"
+      example: "Foo : Bar : Baz"
     AdministrativeTagEscaped:
       type: string
       # allow CGI-escaped and bare colons to allow for differences between local
       # environments and deployed environments that use Apache & Passenger
       pattern: '^.+(\+(?:%3A|:)\+.+)+$'
-      example: 'Foo+%3A+Bar+%3A+Baz'
+      example: "Foo+%3A+Bar+%3A+Baz"
     Version:
       type: object
-      description: 'Similar to the version inventory specified by OCFL: https://ocfl.io/draft/spec/#version-inventory'
+      description: "Similar to the version inventory specified by OCFL: https://ocfl.io/draft/spec/#version-inventory"
       properties:
         versionId:
           type: integer
@@ -3267,12 +3289,12 @@ components:
           description: a message that explans what changed
     VersionLog:
       type: object
-      description: 'Similar to the version inventory specified by OCFL: https://ocfl.io/draft/spec/#version-inventory'
+      description: "Similar to the version inventory specified by OCFL: https://ocfl.io/draft/spec/#version-inventory"
       properties:
         versions:
           type: array
           items:
-            $ref: '#/components/schemas/Version'
+            $ref: "#/components/schemas/Version"
     VersionStatus:
       type: object
       required:
@@ -3305,7 +3327,7 @@ components:
       type: object
       properties:
         output:
-          $ref: '#/components/schemas/ErrorResponse'
+          $ref: "#/components/schemas/ErrorResponse"
         status:
           type: string
           description: the status of the background job
@@ -3319,13 +3341,13 @@ components:
         errors:
           type: array
           items:
-            $ref: '#/components/schemas/Error'
+            $ref: "#/components/schemas/Error"
     Error:
       type: object
       properties:
         title:
           type: string
-          description: 'a short, human-readable summary of the problem that SHOULD NOT change from occurrence to occurrence of the problem.'
+          description: "a short, human-readable summary of the problem that SHOULD NOT change from occurrence to occurrence of the problem."
           example: Invalid Attribute
         detail:
           type: string
@@ -3334,7 +3356,7 @@ components:
         meta:
           type: object
           description: used to include non-standard meta-information
-          example: { backtrace: ['where things went wrong'] }
+          example: { backtrace: ["where things went wrong"] }
         source:
           type: object
           properties:
@@ -3360,11 +3382,11 @@ components:
         - constituent_ids
       properties:
         virtual_object_id:
-          $ref: '#/components/schemas/Druid'
+          $ref: "#/components/schemas/Druid"
         constituent_ids:
           type: array
           items:
-            $ref: '#/components/schemas/Druid'
+            $ref: "#/components/schemas/Druid"
   securitySchemes:
     bearerAuth:
       type: http

--- a/spec/requests/release_tags_spec.rb
+++ b/spec/requests/release_tags_spec.rb
@@ -39,6 +39,29 @@ RSpec.describe 'Operations on release tags' do
 
         expect(response.parsed_body).to contain_exactly(tag.to_h.stringify_keys)
       end
+
+      context 'with public' do
+        let(:cocina_object) do
+          build(:dro, id: druid).new(structural: {
+                                       isMemberOf: [collection.externalIdentifier]
+                                     })
+        end
+
+        let(:collection) do
+          build(:collection)
+        end
+
+        let!(:collection_tag) do
+          ReleaseTag.create!(druid: collection.externalIdentifier, who: 'petucket', what: 'collection', released_to: 'PURL Sitemap', release: true)
+                    .to_cocina
+        end
+
+        it 'returns the release tags' do
+          get "/v1/objects/#{druid}/release_tags?public=true", headers: auth_headers
+
+          expect(response.parsed_body).to contain_exactly(collection_tag.to_h.stringify_keys, tag.to_h.stringify_keys)
+        end
+      end
     end
 
     context 'when an AdminPolicy' do


### PR DESCRIPTION
## Why was this change made? 🤔

This will allow the release_publish robot to tell purl-fetcher what the public release tags are.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



