### PR TITLE
Change UpdateDoi robot to retain existing URL.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '~> 7.2.1'
 
 # DLSS/domain-specific dependencies
 gem 'cocina-models', '~> 0.103.0'
-gem 'datacite', '~> 0.3.0'
+gem 'datacite', '~> 0.5'
 gem 'dor-workflow-client', '~> 7.6'
 gem 'druid-tools', '~> 2.2'
 gem 'folio_client', '~> 0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
     crass (1.0.6)
     csv (3.3.4)
     daemons (1.4.1)
-    datacite (0.3.0)
+    datacite (0.5.0)
       dry-monads (~> 1.3)
       faraday (~> 2.0)
       json_schema (~> 0.21.0)
@@ -621,7 +621,7 @@ DEPENDENCIES
   connection_pool
   csv
   daemons
-  datacite (~> 0.3.0)
+  datacite (~> 0.5)
   debug
   diffy
   dlss-capistrano

--- a/app/jobs/robots/dor_repo/accession/update_doi.rb
+++ b/app/jobs/robots/dor_repo/accession/update_doi.rb
@@ -26,7 +26,9 @@ module Robots
             raise "Item requested a DOI be updated, but it doesn't meet all the preconditions. " \
                   'Datacite requires that this object have creators and a datacite extension with resourceTypeGeneral'
           end
-          attributes = Cocina::ToDatacite::Attributes.mapped_from_cocina(Cocina::Models.without_metadata(cocina_object))
+
+          attributes = Cocina::ToDatacite::Attributes
+                       .mapped_from_cocina(Cocina::Models.without_metadata(cocina_object), url:)
 
           Honeybadger.context(attributes:, doi:, druid:)
 
@@ -40,6 +42,14 @@ module Robots
 
         def doi
           @doi ||= cocina_object.identification&.doi
+        end
+
+        def url
+          metadata_result = client.metadata(id: doi)
+          return unless metadata_result.success?
+
+          metadata = metadata_result.value!
+          metadata.dig('data', 'attributes', 'url')
         end
 
         def client

--- a/spec/services/cocina/to_datacite/attributes_spec.rb
+++ b/spec/services/cocina/to_datacite/attributes_spec.rb
@@ -3,7 +3,26 @@
 require 'rails_helper'
 
 RSpec.describe Cocina::ToDatacite::Attributes do
-  let(:attributes) { described_class.mapped_from_cocina(cocina_item) }
+  let(:attributes) { described_class.mapped_from_cocina(cocina_item, url:) }
+  let(:cocina_item) do
+    Cocina::Models::DRO.new(externalIdentifier: druid,
+                            type: Cocina::Models::ObjectType.object,
+                            label:,
+                            version: 1,
+                            description: {
+                              title: [{ value: title }],
+                              purl:
+                            },
+                            identification: {
+                              sourceId: 'sul:8.559351',
+                              doi:
+                            },
+                            access: {},
+                            administrative: {
+                              hasAdminPolicy: apo_druid
+                            },
+                            structural: {})
+  end
 
   let(:druid) { 'druid:bb666bb1234' }
   let(:doi) { "10.25740/#{druid.split(':').last}" }
@@ -11,32 +30,13 @@ RSpec.describe Cocina::ToDatacite::Attributes do
   let(:label) { 'label' }
   let(:title) { 'title' }
   let(:apo_druid) { 'druid:pp000pp0000' }
+  let(:url) { nil }
 
   before do
     allow(Time.zone).to receive(:today).and_return(instance_double(Date, year: 2011))
   end
 
   context 'with a minimal description' do
-    let(:cocina_item) do
-      Cocina::Models::DRO.new(externalIdentifier: druid,
-                              type: Cocina::Models::ObjectType.object,
-                              label:,
-                              version: 1,
-                              description: {
-                                title: [{ value: title }],
-                                purl:
-                              },
-                              identification: {
-                                sourceId: 'sul:8.559351',
-                                doi:
-                              },
-                              access: {},
-                              administrative: {
-                                hasAdminPolicy: apo_druid
-                              },
-                              structural: {})
-    end
-
     it 'creates the attributes hash' do
       expect(attributes).to eq(
         {
@@ -57,6 +57,14 @@ RSpec.describe Cocina::ToDatacite::Attributes do
           ]
         }
       )
+    end
+  end
+
+  context 'with a provided url' do
+    let(:url) { 'https://example.com' }
+
+    it 'uses the url in the attributes hash' do
+      expect(attributes[:url]).to eq(url)
     end
   end
 


### PR DESCRIPTION
closes #5332

## Why was this change made? 🤔
So that @amyehodge can change the URL for a Datacite DOI to resolve to something other than a PURL page without that URL being overwritten by a subsequent accessioning.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



