### PR TITLE
Raise when version mismatch with Preservation.

### DIFF
--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe VersionService do
     context "when Preservation's current version is greater than the current version" do
       it 'raises an exception' do
         expect(Preservation::Client.objects).to receive(:current_version).and_return(3)
-        expect { open }.to raise_error(VersionService::VersioningError, 'Cannot sync to a version greater than current: 1, requested 3')
+        expect { open }.to raise_error(VersionService::VersioningError, 'Version from Preservation is out of sync. Preservation expects 3 but current version is 1')
       end
     end
 


### PR DESCRIPTION
closes #5034

## Why was this change made? 🤔
ObjectVersions are going to be removed, but still want to make version check with pres.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

