### PR TITLE
Add more context to HB when editing via QuickMARC

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -17,10 +17,10 @@ Lint/SuppressedException:
 Metrics/AbcSize:
   Max: 39
 
-# Offense count: 6
+# Offense count: 7
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 114
+  Max: 118
 
 # Offense count: 15
 # Configuration parameters: AllowedMethods, AllowedPatterns.


### PR DESCRIPTION
# Why was this change made?

Errors from the QuickMARC API were previously being eaten. This gives us more actionable exceptions and alerts.

If there's a QuickMARC error, don't bother retrying subsequent Folio API interactions. Instead, log a *single* HB alert with a useful title and sufficient context for a developer to figure out what is going on.

# How was this change tested?

CI, tested with a prod object
