### PR TITLE
Refactor UrAdminPolicyFactory to stop creating AdminPolicy.

### DIFF
--- a/app/models/repository_object.rb
+++ b/app/models/repository_object.rb
@@ -61,7 +61,9 @@ class RepositoryObject < ApplicationRecord
         object_type: cocina_object.class.name.demodulize.underscore
       }
       args[:source_id] = cocina_object.identification.sourceId if cocina_object.respond_to?(:identification)
-      create!(**args).update_opened_version_from(cocina_object:)
+      create!(**args).tap do |repo_obj|
+        repo_obj.update_opened_version_from(cocina_object:)
+      end
     end
 
     private

--- a/app/services/ur_admin_policy_factory.rb
+++ b/app/services/ur_admin_policy_factory.rb
@@ -24,8 +24,7 @@ class UrAdminPolicyFactory
       }
     )
 
-    RepositoryObject.create_from(cocina_object: admin_policy_cocina)
-    cocina_object_with_metadata = CocinaObjectStore.store(admin_policy_cocina, skip_lock: true)
-    Indexer.reindex(cocina_object: cocina_object_with_metadata)
+    repository_object = RepositoryObject.create_from(cocina_object: admin_policy_cocina)
+    Indexer.reindex(cocina_object: repository_object.head_version.to_cocina_with_metadata)
   end
 end

--- a/spec/services/ur_admin_policy_factory_spec.rb
+++ b/spec/services/ur_admin_policy_factory_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe UrAdminPolicyFactory do
   end
 
   it 'creates the Ur-AdminPolicy' do
-    expect(AdminPolicy.exists?(external_identifier: druid)).to be false
+    expect(RepositoryObject.exists?(external_identifier: druid)).to be false
     policy
-    expect(AdminPolicy.exists?(external_identifier: druid)).to be true
-    expect(Indexer).to have_received(:reindex)
+    expect(RepositoryObject.exists?(external_identifier: druid)).to be true
+    expect(Indexer).to have_received(:reindex).with(cocina_object: an_instance_of(Cocina::Models::AdminPolicyWithMetadata))
   end
 end


### PR DESCRIPTION
refs #5014

## Why was this change made? 🤔
AdminPolicy is deprecated.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



