### PR TITLE
Use cocina-models W3CDTF validator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ gem 'parallel' # used for validating cocina tools and for rolling indexer
 gem 'pg'
 gem 'retries' # for Goobi
 gem 'rsolr'
-gem 'rss', '~> 0.2' # Provides Time.w3cdtf used for BadW3cdtfDates report
 gem 'ruby-cache', '~> 0.3.0'
 gem 'sidekiq', '~> 7.0'
 gem 'sneakers', '~> 2.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,8 +445,6 @@ GEM
     rspec-support (3.13.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rss (0.3.0)
-      rexml
     rubocop (1.63.5)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -621,7 +619,6 @@ DEPENDENCIES
   rsolr
   rspec-rails
   rspec_junit_formatter
-  rss (~> 0.2)
   rubocop
   rubocop-performance
   rubocop-rails

--- a/app/reports/invalid_w3cdtf_dates.rb
+++ b/app/reports/invalid_w3cdtf_dates.rb
@@ -83,16 +83,6 @@ class InvalidW3cdtfDates
   end
 
   def self.valid_w3cdtf?(date_value)
-    Time.w3cdtf(date_value)
-  rescue ArgumentError
-    # NOTE: the upstream W3CDTF implementation in the `rss` gem does not
-    #       allow two patterns that should be valid per the specification:
-    #
-    # * YYYY
-    # * YYYY-MM
-    #
-    # So we catch the false positives from the upstream gem and allow
-    # these two patterns to validate
-    /\A\d{4}(-0[1-9]|-1[0-2])?\Z/.match?(date_value)
+    Cocina::Models::Validators::W3cdtfValidator.validate(date_value)
   end
 end


### PR DESCRIPTION
# Why was this change made?

We should not have two standards for validating dates.

# How was this change tested?

- [x] CI
- [x] sdr-infra
