### PR TITLE
Add log formatter to application config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -73,6 +73,11 @@ module DorServices
       Cocina::Models::Mapping::Purl.base_url = Settings.release.purl_base_url
     end
 
+    # Add timestamps to all loggers (both Rack-based ones and e.g. Sidekiq's)
+    config.log_formatter = proc do |severity, datetime, _progname, msg|
+      "[#{datetime.to_fs(:iso8601)}] [#{severity}] #{msg}\n"
+    end
+
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,10 +48,7 @@ Rails.application.configure do
   end
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [
-    ->(_request) { Time.now.iso8601 },
-    :request_id
-  ]
+  config.log_tags = [:request_id]
 
   # "info" includes generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you


### PR DESCRIPTION
# Why was this change made?

Make logger calls outside of Rack (such as those called in background jobs) pick up timestamps.

# How was this change tested?

Called `Rails.logger.info('foobar')` locally and in stage and verify they have timestamps in the log file, and checked that passenger request log entries also have timestamps.
