### PR TITLE
Bump cocina-models to 0.101.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'rails', '~> 7.2.1'
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.101.0'
+gem 'cocina-models', '~> 0.101.1'
 gem 'datacite', '~> 0.3.0'
 gem 'dor-workflow-client', '~> 7.6'
 gem 'druid-tools', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.101.0)
+    cocina-models (0.101.1)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -172,9 +172,9 @@ GEM
       ed25519
     docile (1.4.1)
     domain_name (0.6.20240107)
-    dor-services-client (15.6.0)
+    dor-services-client (15.6.1)
       activesupport (>= 7.0.0)
-      cocina-models (~> 0.101.0)
+      cocina-models (~> 0.101.1)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -613,7 +613,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.101.0)
+  cocina-models (~> 0.101.1)
   committee
   config
   csv


### PR DESCRIPTION
## Why was this change made? 🤔

To keep in sync with latest cocina-models patch release and client update. 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



