### PR TITLE
Configure docker image to have contribsys key for sidekiq pro.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ workflows:
           context: dlss
           name: publish-latest
           image: suldlss/dor-services-app
+          extra_build_args: --build-arg BUNDLE_GEMS__CONTRIBSYS__COM
           requires:
             - validate
             - lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM ruby:3.3.1-bookworm
 ENV RAILS_ENV=production
 ENV BUNDLER_WITHOUT="development test"
 
+# For Sidekiq Pro
+ARG BUNDLE_GEMS__CONTRIBSYS__COM
+ENV BUNDLE_GEMS__CONTRIBSYS__COM $BUNDLE_GEMS__CONTRIBSYS__COM
+
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         postgresql-client postgresql-contrib libpq-dev \


### PR DESCRIPTION
## Why was this change made? 🤔
Dockerfile needs contribsys key in order to build. This is because of the recent addition of Sidekiq Pro.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



