### PR TITLE
Remove legacy publish shelve and all usage of stacks and purl mounts.

### DIFF
--- a/app/jobs/shelve_job.rb
+++ b/app/jobs/shelve_job.rb
@@ -11,7 +11,7 @@ class ShelveJob < ApplicationJob
 
     # Skip if publish_shelve is enabled
     # However, web archive crawls still need to be shelved.
-    if Settings.enabled_features.publish_shelve && !WasService.crawl?(druid:)
+    unless WasService.crawl?(druid:)
       return LogSuccessJob.perform_later(druid:,
                                          workflow: 'accessionWF',
                                          background_job_result:,

--- a/app/services/delete_service.rb
+++ b/app/services/delete_service.rb
@@ -7,8 +7,6 @@ class DeleteService
   #   - Removes content from dor workspace
   #   - Removes content from assembly workspace
   #   - Removes content from sdr export area
-  #   - Removes content from stacks
-  #   - Removes content from purl
   #   - Removes active workflows
   # @param [Cocina::Models::DRO|AdminPolicy||Collection] cocina object wish to remove
   def self.destroy(cocina_object, user_name:)
@@ -22,8 +20,6 @@ class DeleteService
 
   def destroy
     CleanupService.cleanup_by_druid druid
-    cleanup_stacks
-    cleanup_purl_doc_cache
     remove_active_workflows
     delete_from_dor
     EventFactory.create(druid:, event_type: 'delete', data: { request: cocina_object.to_h, source_id: cocina_object&.identification&.sourceId, user_name: })
@@ -32,16 +28,6 @@ class DeleteService
   private
 
   attr_reader :cocina_object, :user_name
-
-  def cleanup_stacks
-    stacks_druid = DruidTools::StacksDruid.new(druid, Settings.stacks.local_stacks_root)
-    PruneService.new(druid: stacks_druid).prune!
-  end
-
-  def cleanup_purl_doc_cache
-    purl_druid = DruidTools::PurlDruid.new(druid, Settings.stacks.local_document_cache_root)
-    PruneService.new(druid: purl_druid).prune!
-  end
 
   def remove_active_workflows
     WorkflowClientFactory.build.delete_all_workflows(pid: druid)

--- a/app/services/shelving_service.rb
+++ b/app/services/shelving_service.rb
@@ -87,9 +87,7 @@ class ShelvingService
   def stacks_location
     # Currently the best know way to identify objects like this is to see if the wasCrawlPreassemblyWF workflow is present.
     # If this condition is met, then shelf to /web-archiving-stacks/data/collections/<collection_id>, where collection_id is the unnamespaced druid of the (first) collection.
-    return was_stack_location if was?
-
-    Settings.stacks.local_stacks_root
+    was_stack_location
   end
 
   def was?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,6 @@ enabled_features:
   create_ur_admin_policy: false
   datacite_update: false
   orcid_update: true
-  publish_shelve: false
 
 # Ur Admin Policy
 ur_admin_policy:
@@ -16,8 +15,6 @@ ur_admin_policy:
 stacks:
   document_cache_host: 'purl-test.stanford.edu'
   local_workspace_root: '/dor/workspace'
-  local_stacks_root: '/stacks'
-  local_document_cache_root: '/purl/document_cache'
   transfer_stage_root: '/transfer-stage'
 
 # Suri

--- a/spec/jobs/shelve_job_spec.rb
+++ b/spec/jobs/shelve_job_spec.rb
@@ -8,32 +8,22 @@ RSpec.describe ShelveJob do
   let(:druid) { 'druid:mk420bs7601' }
   let(:result) { create(:background_job_result) }
   let(:cocina_object) { instance_double(Cocina::Models::DRO) }
-  let(:valid) { true }
-  let(:invalid_filenames) { [] }
 
   before do
     allow(CocinaObjectStore).to receive(:find).with(druid).and_return(cocina_object)
     allow(result).to receive(:processing!)
-    allow(EventFactory).to receive(:create)
+    allow(ShelvingService).to receive(:shelve)
+    allow(LogSuccessJob).to receive(:perform_later)
   end
 
-  context 'with no errors' do
+  context 'when not a WAS crawl' do
     before do
-      allow(ShelvingService).to receive(:shelve)
-      allow(LogSuccessJob).to receive(:perform_later)
+      allow(WasService).to receive(:crawl?).with(druid:).and_return(false)
+    end
+
+    it 'skips shelving' do
       perform
-    end
-
-    it 'marks the job as processing' do
-      expect(result).to have_received(:processing!).once
-    end
-
-    it 'invokes the ShelvingService' do
-      expect(ShelvingService).to have_received(:shelve).with(cocina_object).once
-    end
-
-    it 'marks the job as complete' do
-      expect(EventFactory).to have_received(:create)
+      expect(ShelvingService).not_to have_received(:shelve)
       expect(LogSuccessJob).to have_received(:perform_later)
         .with(druid:,
               background_job_result: result,
@@ -42,64 +32,19 @@ RSpec.describe ShelveJob do
     end
   end
 
-  context 'with errors returned by ShelvingService' do
-    let(:error_message) { "file isn't where we looked" }
-
+  context 'when a WAS crawl' do
     before do
-      allow(ShelvingService).to receive(:shelve).and_raise(LegacyShelvableFilesStager::FileNotFound, error_message)
-      allow(LogFailureJob).to receive(:perform_later)
+      allow(WasService).to receive(:crawl?).with(druid:).and_return(true)
     end
 
-    it 'marks the job as errored' do
+    it 'performs shelving' do
       perform
-      expect(result).to have_received(:processing!).once
       expect(ShelvingService).to have_received(:shelve).with(cocina_object).once
-      expect(LogFailureJob).to have_received(:perform_later)
+      expect(LogSuccessJob).to have_received(:perform_later)
         .with(druid:,
               background_job_result: result,
               workflow: 'accessionWF',
-              workflow_process: 'shelve',
-              output: { errors: [{ detail: error_message, title: 'Unable to shelve files' }] })
-    end
-  end
-
-  context 'when publish_shelve feature flag is enabled' do
-    before do
-      allow(Settings.enabled_features).to receive(:publish_shelve).and_return(true)
-      allow(ShelvingService).to receive(:shelve)
-      allow(LogSuccessJob).to receive(:perform_later)
-    end
-
-    context 'when not a WAS crawl' do
-      before do
-        allow(WasService).to receive(:crawl?).with(druid:).and_return(false)
-      end
-
-      it 'skips shelving' do
-        perform
-        expect(ShelvingService).not_to have_received(:shelve)
-        expect(LogSuccessJob).to have_received(:perform_later)
-          .with(druid:,
-                background_job_result: result,
-                workflow: 'accessionWF',
-                workflow_process: 'shelve')
-      end
-    end
-
-    context 'when a WAS crawl' do
-      before do
-        allow(WasService).to receive(:crawl?).with(druid:).and_return(true)
-      end
-
-      it 'performs shelving' do
-        perform
-        expect(ShelvingService).to have_received(:shelve).with(cocina_object).once
-        expect(LogSuccessJob).to have_received(:perform_later)
-          .with(druid:,
-                background_job_result: result,
-                workflow: 'accessionWF',
-                workflow_process: 'shelve')
-      end
+              workflow_process: 'shelve')
     end
   end
 end

--- a/spec/services/cleanup_service_spec.rb
+++ b/spec/services/cleanup_service_spec.rb
@@ -203,7 +203,6 @@ RSpec.describe CleanupService do
     let(:workspace_dir) { File.join(fixture_dir, 'workspace') }
     let(:export_dir) { File.join(fixture_dir, 'export') }
     let(:assembly_dir) { File.join(fixture_dir, 'assembly') }
-    let(:stacks_dir) { File.join(fixture_dir, 'stacks') }
 
     let(:druid1) { 'druid:cd456ef7890' }
     let(:druid2) { 'druid:cd456gh1234' }
@@ -214,13 +213,11 @@ RSpec.describe CleanupService do
         local_export_home: export_dir,
         local_assembly_root: assembly_dir
       )
-      allow(Settings.stacks).to receive(:local_stacks_root).and_return(stacks_dir)
 
       FileUtils.mkdir fixture_dir
       FileUtils.mkdir workspace_dir
       FileUtils.mkdir export_dir
       FileUtils.mkdir assembly_dir
-      FileUtils.mkdir stacks_dir
     end
 
     after do

--- a/spec/services/delete_service_spec.rb
+++ b/spec/services/delete_service_spec.rb
@@ -40,31 +40,6 @@ RSpec.describe DeleteService do
     end
   end
 
-  describe '#cleanup_stacks' do
-    let(:fixture_dir) { '/tmp/cleanup-spec' }
-    let(:stacks_dir) { File.join(fixture_dir, 'stacks') }
-    let(:stacks_druid) { DruidTools::StacksDruid.new(druid, Settings.stacks.local_stacks_root) }
-
-    before do
-      allow(Settings.stacks).to receive(:local_stacks_root).and_return(stacks_dir)
-      FileUtils.mkdir fixture_dir
-      FileUtils.mkdir stacks_dir
-
-      stacks_druid.mkdir
-
-      File.write(File.join(stacks_druid.path, 'tempfile'), 'junk')
-    end
-
-    after do
-      FileUtils.rm_rf fixture_dir
-    end
-
-    it 'prunes the item from the local stacks root' do
-      expect { service.send(:cleanup_stacks) }.to change { File.exist?(stacks_druid.path) }
-        .from(true).to(false)
-    end
-  end
-
   describe '#delete_from_dor' do
     before do
       create(:repository_object, external_identifier: druid)

--- a/spec/services/shelving_service_spec.rb
+++ b/spec/services/shelving_service_spec.rb
@@ -54,11 +54,10 @@ RSpec.describe ShelvingService do
   let(:group_difference) { instance_double(Moab::FileGroupDifference) }
   let(:workflow_client) { instance_double(Dor::Workflow::Client, workflows:) }
   let(:workflows) { ['accessionWF', 'registrationWF'] }
-  let(:stacks_object_pathname) { Pathname(DruidTools::StacksDruid.new(druid, stacks_root).path) }
+  let(:stacks_object_pathname) { Pathname('/web-archiving-stacks/data/collections/bb077hj4590/ng/782/rw/8378') }
 
   before do
     allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
-    allow(Settings.stacks).to receive_messages(local_stacks_root: stacks_root, local_workspace_root: workspace_root)
     allow(Cocina::ToXml::ContentMetadataGenerator).to receive(:generate).and_return(content_metadata)
     allow(Preservation::Client.objects).to receive(:metadata).with(druid:, filepath: 'contentMetadata.xml').and_return(previous_content_metadata)
     allow(Preservation::Client.objects).to receive(:current_version).with(druid).and_return(1)
@@ -75,7 +74,6 @@ RSpec.describe ShelvingService do
 
   context 'when structural present and previous version exists in preservation' do
     it 'pushes file changes for shelve-able files into the stacks' do
-      stacks_object_pathname = Pathname(DruidTools::StacksDruid.new(druid, stacks_root).path)
       # make sure the DigitalStacksService is getting the correct delete, rename, and shelve requests
       # (These methods are unit tested in digital_stacks_service_spec.rb)
       described_class.shelve(cocina_object)
@@ -94,7 +92,6 @@ RSpec.describe ShelvingService do
     end
 
     it 'pushes file changes for shelve-able files into the stacks' do
-      stacks_object_pathname = Pathname(DruidTools::StacksDruid.new(druid, stacks_root).path)
       # make sure the DigitalStacksService is getting the correct delete, rename, and shelve requests
       # (These methods are unit tested in digital_stacks_service_spec.rb)
       described_class.shelve(cocina_object)
@@ -116,7 +113,6 @@ RSpec.describe ShelvingService do
 
   context 'when a web archive' do
     let(:workflows) { %w[accessionWF registrationWF wasCrawlPreassemblyWF] }
-    let(:stacks_object_pathname) { Pathname('/web-archiving-stacks/data/collections/bb077hj4590/ng/782/rw/8378') }
 
     it 'pushes file changes for shelve-able files into the stacks' do
       # make sure the DigitalStacksService is getting the correct delete, rename, and shelve requests


### PR DESCRIPTION
## Why was this change made? 🤔
We've switching to new publish-shelve API.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

