### PR TITLE
Get connection from ActiveRecord::Base instead of ObjectVersion.

### DIFF
--- a/db/migrate/20220422143440_require_object_versions.rb
+++ b/db/migrate/20220422143440_require_object_versions.rb
@@ -1,7 +1,7 @@
 class RequireObjectVersions < ActiveRecord::Migration[5.2]
   def change
-    ObjectVersion.connection.execute("update object_versions set tag = concat(version::varchar, '.0.0') where tag is null;")
-    ObjectVersion.connection.execute("update object_versions set description = concat('Version ', tag) where description is null;")
+    ActiveRecord::Base.connection.execute("update object_versions set tag = concat(version::varchar, '.0.0') where tag is null;")
+    ActiveRecord::Base.connection.execute("update object_versions set description = concat('Version ', tag) where description is null;")
     change_column_null :object_versions, :tag, false
     change_column_null :object_versions, :description, false
   end

--- a/db/migrate/20220509120943_change_object_version_description.rb
+++ b/db/migrate/20220509120943_change_object_version_description.rb
@@ -1,5 +1,5 @@
 class ChangeObjectVersionDescription < ActiveRecord::Migration[5.2]
   def change
-    ObjectVersion.connection.execute("update object_versions set description = concat('Version ', version) where description = concat('Version ', tag);")
+    ActiveRecord::Base.connection.execute("update object_versions set description = concat('Version ', version) where description = concat('Version ', tag);")
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ SimpleCov.start :rails do
   add_filter '/spec/'
   add_filter '/bin/'
   add_filter '/app/reports/'
+  add_filter '/db/'
 end
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
@@ -23,6 +24,8 @@ require 'support/factory_bot'
 require 'cocina/rspec'
 require 'rack/test'
 require 'webmock/rspec'
+
+# TODO: Only run SimpleCov in CI
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
## Why was this change made? 🤔
ObjectVersion no longer exists.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



