### PR TITLE
Retry preservation transfer when version mismatch.

### DIFF
--- a/app/jobs/robots/dor_repo/accession/sdr_ingest_transfer.rb
+++ b/app/jobs/robots/dor_repo/accession/sdr_ingest_transfer.rb
@@ -6,7 +6,8 @@ module Robots
       # Transfers the object to preservation
       class SdrIngestTransfer < Robots::Robot
         def initialize
-          super('accessionWF', 'sdr-ingest-transfer')
+          # VersionMismatchError may be caused by storage latency, so retrying.
+          super('accessionWF', 'sdr-ingest-transfer', retriable_exceptions: [PreservationIngestService::VersionMismatchError])
         end
 
         def perform_work

--- a/app/services/preservation_ingest_service.rb
+++ b/app/services/preservation_ingest_service.rb
@@ -7,9 +7,8 @@ require 'moab/stanford'
 # NOTE:  this class makes use of data structures from moab-versioning gem,
 #  but it does NOT access any preservation storage roots directly
 class PreservationIngestService
-  # @param [Cocina::Models::DRO, Cocina::Models::Collection] cocina_object The representation of the digital object
-  # @return [void] Create the Moab/bag manifests for new version, export data to BagIt bag, kick off the SDR preservation workflow
-  # @raise [Preservation::Client::Error] if bad response from preservation catalog.
+  class VersionMismatchError < StandardError; end
+
   def self.transfer(cocina_object)
     new(cocina_object).transfer
   end
@@ -21,6 +20,7 @@ class PreservationIngestService
   # @param [Cocina::Models::DRO, Cocina::Models::Collection] cocina_object The representation of the digital object
   # @return [void] Create the Moab/bag manifests for new version, export data to BagIt bag, kick off the SDR preservation workflow
   # @raise [Preservation::Client::Error] if bad response from preservation catalog.
+  # @raise [PreservationIngestService::VersionMismatchError] if the versionMetadata.xml version does not match the expected version from preservation.
   def transfer
     # Writes versionMetadata.xml, contentMetadata.xml, and cocina.json
     metadata_dir = PreservationMetadataExtractor.extract(workspace:, cocina_object:)
@@ -76,7 +76,7 @@ class PreservationIngestService
   # @param [Integer] expected The version number that should be in the file
   # @param [Integer] found The version number that is actually in the file
   def verify_version_id(pathname, expected, found)
-    raise "Version mismatch in #{pathname}, expected #{expected}, found #{found}" unless expected == found
+    raise VersionMismatchError, "Version mismatch in #{pathname}, expected #{expected}, found #{found}" unless expected == found
 
     true
   end

--- a/spec/services/preservation_ingest_service_spec.rb
+++ b/spec/services/preservation_ingest_service_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe PreservationIngestService do
 
     it 'verifies the version' do
       expect(service.send(:verify_version_id, '/mypath/myfile', 2, 2)).to be_truthy
-      expect { service.send(:verify_version_id, '/mypath/myfile', 1, 2) }.to raise_exception('Version mismatch in /mypath/myfile, expected 1, found 2')
+      expect { service.send(:verify_version_id, '/mypath/myfile', 1, 2) }.to raise_exception(described_class::VersionMismatchError, 'Version mismatch in /mypath/myfile, expected 1, found 2')
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔
This is an existing race condition that was previously handled by job retries; this makes the robot perform retries for same.


## How was this change tested? 🤨
Unit, stage

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



