### PR TITLE
Changes PublicDescMetadataServiceSpec to use RepositoryObjects.

### DIFF
--- a/spec/services/publish/public_desc_metadata_service_spec.rb
+++ b/spec/services/publish/public_desc_metadata_service_spec.rb
@@ -14,11 +14,12 @@ RSpec.describe Publish::PublicDescMetadataService do
     { title: [{ value: 'stuff' }], purl: 'https://purl.stanford.edu/bc123df4567' }
   end
   let(:item) do
-    build(:ar_dro, external_identifier: 'druid:bc123df4567',
-                   access:,
-                   structural:,
-                   description:,
-                   identification:)
+    create(:repository_object_version, :with_repository_object,
+           external_identifier: 'druid:bc123df4567',
+           access:,
+           structural:,
+           description:,
+           identification:)
   end
 
   describe '#ng_xml' do


### PR DESCRIPTION
refs #5014

## Why was this change made? 🤔
Dros are deprecated.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



