### PR TITLE
Update stored cocina version to latest when saving.

### DIFF
--- a/app/models/repository_object_version.rb
+++ b/app/models/repository_object_version.rb
@@ -26,9 +26,9 @@ class RepositoryObjectVersion < ApplicationRecord
   def self.to_model_hash(cocina_object)
     cocina_object
       .to_h
-      .except(:externalIdentifier, :version)
+      .except(:externalIdentifier, :version, :cocinaVersion)
       .tap do |object_hash|
-      object_hash[:cocina_version] = object_hash.delete(:cocinaVersion)
+      object_hash[:cocina_version] = Cocina::Models::VERSION # When saving, set to latest cocina version.
       object_hash[:content_type] = object_hash.delete(:type)
       case cocina_object
       when Cocina::Models::DRO

--- a/spec/models/repository_object_version_spec.rb
+++ b/spec/models/repository_object_version_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe RepositoryObjectVersion do
   describe '.to_model_hash' do
     subject(:model_hash) { described_class.to_model_hash(cocina_instance) }
 
-    let(:cocina_instance) { build(cocina_object_type) }
+    let(:cocina_instance) { build(cocina_object_type).new(cocinaVersion: '0.5.0') } # Will test that updated to latest cocina version
 
     context 'with a DRO' do
       let(:cocina_object_type) { :dro }


### PR DESCRIPTION
## Why was this change made? 🤔
* This was the behavior with the previous model objects.
* It makes it clearer what was the last cocina version that the data is known to be valid with.

## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



