### PR TITLE
Change EmbargoReleaseService to use RepositoryObject.

### DIFF
--- a/app/models/repository_object_version.rb
+++ b/app/models/repository_object_version.rb
@@ -6,8 +6,11 @@ class RepositoryObjectVersion < ApplicationRecord
   has_many :user_versions, dependent: :destroy
 
   has_one :head_version_of, class_name: 'RepositoryObject', inverse_of: :head_version, dependent: nil
+
   scope :in_virtual_objects, ->(member_druid) { where("structural #> '{hasMemberOrders,0}' -> 'members' ? :druid", druid: member_druid) }
   scope :members_of_collection, ->(collection_druid) { where("structural -> 'isMemberOf' ? :druid", druid: collection_druid) }
+  # Note that this query is slow. Creating a timestamp index on the releaseDate field is not supported by PG.
+  scope :embargoed_and_releaseable, -> { where("(access -> 'embargo' ->> 'releaseDate')::timestamp <= ?", Time.zone.now) }
 
   validates :version, :version_description, presence: true
   after_save :update_object_source_id

--- a/app/services/embargo_release_service.rb
+++ b/app/services/embargo_release_service.rb
@@ -7,7 +7,7 @@
 class EmbargoReleaseService
   def self.release_all
     # Find objects to process
-    embargoed_items_to_release = Dro.embargoed_and_releaseable
+    embargoed_items_to_release = RepositoryObject.currently_embargoed_and_releaseable
 
     return Rails.logger.info('No objects to process') if embargoed_items_to_release.none?
 

--- a/spec/factories/dros.rb
+++ b/spec/factories/dros.rb
@@ -69,32 +69,4 @@ FactoryBot.define do
       }
     end
   end
-
-  trait :with_embargo do
-    access do
-      {
-        view: 'dark',
-        download: 'dark',
-        embargo: {
-          releaseDate: 1.year.from_now.iso8601,
-          view: 'world',
-          download: 'world'
-        }
-      }
-    end
-  end
-
-  trait :with_releasable_embargo do
-    access do
-      {
-        view: 'dark',
-        download: 'dark',
-        embargo: {
-          releaseDate: 1.month.ago.iso8601,
-          view: 'world',
-          download: 'world'
-        }
-      }
-    end
-  end
 end

--- a/spec/services/embargo_release_service_spec.rb
+++ b/spec/services/embargo_release_service_spec.rb
@@ -232,11 +232,11 @@ RSpec.describe EmbargoReleaseService do
   end
 
   describe '#release_all' do
-    let!(:item_with_releasable_embargo) { create(:ar_dro, :with_releasable_embargo) }
+    let!(:item_with_releasable_embargo) { create(:repository_object_version, :with_repository_object, :with_releasable_embargo).repository_object }
 
     before do
-      create(:ar_dro)
-      create(:ar_dro, :with_embargo)
+      create(:repository_object_version, :with_repository_object)
+      create(:repository_object_version, :with_repository_object, :with_embargo)
       allow(described_class).to receive(:release)
     end
 


### PR DESCRIPTION
closes #4997

## Why was this change made? 🤔
Dro is deprecated.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

