### PR TITLE
send optional event data to event service for object updates

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -44,7 +44,8 @@ class ObjectsController < ApplicationController
   end
 
   def update # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-    cocina_object = Cocina::Models.build(params.except(:action, :controller, :id).to_unsafe_h)
+    cocina_object = Cocina::Models.build(params.except(:action, :controller, :id, :event_data).to_unsafe_h)
+    event_data = params[:event_data] || {}
 
     # Ensure the id in the path matches the id in the post body.
     if params[:id] != cocina_object.externalIdentifier
@@ -55,9 +56,9 @@ class ObjectsController < ApplicationController
     # ETag / optimistic locking is optional.
     etag = from_etag(request.headers['If-Match'])
     updated_cocina_object = if etag
-                              UpdateObjectService.update(Cocina::Models.with_metadata(cocina_object, etag))
+                              UpdateObjectService.update(Cocina::Models.with_metadata(cocina_object, etag), event_data:)
                             else
-                              UpdateObjectService.update(cocina_object, skip_lock: true)
+                              UpdateObjectService.update(cocina_object, skip_lock: true, event_data:)
                             end
 
     add_headers(updated_cocina_object)

--- a/app/services/update_object_service.rb
+++ b/app/services/update_object_service.rb
@@ -11,19 +11,21 @@ class UpdateObjectService
   # @param [Cocina::Models::DRO|Collection|AdminPolicy|DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata] cocina_object # rubocop:disable Layout/LineLength
   # @param [boolean] skip_lock do not perform an optimistic lock check
   # @param [boolean] skip_open_check do not check that the object has an open version
+  # @param [Hash] event_data additional data to include in the update event
   # @raise [Cocina::ValidationError] raised when validation of the Cocina object fails.
   # @raise [CocinaObjectNotFoundError] raised if the cocina object does not already exist in the datastore.
   # @raise [StateLockError] raised if optimistic lock failed.
   # @raise [StandardError] raised if the object does not have an open version
   # @return [Cocina::Models::DRO, Cocina::Models::Collection, Cocina::Models::AdminPolicy] normalized cocina object
-  def self.update(cocina_object, skip_lock: false, skip_open_check: false)
-    new(cocina_object:, skip_lock:, skip_open_check:).update
+  def self.update(cocina_object, skip_lock: false, skip_open_check: false, event_data: {})
+    new(cocina_object:, skip_lock:, skip_open_check:, event_data:).update
   end
 
-  def initialize(cocina_object:, skip_lock:, skip_open_check:)
+  def initialize(cocina_object:, skip_lock:, skip_open_check:, event_data:)
     @cocina_object = cocina_object
     @skip_lock = skip_lock
     @skip_open_check = skip_open_check
+    @event_data = event_data
   end
 
   def update # rubocop:disable Metrics/AbcSize
@@ -35,8 +37,8 @@ class UpdateObjectService
 
     updated_cocina_object_with_metadata = persist!
 
-    EventFactory.create(druid:, event_type: 'update',
-                        data: { success: true, request: cocina_object_without_metadata.to_h })
+    data = { success: true, request: cocina_object_without_metadata.to_h }.merge(event_data)
+    EventFactory.create(druid:, event_type: 'update', data:)
 
     Indexer.reindex_later(druid:)
 
@@ -51,7 +53,7 @@ class UpdateObjectService
 
   private
 
-  attr_reader :cocina_object, :skip_lock, :skip_open_check
+  attr_reader :cocina_object, :skip_lock, :skip_open_check, :event_data
 
   delegate :version, to: :cocina_object
 


### PR DESCRIPTION
## Why was this change made? 🤔

Part of https://github.com/sul-dlss/hungry-hungry-hippo/issues/1371

We want to have object update events pass on extra metadata that a client provides to the event 

## How was this change tested? 🤨

Specs