### PR TITLE
Decouple virtual object lookup from public xml construction

### DIFF
--- a/app/services/publish/public_desc_metadata_service.rb
+++ b/app/services/publish/public_desc_metadata_service.rb
@@ -3,12 +3,15 @@
 module Publish
   # Creates the descriptive XML that we display on purl.stanford.edu
   class PublicDescMetadataService
-    attr_reader :cocina_object
+    attr_reader :cocina_object, :constituents
 
     MODS_NS = 'http://www.loc.gov/mods/v3'
 
-    def initialize(cocina_object)
+    # @param [Cocina::Models::Collection,Cocina::Models::DRO] cocina_object
+    # @param [Array<Hash>] constituents a list of constituents (virtual object members) that are part of this object
+    def initialize(cocina_object, constituents)
       @cocina_object = cocina_object
+      @constituents = constituents
     end
 
     # @return [Nokogiri::XML::Document] A copy of the descriptiveMetadata of the object, to be modified
@@ -63,7 +66,7 @@ module Publish
     # expand constituent relations into relatedItem references -- see JUMBO-18
     # @return [Void]
     def add_constituent_relations!
-      VirtualObject.for(druid: cocina_object.externalIdentifier).each do |virtual_object_params|
+      constituents.each do |virtual_object_params|
         # create the MODS relation
         relatedItem = doc.create_element('relatedItem', xmlns: MODS_NS)
         relatedItem['type'] = 'host'

--- a/app/services/published_relationships_filter.rb
+++ b/app/services/published_relationships_filter.rb
@@ -3,8 +3,10 @@
 # Show the relationships that are publically available
 class PublishedRelationshipsFilter
   # @param [Cocina::Models::DRO] cocina_object
-  def initialize(cocina_object)
+  # @param [Array<Hash>] constituents a list of constituents (virtual object members) that are part of this object
+  def initialize(cocina_object, constituents)
     @cocina_object = cocina_object
+    @constituents = constituents
   end
 
   def xml
@@ -21,7 +23,7 @@ class PublishedRelationshipsFilter
 
   private
 
-  attr_reader :cocina_object
+  attr_reader :cocina_object, :constituents
 
   INDENT = "\n      "
 
@@ -36,7 +38,7 @@ class PublishedRelationshipsFilter
   def virtual_objects
     return unless cocina_object.dro?
 
-    VirtualObject.for(druid: cocina_object.externalIdentifier).map do |virtual_object_params|
+    constituents.map do |virtual_object_params|
       "<fedora:isConstituentOf rdf:resource=\"info:fedora/#{virtual_object_params.fetch(:id)}\"/>"
     end.join(INDENT)
   end

--- a/spec/services/publish/dublin_core_service_spec.rb
+++ b/spec/services/publish/dublin_core_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Publish::DublinCoreService do
   let(:cocina_object) do
     build(:dro, id: 'druid:bc123df4567').new(description:)
   end
-  let(:desc_md_xml) { Publish::PublicDescMetadataService.new(cocina_object).ng_xml(include_access_conditions: false) }
+  let(:desc_md_xml) { Publish::PublicDescMetadataService.new(cocina_object, []).ng_xml(include_access_conditions: false) }
 
   describe '#ng_xml' do
     subject(:xml) { service.ng_xml }

--- a/spec/services/publish/public_desc_metadata_service_spec.rb
+++ b/spec/services/publish/public_desc_metadata_service_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Publish::PublicDescMetadataService do
-  subject(:service) { described_class.new(item.to_cocina) }
+  subject(:service) { described_class.new(item.to_cocina, constituents) }
+
+  let(:constituents) { [] }
 
   let(:access) { {} }
   let(:identification) { { sourceId: 'sul:123' } }
@@ -48,23 +50,7 @@ RSpec.describe Publish::PublicDescMetadataService do
     end
 
     context 'with isConstituentOf relationships' do
-      let(:virtual_structural) do
-        {
-          contains: [],
-          hasMemberOrders: [
-            {
-              members: [
-                item.external_identifier
-              ],
-              viewingDirection: 'left-to-right'
-            }
-          ]
-        }
-      end
-
-      before do
-        create(:ar_dro, external_identifier: 'druid:hj097bm8879', structural: virtual_structural)
-      end
+      let(:constituents) { [{ id: 'druid:hj097bm8879', title: 'Test DRO' }] }
 
       it 'writes the relationships into MODS' do
         # test that we have 2 expansions

--- a/spec/services/published_relationships_filter_spec.rb
+++ b/spec/services/published_relationships_filter_spec.rb
@@ -3,14 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe PublishedRelationshipsFilter do
-  subject(:service) { described_class.new(cocina_object) }
+  subject(:service) { described_class.new(cocina_object, constituents) }
+
+  let(:constituents) { [{ id: 'druid:hj097bm8879' }] }
 
   describe '#xml' do
     subject(:doc) { service.xml }
-
-    before do
-      allow(VirtualObject).to receive(:for).and_return([{ id: 'druid:hj097bm8879' }])
-    end
 
     context 'with a DRO' do
       let(:cocina_object) do


### PR DESCRIPTION


## Why was this change made? 🤔
This reduces the number of times we have to run the query against the database


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



