### PR TITLE
Report more context when encountering rolling index errors

### DIFF
--- a/bin/rolling_index
+++ b/bin/rolling_index
@@ -51,6 +51,13 @@ Daemons.run_proc(
           Indexer.delete(solr: solr_conn, identifier:) if DELETE_ENVS.include?(ENV['HONEYBADGER_ENV'])
           # Return `nil`, which is compacted, so the Solr add isn't grumpy
           nil
+        rescue StandardError => e
+          Honeybadger.notify('[DATA ERROR] Unexpected rolling index error',
+                             tags: 'data_error',
+                             error_message: e.message,
+                             backtrace: e.backtrace,
+                             context: { druid: identifier })
+          nil
         ensure
           sleep(Settings.rolling_indexer.pause_time_between_docs)
         end


### PR DESCRIPTION
# Why was this change made?

To make rolling index exceptions more actionable.
