### PR TITLE
Revise the unreleased digital serials report

### DIFF
--- a/app/reports/digital_serials_unreleased.rb
+++ b/app/reports/digital_serials_unreleased.rb
@@ -12,39 +12,47 @@ class DigitalSerialsUnreleased
     SELECT ro.external_identifier as druid,
       jsonb_path_query(rov.structural, '$.isMemberOf') ->> 0 as collection_id,
       jsonb_path_query(rov.identification, '$.catalogLinks[*] ? (@.catalog == "folio").catalogRecordId') ->> 0 as catalog_record_id,
-      jsonb_path_query(rov.description, 'strict $.title.** ? (@.type like_regex "part name").value') ->> 0 as title_part_name,
-      jsonb_path_query(rov.description, 'strict $.title.** ? (@.type like_regex "part number").value') ->> 0 as title_part_number
+      jsonb_path_query_array(rov.description, 'strict $.title[0].** ? (@.type like_regex "part name|part number")') as title_part_name_and_number
     FROM repository_objects AS ro, repository_object_versions AS rov
     WHERE jsonb_path_exists(rov.identification, '$.catalogLinks[*] ? (@.catalog == "folio")')
-        AND jsonb_path_exists(rov.description, 'strict $.title.**.type ? (@ like_regex "part name|part number")')
+        AND jsonb_path_exists(rov.description, 'strict $.title[0].**.type ? (@ like_regex "part name|part number")')
         AND jsonb_path_exists(rov.structural, '$.isMemberOf[*] ? (@ != "druid:yh583fk3400")')
         AND ro.head_version_id = rov.id
         AND ro.object_type = 'dro';
   SQL
 
   def self.report
-    puts 'druid,catalogRecordId,title_part_name,title_part_number,collection_name,collection_id'
-    rows(SQL).compact.each { |row| puts row }
+    puts 'druid,catalogRecordId,title_part_number_before,title_part_name,title_part_number_after,collection_name,collection_id'
+    rows.compact.each { |row| puts row }
   end
 
-  def self.rows(sql_query)
-    sql_result_rows = ActiveRecord::Base.connection.execute(sql_query).to_a
-
-    sql_result_rows.map do |row|
+  def self.rows
+    ActiveRecord::Base.connection.execute(SQL).to_a.map do |row|
       next if released_to_searchworks?(druid: row['druid'])
 
       collection_druid = row['collection_id']
       collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
 
+      title_part_number_before, title_part_name, title_part_number_after = title_part_label_from(JSON.parse(row['title_part_name_and_number']))
+
       [
         row['druid'],
         row['catalog_record_id'],
-        row['title_part_name'],
-        row['title_part_number'],
-        "\"#{collection_name}\"",
+        title_part_number_before,
+        title_part_name,
+        title_part_number_after,
+        collection_name,
         collection_druid
-      ].join(',')
+      ].to_csv
     end
+  end
+
+  def self.title_part_label_from(title_part_list)
+    part_number_position = title_part_list.index { |part| part['type'] == 'part number' }
+    part_number = title_part_list.find { |part| part['type'] == 'part number' }&.[]('value')
+    part_name = title_part_list.find { |part| part['type'] == 'part name' }&.[]('value')
+
+    part_number_position == 0 ? [part_number, part_name, nil] : [nil, part_name, part_number] # rubocop:disable Style/NumericPredicate
   end
 
   def self.released_to_searchworks?(druid:)


### PR DESCRIPTION
# Why was this change made?

Fixes #5329

This commit makes three changes to the named report:

1. Format all fields as valid CSV, favoring the built-in `#to_csv` method over manually inserting quotes and the like;
2. Preserve the order of the part name and number within the title
3. **ONLY** look at the first title for each object

# How was this change tested?

CI, and I ran it successfully in all envs
