### PR TITLE
Fix preservation versions report to use the last closed version instead of head.

### DIFF
--- a/app/reports/preservation_versions.rb
+++ b/app/reports/preservation_versions.rb
@@ -11,7 +11,7 @@ class PreservationVersions
 
   def report
     # Objects with a closed version, indicating they have been accessioned.
-    data = RepositoryObject.joins(:head_version).where.not(last_closed_version: nil).pluck(:external_identifier, :version)
+    data = RepositoryObject.joins(:last_closed_version).where.not(last_closed_version: nil).pluck(:external_identifier, :version)
 
     progress_bar = tty_progress_bar(data.length)
     progress_bar.start


### PR DESCRIPTION
## Why was this change made? 🤔
I forgot to hit save in vscode.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Prod

