### PR TITLE
Bump cocina-models to 0.99.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,9 +120,8 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.99.2)
+    cocina-models (0.99.3)
       activesupport
-      commonmarker (= 2.0.1)
       deprecation
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -131,7 +130,6 @@ GEM
       i18n
       jsonpath
       nokogiri
-      openapi3_parser
       openapi_parser (~> 1.0)
       super_diff
       thor
@@ -140,15 +138,11 @@ GEM
       json_schema (~> 0.14, >= 0.14.3)
       openapi_parser (~> 1.0)
       rack (>= 1.5)
-    commonmarker (2.0.1-aarch64-linux)
-    commonmarker (2.0.1-arm64-darwin)
-    commonmarker (2.0.1-x86_64-darwin)
-    commonmarker (2.0.1-x86_64-linux)
     concurrent-ruby (1.3.4)
     config (5.5.2)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
-    connection_pool (2.4.1)
+    connection_pool (2.5.0)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -209,12 +203,12 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
-    dry-struct (1.6.0)
-      dry-core (~> 1.0, < 2)
-      dry-types (>= 1.7, < 2)
+    dry-struct (1.7.0)
+      dry-core (~> 1.1)
+      dry-types (~> 1.8)
       ice_nine (~> 0.11)
       zeitwerk (~> 2.6)
-    dry-types (1.7.2)
+    dry-types (1.8.0)
       bigdecimal (~> 3.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0)
@@ -373,8 +367,6 @@ GEM
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
     okcomputer (1.18.5)
-    openapi3_parser (0.10.0)
-      commonmarker (>= 1.0)
     openapi_parser (1.0.0)
     optimist (3.2.0)
     ostruct (0.6.1)
@@ -559,7 +551,7 @@ GEM
       faraday-retry
       oauth2
       zeitwerk
-    super_diff (0.14.0)
+    super_diff (0.15.0)
       attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff


### PR DESCRIPTION
# Why was this change made?

To get commonmarker out of the dependencies, making the Ruby 3.4 upgrade process smoother.

# How was this change tested?

CI
