### PR TITLE
Shelve files from preservation when using publish/shelve API.

### DIFF
--- a/app/jobs/shelve_job.rb
+++ b/app/jobs/shelve_job.rb
@@ -27,7 +27,7 @@ class ShelveJob < ApplicationJob
       # So reset to avoid: ActiveRecord::StatementInvalid: PG::ConnectionBad: PQconsumeInput() could not receive data from server: Connection timed out : BEGIN
       ActiveRecord::Base.connection_handler.clear_active_connections!
       EventFactory.create(druid:, event_type: 'shelving_complete', data: { background_job_result_id: background_job_result.id })
-    rescue ShelvableFilesStager::FileNotFound => e
+    rescue LegacyShelvableFilesStager::FileNotFound => e
       return LogFailureJob.perform_later(druid:,
                                          background_job_result:,
                                          workflow: 'accessionWF',

--- a/app/services/legacy_shelvable_files_stager.rb
+++ b/app/services/legacy_shelvable_files_stager.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Ensures that shelve-able files are in the staging area.  If they are not found
+# in the staging area, it attempts to get it from preservation if the file hasn't
+# been changed. Othewise it raises an error.
+class LegacyShelvableFilesStager
+  class FileNotFound < RuntimeError; end
+
+  def self.stage(identifier, preserve_diff, shelve_diff, content_dir)
+    new(identifier, preserve_diff, shelve_diff, content_dir).stage
+  end
+
+  def initialize(identifier, preserve_diff, shelve_diff, content_dir)
+    @identifier = identifier
+    @preserve_diff = preserve_diff
+    @shelve_diff = shelve_diff
+    @content_dir = content_dir
+  end
+
+  # Ensure all the files are found in the object's content files in the workspace area
+  def stage
+    return true if filelist.empty?
+
+    filelist.each do |file|
+      next if file_in_staging?(file)
+
+      # If they preserved the file in a previous version, but didn't shelve it, we can copy it to staging.
+      # We infer that the file is unchanged if was not also added to preservation in this version.
+      next if file_deltas[:added].include?(file) && file_previously_in_preservation?(file) && copy_file_from_preservation(file)
+
+      raise FileNotFound, "Unable to find #{file} in the content directory"
+    end
+
+    true
+  end
+
+  private
+
+  attr_reader :identifier, :preserve_diff, :shelve_diff, :content_dir, :content_metadata
+
+  delegate :file_deltas, to: :shelve_diff
+
+  def filelist
+    @filelist ||= file_deltas[:modified] + file_deltas[:added] + file_deltas[:copyadded].collect { |_old, new| new }
+  end
+
+  def file_in_staging?(file)
+    filepath(file).exist?
+  end
+
+  def filepath(file)
+    content_dir.join(file)
+  end
+
+  def file_previously_in_preservation?(file)
+    preserve_diff.file_deltas[:added].exclude?(file)
+  end
+
+  # Copy from preservation into the workspace
+  def copy_file_from_preservation(file)
+    FileUtils.mkdir_p(filepath(file).dirname)
+    File.open(filepath(file), 'wb') do |streamed|
+      writer = proc do |chunk, _overall_received_bytes|
+        streamed.write chunk
+      end
+      Preservation::Client.objects.content(druid: identifier, filepath: file, on_data: writer)
+    end
+  end
+end

--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -112,6 +112,7 @@ module Publish
     end
 
     def publish_shelve
+      ShelvableFilesStager.stage(druid:, version: cocina_object.version, filepaths: filepaths_to_shelve, workspace_content_pathname:) if filepaths_to_shelve.present?
       PurlFetcher::Client::PublishShelve.publish_and_shelve(cocina: public_cocina, filepath_map:)
     end
 
@@ -131,11 +132,12 @@ module Publish
       end
     end
 
-    def filepath_map
-      return {} unless public_cocina.dro?
+    def filepaths_to_shelve
+      @filepaths_to_shelve ||= public_cocina.dro? ? DigitalStacksDiffer.call(cocina_object: public_cocina) : []
+    end
 
-      files_to_shelve = DigitalStacksDiffer.call(cocina_object: public_cocina)
-      files_to_shelve.index_with do |filename|
+    def filepath_map
+      filepaths_to_shelve.index_with do |filename|
         workspace_content_pathname.join(filename).to_s
       end
     end

--- a/app/services/shelving_service.rb
+++ b/app/services/shelving_service.rb
@@ -38,7 +38,7 @@ class ShelvingService
       retry
     end
 
-    ShelvableFilesStager.stage(druid, preserve_diff, shelve_diff, workspace_content_pathname)
+    LegacyShelvableFilesStager.stage(druid, preserve_diff, shelve_diff, workspace_content_pathname)
 
     # workspace_content_pathname = workspace_content_dir(shelve_diff, workspace_druid)
     # delete, rename, or copy files to the stacks area

--- a/spec/jobs/shelve_job_spec.rb
+++ b/spec/jobs/shelve_job_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ShelveJob do
     let(:error_message) { "file isn't where we looked" }
 
     before do
-      allow(ShelvingService).to receive(:shelve).and_raise(ShelvableFilesStager::FileNotFound, error_message)
+      allow(ShelvingService).to receive(:shelve).and_raise(LegacyShelvableFilesStager::FileNotFound, error_message)
       allow(LogFailureJob).to receive(:perform_later)
     end
 

--- a/spec/services/legacy_shelvable_files_stager_spec.rb
+++ b/spec/services/legacy_shelvable_files_stager_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LegacyShelvableFilesStager do
+  subject(:stage) { described_class.stage(druid, preserve_diff, shelve_diff, content_dir) }
+
+  let(:workspace_root) { Dir.mktmpdir }
+  let(:druid) { 'druid:jq937jp0017' }
+  let(:preserve_diff) { instance_double(Moab::FileGroupDifference, file_deltas: { added: [] }) }
+  let(:workspace_druid) { DruidTools::Druid.new(druid, workspace_root) }
+
+  # create an empty workspace location for object content files
+  let(:content_dir) { Pathname(workspace_druid.path('content', true)) }
+
+  # read in a FileInventoryDifference manifest from the fixtures area
+  let(:content_diff_reports) { Pathname('spec').join('fixtures', 'content_diff_reports') }
+  let(:inventory_diff_xml) { content_diff_reports.join('ng782rw8378-v3-v4.xml') }
+  let(:inventory_diff) { Moab::FileInventoryDifference.parse(inventory_diff_xml.read) }
+  let(:shelve_diff) { inventory_diff.group_difference('content') }
+
+  context 'when the manifest files are not in the workspace' do
+    let(:preserve_diff) { instance_double(Moab::FileGroupDifference, file_deltas:) }
+
+    before do
+      # create the one modified file:
+      FileUtils.touch(content_dir.join('SUB2_b2000_1.bvals'))
+    end
+
+    context 'when the file is not already in preservation' do
+      let(:file_deltas) { { added: ['dir/SUB2_b2000_2.bvecs', 'SUB2_b2000_2.nii.gz'] } }
+
+      it 'raises an error' do
+        expect { stage }.to raise_error('Unable to find dir/SUB2_b2000_2.bvecs in the content directory')
+      end
+    end
+
+    context 'when the file is in preservation' do
+      let(:file_deltas) { { added: [] } }
+
+      before do
+        allow(Preservation::Client.objects).to receive(:content) do |*args|
+          args.first.fetch(:on_data).call('my stuff')
+        end
+      end
+
+      it 'copies the file into the staging area' do
+        expect { stage }.to change { content_dir.join('dir/SUB2_b2000_2.bvecs').exist? }.from(false).to(true)
+      end
+    end
+  end
+
+  context 'when the content files are in the workspace area' do
+    before do
+      # put the content files in the content_pathname location .../ng/782/rw/8378/ng782rw8378/content
+      deltas = shelve_diff.file_deltas
+      filelist = deltas[:modified] + deltas[:added] + deltas[:copyadded].collect { |_old, new| new }
+      filelist.each do |file|
+        filepath = content_dir.join(file)
+        FileUtils.mkdir_p(File.dirname(filepath))
+        FileUtils.touch(filepath)
+      end
+    end
+
+    it { is_expected.to be true }
+  end
+end

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -252,12 +252,14 @@ RSpec.describe Publish::MetadataTransferService do
       allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
       allow(PurlFetcher::Client::PublishShelve).to receive(:publish_and_shelve)
       allow(DigitalStacksDiffer).to receive(:call).and_return(['images/jt667tw2770_05_0001.jp2'])
+      allow(ShelvableFilesStager).to receive(:stage)
     end
 
     it 'shelves and publishes to purl fetcher service' do
       publish_shelve
       expect(PurlFetcher::Client::PublishShelve).to have_received(:publish_and_shelve).with(cocina: Cocina::Models::DRO, filepath_map: { 'images/jt667tw2770_05_0001.jp2' =>
            'tmp/dor/workspace/bc/123/df/4567/bc123df4567/content/images/jt667tw2770_05_0001.jp2' })
+      expect(ShelvableFilesStager).to have_received(:stage).with(druid: "druid:#{druid}", version: 1, filepaths: ['images/jt667tw2770_05_0001.jp2'], workspace_content_pathname: Pathname('tmp/dor/workspace/bc/123/df/4567/bc123df4567/content'))
     end
 
     context 'when a collection' do
@@ -271,6 +273,7 @@ RSpec.describe Publish::MetadataTransferService do
         publish_shelve
         expect(PurlFetcher::Client::PublishShelve).to have_received(:publish_and_shelve).with(cocina: Cocina::Models::Collection, filepath_map: {})
         expect(DigitalStacksDiffer).not_to have_received(:call)
+        expect(ShelvableFilesStager).not_to have_received(:stage)
       end
     end
   end

--- a/spec/services/shelving_service_spec.rb
+++ b/spec/services/shelving_service_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe ShelvingService do
     allow(Cocina::ToXml::ContentMetadataGenerator).to receive(:generate).and_return(content_metadata)
     allow(Preservation::Client.objects).to receive(:metadata).with(druid:, filepath: 'contentMetadata.xml').and_return(previous_content_metadata)
     allow(Preservation::Client.objects).to receive(:current_version).with(druid).and_return(1)
-    allow(ShelvableFilesStager).to receive(:stage)
+    allow(LegacyShelvableFilesStager).to receive(:stage)
     allow(DigitalStacksService).to receive(:remove_from_stacks)
     allow(DigitalStacksService).to receive(:rename_in_stacks)
     allow(DigitalStacksService).to receive(:shelve_to_stacks)
@@ -79,7 +79,7 @@ RSpec.describe ShelvingService do
       # make sure the DigitalStacksService is getting the correct delete, rename, and shelve requests
       # (These methods are unit tested in digital_stacks_service_spec.rb)
       described_class.shelve(cocina_object)
-      expect(ShelvableFilesStager).to have_received(:stage).with(druid, Moab::FileGroupDifference, Moab::FileGroupDifference, Pathname)
+      expect(LegacyShelvableFilesStager).to have_received(:stage).with(druid, Moab::FileGroupDifference, Moab::FileGroupDifference, Pathname)
       expect(DigitalStacksService).to have_received(:remove_from_stacks).with(stacks_object_pathname, Moab::FileGroupDifference)
       expect(DigitalStacksService).to have_received(:rename_in_stacks).with(stacks_object_pathname, Moab::FileGroupDifference)
       expect(DigitalStacksService).to have_received(:shelve_to_stacks).with(Pathname, stacks_object_pathname, Moab::FileGroupDifference)
@@ -98,7 +98,7 @@ RSpec.describe ShelvingService do
       # make sure the DigitalStacksService is getting the correct delete, rename, and shelve requests
       # (These methods are unit tested in digital_stacks_service_spec.rb)
       described_class.shelve(cocina_object)
-      expect(ShelvableFilesStager).to have_received(:stage).with(druid, Moab::FileGroupDifference, Moab::FileGroupDifference, Pathname)
+      expect(LegacyShelvableFilesStager).to have_received(:stage).with(druid, Moab::FileGroupDifference, Moab::FileGroupDifference, Pathname)
       expect(DigitalStacksService).to have_received(:remove_from_stacks).with(stacks_object_pathname, Moab::FileGroupDifference)
       expect(DigitalStacksService).to have_received(:rename_in_stacks).with(stacks_object_pathname, Moab::FileGroupDifference)
       expect(DigitalStacksService).to have_received(:shelve_to_stacks).with(Pathname, stacks_object_pathname, Moab::FileGroupDifference)
@@ -122,7 +122,7 @@ RSpec.describe ShelvingService do
       # make sure the DigitalStacksService is getting the correct delete, rename, and shelve requests
       # (These methods are unit tested in digital_stacks_service_spec.rb)
       described_class.shelve(cocina_object)
-      expect(ShelvableFilesStager).to have_received(:stage).with(druid, Moab::FileGroupDifference, Moab::FileGroupDifference, Pathname)
+      expect(LegacyShelvableFilesStager).to have_received(:stage).with(druid, Moab::FileGroupDifference, Moab::FileGroupDifference, Pathname)
       expect(DigitalStacksService).to have_received(:remove_from_stacks).with(stacks_object_pathname, Moab::FileGroupDifference)
       expect(DigitalStacksService).to have_received(:rename_in_stacks).with(stacks_object_pathname, Moab::FileGroupDifference)
       expect(DigitalStacksService).to have_received(:shelve_to_stacks).with(Pathname, stacks_object_pathname, Moab::FileGroupDifference)


### PR DESCRIPTION
closes #5082

## Why was this change made? 🤔
Maintain functionality of legacy shelving.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, stage

