### PR TITLE
Adds filtering by event type to event show endpoint.

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,6 +4,7 @@
 class EventsController < ApplicationController
   def index
     @events = Event.where(druid: params[:object_id]).order(created_at: :desc)
+    @events = @events.where(event_type: params[:event_types]) if params[:event_types].present?
   end
 
   def create

--- a/openapi.yml
+++ b/openapi.yml
@@ -677,6 +677,14 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/Druid"
+        - name: event_types
+          in: query
+          description: Filter events by type
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
     post:
       tags:
         - events

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -48,5 +48,21 @@ RSpec.describe 'Add and retrieve events' do
         expect(json[1]['event_type']).to eq 'publish'
       end
     end
+
+    context 'when events are limited by type' do
+      before do
+        create(:event, druid:, event_type: 'publish')
+        create(:event, druid:, event_type: 'unpublish')
+      end
+
+      it 'returns event of that type' do
+        get "/v1/objects/#{druid}/events?event_types[]=unpublish&event_types[]=foo",
+            headers: { 'Authorization' => "Bearer #{jwt}" }
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json.length).to eq 1
+        expect(json[0]['event_type']).to eq 'unpublish'
+      end
+    end
   end
 end


### PR DESCRIPTION
closes #5361

## Why was this change made? 🤔
So that H3 can use events for history table.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



