### PR TITLE
Fix docker compose build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ENV BUNDLER_WITHOUT="development test"
 
 # For Sidekiq Pro
 ARG BUNDLE_GEMS__CONTRIBSYS__COM
-ENV BUNDLE_GEMS__CONTRIBSYS__COM $BUNDLE_GEMS__CONTRIBSYS__COM
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,9 @@
 services:
   web:
-    build: .
+    build:
+      context: .
+      args:
+        BUNDLE_GEMS__CONTRIBSYS__COM: "${BUNDLE_GEMS__CONTRIBSYS__COM}"
     volumes:
       - ./:/app
     working_dir: /app
@@ -30,7 +33,10 @@ services:
       SETTINGS__SURI__URL: http://suri:3000
       SETTINGS__WORKFLOW__URL: http://workflow:3000
   workers:
-    build: .
+    build:
+      context: .
+      args:
+        BUNDLE_GEMS__CONTRIBSYS__COM: "${BUNDLE_GEMS__CONTRIBSYS__COM}"
     volumes:
       - ./:/app
     working_dir: /app


### PR DESCRIPTION
# Why was this change made?

For some reason, the Sidekiq Pro env variable was no longer being automagically injected. No idea why or what changed. This takes a more explicit approach.

# How was this change tested?

Successfully ran `docker compose build`


