### PR TITLE
Changes collections_for_object_spec to use RepositoryObject models.

### DIFF
--- a/spec/factories/repository_object_versions.rb
+++ b/spec/factories/repository_object_versions.rb
@@ -67,7 +67,7 @@ FactoryBot.define do
   end
 
   trait :with_repository_object do
-    repository_object
+    repository_object { association :repository_object, external_identifier: }
 
     after(:build) do |repository_object_version, _evaluator|
       repository_object = repository_object_version.repository_object


### PR DESCRIPTION
refs #5014

## Why was this change made? 🤔
Dros are deprecated.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



