### PR TITLE
Support discarding open object versions.

### DIFF
--- a/app/jobs/cleanup_version_job.rb
+++ b/app/jobs/cleanup_version_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Cleans up files and workflows when a version is discarded.
+class CleanupVersionJob < ApplicationJob
+  queue_as :default
+
+  # @param [String] druid the identifier of the object to be cleaned up
+  # @param [String] version the version of the object to be cleaned up
+  def perform(druid:, version:)
+    CleanupService.delete_accessioning_workflows(druid, version)
+    CleanupService.cleanup_by_druid(druid)
+
+    EventFactory.create(druid:,
+                        event_type: 'cleanup-workspace',
+                        data: { status: 'success' })
+  rescue Errno::ENOENT, Errno::ENOTEMPTY => e
+    EventFactory.create(druid:, event_type: 'cleanup-workspace',
+                        data: { status: 'failure', message: e.message, backtrace: e.backtrace })
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
         collection do
           get 'openable'
           get 'current'
+          delete 'current', action: 'destroy_current'
           get 'status'
           post 'current/close', action: 'close_current'
         end

--- a/openapi.yml
+++ b/openapi.yml
@@ -960,6 +960,26 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/Druid"
+    delete:
+      tags:
+        - versions
+      summary: Destroys current open version for this object
+      description: ""
+      operationId: "versions#destroy_current"
+      responses:
+        "204":
+          description: Deleted
+        "409":
+          description: Current version is not open
+        "404":
+          description: Object not found
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: "#/components/schemas/Druid"
   "/v1/objects/{object_id}/versions/status":
     get:
       tags:
@@ -3585,6 +3605,7 @@ components:
         - assembling
         - accessioning
         - closeable
+        - discardable
       properties:
         versionId:
           type: integer

--- a/spec/jobs/cleanup_job_spec.rb
+++ b/spec/jobs/cleanup_job_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe CleanupJob do
   let(:result) { create(:background_job_result) }
 
   before do
-    # allow(CocinaObjectStore).to receive(:find).with(druid).and_return(item)
     allow(result).to receive(:processing!)
     allow(EventFactory).to receive(:create)
   end

--- a/spec/jobs/cleanup_version_job_spec.rb
+++ b/spec/jobs/cleanup_version_job_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CleanupVersionJob do
+  subject(:perform) do
+    described_class.perform_now(druid:, version:)
+  end
+
+  let(:druid) { 'druid:mk420bs7601' }
+  let(:version) { '2' }
+
+  before do
+    allow(EventFactory).to receive(:create)
+    allow(CleanupService).to receive(:delete_accessioning_workflows)
+  end
+
+  context 'with no errors' do
+    before do
+      allow(CleanupService).to receive(:cleanup_by_druid)
+    end
+
+    it 'cleans up and records an event' do
+      perform
+
+      expect(CleanupService).to have_received(:delete_accessioning_workflows).with(druid, version)
+      expect(CleanupService).to have_received(:cleanup_by_druid).with(druid)
+      expect(EventFactory).to have_received(:create).with(druid: druid, event_type: 'cleanup-workspace', data: { status: 'success' })
+    end
+  end
+
+  context 'with errors' do
+    before do
+      allow(CleanupService).to receive(:cleanup_by_druid).and_raise(Errno::ENOENT)
+    end
+
+    it 'records an event' do
+      perform
+
+      expect(EventFactory).to have_received(:create).with(druid: druid, event_type: 'cleanup-workspace', data: { status: 'failure', message: 'No such file or directory', backtrace: Array })
+    end
+  end
+end


### PR DESCRIPTION
closes #5194

## Why was this change made? 🤔
This functionality is needed for H3.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



