### PR TITLE
Avoid line breaks and handle commas in columns

### DIFF
--- a/app/reports/druids_refresh_false.rb
+++ b/app/reports/druids_refresh_false.rb
@@ -34,12 +34,12 @@ class DruidsRefreshFalse
         row['catalog_record_id'],
         row['druid'],
         row['object_type'],
-        row['label'],
-        row['structured_title'],
-        row['title'],
-        collection_name,
+        "\"#{row['label']}\"",
+        "\"#{row['structured_title']&.delete('\n')}\"",
+        "\"#{row['title']}\"",
+        "\"#{collection_name}\"",
         collection_druid
-      ]
+      ].join(',')
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Since we're no longer using the CSV module to create this report, we need to handle commas and newlines in cocina metadata. 


## How was this change tested? 🤨
Ran on sdr-infra. 
