### PR TITLE
Include version description in version events.

### DIFF
--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -79,7 +79,8 @@ class VersionService
 
     new_version = repository_object.opened_version.version
     WorkflowService.create(druid:, workflow_name: 'versioningWF', version: new_version.to_s)
-    EventFactory.create(druid:, event_type: 'version_open', data: { who: opening_user_name, version: new_version.to_s })
+    EventFactory.create(druid:, event_type: 'version_open',
+                        data: { who: opening_user_name, version: new_version.to_s, description: })
     # Reloading to get correct lock value.
     repository_object.reload.to_cocina_with_metadata
   end
@@ -142,7 +143,9 @@ class VersionService
     repository_object.close_version!(description:)
     WorkflowService.create(druid:, workflow_name: 'accessionWF', version: version.to_s) if start_accession
 
-    EventFactory.create(druid:, event_type: 'version_close', data: { who: user_name, version: version.to_s })
+    EventFactory.create(druid:, event_type: 'version_close',
+                        data: { who: user_name, version: version.to_s,
+                                description: repository_object.last_closed_version.version_description })
 
     # Accessioning will perform the publishing, so don't publish here
     update_user_version(user_version_mode:, repository_object:, publish: !start_accession)

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -44,9 +44,10 @@ RSpec.describe VersionService do
         expect(workflow_client).to have_received(:create_workflow_by_name)
           .with(druid, 'versioningWF', version: '2', lane_id: nil, context: nil)
 
-        expect(EventFactory).to have_received(:create).with(data: { version: '2', who: 'sunetid' },
-                                                            druid:,
-                                                            event_type: 'version_open')
+        expect(EventFactory).to have_received(:create)
+          .with(data: { version: '2', who: 'sunetid', description: 'same as it ever was' },
+                druid:,
+                event_type: 'version_open')
 
         expect(Indexer).to have_received(:reindex_later).with(druid:)
         expect(repository_object.reload.opened_version.version).to eq 2
@@ -121,9 +122,10 @@ RSpec.describe VersionService do
         expect(workflow_client).to have_received(:create_workflow_by_name)
           .with(druid, 'versioningWF', version: '3', lane_id: nil, context: nil)
 
-        expect(EventFactory).to have_received(:create).with(data: { version: '3', who: 'sunetid' },
-                                                            druid:,
-                                                            event_type: 'version_open')
+        expect(EventFactory).to have_received(:create)
+          .with(data: { version: '3', who: 'sunetid', description: 'same as it ever was' },
+                druid:,
+                event_type: 'version_open')
 
         expect(Indexer).to have_received(:reindex_later).with(druid:)
         expect(repository_object.reload.opened_version.version).to eq 3
@@ -280,9 +282,10 @@ RSpec.describe VersionService do
           expect(repository_object.reload.last_closed_version).to be_present
           expect(repository_object.last_closed_version.version_description).to eq('closing text')
 
-          expect(EventFactory).to have_received(:create).with(data: { version: '2', who: 'jcoyne' },
-                                                              druid:,
-                                                              event_type: 'version_close')
+          expect(EventFactory).to have_received(:create)
+            .with(data: { version: '2', who: 'jcoyne', description: 'closing text' },
+                  druid:,
+                  event_type: 'version_close')
 
           expect(workflow_client).to have_received(:create_workflow_by_name)
             .with(druid, 'accessionWF', version: '2', lane_id: nil, context: nil)


### PR DESCRIPTION
closes #5371

## Why was this change made? 🤔
So that the version description will be available for the H3 history table.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



