### PR TITLE
Set SECRET_KEY_BASE=1 in docker compose as it's essentially unused

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       RAILS_LOG_TO_STDOUT: 'true'
       REDIS_URL: redis://redis:6379/
       # We don't actually use this anywhere but the rails server needs it in production env
-      SECRET_KEY_BASE: e0221b0233dbe4914fae9405c1e179eb1db71379fd999c51265123a6dde45c8281235307dda0b8c06633b702a05679391a950a483f8c624642eb3c3211d4241d
+      SECRET_KEY_BASE: 1
       SOLR_URL: http://solr:8983/solr/dorservices
       SETTINGS__REDIS_URL: redis://redis:6379/
       SETTINGS__SOLR__URL: http://solr:8983/solr/dorservices
@@ -46,7 +46,7 @@ services:
       SETTINGS__SURI__URL: http://suri:3000
       SETTINGS__WORKFLOW_URL: http://workflow:3000
       # We don't actually use this anywhere but the rails server needs it in production env
-      SECRET_KEY_BASE: e0221b0233dbe4914fae9405c1e179eb1db71379fd999c51265123a6dde45c8281235307dda0b8c06633b702a05679391a950a483f8c624642eb3c3211d4241d
+      SECRET_KEY_BASE: 1
   redis:
     image: redis
     ports:


### PR DESCRIPTION
## Why was this change made? 🤔

I didn't see this comment (https://github.com/sul-dlss/dor-services-app/pull/5056#discussion_r1621550558) since it was after the PR was merged. This is just a quick update to pick up that suggestion.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



