### PR TITLE
Add whether version has cocina to version inventory endpoint.

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -113,7 +113,8 @@ class VersionsController < ApplicationController
     repository_object_versions.map do |repository_object_version|
       {
         versionId: repository_object_version.version,
-        message: repository_object_version.version_description
+        message: repository_object_version.version_description,
+        cocina: repository_object_version.has_cocina?
       }
     end
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -3533,6 +3533,9 @@ components:
         message:
           type: string
           description: a message that explains what changed
+        cocina:
+          type: boolean
+          description: whether the version has cocina data. (Legacy versions may not have cocina data.)
     VersionLog:
       type: object
       description: "Similar to the version inventory specified by OCFL: https://ocfl.io/draft/spec/#version-inventory"

--- a/spec/requests/versions_inventory_spec.rb
+++ b/spec/requests/versions_inventory_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Versions' do
 
   before do
     repository_object.save # we need at least one persisted version so we can run this test
-    repository_object.versions.create!(version: 2, version_description: 'draft')
+    repository_object.versions.create!(version: 2, version_description: 'draft', cocina_version: Cocina::Models::CocinaVersion)
   end
 
   it 'returns a 200' do
@@ -25,7 +25,7 @@ RSpec.describe 'Versions' do
         headers: { 'Authorization' => "Bearer #{jwt}" }
 
     expect(response).to have_http_status(:ok)
-    expect(response.body).to eq '{"versions":[{"versionId":1,"message":"Initial version"},' \
-                                '{"versionId":2,"message":"draft"}]}'
+    expect(response.body).to eq '{"versions":[{"versionId":1,"message":"Initial version","cocina":false},' \
+                                '{"versionId":2,"message":"draft","cocina":true}]}'
   end
 end


### PR DESCRIPTION
closes #5149

## Why was this change made? 🤔
Argo needs this info to determine whether a version detail page can be rendered.


## How was this change tested? 🤨

Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



