### PR TITLE
Add a commit mode to migrate-cocina

### DIFF
--- a/app/models/repository_object.rb
+++ b/app/models/repository_object.rb
@@ -13,7 +13,7 @@ class RepositoryObject < ApplicationRecord
   class VersionAlreadyOpened < StandardError; end
   class VersionNotOpened < StandardError; end
 
-  has_many :versions, -> { order(version: :asc) }, class_name: 'RepositoryObjectVersion', dependent: :destroy, inverse_of: 'repository_object'
+  has_many :versions, -> { order(version: :asc) }, class_name: 'RepositoryObjectVersion', dependent: :destroy, inverse_of: 'repository_object', autosave: true
   has_many :user_versions, through: :versions
 
   belongs_to :head_version, class_name: 'RepositoryObjectVersion', optional: true

--- a/bin/migrate-cocina
+++ b/bin/migrate-cocina
@@ -84,16 +84,8 @@ def perform_migrate(migrator_class:, obj:, mode:)
   current_object_version = obj.head_version.version
   obj = open_version(cocina_object: obj, version_description: migrator.version_description, mode:) if migrator.version?
 
-  # For active record migrations, we need to wrap the migration in a transaction and save the object instead of
-  # opening/closing versions
-  if mode == :commit
-    obj.transaction do
-      migrator.migrate
-      obj.save!
-    end
-  else
-    migrator.migrate # This is where the actual migration happens
-  end
+  migrator.migrate # This is where the actual migration happens
+
   updated_cocina_object = obj.head_version.to_cocina_with_metadata # This validates the cocina object
   Cocina::ObjectValidator.validate(updated_cocina_object) # This validation is performed by UpdateObjectService.
 
@@ -102,6 +94,12 @@ def perform_migrate(migrator_class:, obj:, mode:)
     updated_cocina_object = UpdateObjectService.update(updated_cocina_object, skip_open_check: !migrator.version?)
     Publish::MetadataTransferService.publish(updated_cocina_object) if migrator.publish?
     close_version(cocina_object: updated_cocina_object, version_description: migrator.version_description) unless updated_cocina_object.version == current_object_version
+  elsif mode == :commit
+    # For active record migrations, we need to wrap the migration in a transaction and save the object instead of
+    # opening/closing versions
+    obj.transaction do
+      obj.save!
+    end
   end
   [obj.id, obj.external_identifier, 'SUCCESS']
 rescue Dry::Struct::Error, Cocina::Models::ValidationError, Cocina::ValidationError => e

--- a/bin/migrate-cocina
+++ b/bin/migrate-cocina
@@ -20,8 +20,8 @@ options = { processes: 4, mode: :dryrun, sample: nil }
 
 parser = OptionParser.new do |option_parser|
   option_parser.banner = 'Usage: bin/migrate-cocina MIGRATION_CLASS [options]'
-  option_parser.on('--mode [MODE]', %i[dryrun migrate verify],
-                   'Migration mode (dryrun, migrate, verify). Default is dryrun')
+  option_parser.on('--mode [MODE]', %i[commit dryrun migrate verify],
+                   'Migration mode (commit dryrun, migrate, verify). Default is dryrun')
   option_parser.on('-pPROCESSES', '--processes PROCESSES', Integer, "Number of processes. Default is #{options[:processes]}.")
   option_parser.on('-sSAMPLE', '--sample SAMPLE', Integer, 'Sample size per type, otherwise all objects.')
   option_parser.on('-h', '--help', 'Displays help.') do
@@ -84,7 +84,14 @@ def perform_migrate(migrator_class:, obj:, mode:)
   current_object_version = obj.head_version.version
   obj = open_version(cocina_object: obj, version_description: migrator.version_description, mode:) if migrator.version?
 
-  migrator.migrate # This is where the actual migration happens
+  if mode == :commit
+    obj.transaction do
+      migrator.migrate
+      obj.save!
+    end
+  else
+    migrator.migrate # This is where the actual migration happens
+  end
   updated_cocina_object = obj.head_version.to_cocina_with_metadata # This validates the cocina object
   Cocina::ObjectValidator.validate(updated_cocina_object) # This validation is performed by UpdateObjectService.
 

--- a/bin/migrate-cocina
+++ b/bin/migrate-cocina
@@ -84,6 +84,8 @@ def perform_migrate(migrator_class:, obj:, mode:)
   current_object_version = obj.head_version.version
   obj = open_version(cocina_object: obj, version_description: migrator.version_description, mode:) if migrator.version?
 
+  # For active record migrations, we need to wrap the migration in a transaction and save the object instead of
+  # opening/closing versions
   if mode == :commit
     obj.transaction do
       migrator.migrate


### PR DESCRIPTION
## Why was this change made? 🤔

Add a commit method to migrate-cocina so that we can save changes to `RepositoryObjects`, `RepositoryObjectVersions`, etc in the migration for use cases where we do not want to use the `UpdateVersionService` as that will not always work for prior versions.

This also adds `autosave: true` to the `RepositoryObjectVersion` association in `RepositoryObject` so that we do not require individual saves for versions.

## How was this change tested? 🤨

Beyond existing unit tests, I tested this by running on stage.

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



