### PR TITLE
Switch logging to debug

### DIFF
--- a/app/services/embargo_release_service.rb
+++ b/app/services/embargo_release_service.rb
@@ -11,7 +11,7 @@ class EmbargoReleaseService
 
     return Rails.logger.info('No objects to process') if embargoed_items_to_release.none?
 
-    Rails.logger.info("Found #{embargoed_items_to_release.count} objects")
+    Rails.logger.debug { "Found #{embargoed_items_to_release.count} objects" }
 
     embargoed_items_to_release.pluck(:external_identifier).each do |druid|
       release(druid)


### PR DESCRIPTION
This avoids creating a cron email when the job is running that just says:

> I, [2025-01-09T02:16:03.789343 #1189047]  INFO -- : Found 87 objects

This email is just noise.

