### PR TITLE
Update object_created_spec to use RepositoryObjects.

### DIFF
--- a/app/models/repository_object.rb
+++ b/app/models/repository_object.rb
@@ -32,7 +32,7 @@ class RepositoryObject < ApplicationRecord
   scope :collections, -> { where(object_type: 'collection') }
   scope :admin_policies, -> { where(object_type: 'admin_policy') }
 
-  delegate :to_cocina, to: :head_version
+  delegate :to_cocina, :to_cocina_with_metadata, to: :head_version
 
   # NOTE: This block uses metaprogramming to create the equivalent of scopes that query the RepositoryObjectVersion table using only rows that are a `current` in the RepositoryObject table
   #


### PR DESCRIPTION
refs #5014

## Why was this change made? 🤔
Dros are deprecated.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



