### PR TITLE
Adds endpoint for getting solr doc for a user version.

### DIFF
--- a/app/controllers/user_versions_controller.rb
+++ b/app/controllers/user_versions_controller.rb
@@ -3,14 +3,14 @@
 # Controller for user versions
 class UserVersionsController < ApplicationController
   before_action :find_repository_object
+  before_action :find_user_version, only: %i[show update solr]
 
   def index
     render json: { user_versions: @repository_object.user_versions.map(&:as_json) }
   end
 
   def show
-    user_version = @repository_object.user_versions.find_by!(version: params[:id])
-    render json: user_version.repository_object_version.to_cocina_with_metadata
+    render json: @user_version.repository_object_version.to_cocina_with_metadata
   rescue RepositoryObjectVersion::NoCocina
     json_api_error(status: :not_found, message: 'No Cocina for specified version')
   end
@@ -26,22 +26,31 @@ class UserVersionsController < ApplicationController
   end
 
   def update
-    user_version = @repository_object.user_versions.find_by!(version: params[:id])
-    user_version.withdrawn = params[:withdrawn] if params.key?(:withdrawn)
+    @user_version.withdrawn = params[:withdrawn] if params.key?(:withdrawn)
     if params.key?(:version)
       repository_object_version = @repository_object.versions.find_by!(version: params[:version])
-      user_version.repository_object_version = repository_object_version
+      @user_version.repository_object_version = repository_object_version
     end
-    if user_version.save
-      render json: user_version.as_json
+    if @user_version.save
+      render json: @user_version.as_json
     else
-      json_api_error(status: :unprocessable_entity, message: user_version.errors.full_messages.to_sentence)
+      json_api_error(status: :unprocessable_entity, message: @user_version.errors.full_messages.to_sentence)
     end
+  end
+
+  def solr
+    render json: Indexing::Builders::DocumentBuilder.for(
+      model: @user_version.repository_object_version.to_cocina_with_metadata
+    ).to_solr
   end
 
   private
 
   def find_repository_object
     @repository_object = RepositoryObject.find_by!(external_identifier: params[:object_id])
+  end
+
+  def find_user_version
+    @user_version = @repository_object.user_versions.find_by!(version: params[:id])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,7 +78,11 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :user_versions, only: %i[index show create update]
+      resources :user_versions, only: %i[index show create update] do
+        member do
+          get 'solr'
+        end
+      end
 
       resources :release_tags, only: [:create, :index]
     end

--- a/openapi.yml
+++ b/openapi.yml
@@ -1236,6 +1236,38 @@ paths:
           required: true
           schema:
             type: string
+  "/v1/objects/{object_id}/user_versions/{version_id}/solr":
+    get:
+      tags:
+        - versions
+      summary: Show solr document for a particular user version
+      operationId: "user_versions#solr"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: "#/components/schemas/Druid"
+        - name: version_id
+          in: path
+          description: ID of the version
+          required: true
+          schema:
+            type: string
   /v1/objects:
     post:
       tags:

--- a/spec/requests/show_user_version_solr_spec.rb
+++ b/spec/requests/show_user_version_solr_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Show single user version' do
+  let(:druid) { 'druid:mx123qw2323' }
+
+  let(:workflows) do
+    instance_double(Indexing::Indexers::WorkflowsIndexer, to_solr: { 'wf_ssim' => ['accessionWF'] })
+  end
+
+  context 'when found' do
+    before do
+      repository_object = create(:repository_object, :with_repository_object_version, :closed, external_identifier: druid)
+      create(:user_version, version: 1, repository_object_version: repository_object.versions.first)
+      allow(Indexing::Indexers::WorkflowsIndexer).to receive(:new).and_return(workflows)
+      allow(Indexing::WorkflowFields).to receive(:for).and_return({ milestones_ssim: %w[foo bar] })
+    end
+
+    it 'returns a 200' do
+      get "/v1/objects/#{druid}/user_versions/1/solr",
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(id: druid)
+      expect(response.parsed_body).to include(rights_descriptions_ssim: ['world', 'dark (file)'])
+    end
+  end
+end


### PR DESCRIPTION
refs https://github.com/sul-dlss/argo/issues/4515

## Why was this change made? 🤔
So that solr can render the details page for a user version, as it is tightly bound to a solr doc. Generating a solr doc on the fly avoids having to repeat logic in Argo.


## How was this change tested? 🤨
Unit


⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



