### PR TITLE
Ignore when item is already unpublished.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,7 @@ GEM
     public_suffix (6.0.0)
     puma (6.4.2)
       nio4r (~> 2.0)
-    purl_fetcher-client (1.5.2)
+    purl_fetcher-client (1.5.3)
       activesupport
       faraday (~> 2.1)
     racc (1.8.0)

--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -109,6 +109,8 @@ module Publish
     #
     def publish_delete_on_success
       PurlFetcher::Client::Unpublish.unpublish(druid:)
+    rescue PurlFetcher::Client::AlreadyDeletedResponseError
+      # It's fine. The object is already deleted.
     end
 
     def publish_shelve


### PR DESCRIPTION
closes #5114

## Why was this change made? 🤔
This happens and shouldn't raise an error.


## How was this change tested? 🤨

Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



