### PR TITLE
Map organizations that are structured values to Datacite contributors.

### DIFF
--- a/app/services/cocina/to_datacite/creator_contributor_funder.rb
+++ b/app/services/cocina/to_datacite/creator_contributor_funder.rb
@@ -88,19 +88,21 @@ module Cocina
       end
 
       def organizational_name(cocina_contributor)
+        name = cocina_contributor.name.first.structuredValue.first || cocina_contributor.name.first
         {
-          name: cocina_contributor.name.first.value,
-          nameType: 'Organizational'
-        }
+          name: name.value,
+          nameType: 'Organizational',
+          nameIdentifiers: name_identifiers(name).presence
+        }.compact
       end
 
       def name_identifiers(cocina_contributor)
         Array(cocina_contributor.identifier).map do |identifier|
           {
-            nameIdentifier: identifier.value,
+            nameIdentifier: identifier.value || identifier.uri,
             nameIdentifierScheme: identifier.type,
             schemeURI: identifier.source.uri
-          }
+          }.compact
         end
       end
 

--- a/spec/services/cocina/to_datacite/attributes_spec.rb
+++ b/spec/services/cocina/to_datacite/attributes_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Cocina::ToDatacite::Attributes do
                                   {
                                     name: [
                                       {
-                                        value: 'Stanford University'
+                                        value: 'National Institute of Health'
                                       }
                                     ],
                                     type: 'organization',
@@ -169,6 +169,48 @@ RSpec.describe Cocina::ToDatacite::Attributes do
                                         value: 'author',
                                         code: 'aut',
                                         uri: 'http://id.loc.gov/vocabulary/relators/aut',
+                                        source: {
+                                          code: 'marcrelator',
+                                          uri: 'http://id.loc.gov/vocabulary/relators/'
+                                        }
+                                      }
+                                    ],
+                                    note: [
+                                      {
+                                        type: 'citation status',
+                                        value: 'false'
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    name: [
+                                      {
+                                        structuredValue: [
+                                          {
+                                            value: 'Stanford University',
+                                            identifier: [
+                                              {
+                                                type: 'ROR',
+                                                uri: 'https://ror.org/00f54p054',
+                                                source: {
+                                                  code: 'ror'
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            value: 'Department of Animal Husbandry'
+                                          }
+                                        ]
+                                      }
+                                    ],
+                                    type: 'organization',
+                                    status: 'primary',
+                                    role: [
+                                      {
+                                        value: 'degree granting institution',
+                                        code: 'dgg',
+                                        uri: 'http://id.loc.gov/vocabulary/relators/dgg',
                                         source: {
                                           code: 'marcrelator',
                                           uri: 'http://id.loc.gov/vocabulary/relators/'
@@ -277,20 +319,33 @@ RSpec.describe Cocina::ToDatacite::Attributes do
           ],
           creators: [
             {
-              name: 'Stanford University',
+              name: 'National Institute of Health',
               nameType: 'Organizational'
             }
           ],
-          contributors: [{
-            name: 'Stanford, Jane',
-            givenName: 'Jane',
-            familyName: 'Stanford',
-            nameType: 'Personal',
-            contributorType: 'Other'
-          }],
+          contributors: [
+            {
+              name: 'Stanford, Jane',
+              givenName: 'Jane',
+              familyName: 'Stanford',
+              nameType: 'Personal',
+              contributorType: 'Other'
+            },
+            {
+              name: 'Stanford University',
+              nameType: 'Organizational',
+              contributorType: 'Other',
+              nameIdentifiers: [
+                {
+                  nameIdentifier: 'https://ror.org/00f54p054',
+                  nameIdentifierScheme: 'ROR'
+                }
+              ]
+            }
+          ],
           fundingReferences: [
             {
-              funderName: 'Stanford University'
+              funderName: 'National Institute of Health'
             }
           ],
           dates: [],


### PR DESCRIPTION
closes #5285

## Why was this change made? 🤔
H3 is now sending organizations that have a main organization and a suborganization/department. These need to be mapped to Datacite.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



