### PR TITLE
Adds show endpoint for object versions.

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -6,11 +6,16 @@ class VersionsController < ApplicationController
   before_action :load_version, only: %i[current close_current openable status]
 
   def index
-    repository_object = RepositoryObject.find_by!(external_identifier: params[:object_id])
+    render json: { versions: repository_object_version_content(find_repository_object.versions) }
+  end
 
-    # add an entry with version id and description for each RepositoryObjectVersion
+  def show
+    repository_object = find_repository_object
+    repository_object_version = repository_object.versions.find_by!(version: params[:id])
 
-    render json: { versions: repository_object_version_content(repository_object.versions) }
+    render json: repository_object_version.to_cocina_with_metadata
+  rescue RepositoryObjectVersion::NoCocina => e
+    render build_error('No content for this version', e, status: :bad_request)
   end
 
   def create
@@ -111,5 +116,9 @@ class VersionsController < ApplicationController
         message: repository_object_version.version_description
       }
     end
+  end
+
+  def find_repository_object
+    RepositoryObject.find_by!(external_identifier: params[:object_id])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,7 @@ Rails.application.routes.draw do
 
       resources :events, only: [:create, :index], defaults: { format: :json }
 
-      resources :versions, only: [:create, :index] do
+      resources :versions, only: %i[create index show] do
         collection do
           get 'openable'
           get 'current'

--- a/openapi.yml
+++ b/openapi.yml
@@ -1103,6 +1103,44 @@ paths:
           schema:
             type: string
           example: "some_sunetid"
+  "/v1/objects/{object_id}/versions/{version_id}":
+    get:
+      tags:
+        - versions
+      summary: Show the cocina for a particular object version
+      operationId: "versions#show"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DRO"
+        "400":
+          description: The version exists but there is no record of the cocina data.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: "#/components/schemas/Druid"
+        - name: version_id
+          in: path
+          description: ID of the version
+          required: true
+          schema:
+            type: string
   "/v1/objects/{object_id}/user_versions":
     get:
       tags:

--- a/spec/requests/show_object_version_spec.rb
+++ b/spec/requests/show_object_version_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Show single object version' do
+  let(:druid) { 'druid:mx123qw2323' }
+
+  before do
+    repository_object = create(:repository_object, :with_repository_object_version, :closed, external_identifier: druid)
+    create(:repository_object_version, repository_object:, version: 2, closed_at: Time.zone.now, cocina_version: nil)
+  end
+
+  context 'when found' do
+    it 'returns a 200' do
+      get "/v1/objects/#{druid}/versions/1",
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(type: 'https://cocina.sul.stanford.edu/models/book')
+      expect(response.parsed_body).to include(version: 1)
+    end
+  end
+
+  context 'when version has no cocina' do
+    it 'returns a 400' do
+      get "/v1/objects/#{druid}/versions/2",
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end


### PR DESCRIPTION
closes #5147

## Why was this change made? 🤔
So that Argo can display object versions.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



