### PR TITLE
Adds enabled flag for solr.

### DIFF
--- a/app/services/indexer.rb
+++ b/app/services/indexer.rb
@@ -4,6 +4,8 @@
 class Indexer
   # @param [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata]
   def self.reindex(cocina_object:)
+    return unless Settings.solr.enabled
+
     solr_doc = Indexing::Builders::DocumentBuilder.for(
       model: cocina_object
     ).to_solr
@@ -12,6 +14,8 @@ class Indexer
   end
 
   def self.delete(druid:)
+    return unless Settings.solr.enabled
+
     solr.delete_by_id(druid)
     solr.commit
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,6 +37,7 @@ version_service:
 
 # URLs
 solr:
+  enabled: true
   select_path: 'select'
   timeout: 120
   url: 'https://solr.example.com/solr/collection'

--- a/spec/services/indexer_spec.rb
+++ b/spec/services/indexer_spec.rb
@@ -27,6 +27,19 @@ RSpec.describe Indexer do
       expect(solr).to have_received(:add).with(solr_doc)
       expect(solr).to have_received(:commit)
     end
+
+    context 'when solr is not enabled' do
+      before do
+        allow(Settings.solr).to receive(:enabled).and_return(false)
+      end
+
+      it 'does not reindex the object' do
+        described_class.reindex(cocina_object:)
+        expect(Indexing::Builders::DocumentBuilder).not_to have_received(:for)
+        expect(solr).not_to have_received(:add)
+        expect(solr).not_to have_received(:commit)
+      end
+    end
   end
 
   describe '#delete' do
@@ -34,6 +47,18 @@ RSpec.describe Indexer do
       described_class.delete(druid:)
       expect(solr).to have_received(:delete_by_id).with(druid)
       expect(solr).to have_received(:commit)
+    end
+
+    context 'when solr is not enabled' do
+      before do
+        allow(Settings.solr).to receive(:enabled).and_return(false)
+      end
+
+      it 'does not delete the object' do
+        described_class.delete(druid:)
+        expect(solr).not_to have_received(:delete_by_id)
+        expect(solr).not_to have_received(:commit)
+      end
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔
So that DSA can be used for a local docker integration test without needing solr.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



