### PR TITLE
Index all orcids.

### DIFF
--- a/app/services/indexing/builders/orcid_builder.rb
+++ b/app/services/indexing/builders/orcid_builder.rb
@@ -20,25 +20,12 @@ module Indexing
       end
 
       def build
-        cited_contributors.filter_map { |contributor| orcidid(contributor) }
+        contributors.filter_map { |contributor| orcidid(contributor) }
       end
 
       private
 
       attr_reader :contributors
-
-      # @param [Cocina::Models::Contributor] array of contributors
-      # @return [Array<String>] array of contributors who are listed as cited
-      # Note that non-cited contributors are excluded.
-      def cited_contributors
-        contributors.select { |contributor| cited?(contributor) }
-      end
-
-      # @param [Cocina::Models::Contributor] contributor to check
-      # @return [Boolean] true unless the contributor has a citation status of false
-      def cited?(contributor)
-        contributor.note.none? { |note| note.type == 'citation status' && note.value == 'false' }
-      end
 
       # @param [Cocina::Models::Contributor] contributor to check
       # @return [String, nil] orcid id including host if present


### PR DESCRIPTION
closes #5376

## Why was this change made? 🤔
The use of citation status note is deprecated.


## How was this change tested? 🤨
Apparently this was untested, as removing it didn't break anything. Sigh.

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



