### PR TITLE
Adds rake tasks for creating new object versions and moving user versions.

### DIFF
--- a/app/models/repository_object.rb
+++ b/app/models/repository_object.rb
@@ -90,12 +90,14 @@ class RepositoryObject < ApplicationRecord # rubocop:disable Metrics/ClassLength
     reload # Syncs up head_version and opened_version
   end
 
-  def open_version!(description:)
+  # @param [String] description for the version
+  # @param [RepositoryObjectVersion,nil] from_version existing version to base the new version on. If nil, then uses last_closed_version.
+  def open_version!(description:, from_version: nil)
     raise VersionAlreadyOpened, "Cannot open new version because one is already open: #{head_version.version}" if open?
 
     RepositoryObject.transaction do
-      new_version = last_closed_version.dup
-      new_version.update!(version: new_version.version + 1, version_description: description, closed_at: nil)
+      new_version = (from_version || last_closed_version).dup
+      new_version.update!(version: last_closed_version.version + 1, version_description: description, closed_at: nil)
       update!(opened_version: new_version, head_version: new_version)
     end
   end

--- a/lib/tasks/dor_services_app.rake
+++ b/lib/tasks/dor_services_app.rake
@@ -5,4 +5,22 @@ namespace :dsa do
   task embargo_release: :environment do
     EmbargoReleaseService.release_all
   end
+
+  desc 'Open a new version from an existing version'
+  task :open_version, %i[druid description from_version] => :environment do |_task, args|
+    repository_object = RepositoryObject.find_by!(external_identifier: args[:druid])
+    VersionService.open(cocina_object: repository_object.to_cocina, description: args[:description],
+                        assume_accessioned: false, from_version:  args[:from_version].to_i)
+  end
+
+  desc 'Move a user version'
+  task :move_user_version, %i[druid user_version to_version] => :environment do |_task, args|
+    UserVersionService.move(druid: args[:druid], version: args[:to_version].to_i, user_version: args[:user_version].to_i)
+  end
+
+  desc 'Closes a repository object without changing a user version'
+  task :close_version, %i[druid] => :environment do |_task, args|
+    repository_object = RepositoryObject.find_by!(external_identifier: args[:druid])
+    VersionService.close(druid: args[:druid], version: repository_object.head_version.version, user_version_mode: :none)
+  end
 end

--- a/spec/models/repository_object_spec.rb
+++ b/spec/models/repository_object_spec.rb
@@ -143,6 +143,26 @@ RSpec.describe RepositoryObject do
         expect(newly_created_version.closed_at).to be_nil
       end
     end
+
+    context 'when based on an earlier version' do
+      before do
+        repository_object.head_version.label = 'Version 1'
+        repository_object.close_version!
+        repository_object.open_version!(description: 'Another version')
+        repository_object.head_version.label = 'Version 2'
+        repository_object.close_version!
+      end
+
+      it 'creates a new version and updates the head and opened version pointers' do
+        expect { repository_object.open_version!(description:, from_version: repository_object.versions.first) }.to change(RepositoryObjectVersion, :count).by(1)
+        newly_created_version = repository_object.versions.last
+        expect(newly_created_version.version).to eq(3)
+        expect(repository_object.head_version).to eq(newly_created_version)
+        expect(repository_object.opened_version).to eq(newly_created_version)
+        expect(newly_created_version.label).to eq 'Version 1'
+        expect(newly_created_version.closed_at).to be_nil
+      end
+    end
   end
 
   describe '#close_version!' do


### PR DESCRIPTION
## Why was this change made? 🤔
Support fixing earlier versions by making new versions.


## How was this change tested? 🤨
Andrew


⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



