### PR TITLE
typo in settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -83,7 +83,7 @@ cleanup:
   local_workspace_root: '/dor/workspace'
   local_assembly_root: '/dor/assembly'
   local_export_home: '/dor/export'
-  local_backup_path: /dor/stopped'
+  local_backup_path: '/dor/stopped'
 
 dor:
   hmac_secret: 'my$ecretK3y'


### PR DESCRIPTION
## Why was this change made? 🤔

Doh.  The backup folder for objects where we are stopping accessioning is not correctly configured.  This fixes it.

```
dor_services@dor-services-app-prod-a:/dor$ ls -al
total 7414784
drwxr-xr-x  11 dor_services dor_services       4096 Oct 22 08:37  .
drwxr-xr-x  28 root         root               4096 Jul 23 10:43  ..
drwxrwsr-x 140 dor_services dor_services      32768 Nov 20 15:43  assembly
drwxr-xr-x  20 dor_services dor_services   27148288 Nov 20 15:55  export
drwxrwxr-x   2 dor_services dor_services      16384 Sep 17  2013  import
drwxrwxr-x  57 dor_services dor_services       8192 Oct 23 10:28  preassembly
-rw-------   1 root         root         7562592256 Sep 15  2021  production.log
drwxr-xr-x   4 root         root               4096 Oct 17  2013  sdr1transfer
drwxrwxr-x  65 dor_services users              8192 Oct  8 12:25  staging
drwxr-xr-x   2 dor_services dor_services       4096 Jul 29 16:49  stopped
drwxr-xr-x  12 dor_services dor_services       4096 Nov 20 15:24 "stopped'"
drwxrwsr-x 398 dor_services dor_services      32768 Nov 20 15:42  workspace
```

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



