### PR TITLE
allow the start accession DSA endpoint to accept workflow context

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -76,7 +76,9 @@ class ObjectsController < ApplicationController
   # The versioning params are included below for reference.
   #  :descriptions [String] (required) description of version change
   #  :opening_user_name [String] (optional) opening sunetid to add to the events datastream
+  # You can also pass information that will be used to start the workflow:
   #  :workflow [String] (optional) the workflow to start (defaults to 'assemblyWF')
+  #  :context [Hash] (optional) workflow context to pass to the workflow service (defaults to nil)
   def accession
     workflow = params[:workflow] || 'assemblyWF'
     EventFactory.create(druid: params[:id], event_type: 'accession_request', data: { workflow: })
@@ -95,7 +97,7 @@ class ObjectsController < ApplicationController
     end
 
     # initialize workflow
-    workflow_client.create_workflow_by_name(@cocina_object.externalIdentifier, workflow, version: updated_cocina_object.version.to_s)
+    workflow_client.create_workflow_by_name(@cocina_object.externalIdentifier, workflow, version: updated_cocina_object.version.to_s, context: workflow_context)
     head :created
   end
 
@@ -209,6 +211,11 @@ class ObjectsController < ApplicationController
 
   def version_open_params
     params.permit(:description, :opening_user_name).to_h.symbolize_keys
+  end
+
+  # workflow context is optionally set in the body of the request as json, with the key 'context'
+  def workflow_context
+    params.permit(context: {}).to_h[:context]
   end
 
   def version_close_params

--- a/spec/requests/start_accession_spec.rb
+++ b/spec/requests/start_accession_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
           druid: 'druid:mx123qw2323',
           event_type: 'accession_request' }
       )
-      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, default_start_accession_workflow, version: '1')
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, default_start_accession_workflow, version: '1', context: nil)
       expect(version_service).not_to have_received(:open)
     end
 
@@ -47,7 +47,7 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
       post "/v1/objects/#{druid}/accession?#{params.merge(workflow: 'gisAssemblyWF').to_query}",
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
-      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'gisAssemblyWF', version: '1')
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'gisAssemblyWF', version: '1', context: nil)
     end
   end
 
@@ -59,7 +59,7 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
     it 'opens a version and starts default workflow' do
       post("/v1/objects/#{druid}/accession?#{params.to_query}",
            headers: { 'Authorization' => "Bearer #{jwt}" })
-      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, default_start_accession_workflow, version: '2')
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, default_start_accession_workflow, version: '2', context: nil)
       expect(version_service).to have_received(:open).with(
         assume_accessioned: false,
         cocina_object:,
@@ -70,7 +70,18 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
     it 'can override the default workflow' do
       post "/v1/objects/#{druid}/accession?#{params.merge(workflow: 'gisAssemblyWF').to_query}",
            headers: { 'Authorization' => "Bearer #{jwt}" }
-      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'gisAssemblyWF', version: '2')
+      expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'gisAssemblyWF', version: '2', context: nil)
+    end
+
+    context 'with context' do
+      let(:workflow_context) { { 'requireOCR' => true } }
+
+      it 'sends workflow context' do
+        post "/v1/objects/#{druid}/accession?#{params.to_query}",
+             params: { context: workflow_context }.to_json,
+             headers: { 'Authorization' => "Bearer #{jwt}", 'CONTENT_TYPE' => 'application/json' }
+        expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, default_start_accession_workflow, version: '2', context: workflow_context)
+      end
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Part of sul-dlss/dor-services-client#427 -- allows us to send workflow context to the workflow service via json in the body of the `accession` request.  The workflow client and workflow server are already setup to receive it and store it.

## How was this change tested? 🤨

New specs and QA