### PR TITLE
Adds additional to user version log. Adds validation so that cannot withdraw head.

### DIFF
--- a/app/models/repository_object.rb
+++ b/app/models/repository_object.rb
@@ -37,6 +37,10 @@ class RepositoryObject < ApplicationRecord
 
   delegate :to_cocina, :to_cocina_with_metadata, to: :head_version
 
+  def head_user_version
+    @head_user_version ||= user_versions.maximum(:version)
+  end
+
   # NOTE: This block uses metaprogramming to create the equivalent of scopes that query the RepositoryObjectVersion table using only rows that are a `current` in the RepositoryObject table
   #
   # So it's a more easily extensible version of:

--- a/app/models/user_version.rb
+++ b/app/models/user_version.rb
@@ -7,6 +7,7 @@ class UserVersion < ApplicationRecord
 
   validate :repository_object_version_is_closed
   validate :repository_object_version_has_cocina
+  validate :can_withdraw
 
   def repository_object_version_is_closed
     # Validate that the repository object version is closed
@@ -14,21 +15,45 @@ class UserVersion < ApplicationRecord
   end
 
   def repository_object_version_has_cocina
-    # Validate that the repository object version has cocina (lecacy versions may not)
+    # Validate that the repository object version has cocina (legacy versions may not)
     errors.add(:repository_object_version, 'cannot set a user version to an RepositoryObjectVersion without cocina') unless repository_object_version.has_cocina?
+  end
+
+  def can_withdraw
+    # Validate that the user version can be withdrawn or restored
+    errors.add(:repository_object_version, 'head version cannot be withdrawn') if withdrawn && (head? || version.nil?)
   end
 
   def as_json
     {
       userVersion: version,
       version: repository_object_version.version,
-      withdrawn:
+      withdrawn:,
+      withdrawable: withdrawable?,
+      restorable: restorable?,
+      head: head?
     }
+  end
+
+  def withdrawable?
+    !withdrawn && !head?
+  end
+
+  def restorable?
+    withdrawn
+  end
+
+  def head?
+    version == head_version
   end
 
   private
 
   def set_version
-    self.version = repository_object_version.user_versions.maximum(:version).to_i + 1 unless version
+    self.version = head_version.to_i + 1 unless version
+  end
+
+  def head_version
+    repository_object_version.repository_object.head_user_version
   end
 end

--- a/app/services/user_version_service.rb
+++ b/app/services/user_version_service.rb
@@ -27,8 +27,10 @@ class UserVersionService
   # @raise [UserVersionService::UserVersioningError] RepositoryObject not found for the druid
   # @raise [UserVersionService::UserVersioningError] RepositoryObjectVersion not found for the version
   def self.withdraw(druid:, user_version:, withdraw: true)
-    user_version_for(druid:, user_version:).update(withdrawn: withdraw)
+    user_version_for(druid:, user_version:).update!(withdrawn: withdraw)
     EventFactory.create(druid:, event_type: 'user_version_withdrawn', data: { version: user_version.to_s, withdrawn: withdraw })
+  rescue ActiveRecord::RecordInvalid => e
+    raise(UserVersioningError, e.message)
   end
 
   # @param [String] druid of the item

--- a/openapi.yml
+++ b/openapi.yml
@@ -3461,6 +3461,18 @@ components:
         userVersion:
           type: integer
           description: the number of the user version
+        withdrawn:
+          type: boolean
+          description: whether the user version is withdrawn
+        withdrawable:
+          type: boolean
+          description: whether the user version can be withdrawn
+        restorable:
+          type: boolean
+          description: whether the user version can be restored
+        head:
+          type: boolean
+          description: whether the user version is the head
     UserVersionLog:
       type: object
       description: "User versions for an object."

--- a/spec/models/user_version_spec.rb
+++ b/spec/models/user_version_spec.rb
@@ -45,5 +45,11 @@ RSpec.describe UserVersion do
 
       it { is_expected.to include 'Repository object version cannot set a user version to an RepositoryObjectVersion without cocina' }
     end
+
+    context 'when the user version cannot be withdrawn' do
+      let(:user_version) { build(:user_version, repository_object_version:, version: nil, withdrawn: true) }
+
+      it { is_expected.to include 'Repository object version head version cannot be withdrawn' }
+    end
   end
 end

--- a/spec/requests/create_user_version_spec.rb
+++ b/spec/requests/create_user_version_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Create user version' do
            params: { version: repository_object_version.version }.to_json
 
       expect(response).to have_http_status(:created)
-      expect(response.parsed_body).to eq({ 'userVersion' => 1, 'version' => 1, 'withdrawn' => false })
+      expect(response.parsed_body).to eq({ 'userVersion' => 1, 'version' => 1, 'withdrawn' => false, 'withdrawable' => false, 'restorable' => false, 'head' => true })
 
       expect(repository_object_version.reload.user_versions.count).to eq(1)
     end

--- a/spec/requests/user_versions_inventory_spec.rb
+++ b/spec/requests/user_versions_inventory_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe 'User versions' do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq('user_versions' => [
-                                           { 'userVersion' => 1, 'version' => 2, 'withdrawn' => false },
-                                           { 'userVersion' => 2, 'version' => 3, 'withdrawn' => false }
+                                           { 'userVersion' => 1, 'version' => 2, 'withdrawn' => false, 'withdrawable' => true, 'restorable' => false, 'head' => false },
+                                           { 'userVersion' => 2, 'version' => 3, 'withdrawn' => false, 'withdrawable' => false, 'restorable' => false, 'head' => true }
                                          ])
     end
   end

--- a/spec/services/user_version_service_spec.rb
+++ b/spec/services/user_version_service_spec.rb
@@ -3,41 +3,39 @@
 require 'rails_helper'
 
 RSpec.describe UserVersionService do
-  let(:druid) { 'druid:xz456jk0987' }
-  let(:repository_object_version) { repository_object.versions.first }
-  let(:repository_object) { create(:repository_object, :with_repository_object_version, object_type:, external_identifier: druid) }
+  let(:druid) { repository_object.external_identifier }
+  let(:repository_object) { repository_object_version1.repository_object }
+  let(:repository_object_version1) { create(:repository_object_version, :with_repository_object, closed_at: Time.zone.now) }
+  let!(:repository_object_version2) { create(:repository_object_version, version: 2, repository_object:, closed_at: Time.zone.now) }
   let(:object_type) { 'dro' }
-  let(:user_version) { UserVersion.create!(version: 1, repository_object_version:) }
 
   describe '.create' do
     subject(:user_version_service_create) { described_class.create(druid:, version: 1) }
 
     context 'when the repository object version is closed' do
-      before do
-        repository_object_version.update(closed_at: Time.current)
-      end
-
       it 'creates a user version' do
         user_version_service_create
-        expect(repository_object_version.user_versions.count).to eq 1
+        expect(repository_object.user_versions.count).to eq 1
       end
     end
 
     context 'when the repository object version is open' do
       before do
-        repository_object_version.update(closed_at: nil)
+        repository_object_version1.update(closed_at: nil)
       end
 
       it 'does not create a user version' do
         expect { user_version_service_create }.to raise_error UserVersionService::UserVersioningError
-        expect(repository_object_version.user_versions.count).to eq 0
+        expect(repository_object.user_versions.count).to eq 0
       end
     end
 
     context 'when the repository object is not found' do
+      let(:druid) { 'druid:abc123def456' }
+
       it 'does not create a user version' do
         expect { user_version_service_create }.to raise_error UserVersionService::UserVersioningError
-        expect(repository_object_version.user_versions.count).to eq 0
+        expect(repository_object.user_versions.count).to eq 0
       end
     end
   end
@@ -45,31 +43,35 @@ RSpec.describe UserVersionService do
   describe '.withdraw' do
     subject(:user_version_service_withdraw) { described_class.withdraw(druid:, user_version: 1) }
 
-    before do
-      repository_object_version.update(closed_at: Time.current)
+    let!(:user_version) { UserVersion.create!(version: 1, repository_object_version: repository_object_version1) }
+
+    context 'when the user version can be withdrawn' do
+      before do
+        UserVersion.create!(version: 2, repository_object_version: repository_object_version2)
+      end
+
+      it 'withdraws the user version' do
+        expect(user_version.withdrawn).to be false
+        user_version_service_withdraw
+        expect(user_version.reload.withdrawn).to be true
+      end
     end
 
-    it 'withdraws the user version' do
-      expect(user_version.withdrawn).to be false
-      user_version_service_withdraw
-      expect(user_version.reload.withdrawn).to be true
+    context 'when the user version cannot be withdrawn' do
+      it 'raises' do
+        expect(user_version.withdrawn).to be false
+        expect { user_version_service_withdraw }.to raise_error UserVersionService::UserVersioningError, 'Validation failed: Repository object version head version cannot be withdrawn'
+      end
     end
   end
 
   describe '.move' do
     subject(:user_version_service_move) { described_class.move(druid:, version: 2, user_version: 1) }
 
-    let(:repository_object_version2) do
-      create(:repository_object_version, repository_object:, version: 2, closed_at: Time.zone.now)
-    end
-
-    before do
-      repository_object_version.update(closed_at: Time.current)
-      repository_object_version2.update(closed_at: Time.current)
-    end
+    let!(:user_version) { UserVersion.create!(version: 1, repository_object_version: repository_object_version1) }
 
     it 'moves the user version' do
-      expect(user_version.repository_object_version).to eq repository_object_version
+      expect(user_version.repository_object_version).to eq repository_object_version1
       user_version_service_move
       expect(user_version.reload.repository_object_version).to eq repository_object_version2
     end
@@ -78,10 +80,7 @@ RSpec.describe UserVersionService do
   describe '.exist?' do
     subject(:user_version_service_exist?) { described_class.exist?(druid:, user_version: 1) }
 
-    before do
-      repository_object_version.update(closed_at: Time.current)
-      user_version.reload # ensures the user_version object exists before the test
-    end
+    let!(:user_version) { UserVersion.create!(version: 1, repository_object_version: repository_object_version1) }
 
     it 'returns true if the user version exists' do
       expect(user_version_service_exist?).to be true


### PR DESCRIPTION
closes #5136

## Why was this change made? 🤔
To support withdrawing from argo.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



