### PR TITLE
Include helpful diagnostic information in UpdateDoiMetadataJob

### DIFF
--- a/spec/jobs/update_doi_metadata_job_spec.rb
+++ b/spec/jobs/update_doi_metadata_job_spec.rb
@@ -3,13 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe UpdateDoiMetadataJob do
-  subject(:perform) do
-    described_class.perform_now(cocina_item.to_json)
-  end
+  subject(:perform) { described_class.perform_now(cocina_item.to_json) }
 
+  let(:attributes) { { titles: [{ title: 'test deposit' }] } }
   let(:cocina_item) do
     Cocina::Models.build({
-                           'externalIdentifier' => 'druid:bc123df4567',
+                           'externalIdentifier' => druid,
                            'type' => Cocina::Models::ObjectType.image,
                            'version' => 1,
                            'label' => 'testing',
@@ -26,41 +25,47 @@ RSpec.describe UpdateDoiMetadataJob do
                              'contains' => []
                            },
                            identification: {
-                             doi: '10.80343/bc123df4567',
+                             doi:,
                              sourceId: 'sul:123'
                            }
                          })
   end
+  let(:doi) { '10.80343/bc123df4567' }
+  let(:druid) { 'druid:bc123df4567' }
 
-  let(:attributes) { { titles: [{ title: 'test deposit' }] } }
+  before do
+    allow(Honeybadger).to receive(:context)
+    allow(Cocina::ToDatacite::Attributes).to receive(:mapped_from_cocina).and_return(attributes)
+    stub_request(:put, 'https://fake.datacite.example.com/dois/10.80343/bc123df4567')
+      .with(
+        body: '{"data":{"attributes":{"titles":[{"title":"test deposit"}]}}}'
+      )
+      .to_return(status: datacite_response_status, body: '', headers: {})
+  end
 
   context 'with no errors' do
-    before do
-      allow(Cocina::ToDatacite::Attributes).to receive(:mapped_from_cocina).and_return(attributes)
-      stub_request(:put, 'https://fake.datacite.example.com/dois/10.80343/bc123df4567')
-        .with(
-          body: '{"data":{"attributes":{"titles":[{"title":"test deposit"}]}}}'
-        )
-        .to_return(status: 200, body: '', headers: {})
-    end
+    let(:datacite_response_status) { 200 }
 
-    it 'is successful' do
+    it 'succeeds and injects helpful information into Honeybadger context' do
       expect { perform }.not_to raise_error
+      expect(Honeybadger).to have_received(:context).once.with(
+        attributes:,
+        doi:,
+        druid:
+      )
     end
   end
 
   context 'with a remote error' do
-    before do
-      allow(Cocina::ToDatacite::Attributes).to receive(:mapped_from_cocina).and_return(attributes)
-      stub_request(:put, 'https://fake.datacite.example.com/dois/10.80343/bc123df4567')
-        .with(
-          body: '{"data":{"attributes":{"titles":[{"title":"test deposit"}]}}}'
-        )
-        .to_return(status: 500, body: '', headers: {})
-    end
+    let(:datacite_response_status) { 500 }
 
-    it 'raises an error' do
+    it 'raises an error and injects helpful information into Honeybadger context' do
       expect { perform }.to raise_error RuntimeError
+      expect(Honeybadger).to have_received(:context).once.with(
+        attributes:,
+        doi:,
+        druid:
+      )
     end
   end
 end


### PR DESCRIPTION
# Why was this change made?

This commit gives us more breadcrumbs in Honeybadger in situations like https://app.honeybadger.io/projects/50568/faults/106916123

# How was this change tested?

CI
