### PR TITLE
[HOLD] add endpoint to check if text extraction workflows are running

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -50,6 +50,7 @@ class VersionsController < ApplicationController
       open: version_service.open?,
       openable: version_service.can_open?,
       assembling: workflow_state_service.assembling?,
+      text_extracting: workflow_state_service.text_extracting?,
       accessioning: workflow_state_service.accessioning?,
       closeable: version_service.can_close?
     }

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -183,7 +183,7 @@ class VersionService
 
   private
 
-  delegate :assembling?, :accessioning?, to: :workflow_state_service
+  delegate :assembling?, :text_extracting?, :accessioning?, to: :workflow_state_service
 
   def workflow_client
     @workflow_client ||= WorkflowClientFactory.build
@@ -196,6 +196,7 @@ class VersionService
   def ensure_closeable!
     raise VersionService::VersioningError, "Trying to close version #{version} on #{druid} which is not opened for versioning" unless open?
     raise VersionService::VersioningError, "Trying to close version #{version} on #{druid} which has active assemblyWF" if assembling?
+    raise VersionService::VersioningError, "Trying to close version #{version} on #{druid} which has active text extraction workflow" if text_extracting?
     raise VersionService::VersioningError, "accessionWF already created for versioned object #{druid}" if accessioning?
   end
 

--- a/app/services/workflow_state_service.rb
+++ b/app/services/workflow_state_service.rb
@@ -31,6 +31,14 @@ class WorkflowStateService
       active_workflow?(workflow: 'gisAssemblyWF')
   end
 
+  # Checks if the latest version has any text extraction workflows with incomplete steps.
+  # @return [Boolean] true if object is currently having text extracted
+  def text_extracting?
+    # Omitting the last step for these workflows since the last step is closing the version.
+    # NOTE: we can add captioning workflows here if/when they are created
+    active_workflow_except_step?(workflow: 'ocrWF', process: 'end-ocr')
+  end
+
   # The following methods were extracted from VersionService.
   # As such, they may not represent the current best practice for determining workflow state
   # and will probably be subject to further refactoring or removal.

--- a/openapi.yml
+++ b/openapi.yml
@@ -3356,6 +3356,7 @@ components:
         - open
         - openable
         - assembling
+        - text_extracting
         - accessioning
         - closeable
       properties:
@@ -3371,6 +3372,9 @@ components:
         assembling:
           type: boolean
           description: whether there is an active assembly workflow (not just assemblyWF)
+        text_extracting:
+          type: boolean
+          description: whether there is an active text extraction workflow
         accessioning:
           type: boolean
           description: whether there is an active accessioningWF workflow

--- a/spec/requests/versions_spec.rb
+++ b/spec/requests/versions_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe 'Operations regarding object versions' do
 
     describe '/versions/status' do
       let(:version_service) { instance_double(VersionService, can_open?: false, can_close?: true, open?: true) }
-      let(:workflow_state_service) { instance_double(WorkflowStateService, assembling?: true, accessioning?: false) }
+      let(:workflow_state_service) { instance_double(WorkflowStateService, text_extracting?: false, assembling?: true, accessioning?: false) }
 
       before do
         allow(VersionService).to receive(:new).and_return(version_service)
@@ -203,6 +203,7 @@ RSpec.describe 'Operations regarding object versions' do
                                                                         versionId: 1,
                                                                         open: true,
                                                                         openable: false,
+                                                                        text_extracting: false,
                                                                         assembling: true,
                                                                         accessioning: false,
                                                                         closeable: true

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe VersionService do
 
     context 'when description and user_name are passed in' do
       before do
-        allow(workflow_state_service).to receive_messages(accessioning?: false, assembling?: false)
+        allow(workflow_state_service).to receive_messages(accessioning?: false, text_extracting?: false, assembling?: false)
       end
 
       context 'when user_version is none' do
@@ -354,7 +354,7 @@ RSpec.describe VersionService do
       let(:start_accession) { false }
 
       before do
-        allow(workflow_state_service).to receive_messages(accessioning?: false, assembling?: false)
+        allow(workflow_state_service).to receive_messages(accessioning?: false, text_extracting?: false, assembling?: false)
       end
 
       it 'passes the correct value of create_accession_wf' do
@@ -376,7 +376,7 @@ RSpec.describe VersionService do
 
     context 'when the object has an active accesssionWF' do
       before do
-        allow(workflow_state_service).to receive_messages(assembling?: false, accessioning?: true)
+        allow(workflow_state_service).to receive_messages(assembling?: false, text_extracting?: false, accessioning?: true)
       end
 
       it 'raises an exception' do
@@ -397,7 +397,7 @@ RSpec.describe VersionService do
 
     context 'when the object has no assemblyWF' do
       before do
-        allow(workflow_state_service).to receive_messages(assembling?: false, accessioning?: false)
+        allow(workflow_state_service).to receive_messages(assembling?: false, text_extracting?: false, accessioning?: false)
       end
 
       it 'creates the accessioningWF' do
@@ -412,7 +412,7 @@ RSpec.describe VersionService do
       let(:description) { nil }
 
       before do
-        allow(workflow_state_service).to receive_messages(assembling?: false, accessioning?: false)
+        allow(workflow_state_service).to receive_messages(assembling?: false, text_extracting?: false, accessioning?: false)
       end
 
       it 'closes the object version using existing signficance and description' do
@@ -436,7 +436,7 @@ RSpec.describe VersionService do
       let!(:repository_object) { create(:repository_object, external_identifier: druid) }
 
       before do
-        allow(workflow_state_service).to receive_messages(accessioning?: false, assembling?: false)
+        allow(workflow_state_service).to receive_messages(accessioning?: false, text_extracting?: false, assembling?: false)
       end
 
       it 'returns true' do
@@ -452,7 +452,7 @@ RSpec.describe VersionService do
 
     context 'when the object has an active accesssionWF' do
       before do
-        allow(workflow_state_service).to receive_messages(assembling?: false, accessioning?: true)
+        allow(workflow_state_service).to receive_messages(assembling?: false, text_extracting?: false, accessioning?: true)
       end
 
       it 'returns false' do
@@ -462,7 +462,17 @@ RSpec.describe VersionService do
 
     context 'when the object has an active assemblyWF' do
       before do
-        allow(workflow_state_service).to receive_messages(assembling?: true)
+        allow(workflow_state_service).to receive_messages(assembling?: true, text_extracting?: false)
+      end
+
+      it 'returns false' do
+        expect(can_close).to be false
+      end
+    end
+
+    context 'when the object has an active text extraction workflow' do
+      before do
+        allow(workflow_state_service).to receive_messages(assembling?: false, text_extracting?: true)
       end
 
       it 'returns false' do


### PR DESCRIPTION
## Why was this change made? 🤔

Part of sul-dlss/argo#4470

We need the ability to know if an object is in the middle of a text extraction WF (e.g. ocrWF) so we can disable various things (like editing or starting a new ocrWF in Argo).

HOLD for further changes in dor-services-client and Argo

see also https://github.com/sul-dlss/argo/pull/4460 and https://github.com/sul-dlss/argo/issues/4458 for related work in assemblyWF

## How was this change tested? 🤨

Updated tests