### PR TITLE
allow the workspace call to return the location created

### DIFF
--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -11,7 +11,7 @@ class WorkspacesController < ApplicationController
   # POST /v1/objects/:druid/workspace
   def create
     result = WorkspaceService.create(params[:object_id], params[:source])
-    head :created, location: result
+    render status: :created, json: { path: result }
   end
 
   def destroy

--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -10,7 +10,7 @@ class WorkspacesController < ApplicationController
 
   # POST /v1/objects/:druid/workspace
   def create
-    result = WorkspaceService.create(params[:object_id], params[:source])
+    result = WorkspaceService.create(params[:object_id], params[:source], content: ActiveModel::Type::Boolean.new.cast(params[:content]), metadata: ActiveModel::Type::Boolean.new.cast(params[:metadata]))
     render status: :created, json: { path: result }
   end
 

--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -10,8 +10,8 @@ class WorkspacesController < ApplicationController
 
   # POST /v1/objects/:druid/workspace
   def create
-    WorkspaceService.create(params[:object_id], params[:source])
-    head :created
+    result = WorkspaceService.create(params[:object_id], params[:source])
+    head :created, location: result
   end
 
   def destroy

--- a/app/services/workspace_service.rb
+++ b/app/services/workspace_service.rb
@@ -4,12 +4,17 @@
 class WorkspaceService
   # @param [String] druid the identifier of the item to create the workspace for
   # @param [String, nil] source the path to link to (optional)
+  # @param [Boolean] content whether to create the content directory (optional)
+  # @param [Boolean] metadata whether to create the metadata directory (optional)
   # @return [String] the path to the created workspace
-  def self.create(druid, source)
+  def self.create(druid, source, content: false, metadata: false)
     druid_obj = DruidTools::Druid.new(druid, Settings.stacks.local_workspace_root)
     return mkdir_with_final_link(druid_obj:, source:) if source
 
-    druid_obj.mkdir&.first # druid_obj.mkdir returns an array - we want the first entry
+    path = druid_obj.mkdir&.first # druid_obj.mkdir returns an array - we want the first entry
+    druid_obj.content_dir if content # druid-tools will create the content/metadata directories if they don't exist
+    druid_obj.metadata_dir if metadata
+    path
   end
 
   def self.mkdir_with_final_link(druid_obj:, source:)

--- a/app/services/workspace_service.rb
+++ b/app/services/workspace_service.rb
@@ -3,14 +3,13 @@
 # Creates workspaces.  This replaces https://github.com/sul-dlss/dor-services/blob/main/lib/dor/models/concerns/assembleable.rb
 class WorkspaceService
   # @param [String] druid the identifier of the item to create the workspace for
-  # @param [String, nil] source the path to create
+  # @param [String, nil] source the path to link to (optional)
+  # @return [String] the path to the created workspace
   def self.create(druid, source)
     druid_obj = DruidTools::Druid.new(druid, Settings.stacks.local_workspace_root)
     return mkdir_with_final_link(druid_obj:, source:) if source
 
-    Honeybadger.notify('Source was not provided to WorkspaceService.create. ' \
-                       "I'm pretty sure that source is always supplied and ought to be required")
-    druid_obj.mkdir
+    druid_obj.mkdir&.first # druid_obj.mkdir returns an array - we want the first entry
   end
 
   def self.mkdir_with_final_link(druid_obj:, source:)
@@ -20,6 +19,7 @@ class WorkspaceService
     real_path = File.expand_path('..', new_path)
     FileUtils.mkdir_p(real_path)
     FileUtils.ln_s(source, new_path, force: true)
+    new_path
   end
   private_class_method :mkdir_with_final_link
 end

--- a/spec/requests/workspaces_spec.rb
+++ b/spec/requests/workspaces_spec.rb
@@ -20,7 +20,40 @@ RSpec.describe 'Workspaces' do
         post "/v1/objects/#{druid}/workspace",
              headers: { 'Authorization' => "Bearer #{jwt}" }
 
-        expect(WorkspaceService).to have_received(:create).with(druid, nil)
+        expect(WorkspaceService).to have_received(:create).with(druid, nil, content: nil, metadata: nil)
+        expect(response).to have_http_status(:created)
+        expect(response.body).to eq({ path: path_to_workspace }.to_json)
+      end
+    end
+
+    context 'when content params are passed' do
+      it 'is successful and returns the created directory' do
+        post "/v1/objects/#{druid}/workspace?content=true",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+
+        expect(WorkspaceService).to have_received(:create).with(druid, nil, content: true, metadata: nil)
+        expect(response).to have_http_status(:created)
+        expect(response.body).to eq({ path: path_to_workspace }.to_json)
+      end
+    end
+
+    context 'when metadata params are passed' do
+      it 'is successful and returns the created directory' do
+        post "/v1/objects/#{druid}/workspace?metadata=true",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+
+        expect(WorkspaceService).to have_received(:create).with(druid, nil, content: nil, metadata: true)
+        expect(response).to have_http_status(:created)
+        expect(response.body).to eq({ path: path_to_workspace }.to_json)
+      end
+    end
+
+    context 'when content and metadata params are passed' do
+      it 'is successful and returns the created directory' do
+        post "/v1/objects/#{druid}/workspace?metadata=true&content=true",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+
+        expect(WorkspaceService).to have_received(:create).with(druid, nil, content: true, metadata: true)
         expect(response).to have_http_status(:created)
         expect(response.body).to eq({ path: path_to_workspace }.to_json)
       end
@@ -33,7 +66,7 @@ RSpec.describe 'Workspaces' do
         post "/v1/objects/#{druid}/workspace?source=#{source}",
              headers: { 'Authorization' => "Bearer #{jwt}" }
 
-        expect(WorkspaceService).to have_received(:create).with(druid, source)
+        expect(WorkspaceService).to have_received(:create).with(druid, source, content: nil, metadata: nil)
         expect(response).to have_http_status(:created)
         expect(response.body).to eq({ path: path_to_workspace }.to_json)
       end

--- a/spec/requests/workspaces_spec.rb
+++ b/spec/requests/workspaces_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Workspaces' do
 
         expect(WorkspaceService).to have_received(:create).with(druid, nil)
         expect(response).to have_http_status(:created)
-        expect(response.headers['Location']).to eq(path_to_workspace)
+        expect(response.body).to eq({ path: path_to_workspace }.to_json)
       end
     end
 
@@ -35,7 +35,7 @@ RSpec.describe 'Workspaces' do
 
         expect(WorkspaceService).to have_received(:create).with(druid, source)
         expect(response).to have_http_status(:created)
-        expect(response.headers['Location']).to eq(path_to_workspace)
+        expect(response.body).to eq({ path: path_to_workspace }.to_json)
       end
     end
   end

--- a/spec/requests/workspaces_spec.rb
+++ b/spec/requests/workspaces_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Workspaces' do
+  let(:druid) { 'druid:mx123qw2323' }
+  let(:path_to_workspace) { '/path/to/workspace' }
+
+  before do
+    allow(CocinaObjectStore).to receive(:exists!).and_return(true)
+  end
+
+  context 'when successful' do
+    before do
+      allow(WorkspaceService).to receive(:create).and_return(path_to_workspace)
+    end
+
+    context 'when no source is passed' do
+      it 'is successful and returns the created directory' do
+        post "/v1/objects/#{druid}/workspace",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+
+        expect(WorkspaceService).to have_received(:create).with(druid, nil)
+        expect(response).to have_http_status(:created)
+        expect(response.headers['Location']).to eq(path_to_workspace)
+      end
+    end
+
+    context 'when source is passed' do
+      let(:source) { '/path/to/source' }
+
+      it 'is successful and returns the created directory' do
+        post "/v1/objects/#{druid}/workspace?source=#{source}",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+
+        expect(WorkspaceService).to have_received(:create).with(druid, source)
+        expect(response).to have_http_status(:created)
+        expect(response.headers['Location']).to eq(path_to_workspace)
+      end
+    end
+  end
+end

--- a/spec/services/workspace_service_spec.rb
+++ b/spec/services/workspace_service_spec.rb
@@ -20,14 +20,34 @@ RSpec.describe WorkspaceService do
     let(:druid_path) { File.join(temp_workspace, 'mx', '123', 'qw', '2323', 'mx123qw2323') }
     let(:druid) { 'druid:mx123qw2323' }
 
-    it 'creates a plain directory in the workspace when passed no source directory' do
+    it 'creates a plain directory in the workspace when not passed a source directory' do
       result = described_class.create(druid, nil)
       expect(File).to be_directory(druid_path)
       expect(File).not_to be_symlink(druid_path)
       expect(result).to eq(druid_path)
+      expect(File).not_to be_directory(File.join(druid_path, 'content'))
+      expect(File).not_to be_directory(File.join(druid_path, 'metadata'))
     end
 
-    it 'creates a link in the workspace to a passed in source directory' do
+    it 'creates a plain directory with content subfolder in the workspace when not passed a source directory' do
+      result = described_class.create(druid, nil, content: true)
+      expect(File).to be_directory(druid_path)
+      expect(File).not_to be_symlink(druid_path)
+      expect(result).to eq(druid_path)
+      expect(File).to be_directory(File.join(druid_path, 'content'))
+      expect(File).not_to be_directory(File.join(druid_path, 'metadata'))
+    end
+
+    it 'creates a plain directory with metadata subfolder in the workspace when not passed a source directory' do
+      result = described_class.create(druid, nil, metadata: true)
+      expect(File).to be_directory(druid_path)
+      expect(File).not_to be_symlink(druid_path)
+      expect(result).to eq(druid_path)
+      expect(File).not_to be_directory(File.join(druid_path, 'content'))
+      expect(File).to be_directory(File.join(druid_path, 'metadata'))
+    end
+
+    it 'creates a link in the workspace when passed in source directory' do
       source_dir = '/tmp/content_dir'
       FileUtils.mkdir_p(source_dir)
       result = described_class.create(druid, source_dir)

--- a/spec/services/workspace_service_spec.rb
+++ b/spec/services/workspace_service_spec.rb
@@ -21,18 +21,20 @@ RSpec.describe WorkspaceService do
     let(:druid) { 'druid:mx123qw2323' }
 
     it 'creates a plain directory in the workspace when passed no source directory' do
-      described_class.create(druid, nil)
+      result = described_class.create(druid, nil)
       expect(File).to be_directory(druid_path)
       expect(File).not_to be_symlink(druid_path)
+      expect(result).to eq(druid_path)
     end
 
     it 'creates a link in the workspace to a passed in source directory' do
       source_dir = '/tmp/content_dir'
       FileUtils.mkdir_p(source_dir)
-      described_class.create(druid, source_dir)
+      result = described_class.create(druid, source_dir)
 
       expect(File).to be_symlink(druid_path)
       expect(File.readlink(druid_path)).to eq(source_dir)
+      expect(result).to eq(druid_path)
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

ocrWF will be making a call to create the relevant `/dor/workspace` druid tree directory. It will not need the source path and symlink, it just wants to the workspace folder.   So this:

- removes the HB alert since we this will be the first consumer to not be sending in the source
- allows DSA to return the directory location created, so it can be used by the caller
- allows client to request metadata and/or content subdirectories also be created (but only if no source is passed in, since if source is passed in, the subdirectories should already exist at the source, and the created directory is actually just a symlink there)

There is a corresponding [dor-services-client PR](https://github.com/sul-dlss/dor-services-client/pull/436) to grab the location and return to the consumer.

## How was this change tested? 🤨

Updated existing spec
Created a new spec
Localhost using updated dor-services-client: https://github.com/sul-dlss/dor-services-client/pull/436