### PR TITLE
In clean up service, re-open head version.

### DIFF
--- a/app/services/cleanup_service.rb
+++ b/app/services/cleanup_service.rb
@@ -36,14 +36,21 @@ class CleanupService
 
     @version = repository_object.head_version.version
 
-    $stdout.puts "Head version of object #{druid} cannot be discarded" unless repository_object.can_discard_open_version?
-
-    repository_object.discard_open_version! if repository_object.can_discard_open_version? && !dryrun
-
     $stdout.puts '*** DRY RUN - NO ACTIONS WILL BE PERFORMED' if dryrun
     $stdout.puts "...object found is an item: version #{version}"
 
     $stdout.puts "...v#{version} of the object has not been sent to preservation"
+
+    if repository_object.can_discard_open_version?
+      $stdout.puts "Discarding head version of object #{druid}"
+      repository_object.discard_open_version! unless dryrun
+    else
+      $stdout.puts "Head version of object #{druid} cannot be discarded"
+      if repository_object.closed?
+        $stdout.puts "Reopening object #{druid}"
+        repository_object.reopen! unless dryrun
+      end
+    end
 
     # backup folders
     $stdout.puts '...backing up content folders'

--- a/spec/services/cleanup_service_spec.rb
+++ b/spec/services/cleanup_service_spec.rb
@@ -113,6 +113,20 @@ RSpec.describe CleanupService do
       end
     end
 
+    context 'when head version can be reopened' do
+      before do
+        repository_object.close_version!
+      end
+
+      it 'cleans up and reopens repository object' do
+        expect { described_class.stop_accessioning(druid) }.to output(/Reopening object #{druid}/).to_stdout
+        expect(repository_object.reload).to be_open
+        expect(service).to have_received(:backup_content_by_druid).once
+        expect(service).to have_received(:cleanup_by_druid).once
+        expect(service).to have_received(:delete_accessioning_workflows).once
+      end
+    end
+
     context 'when object cannot be opened and preservationIngestWF does not exist' do
       before do
         allow(VersionService).to receive_messages(can_open?: false)


### PR DESCRIPTION
closes #5152

## Why was this change made? 🤔
To help with cleanup.


## How was this change tested? 🤨
Unit
⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



