### PR TITLE
Add report to find repository objects with files shelved but not publ…

### DIFF
--- a/app/reports/shelved_not_published.rb
+++ b/app/reports/shelved_not_published.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'json'
+
+# Generates a report of repository objects with files that are
+# shelved but not published
+
+# bin/rails r -e production "ShelvedNotPublished.report"
+#
+class ShelvedNotPublished
+  SQL = <<~SQL.squish.freeze
+    SELECT ro.external_identifier,
+      jsonb_path_query(rov.administrative, '$.hasAdminPolicy') AS admin_policy,
+      rov.content_type,
+      jsonb_path_query_array(rov.structural, '$.contains[*].structural.contains[*].administrative[*].shelve') AS shelve,
+      jsonb_path_query_array(rov.structural, '$.contains[*].structural.contains[*].administrative[*].publish') AS publish
+      FROM repository_objects AS ro, repository_object_versions AS rov
+      WHERE ro.head_version_id = rov.id
+      AND ro.object_type = 'dro'
+  SQL
+
+  def self.report
+    puts 'druid,admin_policy,type'
+    ActiveRecord::Base.connection.execute(SQL).each do |row|
+      next unless row['shelve'].include?('true') && row['publish'].include?('false')
+
+      JSON.parse(row['shelve']).each_with_index do |val, key|
+        next unless val == true
+        next unless JSON.parse(row['publish'])[key] == false
+
+        puts "#{row['external_identifier']},#{row['admin_policy']},#{row['content_type']}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #5045 

Adds a report for all objects that have files where `shelve = true` and `publish = false`.

## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



