### PR TITLE
Changes UpdateObjectService to raise when not open.

### DIFF
--- a/spec/services/update_object_service_spec.rb
+++ b/spec/services/update_object_service_spec.rb
@@ -92,14 +92,11 @@ RSpec.describe UpdateObjectService do
         end
 
         before do
-          allow(Honeybadger).to receive(:notify)
           create(:ar_dro, external_identifier: druid)
         end
 
-        it 'notifies honeybadger' do
-          expect(store.update).to be_a Cocina::Models::DROWithMetadata
-          expect(Honeybadger).to have_received(:notify).with('Updating repository item without an open version',
-                                                             context: { druid:, version: 1 })
+        it 'raises' do
+          expect { store.update }.to raise_error(StandardError, "Updating repository item #{druid} without an open version")
         end
       end
 


### PR DESCRIPTION
## Why was this change made? 🤔
Update will not succeed when not open, so catch early.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit