### PR TITLE
Do not query legacy models in graphql endpoint.

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -19,10 +19,7 @@ module Types
       # Lookahead allows access to the actual fields that were requested.
       selected_fields = lookahead.selections.map(&:name)
       # The type of cocina object isn't known, so attempt to retrieve all types.
-      cocina_object = find_cocina_object(clazz: RepositoryObject, selected_fields:, allowed_fields: DRO_ALLOWED_FIELDS, external_identifier:) ||
-                      find_cocina_object(clazz: Dro, selected_fields:, allowed_fields: DRO_ALLOWED_FIELDS, external_identifier:) ||
-                      find_cocina_object(clazz: Collection, selected_fields:, allowed_fields: COLLECTION_ALLOWED_FIELDS, external_identifier:) ||
-                      find_cocina_object(clazz: AdminPolicy, selected_fields:, allowed_fields: BASE_ALLOWED_FIELDS, external_identifier:)
+      cocina_object = find_cocina_object(clazz: RepositoryObject, selected_fields:, allowed_fields: DRO_ALLOWED_FIELDS, external_identifier:)
 
       raise GraphQL::ExecutionError, 'Cocina object not found' if cocina_object.nil?
 


### PR DESCRIPTION
## Why was this change made? 🤔
Dro / Collection / AdminPolicy are deprecated.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



