### PR TITLE
Switch DigitalStacksDiffer to use purl-fetcher file digest endpoint.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'marc'
 gem 'marc-vocab', '~> 0.3.0' # for indexing
 gem 'moab-versioning', '~> 6.0', require: 'moab/stanford'
 gem 'preservation-client', '~> 6.0'
-gem 'purl_fetcher-client', '~> 1.4.0'
+gem 'purl_fetcher-client', '~> 1.5.0'
 gem 'stanford-mods' # for indexing
 gem 'sul_orcid_client', '~> 0.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,7 @@ GEM
     public_suffix (6.0.0)
     puma (6.4.2)
       nio4r (~> 2.0)
-    purl_fetcher-client (1.5.1)
+    purl_fetcher-client (1.5.2)
       activesupport
       faraday (~> 2.1)
     racc (1.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,7 @@ GEM
     public_suffix (6.0.0)
     puma (6.4.2)
       nio4r (~> 2.0)
-    purl_fetcher-client (1.4.1)
+    purl_fetcher-client (1.5.1)
       activesupport
       faraday (~> 2.1)
     racc (1.8.0)
@@ -614,7 +614,7 @@ DEPENDENCIES
   preservation-client (~> 6.0)
   propshaft
   puma (~> 6.0)
-  purl_fetcher-client (~> 1.4.0)
+  purl_fetcher-client (~> 1.5.0)
   rack-console
   rails (~> 7.1.0)
   retries

--- a/spec/services/digital_stacks_differ_spec.rb
+++ b/spec/services/digital_stacks_differ_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe DigitalStacksDiffer do
                                              },
                                              {
                                                type: 'md5',
-                                               digest: '3e9498107f73ff827e718d5c743f8813'
+                                               digest: '2b9498107f73ff827e718d5c743f8802'
                                              }
                                            ],
                                            access: {
@@ -51,16 +51,7 @@ RSpec.describe DigitalStacksDiffer do
                                            size: 29_634,
                                            version: 3,
                                            hasMimeType: 'image/jpeg',
-                                           hasMessageDigests: [
-                                             {
-                                               type: 'sha1',
-                                               digest: '85a32f398e228e8228ad84422941110597e0d87a'
-                                             },
-                                             {
-                                               type: 'md5',
-                                               digest: '3e9498107f73ff827e718d5c743f8813'
-                                             }
-                                           ],
+                                           hasMessageDigests: not_on_shelves_message_digests,
                                            access: {
                                              view: 'world',
                                              download: 'world'
@@ -86,7 +77,7 @@ RSpec.describe DigitalStacksDiffer do
                                              },
                                              {
                                                type: 'md5',
-                                               digest: '3e9498107f73ff827e718d5c743f8813'
+                                               digest: '5g9498107f73ff827e718d5c743f8836'
                                              }
                                            ],
                                            access: {
@@ -137,123 +128,41 @@ RSpec.describe DigitalStacksDiffer do
                                })
   end
 
-  let(:purl_cocina_object) do
-    cocina_object.new(structural: {
-                        contains: [
-                          {
-                            type: Cocina::Models::FileSetType.file.to_s,
-                            externalIdentifier: 'hj185xx2222_1',
-                            label: 'Image 1',
-                            version: 3,
-                            structural: {
-                              contains: [
-                                {
-                                  type: Cocina::Models::ObjectType.file.to_s,
-                                  externalIdentifier: 'druid:hj185xx2222/only_on_shelves.jpg',
-                                  label: 'only on shelves',
-                                  filename: 'only_on_shelves.jpg',
-                                  size: 29_634,
-                                  version: 3,
-                                  hasMimeType: 'image/jpeg',
-                                  hasMessageDigests: [
-                                    {
-                                      type: 'sha1',
-                                      digest: '85a32f398e228e8228ad84422941110597e0d87a'
-                                    },
-                                    {
-                                      type: 'md5',
-                                      digest: '3e9498107f73ff827e718d5c743f8813'
-                                    }
-                                  ],
-                                  access: {
-                                    view: 'world',
-                                    download: 'world'
-                                  },
-                                  administrative: {
-                                    sdrPreserve: true,
-                                    shelve: true,
-                                    publish: true
-                                  }
-                                },
-                                {
-                                  type: Cocina::Models::ObjectType.file.to_s,
-                                  externalIdentifier: 'druid:hj185xx2222/changed_on_shelves.jpg',
-                                  label: 'changed on shelves',
-                                  filename: 'changed_on_shelves.jpg',
-                                  size: 29_634,
-                                  version: 3,
-                                  hasMimeType: 'image/jpeg',
-                                  hasMessageDigests: [
-                                    {
-                                      type: 'sha1',
-                                      digest: '96a32f398e228e8228ad84422941110597e0d87a'
-                                    },
-                                    {
-                                      type: 'md5',
-                                      digest: '4f9498107f73ff827e718d5c743f8813'
-                                    }
-                                  ],
-                                  access: {
-                                    view: 'world',
-                                    download: 'world'
-                                  },
-                                  administrative: {
-                                    sdrPreserve: true,
-                                    shelve: true,
-                                    publish: true
-                                  }
-                                },
-                                {
-                                  type: Cocina::Models::ObjectType.file.to_s,
-                                  externalIdentifier: 'druid:hj185xx2222/same_on_shelves.jpg',
-                                  label: 'same on shelves',
-                                  filename: 'same_on_shelves.jpg',
-                                  size: 29_634,
-                                  version: 3,
-                                  hasMimeType: 'image/jpeg',
-                                  hasMessageDigests: [
-                                    {
-                                      type: 'sha1',
-                                      digest: '85a32f398e228e8228ad84422941110597e0d87a'
-                                    },
-                                    {
-                                      type: 'md5',
-                                      digest: '3e9498107f73ff827e718d5c743f8813'
-                                    }
-                                  ],
-                                  access: {
-                                    view: 'world',
-                                    download: 'world'
-                                  },
-                                  administrative: {
-                                    sdrPreserve: true,
-                                    shelve: true,
-                                    publish: true
-                                  }
-                                }
-                              ]
-                            }
-                          }
-                        ],
-                        isMemberOf: [
-                          'druid:bc778pm9866'
-                        ]
-                      })
+  let(:not_on_shelves_message_digests) do
+    [
+      {
+        type: 'sha1',
+        digest: '85a32f398e228e8228ad84422941110597e0d87a'
+      },
+      {
+        type: 'md5',
+        digest: '4f9498107f73ff827e718d5c743f8824'
+      }
+    ]
   end
 
+  let(:purl_files_by_digest) do
+    [
+      { '9e9498107f73ff827e718d5c743f8819' => 'only_on_shelves.jpg' },
+      { '0f9498107f73ff827e718d5c743f8810' => 'changed_on_shelves.jpg' },
+      { '3e9498107f73ff827e718d5c743f8813' => 'same_on_shelves.jpg' }
+    ]
+  end
+
+  let(:purl_fetcher_reader) { instance_double(PurlFetcher::Client::Reader, files_by_digest: purl_files_by_digest) }
+
   before do
-    stub_request(:get, "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}.json")
-      .to_return(status: 200, body: purl_cocina_object.to_json)
+    allow(PurlFetcher::Client::Reader).to receive(:new).with(host: Settings.purl_fetcher.url).and_return(purl_fetcher_reader)
   end
 
   it 'returns diff' do
     expect(described_class.call(cocina_object:)).to eq(['not_on_shelves.jpg', 'changed_on_shelves.jpg'])
+    expect(purl_fetcher_reader).to have_received(:files_by_digest).with(druid.delete_prefix('druid:'))
   end
 
   context 'when PURL is not found' do
     before do
-      stub_request(:get, "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}.json")
-        .to_return(status: 404)
+      allow(purl_fetcher_reader).to receive(:files_by_digest).and_raise(PurlFetcher::Client::NotFoundResponseError)
     end
 
     it 'returns diff' do
@@ -263,62 +172,26 @@ RSpec.describe DigitalStacksDiffer do
 
   context 'when PURL returns an error' do
     before do
-      stub_request(:get, "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}.json")
-        .to_return(status: 500)
+      allow(purl_fetcher_reader).to receive(:files_by_digest).and_raise(PurlFetcher::Client::ResponseError)
     end
 
     it 'raises an error' do
-      expect { described_class.call(cocina_object:) }.to raise_error(DigitalStacksDiffer::Error, 'Unable to fetch cocina object from PURL for hj185xx2222: 500')
+      expect { described_class.call(cocina_object:) }.to raise_error(DigitalStacksDiffer::Error)
     end
   end
 
   context 'when missing a SHA1' do
-    let(:purl_cocina_object) do
-      cocina_object.new(structural: {
-                          contains: [
-                            {
-                              type: Cocina::Models::FileSetType.file.to_s,
-                              externalIdentifier: 'hj185xx2222_1',
-                              label: 'Image 1',
-                              version: 3,
-                              structural: {
-                                contains: [
-                                  {
-                                    type: Cocina::Models::ObjectType.file.to_s,
-                                    externalIdentifier: 'druid:hj185xx2222/only_on_shelves.jpg',
-                                    label: 'only on shelves',
-                                    filename: 'only_on_shelves.jpg',
-                                    size: 29_634,
-                                    version: 3,
-                                    hasMimeType: 'image/jpeg',
-                                    hasMessageDigests: [
-                                      {
-                                        type: 'md5',
-                                        digest: '3e9498107f73ff827e718d5c743f8813'
-                                      }
-                                    ],
-                                    access: {
-                                      view: 'world',
-                                      download: 'world'
-                                    },
-                                    administrative: {
-                                      sdrPreserve: true,
-                                      shelve: true,
-                                      publish: true
-                                    }
-                                  }
-                                ]
-                              }
-                            }
-                          ],
-                          isMemberOf: [
-                            'druid:bc778pm9866'
-                          ]
-                        })
+    let(:not_on_shelves_message_digests) do
+      [
+        {
+          type: 'sha1',
+          digest: '85a32f398e228e8228ad84422941110597e0d87a'
+        }
+      ]
     end
 
     it 'raises an error' do
-      expect { described_class.call(cocina_object:) }.to raise_error(DigitalStacksDiffer::Error, 'Unable to find sha1 for file druid:hj185xx2222/only_on_shelves.jpg')
+      expect { described_class.call(cocina_object:) }.to raise_error(DigitalStacksDiffer::Error, 'Unable to find md5 for file druid:hj185xx2222/not_on_shelves.jpg')
     end
   end
 end


### PR DESCRIPTION
closes #5108

## Why was this change made? 🤔
To make DSA less tightly bound to purl cocina.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, integration tests.

