### PR TITLE
Remove obsolete feature flag file_hierarchy_validation

### DIFF
--- a/app/validators/cocina/object_validator.rb
+++ b/app/validators/cocina/object_validator.rb
@@ -26,8 +26,6 @@ module Cocina
       validator = Cocina::CollectionExistenceValidator.new(cocina_object)
       raise ValidationError, validator.error unless validator.valid?
 
-      return unless Settings.enabled_features.file_hierarchy_validation
-
       # Only DROs have files
       validator = Cocina::FileHierarchyValidator.new(cocina_object)
       raise ValidationError, validator.error unless validator.valid?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,7 +3,6 @@ enabled_features:
   registration: true
   create_ur_admin_policy: false
   datacite_update: false
-  file_hierarchy_validation: true
   orcid_update: true
   publish_shelve: false
 

--- a/spec/validators/cocina/object_validator_spec.rb
+++ b/spec/validators/cocina/object_validator_spec.rb
@@ -13,47 +13,27 @@ RSpec.describe Cocina::ObjectValidator do
     allow(Cocina::FileHierarchyValidator).to receive(:new).and_return(file_hierarchy_validator)
   end
 
-  context 'with file_hierarchy_validation on' do
-    before { allow(Settings.enabled_features).to receive(:file_hierarchy_validation).and_return(true) }
+  context 'when a RequestDRO' do
+    let(:cocina_object) { instance_double(Cocina::Models::RequestDRO, dro?: true) }
 
-    context 'when a request DRO' do
-      let(:cocina_object) { instance_double(Cocina::Models::RequestDRO, dro?: true) }
+    it 'validates' do
+      described_class.validate(cocina_object)
 
-      it 'validates' do
-        described_class.validate(cocina_object)
-
-        expect(apo_existence_validator).to have_received(:valid?)
-        expect(collection_existence_validator).to have_received(:valid?)
-        expect(file_hierarchy_validator).to have_received(:valid?)
-      end
-    end
-
-    context 'when a DRO' do
-      let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: true, externalIdentifier: nil) }
-
-      it 'validates' do
-        described_class.validate(cocina_object)
-
-        expect(apo_existence_validator).to have_received(:valid?)
-        expect(collection_existence_validator).to have_received(:valid?)
-        expect(file_hierarchy_validator).to have_received(:valid?)
-      end
+      expect(apo_existence_validator).to have_received(:valid?)
+      expect(collection_existence_validator).to have_received(:valid?)
+      expect(file_hierarchy_validator).to have_received(:valid?)
     end
   end
 
-  context 'with file_hierarchy_validation off' do
-    before { allow(Settings.enabled_features).to receive(:file_hierarchy_validation).and_return(false) }
+  context 'when a DRO' do
+    let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: true, externalIdentifier: nil) }
 
-    context 'when a DRO' do
-      let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: true, externalIdentifier: nil) }
+    it 'validates' do
+      described_class.validate(cocina_object)
 
-      it 'does not validate the file_hierarchy' do
-        described_class.validate(cocina_object)
-
-        expect(apo_existence_validator).to have_received(:valid?)
-        expect(collection_existence_validator).to have_received(:valid?)
-        expect(file_hierarchy_validator).not_to have_received(:valid?)
-      end
+      expect(apo_existence_validator).to have_received(:valid?)
+      expect(collection_existence_validator).to have_received(:valid?)
+      expect(file_hierarchy_validator).to have_received(:valid?)
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



