### PR TITLE
Support new user version mode for update if exists.

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -91,6 +91,7 @@ class VersionsController < ApplicationController
       :user_name,
       :user_versions
     ).to_h.symbolize_keys
+    new_params[:user_version_mode] = new_params.delete(:user_versions).to_sym if new_params.key?(:user_versions)
     boolean_param(new_params, :start_accession)
   end
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -1028,6 +1028,7 @@ paths:
               - "none"
               - "new"
               - "update"
+              - "update_if_existing"
   "/v1/objects/{object_id}/versions":
     get:
       tags:


### PR DESCRIPTION
closes #5140

## Why was this change made? 🤔
So that users can modify objects with user versions (i.e., created in H2) from Argo. Otherwise, the user version doesn't move to the latest object version.


## How was this change tested? 🤨

Unit, stage

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



