### PR TITLE
Avoid duplicate publishing.

### DIFF
--- a/spec/services/user_version_service_spec.rb
+++ b/spec/services/user_version_service_spec.rb
@@ -84,7 +84,9 @@ RSpec.describe UserVersionService do
   end
 
   describe '.move' do
-    subject(:user_version_service_move) { described_class.move(druid:, version: 2, user_version: 1) }
+    subject(:user_version_service_move) { described_class.move(druid:, version: 2, user_version: 1, publish:) }
+
+    let(:publish) { true }
 
     let!(:user_version) { UserVersion.create!(version: 1, repository_object_version: repository_object_version1) }
 
@@ -94,6 +96,15 @@ RSpec.describe UserVersionService do
       expect(user_version.reload.repository_object_version).to eq repository_object_version2
       expect(PublishJob).to have_received(:perform_later).with(druid:, user_version: 1,
                                                                background_job_result: BackgroundJobResult)
+    end
+
+    context 'when publishing is false' do
+      let(:publish) { false }
+
+      it 'does not publish the user version' do
+        user_version_service_move
+        expect(PublishJob).not_to have_received(:perform_later)
+      end
     end
   end
 

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -350,6 +350,7 @@ RSpec.describe VersionService do
           allow(Preservation::Client.objects).to receive(:current_version).and_return(2)
           allow(workflow_state_service).to receive_messages(accessioned?: true, accessioning?: false)
           allow(cocina_object).to receive(:version).and_return(2)
+          allow(UserVersionService).to receive(:move).and_call_original
           described_class.open(cocina_object:, description: 'same as it ever was', opening_user_name: 'sunetid')
           repository_object.versions.last.update!(closed_at: nil)
           repository_object.head_version = repository_object.versions.last
@@ -362,6 +363,7 @@ RSpec.describe VersionService do
           expect(repository_object.last_closed_version.user_versions.count).to eq 1
           expect(repository_object.last_closed_version.user_versions.first.version).to eq 1
           expect(repository_object.versions.find_by(version: 2).user_versions.count).to eq 0
+          expect(UserVersionService).to have_received(:move).with(druid:, version: 3, user_version: 1, publish: false)
         end
       end
 


### PR DESCRIPTION
closes #5313

## Why was this change made? 🤔
Accessioning and moving versions was causing concurrent publishing, which was causing PurlFetcher locking errors.


## How was this change tested? 🤨
Unit
⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



