### PR TITLE
Remove obsolete feature flag read_folio

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -22,12 +22,8 @@ end
 
 class FolioCheck < OkComputer::Check
   def check
-    if Settings.enabled_features.read_folio
-      Timeout.timeout(5) do
-        Catalog::FolioReader.to_marc(barcode: '12345')
-      end
-    else
-      mark_message 'folio disabled'
+    Timeout.timeout(5) do
+      Catalog::FolioReader.to_marc(barcode: '12345')
     end
   rescue StandardError => e
     mark_failure
@@ -98,6 +94,6 @@ end
 
 OkComputer::Registry.register 'rabbit-queues', RabbitQueueExistsCheck.new(['dsa.create-event', 'dor.indexing-by-druid']) if Settings.rabbitmq.enabled
 
-OkComputer.make_optional %w(external-folio) if Settings.enabled_features.read_folio
+OkComputer.make_optional %w(external-folio)
 
 OkComputer::Registry.register 'external-solr', OkComputer::HttpCheck.new("#{Settings.solr.url.gsub(%r{/$}, '')}/admin/ping")

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,10 +4,8 @@ enabled_features:
   create_ur_admin_policy: false
   datacite_update: false
   file_hierarchy_validation: true
-  read_folio: true
   orcid_update: true
   publish_shelve: false
-
 
 # Ur Admin Policy
 ur_admin_policy:

--- a/spec/requests/status_spec.rb
+++ b/spec/requests/status_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe 'Status (okcomputer)' do
   describe 'for Folio connection' do
     before do
       allow(Catalog::FolioReader).to receive(:to_marc).and_return('some marc stuff')
-      allow(Settings.enabled_features).to receive(:read_folio).and_return(true)
     end
 
     it 'is successful' do

--- a/spec/services/goobi_service_spec.rb
+++ b/spec/services/goobi_service_spec.rb
@@ -231,8 +231,6 @@ RSpec.describe GoobiService do
     end
 
     context 'when folio enabled' do
-      before { allow(Settings.enabled_features).to receive(:read_folio).and_return(true) }
-
       context 'without ocr tag present' do
         let(:tags) { ['DPG : Workflow : book_workflow & stuff', 'Process : Content Type : Book', 'LAB : MAPS'] }
 


### PR DESCRIPTION
## Why was this change made? 🤔

We no longer bother to check this flag, so remove it.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



