### PR TITLE
Update datacite gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '~> 8.0.0'
 
 # DLSS/domain-specific dependencies
 gem 'cocina-models', '~> 0.103.0'
-gem 'datacite', '~> 0.5'
+gem 'datacite', '~> 0.6'
 gem 'dor-workflow-client', '~> 7.6'
 gem 'druid-tools', '~> 2.2'
 gem 'folio_client', '~> 0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,10 +149,9 @@ GEM
     crass (1.0.6)
     csv (3.3.5)
     daemons (1.4.1)
-    datacite (0.5.0)
+    datacite (0.6.0)
       dry-monads (~> 1.3)
       faraday (~> 2.0)
-      json_schema (~> 0.21.0)
       zeitwerk (~> 2.4)
     date (3.4.1)
     debug (1.10.0)
@@ -625,7 +624,7 @@ DEPENDENCIES
   connection_pool
   csv
   daemons
-  datacite (~> 0.5)
+  datacite (~> 0.6)
   debug
   diffy
   dlss-capistrano


### PR DESCRIPTION
closes #5365

## Why was this change made? 🤔
To allow submitting to datacite using the latest datacite metadata schema.


## How was this change tested? 🤨
QA

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



