### PR TITLE
[README] fix OpenAPI validator badge image

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/955223f2386ae5f10e33/maintainability)](https://codeclimate.com/github/sul-dlss/dor-services-app/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/955223f2386ae5f10e33/test_coverage)](https://codeclimate.com/github/sul-dlss/dor-services-app/test_coverage)
 [![GitHub version](https://badge.fury.io/gh/sul-dlss%2Fdor-services-app.svg)](https://badge.fury.io/gh/sul-dlss%2Fdor-services-app)
-[![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/dor-services-app/main/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/dor-services-app/main/openapi.yml)
+[![OpenAPI Validator](https://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/dor-services-app/main/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/dor-services-app/main/openapi.yml)
 
 # DOR Services App
 


### PR DESCRIPTION
## Why was this change made? 🤔

image link needs to be https to work



## How was this change tested? 🤨

markdown preview:

before:
<img width="727" alt="Screenshot 2025-01-21 at 9 55 15 PM" src="https://github.com/user-attachments/assets/6b96c14d-ee7a-4d7c-9416-63eea17d4bf1" />

after:
<img width="872" alt="Screenshot 2025-01-21 at 9 56 39 PM" src="https://github.com/user-attachments/assets/2d2d5c93-2532-4636-bb90-bb69214d481f" />
