### PR TITLE
Stop cron emails for info-level messages

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -26,6 +26,8 @@ require 'config'
 
 Config.load_and_set_settings(Config.setting_files('config', 'production'))
 
+env 'RAILS_LOG_LEVEL', 'warn'
+
 # These define jobs that checkin with Honeybadger.
 # If changing the schedule of one of these jobs, also update at https://app.honeybadger.io/projects/50568/check_ins
 job_type :rake_hb,


### PR DESCRIPTION
# Why was this change made?

Prevent crontab spam from H2, especially prod. We don't want email about sidekiq successfully connecting to redis every day, and we don't want developers ignoring crontab email lest something actually interesting come across the wire.

# How was this change tested?

Ran `bin/rails r -e p "puts Rails.logger.level"` before and after the change.
