### PR TITLE
Set resourceType to an empty string for Datacite if it's nil

### DIFF
--- a/app/services/cocina/to_datacite/form.rb
+++ b/app/services/cocina/to_datacite/form.rb
@@ -19,10 +19,10 @@ module Cocina
       def type_attributes
         return unless resource_type_general || resource_type
 
-        {
-          resourceTypeGeneral: resource_type_general,
-          resourceType: resource_type
-        }
+        {}.tap do |types_attributes|
+          types_attributes[:resourceTypeGeneral] = resource_type_general
+          types_attributes[:resourceType] = resource_type || ''
+        end
       end
 
       private

--- a/app/services/cocina/to_datacite/form.rb
+++ b/app/services/cocina/to_datacite/form.rb
@@ -19,10 +19,10 @@ module Cocina
       def type_attributes
         return unless resource_type_general || resource_type
 
-        {}.tap do |types_attributes|
-          types_attributes[:resourceTypeGeneral] = resource_type_general
-          types_attributes[:resourceType] = resource_type || ''
-        end
+        {
+          resourceTypeGeneral: resource_type_general,
+          resourceType: resource_type || ''
+        }
       end
 
       private

--- a/spec/services/cocina/to_datacite/attributes_spec.rb
+++ b/spec/services/cocina/to_datacite/attributes_spec.rb
@@ -185,18 +185,6 @@ RSpec.describe Cocina::ToDatacite::Attributes do
                                 ],
                                 form: [
                                   {
-                                    structuredValue: [
-                                      {
-                                        value: 'Data',
-                                        type: 'type'
-                                      }
-                                    ],
-                                    source: {
-                                      value: 'Stanford self-deposit resource types'
-                                    },
-                                    type: 'resource type'
-                                  },
-                                  {
                                     value: 'Dataset',
                                     type: 'resource type',
                                     uri: 'http://id.loc.gov/vocabulary/resourceTypes/dat',
@@ -349,7 +337,7 @@ RSpec.describe Cocina::ToDatacite::Attributes do
           titles: [{ title: }],
           types: {
             resourceTypeGeneral: 'Dataset',
-            resourceType: 'Data'
+            resourceType: ''
           }
         }
       )


### PR DESCRIPTION
## Why was this change made? 🤔

This avoids including the option `resourceType` in the datacite package if it is nil.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



