### PR TITLE
Changes strategy when staging files from preservation for shelving.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'mais_orcid_client'
 gem 'marc'
 gem 'marc-vocab', '~> 0.3.0' # for indexing
 gem 'moab-versioning', '~> 6.0', require: 'moab/stanford'
-gem 'preservation-client', '~> 6.0'
+gem 'preservation-client', '~> 7.0'
 gem 'purl_fetcher-client', '~> 2.1'
 gem 'stanford-mods' # for indexing
 gem 'sul_orcid_client', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,7 +363,7 @@ GEM
     patience_diff (1.2.0)
       optimist (~> 3.0)
     pg (1.5.8)
-    preservation-client (6.2.0)
+    preservation-client (7.0.1)
       activesupport (>= 4.2, < 8)
       faraday (~> 2.0)
       moab-versioning (>= 5.0.0, < 7)
@@ -618,7 +618,7 @@ DEPENDENCIES
   okcomputer
   parallel
   pg
-  preservation-client (~> 6.0)
+  preservation-client (~> 7.0)
   propshaft
   puma (~> 6.0)
   purl_fetcher-client (~> 2.1)


### PR DESCRIPTION
closes #5193

## Why was this change made? 🤔
So that errors are correctly handled when getting files from preservation so that garbage is not shelved.


## How was this change tested? 🤨
Unit
⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



