### PR TITLE
Stop producing relationship nodes within contentMetadata

### DIFF
--- a/app/services/cocina/to_xml/content_metadata_generator.rb
+++ b/app/services/cocina/to_xml/content_metadata_generator.rb
@@ -151,14 +151,6 @@ module Cocina
         cocina_fileset.structural.contains.filter { |cocina_file| cocina_file.administrative.publish }.each do |cocina_file|
           resource.add_child(Nokogiri::XML::Node.new('label', @xml_doc).tap { |tag| tag.content = label })
           resource.add_child(create_external_file_node(cocina_file, cocina_fileset.externalIdentifier, external_druid))
-          resource.add_child(create_relationship_node(external_druid))
-        end
-      end
-
-      def create_relationship_node(external_druid)
-        Nokogiri::XML::Node.new('relationship', @xml_doc).tap do |relationship|
-          relationship['objectId'] = external_druid
-          relationship['type'] = 'alsoAvailableAs'
         end
       end
 

--- a/spec/fixtures/hj097bm8879_publicObject.xml
+++ b/spec/fixtures/hj097bm8879_publicObject.xml
@@ -17,14 +17,12 @@
     <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId="cocina-fileSet-9475bc2c-7552-43d8-b8ab-8cd2212d5873" mimetype="image/jp2">
       <imageData width="6475" height="4747"/>
     </externalFile>
-    <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
   </resource>
   <resource id="cocina-fileSet-hj097bm8879-929604b0-00bc-40b1-af71-5c17f066e2fd" sequence="2" type="image">
     <label>(Title Page to) Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]</label>
     <externalFile fileId="2542B.jp2" objectId="druid:jw923xn5254" resourceId="cocina-fileSet-929604b0-00bc-40b1-af71-5c17f066e2fd" mimetype="image/jp2">
       <imageData width="3139" height="4675"/>
     </externalFile>
-    <relationship objectId="druid:jw923xn5254" type="alsoAvailableAs"/>
   </resource>
 </contentMetadata>
 <rightsMetadata>

--- a/spec/services/cocina/to_xml/content_metadata_generator_spec.rb
+++ b/spec/services/cocina/to_xml/content_metadata_generator_spec.rb
@@ -911,12 +911,10 @@ RSpec.describe Cocina::ToXml::ContentMetadataGenerator do
             <externalFile fileId="00001.jp2" mimetype="image/jp2" objectId="#{constituent_druid}" resourceId="#{constituent_druid}_1">
               <imageData height="200" width="300"/>
             </externalFile>
-            <relationship objectId="#{constituent_druid}" type="alsoAvailableAs"/>
           </resource>
           <resource id="https://cocina.sul.stanford.edu/fileSet/bc123df5678-#{constituent_druid}_2" sequence="2" type="image">
             <label>Dummy Title</label>
             <externalFile fileId="00002.jp2" mimetype="image/jp2" objectId="#{constituent_druid}" resourceId="#{constituent_druid}_2"/>
-            <relationship objectId="#{constituent_druid}" type="alsoAvailableAs"/>
           </resource>
         </contentMetadata>
       XML


### PR DESCRIPTION


## Why was this change made? 🤔
Nothing uses this data, so we can simplify and have less code


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



