### PR TITLE
Switch how we pass event data from dsa-client to be specific list instea of json

### DIFF
--- a/app/controllers/metadata_refresh_controller.rb
+++ b/app/controllers/metadata_refresh_controller.rb
@@ -13,7 +13,7 @@ class MetadataRefreshController < ApplicationController
                             message: "#{@cocina_object.externalIdentifier} has no catalog links marked as refreshable")
     end
 
-    UpdateObjectService.update(@cocina_object.new(description: result.value!.description_props))
+    UpdateObjectService.update(cocina_object: @cocina_object.new(description: result.value!.description_props))
   rescue Catalog::MarcService::CatalogRecordNotFoundError => e
     json_api_error(status: :bad_request, title: 'Not found in catalog', message: e.message)
   rescue Catalog::MarcService::MarcServiceError => e

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -23,8 +23,8 @@ class ObjectsController < ApplicationController
     end
 
     model_request = Cocina::Models.build_request(params.except(:action, :controller, :assign_doi,
-                                                               :event_who).to_unsafe_h)
-    cocina_object = CreateObjectService.create(model_request, assign_doi: params[:assign_doi], who: params[:event_who])
+                                                               :user_name).to_unsafe_h)
+    cocina_object = CreateObjectService.create(model_request, assign_doi: params[:assign_doi], who: params[:user_name])
 
     add_headers(cocina_object)
     render status: :created, location: object_path(cocina_object.externalIdentifier),
@@ -46,9 +46,9 @@ class ObjectsController < ApplicationController
 
   def update # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     cocina_object = Cocina::Models.build(params.except(:action, :controller, :id, :event_description,
-                                                       :event_who).to_unsafe_h)
+                                                       :user_name).to_unsafe_h)
     description = params[:event_description]
-    who = params[:event_who]
+    who = params[:user_name]
 
     # Ensure the id in the path matches the id in the post body.
     if params[:id] != cocina_object.externalIdentifier

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -45,7 +45,7 @@ class ObjectsController < ApplicationController
 
   def update # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     cocina_object = Cocina::Models.build(params.except(:action, :controller, :id, :event_data).to_unsafe_h)
-    event_data = params[:event_data] || {}
+    event_data = params[:event_data].blank? ? {} : JSON.parse(params[:event_data]).with_indifferent_access
 
     # Ensure the id in the path matches the id in the post body.
     if params[:id] != cocina_object.externalIdentifier

--- a/app/services/apply_admin_policy_defaults.rb
+++ b/app/services/apply_admin_policy_defaults.rb
@@ -36,7 +36,7 @@ class ApplyAdminPolicyDefaults
   end
 
   def apply
-    UpdateObjectService.update(updated_cocina_object)
+    UpdateObjectService.update(cocina_object: updated_cocina_object)
   end
 
   private

--- a/app/services/constituent_service.rb
+++ b/app/services/constituent_service.rb
@@ -38,7 +38,7 @@ class ConstituentService
 
     updated_virtual_object = ResetContentMetadataService.reset(cocina_item: updated_virtual_object, constituent_druids:)
 
-    UpdateObjectService.update(updated_virtual_object)
+    UpdateObjectService.update(cocina_object: updated_virtual_object)
 
     VersionService.close(druid: updated_virtual_object.externalIdentifier, version: updated_virtual_object.version)
 

--- a/app/services/embargo_release_service.rb
+++ b/app/services/embargo_release_service.rb
@@ -60,7 +60,8 @@ class EmbargoReleaseService
 
     structural_props = structural_props_for(cocina_object, access_props)
 
-    UpdateObjectService.update(cocina_object.new({ access: access_props, structural: structural_props }.compact))
+    UpdateObjectService.update(cocina_object: cocina_object.new({ access: access_props,
+                                                                  structural: structural_props }.compact))
   end
 
   def access_props_for(cocina_object)

--- a/bin/migrate-cocina
+++ b/bin/migrate-cocina
@@ -95,7 +95,8 @@ def perform_migrate(migrator_class:, obj:, mode:)
   ## Note: because we are now storing the cocina for every version we cannot remediate cocina breaking changes for a
   # particular cocina version here.
   if mode == :migrate
-    updated_cocina_object = UpdateObjectService.update(updated_cocina_object, skip_open_check: !migrator.version?)
+    updated_cocina_object = UpdateObjectService.update(cocina_object: updated_cocina_object,
+                                                       skip_open_check: !migrator.version?)
     Publish::MetadataTransferService.publish(druid: obj.external_identifier) if migrator.publish?
     unless updated_cocina_object.version == current_object_version
       close_version(cocina_object: updated_cocina_object,

--- a/openapi.yml
+++ b/openapi.yml
@@ -956,7 +956,7 @@ paths:
           description: ID of the version
           required: true
           schema:
-            type: string            
+            type: string
   "/v1/objects/{object_id}/user_versions":
     get:
       tags:
@@ -1045,7 +1045,7 @@ paths:
           description: Version of user version
           required: true
           schema:
-            type: integer           
+            type: integer
       requestBody:
         description: user version to update
         content:
@@ -1138,8 +1138,16 @@ paths:
       parameters:
         - in: query
           name: assign_doi
+          description: If a doi should be assigned to the object
           schema:
             type: boolean
+        - in: query
+          name: who
+          description: The sunetid of the person making the change
+          required: false
+          schema:
+            type: string
+            default: nil
       requestBody:
         required: true
         content:
@@ -1253,7 +1261,7 @@ paths:
       tags:
         - versions
       summary: Finds versions for multiple objects.
-      description: |- 
+      description: |-
         This endpoint is used to find the versions for multiple objects. The request body should be an array of druids.
 
         The response will be an object with the druids as keys and the version status as values.
@@ -1301,6 +1309,20 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/Druid"
+        - name: description
+          in: query
+          description: A description of the change being made to the object
+          required: false
+          schema:
+            type: string
+            default: nil
+        - name: who
+          in: query
+          description: The sunetid of the person making the change
+          required: false
+          schema:
+            type: string
+            default: nil
       requestBody:
         required: true
         content:

--- a/spec/requests/metadata_refresh_spec.rb
+++ b/spec/requests/metadata_refresh_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Refresh metadata' do
       post '/v1/objects/druid:mk420bs7601/refresh_metadata',
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
-      expect(UpdateObjectService).to have_received(:update).with(updated_cocina_object)
+      expect(UpdateObjectService).to have_received(:update).with(cocina_object: updated_cocina_object)
     end
   end
 
@@ -84,7 +84,7 @@ RSpec.describe 'Refresh metadata' do
       post '/v1/objects/druid:mk420bs7601/refresh_metadata',
            headers: { 'Authorization' => "Bearer #{jwt}" }
       expect(response).to be_successful
-      expect(UpdateObjectService).to have_received(:update).with(updated_cocina_object)
+      expect(UpdateObjectService).to have_received(:update).with(cocina_object: updated_cocina_object)
     end
   end
 

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -207,11 +207,11 @@ RSpec.describe 'Update object' do
     end
 
     context 'when who and description provided' do
-      let(:event_who) { 'test_user' }
+      let(:user_name) { 'test_user' }
       let(:event_description) { 'updating stuff' }
 
       it 'returns the updated object' do
-        patch("/v1/objects/#{druid}?event_description=#{event_description}&event_who=#{event_who}",
+        patch("/v1/objects/#{druid}?event_description=#{event_description}&user_name=#{user_name}",
               params: data,
               headers:)
         expect(response).to have_http_status(:ok)

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe 'Update object' do
     end
   end
 
-  context 'when title changes' do
+  context 'when title changes and event data is provided' do
     let(:description) do
       {
         title: [{ value: 'Not a title' }],
@@ -196,12 +196,32 @@ RSpec.describe 'Update object' do
       }
     end
 
-    it 'returns the updated object' do
-      patch("/v1/objects/#{druid}",
-            params: data,
-            headers:)
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to include('Not a title')
+    context 'when event_data is blank' do
+      let(:event_data) do
+        {}
+      end
+
+      it 'returns the updated object' do
+        patch("/v1/objects/#{druid}",
+              params: data,
+              headers:)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Not a title')
+      end
+    end
+
+    context 'when some actual event data is provided' do
+      let(:event_data) do
+        { who: 'test_user', description: 'updating stuff' }
+      end
+
+      it 'returns the updated object' do
+        patch("/v1/objects/#{druid}?event_data=#{event_data.to_json}",
+              params: data,
+              headers:)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Not a title')
+      end
     end
   end
 

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe 'Update object' do
     end
   end
 
-  context 'when title changes and event data is provided' do
+  context 'when title changes' do
     let(:description) do
       {
         title: [{ value: 'Not a title' }],
@@ -196,11 +196,7 @@ RSpec.describe 'Update object' do
       }
     end
 
-    context 'when event_data is blank' do
-      let(:event_data) do
-        {}
-      end
-
+    context 'when no description or who are provided' do
       it 'returns the updated object' do
         patch("/v1/objects/#{druid}",
               params: data,
@@ -210,13 +206,12 @@ RSpec.describe 'Update object' do
       end
     end
 
-    context 'when some actual event data is provided' do
-      let(:event_data) do
-        { who: 'test_user', description: 'updating stuff' }
-      end
+    context 'when who and description provided' do
+      let(:event_who) { 'test_user' }
+      let(:event_description) { 'updating stuff' }
 
       it 'returns the updated object' do
-        patch("/v1/objects/#{druid}?event_data=#{event_data.to_json}",
+        patch("/v1/objects/#{druid}?event_description=#{event_description}&event_who=#{event_who}",
               params: data,
               headers:)
         expect(response).to have_http_status(:ok)

--- a/spec/services/apply_admin_policy_defaults_spec.rb
+++ b/spec/services/apply_admin_policy_defaults_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe ApplyAdminPolicyDefaults do
         it 'copies APO accessTemplate to item access' do
           expect(UpdateObjectService).to have_received(:update)
             .once
-            .with(cocina_object_with(access: default_access))
+            .with(cocina_object: cocina_object_with(access: default_access))
         end
       end
 
@@ -111,7 +111,7 @@ RSpec.describe ApplyAdminPolicyDefaults do
         it 'copies APO accessTemplate to item access' do
           expect(UpdateObjectService).to have_received(:update)
             .once
-            .with(cocina_object_with(access: default_access))
+            .with(cocina_object: cocina_object_with(access: default_access))
         end
       end
     end
@@ -137,7 +137,7 @@ RSpec.describe ApplyAdminPolicyDefaults do
         it 'maps to world collection access' do
           expect(UpdateObjectService).to have_received(:update)
             .once
-            .with(cocina_object_with(access: expected_access))
+            .with(cocina_object: cocina_object_with(access: expected_access))
         end
       end
 
@@ -158,7 +158,7 @@ RSpec.describe ApplyAdminPolicyDefaults do
         it 'maps to world collection access' do
           expect(UpdateObjectService).to have_received(:update)
             .once
-            .with(cocina_object_with(access: expected_access))
+            .with(cocina_object: cocina_object_with(access: expected_access))
         end
       end
 
@@ -179,7 +179,7 @@ RSpec.describe ApplyAdminPolicyDefaults do
         it 'maps to world collection access' do
           expect(UpdateObjectService).to have_received(:update)
             .once
-            .with(cocina_object_with(access: expected_access))
+            .with(cocina_object: cocina_object_with(access: expected_access))
         end
       end
 
@@ -199,7 +199,7 @@ RSpec.describe ApplyAdminPolicyDefaults do
         it 'maps to dark collection access' do
           expect(UpdateObjectService).to have_received(:update)
             .once
-            .with(cocina_object_with(access: expected_access))
+            .with(cocina_object: cocina_object_with(access: expected_access))
         end
       end
     end
@@ -279,7 +279,8 @@ RSpec.describe ApplyAdminPolicyDefaults do
         it 'copies APO accessTemplate to item access' do
           expect(UpdateObjectService).to have_received(:update)
             .once
-            .with(cocina_object_with(access: default_access, structural: { contains: [file_set_with_default_access] }))
+            .with(cocina_object: cocina_object_with(access: default_access,
+                                                    structural: { contains: [file_set_with_default_access] }))
         end
       end
 
@@ -325,7 +326,8 @@ RSpec.describe ApplyAdminPolicyDefaults do
         it 'copies APO accessTemplate to item access' do
           expect(UpdateObjectService).to have_received(:update)
             .once
-            .with(cocina_object_with(access: default_access, structural: { contains: [file_set_with_custom_access] }))
+            .with(cocina_object: cocina_object_with(access: default_access,
+                                                    structural: { contains: [file_set_with_custom_access] }))
         end
       end
     end

--- a/spec/services/create_object_service_spec.rb
+++ b/spec/services/create_object_service_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe CreateObjectService do
         expect(EventFactory).to have_received(:create).with(druid:, event_type: 'registration', data: Hash)
         expect(Catalog::MarcService).not_to have_received(:new)
       end
+
+      context 'when a user_name is provided' do
+        let(:who) { 'test_user' }
+
+        it 'adds the user_name to the event' do
+          store.create(requested_cocina_object, who:)
+          expect(EventFactory).to have_received(:create).with(druid:, event_type: 'registration',
+                                                              data: { who:, request: Hash })
+        end
+      end
     end
 
     context 'when a Collection' do

--- a/spec/services/embargo_release_service_spec.rb
+++ b/spec/services/embargo_release_service_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe EmbargoReleaseService do
 
     before do
       # This allows getting back the cocina object that was saved.
-      allow(UpdateObjectService).to receive(:update) { |cocina_object| cocina_object }
+      allow(UpdateObjectService).to receive(:update) { |cocina_object:, **| cocina_object }
     end
 
     context 'when embargo access is world' do

--- a/spec/services/update_object_service_spec.rb
+++ b/spec/services/update_object_service_spec.rb
@@ -4,8 +4,9 @@ require 'rails_helper'
 
 RSpec.describe UpdateObjectService do
   include Dry::Monads[:result]
-  let(:store) { described_class.new(cocina_object:, skip_lock: true, skip_open_check: false, event_data:) }
-  let(:event_data) { { who: 'test_user', description: 'updating stuff' } }
+  let(:store) { described_class.new(cocina_object:, skip_lock: true, skip_open_check: false, who:, description:) }
+  let(:who) { 'test_user' }
+  let(:description) { 'updating stuff' }
   let(:open) { true }
   let(:druid) { 'druid:zr174jb7823' }
   let!(:repository_object) do
@@ -46,13 +47,15 @@ RSpec.describe UpdateObjectService do
           expect(EventFactory).to have_received(:create).with(
             druid:,
             event_type: 'update',
-            data: { success: true, request: cocina_object.to_h }.merge(event_data)
+            data: { who:, description:, success: true, request: cocina_object.to_h }
           )
         end
       end
 
       context 'when checking lock succeeds' do
-        let(:store) { described_class.new(cocina_object:, skip_lock: false, skip_open_check: false, event_data:) }
+        let(:store) do
+          described_class.new(cocina_object:, skip_lock: false, skip_open_check: false, who:, description:)
+        end
 
         let(:lock) { "#{druid}=#{repository_object.lock}=#{repository_object.head_version.lock}" }
 
@@ -70,7 +73,9 @@ RSpec.describe UpdateObjectService do
       end
 
       context 'when checking lock fails' do
-        let(:store) { described_class.new(cocina_object:, skip_lock: false, skip_open_check: false, event_data:) }
+        let(:store) do
+          described_class.new(cocina_object:, skip_lock: false, skip_open_check: false, who:, description:)
+        end
         let(:lock) { '64e8320d19d62ddb73c501276c5655cf' }
 
         let(:cocina_object) do
@@ -87,7 +92,9 @@ RSpec.describe UpdateObjectService do
 
       context 'when version is not open' do
         let(:open) { false }
-        let(:store) { described_class.new(cocina_object:, skip_lock: false, skip_open_check: false, event_data:) }
+        let(:store) do
+          described_class.new(cocina_object:, skip_lock: false, skip_open_check: false, who:, description:)
+        end
 
         let(:lock) { "#{druid}=0" }
 
@@ -107,7 +114,7 @@ RSpec.describe UpdateObjectService do
 
       context 'when version is not open but skipping open check' do
         let(:open) { false }
-        let(:store) { described_class.new(cocina_object:, skip_lock: false, skip_open_check: true, event_data:) }
+        let(:store) { described_class.new(cocina_object:, skip_lock: false, skip_open_check: true, who:, description:) }
 
         let(:lock) { "#{druid}=#{repository_object.lock}=#{repository_object.head_version.lock}" }
 


### PR DESCRIPTION
## Why was this change made? 🤔

Follow on from https://github.com/sul-dlss/dor-services-app/pull/5364
Fixes https://github.com/sul-dlss/hungry-hungry-hippo/issues/1411

Ref https://github.com/sul-dlss/hungry-hungry-hippo/issues/1411 and https://github.com/sul-dlss/hungry-hungry-hippo/issues/1371

Goes with https://github.com/sul-dlss/dor-services-client/pull/527 and https://github.com/sul-dlss/dor-services-client/pull/528

- switches from using event data as a general hash and instead uses specific params
- updates the open api to reflect this
- adds the ability to send the who param when registering objects and pass this into the event
- refactor the `UpdateObjectService.update` method to use cocina object has a param for consistency


## How was this change tested? 🤨

CI and deploying to QA


