### PR TITLE
Restore the remove release tags migratator but for repository objects

### DIFF
--- a/app/services/migrators/remove_release_tags.rb
+++ b/app/services/migrators/remove_release_tags.rb
@@ -10,7 +10,6 @@ module Migrators
     def migrate
       repository_object.versions.select { |version| version.administrative&.key?('releaseTags') }.each do |version|
         version.administrative.delete('releaseTags')
-        version.save!
       end
     end
   end

--- a/app/services/migrators/remove_release_tags.rb
+++ b/app/services/migrators/remove_release_tags.rb
@@ -4,11 +4,14 @@ module Migrators
   # Migrator that will be used to remove release tags.
   class RemoveReleaseTags < Base
     def migrate?
-      repository_object.head_version.administrative.key?('releaseTags')
+      repository_object.versions.any? { |version| version.administrative.key?('releaseTags') }
     end
 
     def migrate
-      repository_object.head_version.administrative.delete('releaseTags')
+      repository_object.versions.select { |version| version.administrative.key?('releaseTags') }.each do |version|
+        version.administrative.delete('releaseTags')
+        version.save!
+      end
     end
   end
 end

--- a/app/services/migrators/remove_release_tags.rb
+++ b/app/services/migrators/remove_release_tags.rb
@@ -4,11 +4,11 @@ module Migrators
   # Migrator that will be used to remove release tags.
   class RemoveReleaseTags < Base
     def migrate?
-      repository_object.versions.any? { |version| version.administrative.key?('releaseTags') }
+      repository_object.versions.any? { |version| version.administrative&.key?('releaseTags') }
     end
 
     def migrate
-      repository_object.versions.select { |version| version.administrative.key?('releaseTags') }.each do |version|
+      repository_object.versions.select { |version| version.administrative&.key?('releaseTags') }.each do |version|
         version.administrative.delete('releaseTags')
         version.save!
       end

--- a/app/services/migrators/remove_release_tags.rb
+++ b/app/services/migrators/remove_release_tags.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Migrators
+  # Migrator that will be used to remove release tags.
+  class RemoveReleaseTags < Base
+    def migrate?
+      repository_object.head_version.administrative.key?('releaseTags')
+    end
+
+    def migrate
+      repository_object.head_version.administrative.delete('releaseTags')
+    end
+  end
+end

--- a/bin/migrate-cocina
+++ b/bin/migrate-cocina
@@ -50,9 +50,9 @@ def on_finish(results, progress_bar)
   progress_bar.advance(results.size)
 end
 
-def tty_progress_bar(count, clazz_name, mode)
+def tty_progress_bar(count, mode)
   TTY::ProgressBar.new(
-    "#{mode} #{clazz_name} [:bar] (:percent (:current/:total), rate: :rate/s, mean rate: :mean_rate/s, :elapsed total, ETA: :eta_time)",
+    "#{mode} [:bar] (:percent (:current/:total), rate: :rate/s, mean rate: :mean_rate/s, :elapsed total, ETA: :eta_time)",
     bar_format: :box,
     advance: num_for_progress_advance(count),
     total: count
@@ -107,7 +107,7 @@ end
 def migrate(migrator_class:, sample:, processes:, mode:)
   druids = druids_for(migrator_class:, sample:)
 
-  progress_bar = tty_progress_bar(druids.length, ar_class.name, mode)
+  progress_bar = tty_progress_bar(druids.length, mode)
   progress_bar.start
 
   Parallel.map(druids.each_slice(100),

--- a/spec/services/migrators/remove_release_tags_spec.rb
+++ b/spec/services/migrators/remove_release_tags_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Migrators::RemoveReleaseTags do
   describe 'migrate' do
     it 'removes releaseTags' do
       migrator.migrate
+      repository_object.reload
       expect(repository_object.head_version.administrative).to eq({ 'hasAdminPolicy' => 'druid:hy787xj5878' })
     end
   end

--- a/spec/services/migrators/remove_release_tags_spec.rb
+++ b/spec/services/migrators/remove_release_tags_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe Migrators::RemoveReleaseTags do
   describe 'migrate' do
     it 'removes releaseTags' do
       migrator.migrate
-      repository_object.reload
-      expect(repository_object.head_version.administrative).to eq({ 'hasAdminPolicy' => 'druid:hy787xj5878' })
+      expect(repository_object.versions.first.administrative).to eq({ 'hasAdminPolicy' => 'druid:hy787xj5878' })
     end
   end
 

--- a/spec/services/migrators/remove_release_tags_spec.rb
+++ b/spec/services/migrators/remove_release_tags_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Migrators::RemoveReleaseTags do
+  subject(:migrator) { described_class.new(repository_object) }
+
+  let(:repository_object) { create(:repository_object, :with_repository_object_version, repository_object_version:) }
+  let(:repository_object_version) { build(:repository_object_version, administrative:) }
+  let(:administrative) { { hasAdminPolicy: 'druid:hy787xj5878', releaseTags: [] } }
+
+  describe '#migrate?' do
+    subject { migrator.migrate? }
+
+    it { is_expected.to be true }
+  end
+
+  describe 'migrate' do
+    it 'removes releaseTags' do
+      migrator.migrate
+      expect(repository_object.head_version.administrative).to eq({ 'hasAdminPolicy' => 'druid:hy787xj5878' })
+    end
+  end
+
+  describe '#publish?' do
+    it 'returns false as migrated SDR objects should not be published' do
+      expect(migrator.publish?).to be false
+    end
+  end
+
+  describe '#version?' do
+    it 'returns false as migrated SDR objects should not be versioned' do
+      expect(migrator.version?).to be false
+    end
+  end
+
+  describe '#version_description' do
+    it 'raises an error as version? is never true' do
+      expect { migrator.version_description }.to raise_error(NotImplementedError)
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Restores the remove release tags migrator so that we can officially remove them from cocina-models.

## How was this change tested? 🤨

Ran the migration in stage and then validated the cocina against the https://github.com/sul-dlss/cocina-models/pull/721 branch of cocina-models

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



