### PR TITLE
Fix default from symbol to string in Version.close for user_version

### DIFF
--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -38,8 +38,8 @@ class VersionService
   # @param [String] description describes the version change
   # @param [String] user_name add username to the events datastream
   # @param [Boolean] start_accession (true) set to true if you want accessioning to start, false otherwise
-  # @param [Symbol] user_version (:none) one of :none, :new, :update
-  def self.close(druid:, version:, description: nil, user_name: nil, start_accession: true, user_version: :none)
+  # @param [String] user_version (none) one of none, new, update
+  def self.close(druid:, version:, description: nil, user_name: nil, start_accession: true, user_version: 'none')
     new(druid:, version:).close(description:,
                                 user_name:,
                                 start_accession:,

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe VersionService do
         allow(workflow_state_service).to receive_messages(accessioning?: false, assembling?: false)
       end
 
-      context 'when user_version is :none' do
+      context 'when user_version is none' do
         it 'sets description and an event and does not create a user version' do
           close
           expect(repository_object.reload.last_closed_version).to be_present
@@ -268,7 +268,7 @@ RSpec.describe VersionService do
         end
       end
 
-      context 'when user_version is :new' do
+      context 'when user_version is new' do
         let(:user_version_param) { 'new' }
 
         it 'sets description and an event and creates a new user version' do
@@ -289,7 +289,7 @@ RSpec.describe VersionService do
         end
       end
 
-      context 'when user_version is :update' do
+      context 'when user_version is update' do
         let(:user_version_param) { 'update' }
         let(:version) { 3 }
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes param mismatch and test description of user_version param in VersionService.close


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



