### PR TITLE
Add csv to gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'bunny', '~> 2.17' # Send messages to RabbitMQ
 gem 'committee' # validates Open API spec (OAS)
 gem 'config'
+gem 'csv'
 gem 'daemons' # for rolling indexer
 gem 'dry-monads'
 gem 'edtf', '~> 3.0' # used for metadata reports

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    csv (3.3.0)
     daemons (1.4.1)
     datacite (0.3.0)
       dry-monads (~> 1.3)
@@ -582,6 +583,7 @@ DEPENDENCIES
   cocina-models (~> 0.98.0)
   committee
   config
+  csv
   daemons
   datacite (~> 0.3.0)
   debug


### PR DESCRIPTION
## Why was this change made? 🤔
```
warning: /usr/local/rvm/rubies/ruby-3.3.1/lib/ruby/3.3.0/csv.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec.
```


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



