### PR TITLE
Update docker base image to debian base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
-FROM ruby:3.2.2-alpine
+FROM ruby:3.3.1-bookworm
 
 ENV RAILS_ENV=production
 ENV BUNDLER_WITHOUT="development test"
 
-# postgresql-client is required for invoke.sh
-RUN apk add --update --no-cache  \
-  build-base \
-  git \
-  postgresql-dev \
-  postgresql-client \
-  tzdata
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        postgresql-client postgresql-contrib libpq-dev \
+        libxml2-dev clang git
 
 # Get bundler 2.0
 RUN gem install bundler

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ services:
       SETTINGS__SOLR__URL: http://solr:8983/solr/dorservices
       SETTINGS__SURI__URL: http://suri:3000
       SETTINGS__WORKFLOW_URL: http://workflow:3000
+      # We don't actually use this anywhere but the rails server needs it in production env
+      SECRET_KEY_BASE: e0221b0233dbe4914fae9405c1e179eb1db71379fd999c51265123a6dde45c8281235307dda0b8c06633b702a05679391a950a483f8c624642eb3c3211d4241d
   redis:
     image: redis
     ports:


### PR DESCRIPTION
## Why was this change made? 🤔

Update to a debian based docker image in order to support recent version(s) of openapi_parser and use a base closer to our deployed environments.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



