### PR TITLE
remove workflow param from cleanup

### DIFF
--- a/app/controllers/workspaces_controller.rb
+++ b/app/controllers/workspaces_controller.rb
@@ -17,7 +17,7 @@ class WorkspacesController < ApplicationController
   def destroy
     result = BackgroundJobResult.create
     EventFactory.create(druid: params[:object_id], event_type: 'cleanup_request_received', data: { background_job_result_id: result.id })
-    CleanupJob.set(queue: params['lane-id']).perform_later(druid: params[:object_id], background_job_result: result, workflow: params[:workflow])
+    CleanupJob.set(queue: params['lane-id']).perform_later(druid: params[:object_id], background_job_result: result)
     head :created, location: result
   end
 

--- a/app/jobs/cleanup_job.rb
+++ b/app/jobs/cleanup_job.rb
@@ -6,11 +6,12 @@ class CleanupJob < ApplicationJob
 
   # @param [String] druid the identifier of the object to be cleaned up
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
-  # @param [String] workflow Which workflow should this be reported to?
-  def perform(druid:, background_job_result:, workflow:)
+  def perform(druid:, background_job_result:)
     background_job_result.processing!
 
-    workflow_process = workflow == 'accessionWF' ? 'reset-workspace' : 'cleanup'
+    # this job is only called by accessionWF:reset-workspace, so it should complete it when done
+    workflow = 'accessionWF'
+    workflow_process = 'reset-workspace'
 
     begin
       CleanupService.cleanup_by_druid druid

--- a/spec/jobs/cleanup_job_spec.rb
+++ b/spec/jobs/cleanup_job_spec.rb
@@ -4,12 +4,11 @@ require 'rails_helper'
 
 RSpec.describe CleanupJob do
   subject(:perform) do
-    described_class.perform_now(druid:, background_job_result: result, workflow:)
+    described_class.perform_now(druid:, background_job_result: result)
   end
 
   let(:druid) { 'druid:mk420bs7601' }
   let(:result) { create(:background_job_result) }
-  let(:workflow) { 'accessionWF' }
 
   before do
     # allow(CocinaObjectStore).to receive(:find).with(druid).and_return(item)

--- a/spec/requests/cleanup_workspace_spec.rb
+++ b/spec/requests/cleanup_workspace_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe 'Cleanup workspace' do
     end
 
     it 'returns 200' do
-      delete "/v1/objects/#{druid}/workspace?workflow=accessionWF&lane-id=low",
+      delete "/v1/objects/#{druid}/workspace?lane-id=low",
              headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(CleanupJob).to have_received(:set).with(queue: 'low')
       expect(job).to have_received(:perform_later)
-        .with(druid:, background_job_result: BackgroundJobResult, workflow: 'accessionWF')
+        .with(druid:, background_job_result: BackgroundJobResult)
       expect(response).to have_http_status(:created)
       expect(EventFactory).to have_received(:create)
     end


### PR DESCRIPTION
## Why was this change made? 🤔

Part of https://github.com/sul-dlss/common-accessioning/issues/1387

DisseminationWF is gone (see #1385), so remove it's reference.  We also don't need to bother even asking for the workflow anymore for this endpoint since it's always going to be accessionWF.  

This changes needs to be coordinated with https://github.com/sul-dlss/common-accessioning/pull/1386 and https://github.com/sul-dlss/dor-services-client/pull/475

HOLD for #1385

Process:
1. Merge https://github.com/sul-dlss/dor-services-client/pull/475 and then cut a new release
2. Update https://github.com/sul-dlss/common-accessioning/pull/1386 to use new dor-services-client release, merge it
3. Merge https://github.com/sul-dlss/dor-services-app/pull/5186
4. Deploy all

## How was this change tested? 🤨

Spec

