### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -4,5 +4,3 @@ server 'dor-services-app-prod-a.stanford.edu', user: 'dor_services', roles: %w[w
 server 'dor-services-app-prod-b.stanford.edu', user: 'dor_services', roles: %w[web app]
 server 'dor-services-worker-prod-a.stanford.edu', user: 'dor_services', roles: %w[app worker scheduler]
 server 'dor-services-worker-prod-b.stanford.edu', user: 'dor_services', roles: %w[app worker rolling_indexer]
-
-Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -3,5 +3,3 @@
 server 'dor-services-app-qa-a.stanford.edu', user: 'dor_services', roles: %w[web app]
 server 'dor-services-app-qa-b.stanford.edu', user: 'dor_services', roles: %w[web app]
 server 'dor-services-worker-qa-a.stanford.edu', user: 'dor_services', roles: %w[app worker scheduler rolling_indexer]
-
-Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -3,5 +3,3 @@
 server 'dor-services-app-stage-a.stanford.edu', user: 'dor_services', roles: %w[web app]
 server 'dor-services-app-stage-b.stanford.edu', user: 'dor_services', roles: %w[web app]
 server 'dor-services-worker-stage-a.stanford.edu', user: 'dor_services', roles: %w[app worker scheduler rolling_indexer]
-
-Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.