### PR TITLE
opening_user_name can be nil

### DIFF
--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -61,13 +61,13 @@ class VersionService
 
   # Increments the version number and initializes versioningWF for the object
   # @param [Cocina::Models::DRO,Cocina::Models::Collection] cocina_object the item being acted upon
-  # @param [String] description set description of version change
-  # @param [String] opening_user_name add opening username to the events datastream
+  # @param [String] description set description of version change (required)
+  # @param [String] opening_user_name add opening username to the events datastream (optional)
   # @param [Boolean] assume_accessioned If true, does not check whether object has been accessioned.
   # @return [Cocina::Models::DRO, Cocina::Models::AdminPolicy, Cocina::Models::Collection] updated cocina object
   # @raise [VersionService::VersioningError] if the object hasn't been accessioned, or if a version is already opened
   # @raise [Preservation::Client::Error] if bad response from preservation catalog.
-  def open(cocina_object:, description:, opening_user_name:, assume_accessioned:)
+  def open(cocina_object:, description:, assume_accessioned:, opening_user_name: nil)
     raise ArgumentError, 'description is required to open a new version' if description.blank?
 
     ensure_openable!(assume_accessioned:)


### PR DESCRIPTION
## Why was this change made? 🤔

We allow opening_user_name to be nil when opening a new version, but it is possible to get an HB exception if you leave it off when calling the accession method from DSA cient, as shown below.  This should fix the problem by allowing it to be nil via this pathway too.  Error below, triggers this HB alert: https://app.honeybadger.io/projects/50568/faults/107835795   Adding the opening_user_name let's it work:

```
object_client = Dor::Services::Client.object('druid:zb460rp4078')
object_client.accession.start(description: 'do it!', context: {'runOCR' => true})

/Users/petucket/Sites/development/dor-services-client/lib/dor/services/client/versioned_service.rb:45:in `raise_exception_based_on_response!': Internal Server Error: 500 (Response from dor-services-app did not contain a body.                         Check honeybadger for dor-services-app for backtraces,                         and look into adding a `rescue_from` in dor-services-app                         to provide more details to the client in the future) (Dor::Services::Client::UnexpectedResponse)
	from /Users/petucket/Sites/development/dor-services-client/lib/dor/services/client/accession.rb:34:in `start'
	from (irb):34:in `<main>'
	from <internal:kernel>:187:in `loop'
	from bin/console:15:in `<main>'

object_client.accession.start(opening_user_name: 'petucket', description: 'do it!', context: {'runOCR' => true})
 => true
```

The reason is that most consumers just call `VersionService.open`, which sets the opening_user_name to nil if left off.  However, DSA's client call results in a `VersionService.new` and then later calls `#open` on the instance of the object (see https://github.com/sul-dlss/dor-services-client/blob/main/lib/dor/services/client/accession.rb#L16-L31 and the resulting call ends up at https://github.com/sul-dlss/dor-services-app/blob/main/app/controllers/objects_controller.rb#L72-L100), passing whatever params the consumer sent to DSA client.  If the user doesn't send `opening_user_name`, it will not be sent to `#open` at all, and since that method is not defining a default, it blows up.  This just lets the default be nil, as it does in the `.open` method.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



