### PR TITLE
Faster missing druids

### DIFF
--- a/app/services/indexer.rb
+++ b/app/services/indexer.rb
@@ -14,7 +14,9 @@ class Indexer
     solr.add(solr_doc)
     # This logging is to assist with https://github.com/sul-dlss/dor-services-app/issues/5231
     # It is capturing that a Solr document is being committed and the order relative to other commits.
-    Rails.logger.info("[Indexing] Committing #{cocina_object.externalIdentifier} with trace_id=#{trace_id}")
+    if Settings.indexer.logging
+      Rails.logger.info("[Indexing] Committing #{cocina_object.externalIdentifier} with trace_id=#{trace_id}")
+    end
     solr.commit
   end
 
@@ -41,7 +43,9 @@ class Indexer
   def self.trace_id_for(druid:)
     source = Kernel.caller_locations(2, 1).first.to_s.delete_prefix("#{Rails.root}/") # rubocop:disable Rails/FilePath
     SecureRandom.uuid.tap do |trace_id|
-      Rails.logger.info("[Indexing] Reindexing #{druid} from #{source} with trace_id=#{trace_id}")
+      if Settings.indexer.logging
+        Rails.logger.info("[Indexing] Reindexing #{druid} from #{source} with trace_id=#{trace_id}")
+      end
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -156,3 +156,6 @@ rolling_indexer:
   pause_for_solr: 61
   # milliseconds
   commitWithin: 500
+
+indexer:
+  logging: false

--- a/lib/tasks/missing_druids.rake
+++ b/lib/tasks/missing_druids.rake
@@ -6,9 +6,9 @@ namespace :missing_druids do
     results = SolrService.query('id:*', fl: 'id', rows: 10_000_000, wt: 'csv')
     druids_from_solr = results.pluck('id')
 
-    druids_from_db = RepositoryObject.order(external_identifier: :asc).pluck(:external_identifier)
+    druids_from_db = RepositoryObject.order(updated_at: :desc).pluck(:external_identifier)
 
-    missing_druids = druids_from_db - druids_from_solr.sort
+    missing_druids = druids_from_db - druids_from_solr
     File.open('missing_druids.txt', 'w') do |file|
       missing_druids.map { |druid| file.write("#{druid}\n") }
     end
@@ -22,12 +22,35 @@ namespace :missing_druids do
   end
 
   desc 'Index unindexed druids from missing_druids.txt'
+  # By default, this is configured to use a single process.
+  # To parallelize: SETTINGS__ROLLING_INDEXER__NUM_PARALLEL_PROCESSES=4 bin/rake missing_druids:index_unindexed_objects
   task index_unindexed_objects: :environment do
-    File.readlines('missing_druids.txt').each do |line|
-      druid = line.chomp
-      puts "Indexing #{druid}"
-      cocina_object = CocinaObjectStore.find(druid.chomp)
-      Indexer.reindex(cocina_object:)
+    solr_conn = RSolr.connect(timeout: 120, open_timeout: 120, url: Settings.solr.url)
+
+    druids = File.readlines('missing_druids.txt').map(&:chomp)
+
+    batches = druids.each_slice(Settings.rolling_indexer.batch_size)
+    batches.each_with_index do |batch, index|
+      batch_start_time = Time.zone.now
+      solr_docs = Parallel.filter_map(batch, in_processes: Settings.rolling_indexer.num_parallel_processes) do |druid|
+        cocina_object = CocinaObjectStore.find(druid)
+        # This returns a Solr doc hash
+        Indexing::Builders::DocumentBuilder.for(
+          model: cocina_object,
+          trace_id: Indexer.trace_id_for(druid:)
+        ).to_solr
+      rescue CocinaObjectStore::CocinaObjectNotFoundError
+        # Return `nil`, which is compacted, so the Solr add isn't grumpy
+        nil
+      ensure
+        sleep(Settings.rolling_indexer.pause_time_between_docs)
+      end
+
+      solr_conn.add(solr_docs, add_attributes: { commitWithin: Settings.rolling_indexer.commit_within.to_i })
+
+      batch_end_time = Time.zone.now
+      batch_run_seconds = (batch_end_time - batch_start_time).round(3)
+      puts "#{Time.zone.now}\t#{index + 1}\tIndexed #{Settings.rolling_indexer.batch_size} documents in #{batch_run_seconds}\t" # rubocop:disable Layout/LineLength
     end
   end
 end


### PR DESCRIPTION
Parallelizes reindexing rake task and makes indexing logic configurable.

## Why was this change made? 🤔
So that SDR can recover faster from Solr indexing issues.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



