### PR TITLE
Republish constituents after virtual object.

### DIFF
--- a/app/services/member_service.rb
+++ b/app/services/member_service.rb
@@ -37,11 +37,7 @@ class MemberService
     return members unless only_published
 
     members.select do |member|
-      workflow_client.lifecycle(druid: member.external_identifier, milestone_name: 'published', version: member.version).present?
+      WorkflowStateService.published?(druid: member.external_identifier, version: member.version)
     end
-  end
-
-  def workflow_client
-    @workflow_client ||= WorkflowClientFactory.build
   end
 end

--- a/app/services/virtual_object_service.rb
+++ b/app/services/virtual_object_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Finds the constituents of a virtual object.
+class VirtualObjectService
+  def self.constituents(...)
+    new(...).constituents
+  end
+
+  # @param [Cocina::Models::DRO] cocina_dro the cocina model for the virtual object
+  # @param [Boolean] only_published when true, restrict to only published items
+  # @param [Boolean] exclude_opened when true, exclude opened items
+  # @return [Array<String>] the druids for the constituents of this virtual object
+  def initialize(cocina_dro, only_published: false, exclude_opened: false)
+    @cocina_dro = cocina_dro
+    @only_published = only_published
+    @exclude_opened = exclude_opened
+  end
+
+  def constituents
+    return [] unless cocina_dro.dro?
+
+    RepositoryObject.joins(:head_version).where(external_identifier: constituent_druids).select(:external_identifier, :version, :head_version_id, :opened_version_id)
+                    .then { |constituents| exclude_opened_constituents(constituents) }
+                    .then { |constituents| only_published_constituents(constituents) }
+                    .map(&:external_identifier)
+  end
+
+  private
+
+  attr_reader :cocina_dro, :only_published, :exclude_opened
+
+  def constituent_druids
+    cocina_dro.structural.hasMemberOrders.flat_map(&:members).uniq
+  end
+
+  def exclude_opened_constituents(constituents)
+    return constituents unless exclude_opened
+
+    constituents.reject(&:open?)
+  end
+
+  def only_published_constituents(constituents)
+    return constituents unless only_published
+
+    constituents.select do |constituent|
+      WorkflowStateService.published?(druid: constituent.external_identifier, version: constituent.version)
+    end
+  end
+end

--- a/app/services/workflow_state_service.rb
+++ b/app/services/workflow_state_service.rb
@@ -11,6 +11,10 @@ class WorkflowStateService
     new(...).accessioned?
   end
 
+  def self.published?(...)
+    new(...).published?
+  end
+
   def initialize(druid:, version:)
     @druid = druid
     @version = version
@@ -51,6 +55,11 @@ class WorkflowStateService
     return true if workflow_client.lifecycle(druid:, milestone_name: 'accessioned')
 
     false
+  end
+
+  # @return [Boolean] true if the object has previously been published for the version.
+  def published?
+    workflow_client.lifecycle(druid:, milestone_name: 'published', version:).present?
   end
 
   private

--- a/spec/services/virtual_object_service_spec.rb
+++ b/spec/services/virtual_object_service_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe VirtualObjectService do
+  describe '#constituents' do
+    let(:constituents) { described_class.constituents(cocina_object, only_published:, exclude_opened:) }
+    let(:only_published) { false }
+    let(:exclude_opened) { false }
+
+    context 'when the virtual object is a DRO' do
+      let(:cocina_object) do
+        build(:dro).new(structural: {
+                          contains: [],
+                          hasMemberOrders: [
+                            {
+                              members: [
+                                'druid:dj321gm8879', # published and closed
+                                'druid:vs491yc7072', # published and open
+                                'druid:bc778pm9866' # unpublished and closed
+                              ],
+                              viewingDirection: 'left-to-right'
+                            }
+                          ],
+                          isMemberOf: []
+                        })
+      end
+
+      before do
+        create(:repository_object, :closed, external_identifier: 'druid:dj321gm8879')
+        create(:repository_object, external_identifier: 'druid:vs491yc7072')
+        create(:repository_object, :closed, external_identifier: 'druid:bc778pm9866')
+        allow(WorkflowStateService).to receive(:published?).with(druid: 'druid:dj321gm8879', version: 1).and_return(true)
+        allow(WorkflowStateService).to receive(:published?).with(druid: 'druid:vs491yc7072', version: 1).and_return(true)
+        allow(WorkflowStateService).to receive(:published?).with(druid: 'druid:bc778pm9866', version: 1).and_return(false)
+      end
+
+      context 'when not limited' do
+        it 'returns the druids of the constituent objects' do
+          expect(constituents).to eq(['druid:dj321gm8879', 'druid:vs491yc7072', 'druid:bc778pm9866'])
+        end
+      end
+
+      context 'when only published' do
+        let(:only_published) { true }
+
+        it 'returns the druids of the constituent objects' do
+          expect(constituents).to eq(['druid:dj321gm8879', 'druid:vs491yc7072'])
+        end
+      end
+
+      context 'when only closed' do
+        let(:exclude_opened) { true }
+
+        it 'returns the druids of the constituent objects' do
+          expect(constituents).to eq(['druid:dj321gm8879', 'druid:bc778pm9866'])
+        end
+      end
+    end
+
+    context 'when the virtual object is a collection' do
+      let(:cocina_object) { build(:collection) }
+
+      it 'returns an empty array' do
+        expect(constituents).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔
So that when purl-fetcher builds the public xml for the constituents, the constituents get the relationship to the virtual object.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, integration test

