### PR TITLE
pin mais-orcid-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'druid-tools', '~> 2.2'
 gem 'folio_client', '~> 0.8'
 gem 'graphql'
 gem 'lyber-core', '~> 7.7' # For robots
-gem 'mais_orcid_client'
+gem 'mais_orcid_client', '< 1' # MAIS ORCID Client will have breaking changes in v1.0, see https://github.com/sul-dlss/mais_orcid_client/issues/108
 gem 'marc'
 gem 'marc-vocab', '~> 0.3.0' # for indexing
 gem 'moab-versioning', '~> 6.0', require: 'moab/stanford'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -637,7 +637,7 @@ DEPENDENCIES
   jwt
   lograge
   lyber-core (~> 7.7)
-  mais_orcid_client
+  mais_orcid_client (< 1)
   marc
   marc-vocab (~> 0.3.0)
   moab-versioning (~> 6.0)


### PR DESCRIPTION
## Why was this change made? 🤔

We need to pin the mais-orcid-client so that the changes in the new API do not go into effect until we do the new gem release and update the codebase.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



