### PR TITLE
Adds user version index endpoint.

### DIFF
--- a/app/controllers/user_versions_controller.rb
+++ b/app/controllers/user_versions_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Controller for user versions
+class UserVersionsController < ApplicationController
+  def index
+    repository_object = RepositoryObject.find_by!(external_identifier: params[:object_id])
+
+    render json: { user_versions: user_versions_content(repository_object.user_versions) }
+  end
+
+  private
+
+  def user_versions_content(user_versions)
+    user_versions.map do |user_version|
+      {
+        userVersion: user_version.version,
+        version: user_version.repository_object_version.version
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,8 @@ Rails.application.routes.draw do
         end
       end
 
+      resources :user_versions, only: [:index]
+
       resources :release_tags, only: [:create, :index]
     end
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -1102,6 +1102,26 @@ paths:
           schema:
             type: string
           example: "some_sunetid"
+  "/v1/objects/{object_id}/user_versions":
+    get:
+      tags:
+        - versions
+      summary: The user version log for this object
+      operationId: "user_versions#index"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserVersionLog"
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: "#/components/schemas/Druid"        
   /v1/objects:
     post:
       tags:
@@ -3274,6 +3294,24 @@ components:
       # environments and deployed environments that use Apache & Passenger
       pattern: '^.+(\+(?:%3A|:)\+.+)+$'
       example: "Foo+%3A+Bar+%3A+Baz"
+    UserVersion:
+      type: object
+      description: "Information about a user version."
+      properties:
+        version:
+          type: integer
+          description: the number of the object version
+        userVersion:
+          type: integer
+          description: the number of the user version
+    UserVersionLog:
+      type: object
+      description: "User versions for an object."
+      properties:
+        versions:
+          type: array
+          items:
+            $ref: "#/components/schemas/UserVersion"
     Version:
       type: object
       description: "Similar to the version inventory specified by OCFL: https://ocfl.io/draft/spec/#version-inventory"
@@ -3286,7 +3324,7 @@ components:
           description: the number of the version
         message:
           type: string
-          description: a message that explans what changed
+          description: a message that explains what changed
     VersionLog:
       type: object
       description: "Similar to the version inventory specified by OCFL: https://ocfl.io/draft/spec/#version-inventory"

--- a/spec/requests/user_versions_inventory_spec.rb
+++ b/spec/requests/user_versions_inventory_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'User versions' do
+  let(:druid) { 'druid:mx123qw2323' }
+
+  context 'when found' do
+    before do
+      repository_object = create(:repository_object, :closed, external_identifier: druid)
+      create(:repository_object_version, repository_object:, version: 2, closed_at: Time.zone.now)
+      create(:user_version, version: 1, repository_object_version: repository_object.versions.first)
+      create(:user_version, version: 2, repository_object_version: repository_object.versions.last)
+    end
+
+    it 'returns a 200' do
+      get "/v1/objects/#{druid}/user_versions",
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq '{"user_versions":[{"userVersion":1,"version":1},' \
+                                  '{"userVersion":2,"version":2}]}'
+    end
+  end
+end

--- a/spec/requests/versions_inventory_spec.rb
+++ b/spec/requests/versions_inventory_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Release tags' do
+RSpec.describe 'Versions' do
   let(:druid) { 'druid:mx123qw2323' }
 
   let(:repository_object) { build(:repository_object, **attrs) }


### PR DESCRIPTION
closes #4993

## Why was this change made? 🤔
So that user versions can be displayed in argo.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

