### PR TITLE
Add csv dependency to bundler

### DIFF
--- a/app/reports/apo_catalog_record_id.rb
+++ b/app/reports/apo_catalog_record_id.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 # Find items that are goverened by the provided APO and then return all CatalogRecordIds and refresh status.
 #  https://github.com/sul-dlss/dor-services-app/issues/4373
 # Invoke via:

--- a/app/services/registration_csv_converter.rb
+++ b/app/services/registration_csv_converter.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'csv'
-
 # Convert CSV to JSON for registration
 class RegistrationCsvConverter
   include Dry::Monads[:result]


### PR DESCRIPTION
# Why was this change made?

This dependency is moving out of stdlib in Ruby 3.4 so it must be managed by bundler.

# How was this change tested?

CI
