### PR TITLE
Add endpoint for object version solr.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,9 @@ Rails.application.routes.draw do
           get 'status'
           post 'current/close', action: 'close_current'
         end
+        member do
+          get 'solr'
+        end
       end
 
       resources :user_versions, only: %i[index show create update] do

--- a/openapi.yml
+++ b/openapi.yml
@@ -1141,6 +1141,38 @@ paths:
           required: true
           schema:
             type: string
+  "/v1/objects/{object_id}/versions/{version_id}/solr":
+    get:
+      tags:
+        - versions
+      summary: Show solr document for a particular object version
+      operationId: "versions#solr"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: "#/components/schemas/Druid"
+        - name: version_id
+          in: path
+          description: ID of the version
+          required: true
+          schema:
+            type: string            
   "/v1/objects/{object_id}/user_versions":
     get:
       tags:

--- a/spec/requests/show_user_version_spec.rb
+++ b/spec/requests/show_user_version_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Show single user version' do
+RSpec.describe 'Show solr for a user version' do
   let(:druid) { 'druid:mx123qw2323' }
 
   context 'when found' do

--- a/spec/requests/show_version_solr_spec.rb
+++ b/spec/requests/show_version_solr_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Show solr for an object version' do
+  let(:druid) { 'druid:mx123qw2323' }
+
+  let(:workflows) do
+    instance_double(Indexing::Indexers::WorkflowsIndexer, to_solr: { 'wf_ssim' => ['accessionWF'] })
+  end
+
+  context 'when found' do
+    before do
+      create(:repository_object, :with_repository_object_version, :closed, external_identifier: druid)
+      allow(Indexing::Indexers::WorkflowsIndexer).to receive(:new).and_return(workflows)
+      allow(Indexing::WorkflowFields).to receive(:for).and_return({ milestones_ssim: %w[foo bar] })
+    end
+
+    it 'returns a 200' do
+      get "/v1/objects/#{druid}/versions/1/solr",
+          headers: { 'Authorization' => "Bearer #{jwt}" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(id: druid)
+      expect(response.parsed_body).to include(rights_descriptions_ssim: ['world', 'dark (file)'])
+    end
+  end
+end


### PR DESCRIPTION
refs https://github.com/sul-dlss/argo/issues/4521

## Why was this change made? 🤔
Argo needs it to display object versions.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



