### PR TITLE
Support permanently withdrawing user versions.

### DIFF
--- a/app/jobs/withdraw_restore_job.rb
+++ b/app/jobs/withdraw_restore_job.rb
@@ -7,7 +7,7 @@ class WithdrawRestoreJob < ApplicationJob
   def perform(user_version:)
     druid = user_version.repository_object_version.repository_object.external_identifier
     version = user_version.version
-    if user_version.withdrawn
+    if user_version.withdrawn?
       PurlFetcher::Client::Withdraw.withdraw(druid:, version:)
     else
       PurlFetcher::Client::Withdraw.restore(druid:, version:)

--- a/app/models/user_version.rb
+++ b/app/models/user_version.rb
@@ -5,9 +5,12 @@ class UserVersion < ApplicationRecord
   belongs_to :repository_object_version
   before_save :set_version
 
+  enum :state, withdrawn: 'withdrawn', available: 'available', permanently_withdrawn: 'permanently_withdrawn'
+
   validate :repository_object_version_is_closed
   validate :repository_object_version_has_cocina
   validate :can_withdraw
+  validate :when_permanently_withdrawn
 
   def repository_object_version_is_closed
     # Validate that the repository object version is closed
@@ -21,14 +24,19 @@ class UserVersion < ApplicationRecord
 
   def can_withdraw
     # Validate that the user version can be withdrawn or restored
-    errors.add(:repository_object_version, 'head version cannot be withdrawn') if withdrawn && (head? || version.nil?)
+    errors.add(:repository_object_version, 'head version cannot be withdrawn') if withdrawn? && (head? || version.nil?)
+  end
+
+  def when_permanently_withdrawn
+    # Validate that the user version state cannot be changed from permanently withdrawn
+    errors.add(:repository_object_version, 'cannot set user version state when permanently withdrawn') if changed_attributes['state'] == 'permanently_withdrawn'
   end
 
   def as_json
     {
       userVersion: version,
       version: repository_object_version.version,
-      withdrawn:,
+      withdrawn: withdrawn?,
       withdrawable: withdrawable?,
       restorable: restorable?,
       head: head?
@@ -36,11 +44,11 @@ class UserVersion < ApplicationRecord
   end
 
   def withdrawable?
-    !withdrawn && !head?
+    available? && !head?
   end
 
   def restorable?
-    withdrawn
+    withdrawn?
   end
 
   def head?

--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -118,6 +118,7 @@ class VersionService
     EventFactory.create(druid:, event_type: 'version_close', data: { who: user_name, version: version.to_s })
 
     update_user_version(user_version_mode:, repository_object:)
+    update_previous_user_versions(repository_object:)
   end
 
   # Determines whether a version can be closed for an object.
@@ -211,6 +212,15 @@ class VersionService
     return if preservation_version == current_version
 
     raise VersionService::VersioningError, "Version from Preservation is out of sync. Preservation expects #{preservation_version} but current version is #{current_version}"
+  end
+
+  def update_previous_user_versions(repository_object:)
+    return unless repository_object.user_versions.length > 1
+
+    cocina_object = repository_object.to_cocina
+    return unless cocina_object.access.view == 'dark'
+
+    UserVersionService.permanently_withdraw_previous_user_versions(druid:)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/db/migrate/20240807210223_change_user_version_state.rb
+++ b/db/migrate/20240807210223_change_user_version_state.rb
@@ -1,0 +1,11 @@
+class ChangeUserVersionState < ActiveRecord::Migration[7.1]
+  def change
+    add_column :user_versions, :state, :string, default: 'available', null: false
+
+    execute <<~SQL
+      UPDATE user_versions SET state = 'withdrawn' WHERE withdrawn = true;
+    SQL
+
+    remove_column :user_versions, :withdrawn
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,6 +10,13 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
+--
+
+-- *not* creating schema, since initdb creates it
+
+
+--
 -- Name: background_job_result_status; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -340,10 +347,10 @@ ALTER SEQUENCE public.tag_labels_id_seq OWNED BY public.tag_labels.id;
 CREATE TABLE public.user_versions (
     id bigint NOT NULL,
     version integer NOT NULL,
-    withdrawn boolean DEFAULT false NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    repository_object_version_id bigint NOT NULL
+    repository_object_version_id bigint NOT NULL,
+    state character varying DEFAULT 'available'::character varying NOT NULL
 );
 
 
@@ -719,6 +726,7 @@ ALTER TABLE ONLY public.repository_objects
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20240807210223'),
 ('20240531122304'),
 ('20240522142556'),
 ('20240430144139'),

--- a/spec/factories/repository_object_versions.rb
+++ b/spec/factories/repository_object_versions.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
       is_member_of { [] }
       source_id { "sul:#{SecureRandom.uuid}" }
     end
-    version { 1 }
+    sequence(:version)
     version_description { 'Best version ever' }
     lock { 2 }
     cocina_version { Cocina::Models::VERSION }

--- a/spec/factories/user_versions.rb
+++ b/spec/factories/user_versions.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :user_version do
     sequence(:version)
-    withdrawn { false }
+    state { 'available' }
+    repository_object_version
   end
 end

--- a/spec/jobs/withdraw_restore_job_spec.rb
+++ b/spec/jobs/withdraw_restore_job_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe WithdrawRestoreJob do
   end
 
   let(:druid) { 'druid:mk420bs7601' }
-  let(:user_version) { create(:user_version, withdrawn:, repository_object_version:) }
+  let(:user_version) { create(:user_version, state:, repository_object_version:) }
   let(:repository_object_version) { create(:repository_object_version, :with_repository_object, external_identifier: druid, closed_at: Time.current) }
 
   context 'when the version is withdrawn' do
-    let(:withdrawn) { true }
+    let(:state) { 'withdrawn' }
 
     before do
       allow(PurlFetcher::Client::Withdraw).to receive(:withdraw)
@@ -25,7 +25,7 @@ RSpec.describe WithdrawRestoreJob do
   end
 
   context 'when the version is not withdrawn' do
-    let(:withdrawn) { false }
+    let(:state) { 'available' }
 
     before do
       allow(PurlFetcher::Client::Withdraw).to receive(:restore)

--- a/spec/models/user_version_spec.rb
+++ b/spec/models/user_version_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe UserVersion do
 
   let(:attrs) do
     {
-      version: 1,
       version_description: 'My new version',
       closed_at: Time.current
     }
@@ -32,7 +31,6 @@ RSpec.describe UserVersion do
     context 'when the repository object version is open' do
       let(:attrs) do
         {
-          version: 1,
           version_description: 'My new version'
         }
       end
@@ -47,9 +45,68 @@ RSpec.describe UserVersion do
     end
 
     context 'when the user version cannot be withdrawn' do
-      let(:user_version) { build(:user_version, repository_object_version:, version: nil, withdrawn: true) }
+      let(:user_version) { build(:user_version, repository_object_version:, version: nil, state: 'withdrawn') }
 
       it { is_expected.to include 'Repository object version head version cannot be withdrawn' }
+    end
+
+    context 'when the user version is permanently withdrawn' do
+      let(:user_version) do
+        user_version = create(:user_version, repository_object_version:, state: 'permanently_withdrawn')
+        user_version.state = 'available'
+        user_version
+      end
+
+      it { is_expected.to include 'Repository object version cannot set user version state when permanently withdrawn' }
+    end
+  end
+
+  describe '#as_json' do
+    let(:user_version) { build(:user_version, repository_object_version:, state:) }
+
+    context 'when the user version is withdrawn' do
+      let(:state) { 'withdrawn' }
+
+      it 'returns the user version as JSON' do
+        expect(user_version.as_json).to eq(
+          userVersion: user_version.version,
+          version: user_version.repository_object_version.version,
+          withdrawn: true,
+          withdrawable: false,
+          restorable: true,
+          head: false
+        )
+      end
+    end
+
+    context 'when the user version is permanently withdrawn' do
+      let(:state) { 'permanently_withdrawn' }
+
+      it 'returns the user version as JSON' do
+        expect(user_version.as_json).to eq(
+          userVersion: user_version.version,
+          version: user_version.repository_object_version.version,
+          withdrawn: false,
+          withdrawable: false,
+          restorable: false,
+          head: false
+        )
+      end
+    end
+
+    context 'when the user version is available' do
+      let(:state) { 'available' }
+
+      it 'returns the user version as JSON' do
+        expect(user_version.as_json).to eq(
+          userVersion: user_version.version,
+          version: user_version.repository_object_version.version,
+          withdrawn: false,
+          withdrawable: true,
+          restorable: false,
+          head: false
+        )
+      end
     end
   end
 end

--- a/spec/requests/create_user_version_spec.rb
+++ b/spec/requests/create_user_version_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe 'Create user version' do
            params: { version: repository_object_version.version }.to_json
 
       expect(response).to have_http_status(:created)
-      expect(response.parsed_body).to eq({ 'userVersion' => 1, 'version' => 1, 'withdrawn' => false, 'withdrawable' => false, 'restorable' => false, 'head' => true })
-
       expect(repository_object_version.reload.user_versions.count).to eq(1)
+      user_version = repository_object_version.user_versions.first
+      expect(response.parsed_body).to eq({ 'userVersion' => user_version.version, 'version' => repository_object_version.version, 'withdrawn' => false, 'withdrawable' => false, 'restorable' => false, 'head' => true })
     end
   end
 

--- a/spec/requests/update_user_version_spec.rb
+++ b/spec/requests/update_user_version_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Update user version' do
   let(:repository_object) { repository_object_version1.repository_object }
-  let(:repository_object_version1) { create(:repository_object_version, :with_repository_object, closed_at: Time.zone.now) }
+  let(:repository_object_version1) { create(:repository_object_version, :with_repository_object, closed_at: Time.zone.now, version: 1) }
   let!(:repository_object_version2) { create(:repository_object_version, version: 2, repository_object:, closed_at: Time.zone.now) }
   let(:user_version) { create(:user_version, repository_object_version: repository_object_version1, version: 1) }
 
@@ -34,7 +34,7 @@ RSpec.describe 'Update user version' do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to eq({ 'userVersion' => user_version.version, 'version' => 1, 'withdrawn' => true, 'withdrawable' => false, 'restorable' => true, 'head' => false })
 
-      expect(user_version.reload.withdrawn).to be(true)
+      expect(user_version.reload.withdrawn?).to be(true)
     end
   end
 

--- a/spec/services/migrators/remove_release_tags_spec.rb
+++ b/spec/services/migrators/remove_release_tags_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe Migrators::RemoveReleaseTags do
   subject(:migrator) { described_class.new(repository_object) }
 
-  let(:repository_object) { create(:repository_object, :with_repository_object_version, repository_object_version:) }
-  let(:repository_object_version) { build(:repository_object_version, administrative:) }
+  let(:repository_object) { repository_object_version.repository_object }
+  let(:repository_object_version) { build(:repository_object_version, :with_repository_object, administrative:) }
   let(:administrative) { { hasAdminPolicy: 'druid:hy787xj5878', releaseTags: [] } }
 
   describe '#migrate?' do


### PR DESCRIPTION
closes #5158

## Why was this change made? 🤔
So that user can correctly withdraw / restore user versions.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



