### PR TITLE
Make sure current lock is returned when opening version.

### DIFF
--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -74,13 +74,13 @@ class VersionService
 
     repository_object.open_version!(description:, from_version: from_repository_object_version)
 
-    # Reloading to get correct lock value.
     Indexer.reindex_later(cocina_object: repository_object.reload.to_cocina_with_metadata)
 
     new_version = repository_object.opened_version.version
     workflow_client.create_workflow_by_name(druid, 'versioningWF', version: new_version.to_s)
     EventFactory.create(druid:, event_type: 'version_open', data: { who: opening_user_name, version: new_version.to_s })
-    repository_object.to_cocina_with_metadata
+    # Reloading to get most recent lock.
+    repository_object.reload.to_cocina_with_metadata
   end
 
   # @param [String] druid of the item


### PR DESCRIPTION
## Why was this change made? 🤔
Open version endpoint has been returning stale locks.


## How was this change tested? 🤨
Stage

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



