### PR TITLE
Update graphql_spec to use RepositoryObjects.

### DIFF
--- a/spec/requests/graphql_spec.rb
+++ b/spec/requests/graphql_spec.rb
@@ -21,42 +21,11 @@ RSpec.describe 'GraphQL' do
     }.to_json
   end
 
-  let(:druid) { cocina_object.external_identifier }
-  let(:cocina_version) { cocina_object.cocina_version }
+  let(:druid) { repo_object.external_identifier }
+  let(:cocina_version) { repo_object.head_version.cocina_version }
   let(:purl) { "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}" }
 
-  context 'when retrieving a DRO' do
-    let(:cocina_object) { create(:ar_dro) }
-
-    it 'returns data' do
-      post '/graphql',
-           params: query,
-           headers: { 'Authorization' => "Bearer #{jwt}", 'Content-Type' => 'application/json' }
-
-      expect(response).to have_http_status(:success)
-      expect(response.parsed_body.with_indifferent_access).to match(
-        {
-          data: {
-            cocinaObject: {
-              externalIdentifier: druid,
-              type: 'https://cocina.sul.stanford.edu/models/book',
-              cocinaVersion: cocina_version,
-              label: 'Test DRO',
-              description: {
-                purl:,
-                title: [{
-                  value: 'Test DRO'
-                }]
-              },
-              geographic: nil
-            }
-          }
-        }
-      )
-    end
-  end
-
-  context 'when retrieving a RepositoryObject' do
+  context 'when retrieving a Dro' do
     let(:repo_object) { create(:repository_object) }
     let(:druid) { repo_object.external_identifier }
     let(:cocina_version) { version_attributes[:cocina_version] }
@@ -110,7 +79,7 @@ RSpec.describe 'GraphQL' do
   end
 
   context 'when retrieving a Collection' do
-    let(:cocina_object) { create(:ar_collection) }
+    let(:repo_object) { create(:repository_object, :collection, :with_repository_object_version) }
 
     it 'returns data' do
       post '/graphql',
@@ -141,7 +110,7 @@ RSpec.describe 'GraphQL' do
   end
 
   context 'when retrieving an AdminPolicy' do
-    let(:cocina_object) { create(:ar_admin_policy) }
+    let(:repo_object) { create(:repository_object, :admin_policy, :with_repository_object_version) }
 
     it 'returns data' do
       post '/graphql',
@@ -157,7 +126,14 @@ RSpec.describe 'GraphQL' do
               type: 'https://cocina.sul.stanford.edu/models/admin_policy',
               cocinaVersion: cocina_version,
               label: 'Test Admin Policy',
-              description: nil,
+              description: {
+                purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}",
+                title: [
+                  {
+                    value: 'Test Admin Policy'
+                  }
+                ]
+              },
               geographic: nil
             }
           }


### PR DESCRIPTION
refs #5014

## Why was this change made? 🤔
Dros are deprecated.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



