### PR TITLE
Refactors AuditTechnicalMetadataFileList to use RepositoryObjects.

### DIFF
--- a/app/models/repository_object.rb
+++ b/app/models/repository_object.rb
@@ -31,6 +31,7 @@ class RepositoryObject < ApplicationRecord
   scope :dros, -> { where(object_type: 'dro') }
   scope :collections, -> { where(object_type: 'collection') }
   scope :admin_policies, -> { where(object_type: 'admin_policy') }
+  scope :closed, -> { where('last_closed_version_id = head_version_id') }
 
   # NOTE: This block uses metaprogramming to create the equivalent of scopes that query the RepositoryObjectVersion table using only rows that are a `current` in the RepositoryObject table
   #


### PR DESCRIPTION
closes #4996

## Why was this change made? 🤔
Dro is deprecated.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

QA

