### PR TITLE
AuditTechnicalMetadataFileList.process_response needs logger as a param

### DIFF
--- a/app/reports/audit_technical_metadata_file_list.rb
+++ b/app/reports/audit_technical_metadata_file_list.rb
@@ -104,7 +104,7 @@ class AuditTechnicalMetadataFileList
       response = techmd_connection.post("/v1/technical-metadata/audit/#{druid}", req_params, 'Content-Type' => 'application/json')
       logger.debug "#{druid}: audited technical-metadata-service; response status: #{response.status}; response body: #{response.body}"
 
-      process_response(druid, version, response)
+      process_response(druid, version, response, logger)
     end
 
     private
@@ -127,7 +127,7 @@ class AuditTechnicalMetadataFileList
       end
     end
 
-    def process_response(druid, version, response)
+    def process_response(druid, version, response, logger)
       unless EXPECTED_RESPONSE_CODES.include?(response.status)
         logger.warn("#{druid}: unexpected response auditing technical-metadata-service. HTTP status: #{response.status}. response body: #{response.body}")
         return


### PR DESCRIPTION
## Why was this change made? 🤔

noticed a bug that testing didn't exercise, because techMD QA didn't return any unexpected HTTP response codes when testing.

## How was this change tested? 🤨

ran the test report to make sure the happy path didn't blow up (no unexpected responses, so still no exercise of the unexpected response logger code):

```
$ bin/rails r -e p 'AuditTechnicalMetadataFileList.test_report'
druid:bk509qs2277: found technical-metadata-service database; inconsistencies with v11 cocina: {"missing_filenames"=>["asawa.jp2", "maps-africa.jp2", "moore.jp2", "hay.jp2"]}
druid:ww089jm4506: not found in technical-metadata-service database
druid:wy216td0310: found technical-metadata-service database; inconsistencies with v1 cocina: {"missing_filenames"=>["example.jp2"]}
druid:xb970cg0663: found technical-metadata-service database; inconsistencies with v1 cocina: {"missing_filenames"=>["example.jp2"]}
druid:gv185zf2539: not found in technical-metadata-service database
druid:vy263sv2426: found technical-metadata-service database; inconsistencies with v2 cocina: {"missing_filenames"=>["argo-logo.jp2", "image.jp2", "vision_for_stanford.jp2"]}
```

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



