### PR TITLE
Send collection change event when moved

### DIFF
--- a/app/services/update_object_service.rb
+++ b/app/services/update_object_service.rb
@@ -80,8 +80,7 @@ class UpdateObjectService
 
   def need_to_update_members?
     cocina_object.collection? &&
-      Cocina::Models::Builders::TitleBuilder.build(CocinaObjectStore.find(druid).description.title) !=
-        Cocina::Models::Builders::TitleBuilder.build(cocina_object.description.title)
+      object_title(druid) != Cocina::Models::Builders::TitleBuilder.build(cocina_object.description.title)
   end
 
   def collection_changed?
@@ -103,9 +102,9 @@ class UpdateObjectService
     new_collection_druid = (new_collections - previous_collections).first
     previous_collection_druid = (previous_collections - new_collections).first
 
-    collection_changed_description = "Moved from #{object_label(previous_collection_druid)} " \
+    collection_changed_description = "Moved from #{object_title(previous_collection_druid)} " \
                                      "(#{previous_collection_druid}) " \
-                                     "to #{object_label(new_collection_druid)} (#{new_collection_druid})"
+                                     "to #{object_title(new_collection_druid)} (#{new_collection_druid})"
 
     EventFactory.create(druid:, event_type: 'collection_changed',
                         data: { who:, description: collection_changed_description })
@@ -121,10 +120,10 @@ class UpdateObjectService
     cocina_object.structural.isMemberOf || []
   end
 
-  def object_label(druid)
+  def object_title(druid)
     return 'None' unless druid
 
-    CocinaObjectStore.find(druid).label
+    Cocina::Models::Builders::TitleBuilder.build(CocinaObjectStore.find(druid).description.title)
   end
 
   def persist! # rubocop:disable Metrics/MethodLength, Metrics/AbcSize

--- a/app/services/update_object_service.rb
+++ b/app/services/update_object_service.rb
@@ -108,8 +108,8 @@ class UpdateObjectService
     new_collection_druid = (new_collections - old_collections).first
     old_collection_druid = (old_collections - new_collections).first
 
-    new_collection_title = new_collection_druid ? CocinaObjectStore.find(new_collection_druid).label : ''
-    old_collection_title = old_collection_druid ? CocinaObjectStore.find(old_collection_druid).label : ''
+    new_collection_title = new_collection_druid ? CocinaObjectStore.find(new_collection_druid).label : 'None'
+    old_collection_title = old_collection_druid ? CocinaObjectStore.find(old_collection_druid).label : 'None'
 
     collection_changed_description = "Moved from #{old_collection_title} (#{old_collection_druid}) " \
                                      "to #{new_collection_title} (#{new_collection_druid})"

--- a/spec/factories/repository_object_versions.rb
+++ b/spec/factories/repository_object_versions.rb
@@ -118,13 +118,22 @@ FactoryBot.define do
   end
 
   trait :collection_repository_object_version do
-    label { 'Test Collection' }
+    transient do
+      title { 'Test Collection' }
+    end
+    label { title }
     content_type { Cocina::Models::ObjectType.collection }
     administrative do
       { hasAdminPolicy: 'druid:hy787xj5878' }
     end
     access do
       { view: 'world' }
+    end
+    description do
+      {
+        title: [{ value: title }],
+        purl: "https://purl.stanford.edu/#{external_identifier.delete_prefix('druid:')}"
+      }
     end
     structural { nil }
   end

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -13,15 +13,18 @@ RSpec.describe 'Update object' do
   let(:modified) { DateTime.now }
   let(:label) { 'This is my label' }
   let(:title) { 'This is my title' }
+  let(:current_collection_druid) { 'druid:xx888xx7777' }
+  let(:new_collection_druid) { 'druid:bb111bb2222' }
+  let(:updated_collection_druid) { current_collection_druid } # for most tests, collection stays the same
+
   let(:structural) do
     {
       hasMemberOrders: [
         { viewingDirection: 'right-to-left' }
       ],
-      isMemberOf: ['druid:xx888xx7777']
+      isMemberOf: [current_collection_druid.to_s]
     }
   end
-  let(:cocina_structural) { Cocina::Models::DROStructural.new(structural) }
   let(:view) { 'world' }
   let(:download) { 'world' }
   let(:cocina_access) do
@@ -63,7 +66,7 @@ RSpec.describe 'Update object' do
         "identification":#{identification.to_json},
         "structural":{
           "hasMemberOrders":[{"viewingDirection":"right-to-left"}],
-          "isMemberOf":["druid:xx888xx7777"]
+          "isMemberOf":["#{updated_collection_druid}"]
         }
       }
     JSON
@@ -94,460 +97,572 @@ RSpec.describe 'Update object' do
     allow(VersionService).to receive(:open?).and_return(true)
   end
 
-  it 'updates the object' do
-    patch("/v1/objects/#{druid}",
-          params: data,
-          headers:)
-    expect(response).to have_http_status(:ok)
-    expect(response.body).to equal_cocina_model(Cocina::Models.build(JSON.parse(data)))
-    expect(response.headers['Last-Modified']).to end_with 'GMT'
-    expect(response.headers['X-Created-At']).to end_with 'GMT'
-    expect(response.headers['ETag']).to match(%r{W/".+"})
-
-    expect(item.reload.head_version.to_cocina.to_json).to equal_cocina_model(expected)
-    expect(Cocina::ObjectValidator).to have_received(:validate)
-
-    expect(EventFactory).to have_received(:create).with(druid:, data: hash_including(:request, success: true),
-                                                        event_type: 'update')
-  end
-
-  context 'with a non-matching druid (Cocina::Models::ValidationError)' do
-    let(:data) do
-      <<~JSON
-        {
-          "cocinaVersion": "#{Cocina::Models::VERSION}",
-          "externalIdentifier": "druid:xs123xx8388",
-          "type":"#{content_type}",
-          "label":"#{label}","version":1,
-          "access":{
-            "view":"#{view}",
-            "download":"#{view}",
-            "copyright":"All rights reserved unless otherwise indicated.",
-            "useAndReproductionStatement":"Property rights reside with the repository..."
-          },
-          "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
-          "description":#{description.to_json},
-          "identification":#{identification.to_json},
-          "structural":{
-            "hasMemberOrders":[{"viewingDirection":"right-to-left"}],
-            "isMemberOf":["druid:xx888xx7777"]
-          }
-        }
-      JSON
-    end
-    let(:description) do
-      {
-        title: [{ value: title }],
-        purl: 'https://purl.stanford.edu/xs123xx8388'
-      }
-    end
-
-    it 'is a bad request' do
-      patch("/v1/objects/#{druid}",
-            params: data,
-            headers:)
-      expect(response).to have_http_status(:bad_request)
-    end
-  end
-
-  context 'when validation fails' do
-    before do
-      allow(Cocina::ObjectValidator).to receive(:validate).and_raise(Cocina::ValidationError, 'Not on my watch.')
-    end
-
-    it 'is a bad request' do
-      patch("/v1/objects/#{druid}",
-            params: data,
-            headers:)
-      expect(response).to have_http_status(:bad_request)
-    end
-  end
-
-  context 'when incorrect ETag' do
-    it 'is a stale request and does not save' do
-      patch "/v1/objects/#{druid}",
-            params: data,
-            headers: {
-              'Authorization' => "Bearer #{jwt}",
-              'Content-Type' => 'application/json',
-              'If-Match' => 'W/"BAD LOCK"'
-            }
-      expect(response).to have_http_status(:precondition_failed)
-    end
-  end
-
-  context 'when omitted ETag' do
-    it 'updates the item' do
-      patch "/v1/objects/#{druid}",
-            params: data,
-            headers: {
-              'Authorization' => "Bearer #{jwt}",
-              'Content-Type' => 'application/json'
-            }
-      expect(response).to have_http_status(:ok)
-    end
-  end
-
-  context 'when title changes' do
-    let(:description) do
-      {
-        title: [{ value: 'Not a title' }],
-        purl:
-      }
-    end
-
-    context 'when no description or who are provided' do
-      it 'returns the updated object' do
-        patch("/v1/objects/#{druid}",
-              params: data,
-              headers:)
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to include('Not a title')
+  context 'when a dro is provided' do
+    context 'when valid' do
+      before do
+        create(:repository_object, :collection, :with_repository_object_version,
+               external_identifier: current_collection_druid)
+        create(:repository_object, :collection, :with_repository_object_version,
+               external_identifier: new_collection_druid)
+        item.head_version.structural['isMemberOf'] = [current_collection_druid]
+        item.head_version.save!
       end
-    end
-
-    context 'when who and description provided' do
-      let(:user_name) { 'test_user' }
-      let(:event_description) { 'updating stuff' }
-
-      it 'returns the updated object' do
-        patch("/v1/objects/#{druid}?event_description=#{event_description}&user_name=#{user_name}",
-              params: data,
-              headers:)
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to include('Not a title')
-      end
-    end
-  end
-
-  context 'when an image is provided' do
-    let(:label) { 'This is my label' }
-    let(:expected_label) { label }
-    let(:title) { 'This is my title' }
-    let(:structural) do
-      {
-        isMemberOf: ['druid:xx888xx7777']
-      }
-    end
-    let(:view) { 'world' }
-    let(:expected) do
-      build(:dro, id: druid, type: Cocina::Models::ObjectType.image, label: expected_label, title:,
-                  admin_policy_id: 'druid:dd999df4567').new(
-                    access: {
-                      view:,
-                      download: 'world',
-                      copyright: 'All rights reserved unless otherwise indicated.',
-                      useAndReproductionStatement: 'Property rights reside with the repository...'
-                    },
-                    identification:,
-                    structural:
-                  )
-    end
-    let(:data) do
-      <<~JSON
-        {
-          "cocinaVersion": "#{Cocina::Models::VERSION}",
-          "externalIdentifier": "#{druid}",
-          "type":"#{Cocina::Models::ObjectType.image}",
-          "label":"#{expected_label}","version":1,
-          "access":{
-            "view":"#{view}",
-            "download":"world",
-            "copyright":"All rights reserved unless otherwise indicated.",
-            "useAndReproductionStatement":"Property rights reside with the repository..."
-          },
-          "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
-          "description":{
-            "title":[{"value":"#{title}"}],
-            "purl":"#{purl}"
-          },
-          "identification":#{identification.to_json},
-          "structural":{
-            "isMemberOf":["druid:xx888xx7777"]
-          }}
-      JSON
-    end
-
-    let(:identification) do
-      {
-        sourceId: 'googlebooks:999999',
-        catalogLinks: [
-          { catalog: 'symphony', catalogRecordId: '8888', refresh: true }
-        ]
-      }
-    end
-
-    context 'when the save is successful' do
-      let(:expected_label) { 'This is a new label' }
 
       it 'updates the object' do
         patch("/v1/objects/#{druid}",
               params: data,
               headers:)
-        expect(response).to have_http_status :ok
-        expect(response.body).to equal_cocina_model(Cocina::Models.build(JSON.parse(data)))
-        expect(item.reload.head_version.to_cocina.to_json).to equal_cocina_model(expected)
-
-        # Metadata set correctly.
-        expect(item.head_version.label).to eq(expected_label)
-      end
-    end
-
-    # rubocop:disable Layout/LineLength
-    context 'when a really long label' do
-      let(:label) { 'Hearings before the Subcommittee on Elementary, Secondary, and Vocational Education of the Committee on Education and Labor, House of Representatives, Ninety-fifth Congress, first session, on H.R. 15, to extend for five years certain elementary, secondary, and other education programs ....' }
-      let(:truncated_label) { 'Hearings before the Subcommittee on Elementary, Secondary, and Vocational Education of the Committee on Education and Labor, House of Representatives, Ninety-fifth Congress, first session, on H.R. 15, to extend for five years certain elementary, secondar' }
-
-      it 'truncates the title' do
-        patch("/v1/objects/#{druid}",
-              params: data,
-              headers:)
         expect(response).to have_http_status(:ok)
         expect(response.body).to equal_cocina_model(Cocina::Models.build(JSON.parse(data)))
+        expect(response.headers['Last-Modified']).to end_with 'GMT'
+        expect(response.headers['X-Created-At']).to end_with 'GMT'
+        expect(response.headers['ETag']).to match(%r{W/".+"})
+
         expect(item.reload.head_version.to_cocina.to_json).to equal_cocina_model(expected)
-      end
-    end
-    # rubocop:enable Layout/LineLength
+        expect(Cocina::ObjectValidator).to have_received(:validate)
 
-    context 'when files are provided' do
-      let(:file1_id) { 'https://cocina.sul.stanford.edu/file/123-456-789' }
-      let(:file2_id) { 'https://cocina.sul.stanford.edu/file/223-456-789' }
-      let(:file3_id) { 'https://cocina.sul.stanford.edu/file/323-456-789' }
-      let(:file4_id) { 'https://cocina.sul.stanford.edu/file/423-456-789' }
-
-      let(:file1) do
-        {
-          'externalIdentifier' => file1_id,
-          'version' => 1,
-          'type' => Cocina::Models::ObjectType.file,
-          'filename' => '00001.html',
-          'label' => '00001.html',
-          'hasMimeType' => 'text/html',
-          'languageTag' => 'aqp-Latn-US',
-          'use' => 'transcription',
-          'administrative' => {
-            'publish' => false,
-            'sdrPreserve' => true,
-            'shelve' => false
-          },
-          'access' => {
-            'view' => 'dark'
-          },
-          'hasMessageDigests' => [
-            {
-              'type' => 'sha1',
-              'digest' => 'cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7'
-            },
-            {
-              'type' => 'md5',
-              'digest' => 'e6d52da47a5ade91ae31227b978fb023'
-            }
-
-          ]
-        }
+        expect(EventFactory).to have_received(:create).with(druid:, data: hash_including(:request, success: true),
+                                                            event_type: 'update')
       end
 
-      let(:file2) do
-        {
-          'externalIdentifier' => file2_id,
-          'version' => 1,
-          'type' => Cocina::Models::ObjectType.file,
-          'filename' => '00001.jp2',
-          'label' => '00001.jp2',
-          'hasMimeType' => 'image/jp2',
-          'administrative' => {
-            'publish' => true,
-            'sdrPreserve' => true,
-            'shelve' => true
-          },
-          'access' => {
-            'view' => 'stanford',
-            'download' => 'stanford'
-          },
-          'hasMessageDigests' => []
-        }
+      context 'when omitted ETag' do
+        it 'updates the item' do
+          patch "/v1/objects/#{druid}",
+                params: data,
+                headers: {
+                  'Authorization' => "Bearer #{jwt}",
+                  'Content-Type' => 'application/json'
+                }
+          expect(response).to have_http_status(:ok)
+        end
       end
 
-      let(:file3) do
-        {
-          'externalIdentifier' => file3_id,
-          'version' => 1,
-          'type' => Cocina::Models::ObjectType.file,
-          'filename' => '00002.html',
-          'label' => '00002.html',
-          'hasMimeType' => 'text/html',
-          'administrative' => {
-            'publish' => false,
-            'sdrPreserve' => true,
-            'shelve' => false
-          },
-          'access' => {
-            'view' => 'dark',
-            'download' => 'none'
-          },
-          'hasMessageDigests' => []
-        }
-      end
-
-      let(:file4) do
-        {
-          'externalIdentifier' => file4_id,
-          'version' => 1,
-          'type' => Cocina::Models::ObjectType.file,
-          'filename' => '00002.jp2',
-          'label' => '00002.jp2',
-          'hasMimeType' => 'image/jp2',
-          'administrative' => {
-            'publish' => true,
-            'sdrPreserve' => true,
-            'shelve' => true
-          },
-          'access' => {
-            'view' => 'world',
-            'download' => 'world'
-          },
-          'hasMessageDigests' => []
-        }
-      end
-
-      let(:fileset1_id) { 'https://cocina.sul.stanford.edu/fileSet/234-567-890' }
-      let(:fileset2_id) { 'https://cocina.sul.stanford.edu/fileSet/334-567-890' }
-
-      let(:filesets) do
-        [
+      context 'when title changes' do
+        let(:description) do
           {
-            'externalIdentifier' => fileset1_id,
-            'version' => 1,
-            'type' => Cocina::Models::FileSetType.file,
-            'label' => 'Page 1',
-            'structural' => { 'contains' => [file1, file2] }
-          },
-          {
-            'externalIdentifier' => fileset2_id,
-            'version' => 1,
-            'type' => Cocina::Models::FileSetType.file,
-            'label' => 'Page 2',
-            'structural' => { 'contains' => [file3, file4] }
+            title: [{ value: 'Not a title' }],
+            purl:
           }
-        ]
-      end
-
-      let(:fs1) do
-        {
-          'type' => Cocina::Models::FileSetType.file
-        }
-      end
-      let(:data) do
-        <<~JSON
-          {
-            "cocinaVersion": "#{Cocina::Models::VERSION}",
-            "externalIdentifier": "#{druid}",
-            "type":"#{Cocina::Models::ObjectType.image}",
-            "label":"#{label}","version":1,
-            "access":{
-              "view":"#{view}",
-              "download":"world",
-              "copyright":"All rights reserved unless otherwise indicated.",
-              "useAndReproductionStatement":"Property rights reside with the repository..."
-            },
-            "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
-            "description":{
-              "title":[{"value":"#{title}"}],
-              "purl":"#{purl}"
-            },
-            "identification":#{identification.to_json},"structural":{"contains":#{filesets.to_json}}}
-        JSON
-      end
-
-      context 'when access match' do
-        before do
-          # This gives every file and file set the same UUID. In reality, they would be unique.
-          allow(SecureRandom).to receive(:uuid).and_return('123-456-789')
         end
 
+        context 'when no description or who are provided' do
+          it 'returns the updated object' do
+            patch("/v1/objects/#{druid}",
+                  params: data,
+                  headers:)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to include('Not a title')
+          end
+        end
+
+        context 'when who and description provided' do
+          let(:user_name) { 'test_user' }
+          let(:event_description) { 'updating stuff' }
+
+          it 'returns the updated object' do
+            patch("/v1/objects/#{druid}?event_description=#{event_description}&user_name=#{user_name}",
+                  params: data,
+                  headers:)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to include('Not a title')
+          end
+        end
+      end
+
+      context 'when an image is provided' do
+        let(:label) { 'This is my label' }
+        let(:expected_label) { label }
+        let(:title) { 'This is my title' }
         let(:structural) do
           {
-            isMemberOf: [],
-            contains: [
-              {
-                type: Cocina::Models::FileSetType.file,
-                externalIdentifier: fileset1_id, label: 'Page 1', version: 1,
-                structural: {
-                  contains: [
-                    {
-                      type: Cocina::Models::ObjectType.file,
-                      externalIdentifier: file1_id,
-                      label: '00001.html',
-                      filename: '00001.html',
-                      version: 1,
-                      hasMimeType: 'text/html',
-                      languageTag: 'aqp-Latn-US',
-                      use: 'transcription',
-                      hasMessageDigests: [
-                        {
-                          type: 'sha1', digest: 'cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7'
-                        }, {
-                          type: 'md5', digest: 'e6d52da47a5ade91ae31227b978fb023'
-                        }
-                      ],
-                      access: { view: 'dark', download: 'none' },
-                      administrative: { publish: false, sdrPreserve: true, shelve: false }
-                    }, {
-                      type: Cocina::Models::ObjectType.file,
-                      externalIdentifier: file2_id,
-                      label: '00001.jp2',
-                      filename: '00001.jp2',
-                      version: 1,
-                      hasMimeType: 'image/jp2', hasMessageDigests: [],
-                      access: { view: 'stanford', download: 'stanford' },
-                      administrative: { publish: true, sdrPreserve: true, shelve: true }
-                    }
-                  ]
-                }
-              }, {
-                type: Cocina::Models::FileSetType.file,
-                externalIdentifier: fileset2_id,
-                label: 'Page 2', version: 1,
-                structural: {
-                  contains: [
-                    {
-                      type: Cocina::Models::ObjectType.file,
-                      externalIdentifier: file3_id,
-                      label: '00002.html', filename: '00002.html',
-                      version: 1, hasMimeType: 'text/html',
-                      hasMessageDigests: [],
-                      access: { view: 'dark', download: 'none' },
-                      administrative: { publish: false, sdrPreserve: true, shelve: false }
-                    }, {
-                      type: Cocina::Models::ObjectType.file,
-                      externalIdentifier: file4_id,
-                      label: '00002.jp2',
-                      filename: '00002.jp2',
-                      version: 1,
-                      hasMimeType: 'image/jp2',
-                      hasMessageDigests: [],
-                      access: { view: 'world', download: 'world' },
-                      administrative: { publish: true, sdrPreserve: true, shelve: true }
-                    }
-                  ]
-                }
-              }
+            isMemberOf: [current_collection_druid]
+          }
+        end
+        let(:view) { 'world' }
+        let(:expected) do
+          build(:dro, id: druid, type: Cocina::Models::ObjectType.image, label: expected_label, title:,
+                      admin_policy_id: 'druid:dd999df4567').new(
+                        access: {
+                          view:,
+                          download: 'world',
+                          copyright: 'All rights reserved unless otherwise indicated.',
+                          useAndReproductionStatement: 'Property rights reside with the repository...'
+                        },
+                        identification:,
+                        structural:
+                      )
+        end
+        let(:data) do
+          <<~JSON
+            {
+              "cocinaVersion": "#{Cocina::Models::VERSION}",
+              "externalIdentifier": "#{druid}",
+              "type":"#{Cocina::Models::ObjectType.image}",
+              "label":"#{expected_label}","version":1,
+              "access":{
+                "view":"#{view}",
+                "download":"world",
+                "copyright":"All rights reserved unless otherwise indicated.",
+                "useAndReproductionStatement":"Property rights reside with the repository..."
+              },
+              "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
+              "description":{
+                "title":[{"value":"#{title}"}],
+                "purl":"#{purl}"
+              },
+              "identification":#{identification.to_json},
+              "structural":{
+                "isMemberOf":["#{current_collection_druid}"]
+              }}
+          JSON
+        end
+
+        let(:identification) do
+          {
+            sourceId: 'googlebooks:999999',
+            catalogLinks: [
+              { catalog: 'symphony', catalogRecordId: '8888', refresh: true }
             ]
           }
         end
 
-        it 'creates contentMetadata' do
+        context 'when the save is successful' do
+          let(:expected_label) { 'This is a new label' }
+
+          it 'updates the object' do
+            patch("/v1/objects/#{druid}",
+                  params: data,
+                  headers:)
+            expect(response).to have_http_status :ok
+            expect(response.body).to equal_cocina_model(Cocina::Models.build(JSON.parse(data)))
+            expect(item.reload.head_version.to_cocina.to_json).to equal_cocina_model(expected)
+
+            # Metadata set correctly.
+            expect(item.head_version.label).to eq(expected_label)
+          end
+        end
+
+        # rubocop:disable Layout/LineLength
+        context 'when a really long label' do
+          let(:label) { 'Hearings before the Subcommittee on Elementary, Secondary, and Vocational Education of the Committee on Education and Labor, House of Representatives, Ninety-fifth Congress, first session, on H.R. 15, to extend for five years certain elementary, secondary, and other education programs ....' }
+          let(:truncated_label) { 'Hearings before the Subcommittee on Elementary, Secondary, and Vocational Education of the Committee on Education and Labor, House of Representatives, Ninety-fifth Congress, first session, on H.R. 15, to extend for five years certain elementary, secondar' }
+
+          it 'truncates the title' do
+            patch("/v1/objects/#{druid}",
+                  params: data,
+                  headers:)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to equal_cocina_model(Cocina::Models.build(JSON.parse(data)))
+            expect(item.reload.head_version.to_cocina.to_json).to equal_cocina_model(expected)
+          end
+        end
+        # rubocop:enable Layout/LineLength
+
+        context 'when files are provided' do
+          let(:file1_id) { 'https://cocina.sul.stanford.edu/file/123-456-789' }
+          let(:structural) do
+            {
+              isMemberOf: [current_collection_druid.to_s],
+              contains: [
+                {
+                  type: Cocina::Models::FileSetType.file,
+                  externalIdentifier: fileset1_id, label: 'Page 1', version: 1,
+                  structural: {
+                    contains: [
+                      {
+                        type: Cocina::Models::ObjectType.file,
+                        externalIdentifier: file1_id,
+                        label: '00001.html',
+                        filename: '00001.html',
+                        version: 1,
+                        hasMimeType: 'text/html',
+                        languageTag: 'aqp-Latn-US',
+                        use: 'transcription',
+                        hasMessageDigests: [
+                          {
+                            type: 'sha1', digest: 'cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7'
+                          }, {
+                            type: 'md5', digest: 'e6d52da47a5ade91ae31227b978fb023'
+                          }
+                        ],
+                        access: { view: 'dark', download: 'none' },
+                        administrative: { publish: false, sdrPreserve: true, shelve: false }
+                      }, {
+                        type: Cocina::Models::ObjectType.file,
+                        externalIdentifier: file2_id,
+                        label: '00001.jp2',
+                        filename: '00001.jp2',
+                        version: 1,
+                        hasMimeType: 'image/jp2', hasMessageDigests: [],
+                        access: { view: 'stanford', download: 'stanford' },
+                        administrative: { publish: true, sdrPreserve: true, shelve: true }
+                      }
+                    ]
+                  }
+                }, {
+                  type: Cocina::Models::FileSetType.file,
+                  externalIdentifier: fileset2_id,
+                  label: 'Page 2', version: 1,
+                  structural: {
+                    contains: [
+                      {
+                        type: Cocina::Models::ObjectType.file,
+                        externalIdentifier: file3_id,
+                        label: '00002.html', filename: '00002.html',
+                        version: 1, hasMimeType: 'text/html',
+                        hasMessageDigests: [],
+                        access: { view: 'dark', download: 'none' },
+                        administrative: { publish: false, sdrPreserve: true, shelve: false }
+                      }, {
+                        type: Cocina::Models::ObjectType.file,
+                        externalIdentifier: file4_id,
+                        label: '00002.jp2',
+                        filename: '00002.jp2',
+                        version: 1,
+                        hasMimeType: 'image/jp2',
+                        hasMessageDigests: [],
+                        access: { view: 'world', download: 'world' },
+                        administrative: { publish: true, sdrPreserve: true, shelve: true }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          end
+          let(:file2_id) { 'https://cocina.sul.stanford.edu/file/223-456-789' }
+          let(:file3_id) { 'https://cocina.sul.stanford.edu/file/323-456-789' }
+          let(:file4_id) { 'https://cocina.sul.stanford.edu/file/423-456-789' }
+
+          let(:file1) do
+            {
+              'externalIdentifier' => file1_id,
+              'version' => 1,
+              'type' => Cocina::Models::ObjectType.file,
+              'filename' => '00001.html',
+              'label' => '00001.html',
+              'hasMimeType' => 'text/html',
+              'languageTag' => 'aqp-Latn-US',
+              'use' => 'transcription',
+              'administrative' => {
+                'publish' => false,
+                'sdrPreserve' => true,
+                'shelve' => false
+              },
+              'access' => {
+                'view' => 'dark'
+              },
+              'hasMessageDigests' => [
+                {
+                  'type' => 'sha1',
+                  'digest' => 'cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7'
+                },
+                {
+                  'type' => 'md5',
+                  'digest' => 'e6d52da47a5ade91ae31227b978fb023'
+                }
+
+              ]
+            }
+          end
+
+          let(:file2) do
+            {
+              'externalIdentifier' => file2_id,
+              'version' => 1,
+              'type' => Cocina::Models::ObjectType.file,
+              'filename' => '00001.jp2',
+              'label' => '00001.jp2',
+              'hasMimeType' => 'image/jp2',
+              'administrative' => {
+                'publish' => true,
+                'sdrPreserve' => true,
+                'shelve' => true
+              },
+              'access' => {
+                'view' => 'stanford',
+                'download' => 'stanford'
+              },
+              'hasMessageDigests' => []
+            }
+          end
+
+          let(:file3) do
+            {
+              'externalIdentifier' => file3_id,
+              'version' => 1,
+              'type' => Cocina::Models::ObjectType.file,
+              'filename' => '00002.html',
+              'label' => '00002.html',
+              'hasMimeType' => 'text/html',
+              'administrative' => {
+                'publish' => false,
+                'sdrPreserve' => true,
+                'shelve' => false
+              },
+              'access' => {
+                'view' => 'dark',
+                'download' => 'none'
+              },
+              'hasMessageDigests' => []
+            }
+          end
+
+          let(:file4) do
+            {
+              'externalIdentifier' => file4_id,
+              'version' => 1,
+              'type' => Cocina::Models::ObjectType.file,
+              'filename' => '00002.jp2',
+              'label' => '00002.jp2',
+              'hasMimeType' => 'image/jp2',
+              'administrative' => {
+                'publish' => true,
+                'sdrPreserve' => true,
+                'shelve' => true
+              },
+              'access' => {
+                'view' => 'world',
+                'download' => 'world'
+              },
+              'hasMessageDigests' => []
+            }
+          end
+
+          let(:fileset1_id) { 'https://cocina.sul.stanford.edu/fileSet/234-567-890' }
+          let(:fileset2_id) { 'https://cocina.sul.stanford.edu/fileSet/334-567-890' }
+
+          let(:filesets) do
+            [
+              {
+                'externalIdentifier' => fileset1_id,
+                'version' => 1,
+                'type' => Cocina::Models::FileSetType.file,
+                'label' => 'Page 1',
+                'structural' => { 'contains' => [file1, file2] }
+              },
+              {
+                'externalIdentifier' => fileset2_id,
+                'version' => 1,
+                'type' => Cocina::Models::FileSetType.file,
+                'label' => 'Page 2',
+                'structural' => { 'contains' => [file3, file4] }
+              }
+            ]
+          end
+
+          let(:fs1) do
+            {
+              'type' => Cocina::Models::FileSetType.file
+            }
+          end
+          let(:data) do
+            <<~JSON
+              {
+                "cocinaVersion": "#{Cocina::Models::VERSION}",
+                "externalIdentifier": "#{druid}",
+                "type":"#{Cocina::Models::ObjectType.image}",
+                "label":"#{label}","version":1,
+                "access":{
+                  "view":"#{view}",
+                  "download":"world",
+                  "copyright":"All rights reserved unless otherwise indicated.",
+                  "useAndReproductionStatement":"Property rights reside with the repository..."
+                },
+                "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
+                "description":{
+                  "title":[{"value":"#{title}"}],
+                  "purl":"#{purl}"
+                },
+                "identification":#{identification.to_json},"structural":{"isMemberOf":["#{current_collection_druid}"],"contains":#{filesets.to_json}}}
+            JSON
+          end
+
+          before do
+            # This gives every file and file set the same UUID. In reality, they would be unique.
+            allow(SecureRandom).to receive(:uuid).and_return('123-456-789')
+          end
+
+          it 'updates the object with files' do
+            patch("/v1/objects/#{druid}",
+                  params: data,
+                  headers:)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to equal_cocina_model(Cocina::Models.build(JSON.parse(data)))
+            cocina_item = Cocina::Models.without_metadata(CocinaObjectStore.find(druid))
+            expect(cocina_item.to_json).to equal_cocina_model(expected)
+            expect(cocina_item.structural.contains.map { |fs| fs.structural.contains.size }).to eq [2, 2]
+          end
+        end
+
+        context 'when collection is provided' do
+          let(:structural) { { isMemberOf: [current_collection_druid] } }
+
+          let(:data) do
+            <<~JSON
+              {
+                "cocinaVersion":"#{Cocina::Models::VERSION}",
+                "externalIdentifier": "#{druid}",
+                "type":"#{Cocina::Models::ObjectType.image}",
+                "label":"#{label}","version":1,
+                "access":{
+                  "view":"#{view}",
+                  "download":"world",
+                  "copyright":"All rights reserved unless otherwise indicated.",
+                  "useAndReproductionStatement":"Property rights reside with the repository..."
+                },
+                "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
+                "description":{
+                  "title":[{"value":"#{title}"}],
+                  "purl":"#{purl}"
+                },
+                "identification":#{identification.to_json},
+                "structural":{"isMemberOf":["#{current_collection_druid}"]}}
+            JSON
+          end
+
+          it 'creates collection relationship' do
+            patch("/v1/objects/#{druid}",
+                  params: data,
+                  headers:)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to equal_cocina_model(Cocina::Models.build(JSON.parse(data)))
+            expect(item.reload.head_version.to_cocina.to_json).to equal_cocina_model(expected)
+          end
+        end
+      end
+
+      context 'when a book is provided' do
+        let(:label) { 'This is my label' }
+        let(:title) { 'This is my title' }
+        let(:expected) do
+          build(:dro, id: druid, type: Cocina::Models::ObjectType.book, label:, title:,
+                      admin_policy_id: 'druid:dd999df4567').new(
+                        identification: { sourceId: 'googlebooks:999999' },
+                        structural: {
+                          hasMemberOrders: [
+                            { viewingDirection: 'right-to-left' }
+                          ],
+                          isMemberOf: [current_collection_druid]
+                        },
+                        access: { view: 'world', download: 'world' }
+                      )
+        end
+        let(:data) do
+          <<~JSON
+            {
+              "cocinaVersion": "#{Cocina::Models::VERSION}",
+              "externalIdentifier": "#{druid}",
+              "type":"#{Cocina::Models::ObjectType.book}",
+              "label":"#{label}","version":1,
+              "access":{
+                "view":"world",
+                "download":"world"
+              },
+              "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
+              "description":{
+                "title":[{"value":"#{title}"}],
+                "purl":"#{purl}"
+              },
+              "identification":{"sourceId":"googlebooks:999999"},
+              "structural":{
+                "hasMemberOrders":[{"viewingDirection":"right-to-left"}],
+                "isMemberOf":["#{current_collection_druid}"]
+              }}
+          JSON
+        end
+
+        before do
+          allow(AdministrativeTags).to receive(:project).and_return([])
+        end
+
+        it 'registers the book and sets the viewing direction' do
+          patch("/v1/objects/#{druid}",
+                params: data,
+                headers:)
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to equal_cocina_model(Cocina::Models.build(JSON.parse(data)))
+          expect(item.reload.head_version.to_cocina.to_json).to equal_cocina_model(expected)
+        end
+      end
+
+      context 'when an embargo is provided' do
+        let(:expected) do
+          build(:dro, id: druid, label: 'This is my label', title: 'This is my title', admin_policy_id: apo_druid,
+                      type: Cocina::Models::ObjectType.book).new(
+                        identification: { sourceId: 'googlebooks:999999' },
+                        structural: {
+                          isMemberOf: [current_collection_druid.to_s],
+                          hasMemberOrders: [
+                            { viewingDirection: 'right-to-left' }
+                          ]
+                        },
+                        access: {
+                          view: 'stanford',
+                          download: 'stanford',
+                          embargo: {
+                            view: 'world',
+                            download: 'world',
+                            releaseDate: '2020-02-29T07:00:00.000+00:00'
+                          }
+                        }
+                      )
+        end
+        let(:data) do
+          <<~JSON
+            {
+              "cocinaVersion": "#{Cocina::Models::VERSION}",
+              "externalIdentifier": "#{druid}",
+              "type":"#{Cocina::Models::ObjectType.book}",
+              "label":"This is my label","version":1,
+              "access":{"view":"stanford","download":"stanford",
+                "embargo":{"view":"world","download":"world","releaseDate":"2020-02-29T07:00:00.000+00:00"}
+              },
+              "administrative":{"hasAdminPolicy":"#{apo_druid}"},
+              "description":{
+                "title":[{"value":"This is my title"}],
+                "purl":"#{purl}"
+              },
+              "identification":{"sourceId":"googlebooks:999999"},
+              "structural":{"isMemberOf":["#{current_collection_druid}"],"hasMemberOrders":[{"viewingDirection":"right-to-left"}]}}
+          JSON
+        end
+        let(:view) { 'stanford' }
+        let(:download) { 'stanford' }
+
+        before do
+          allow(AdministrativeTags).to receive(:project).and_return([])
+        end
+
+        it 'registers the book and sets the rights' do
           patch("/v1/objects/#{druid}",
                 params: data,
                 headers:)
           expect(response).to have_http_status(:ok)
           expect(response.body).to equal_cocina_model(Cocina::Models.build(JSON.parse(data)))
-          cocina_item = Cocina::Models.without_metadata(CocinaObjectStore.find(druid))
-          expect(cocina_item.to_json).to equal_cocina_model(expected)
-          expect(cocina_item.structural.contains.map { |fs| fs.structural.contains.size }).to eq [2, 2]
+          expect(item.reload.head_version.to_cocina.to_json).to equal_cocina_model(expected)
         end
       end
 
+      context 'when a dro is moved from one collection to another' do
+        # this simulates moving from one collection to another
+        let(:updated_collection_druid) { new_collection_druid }
+
+        it 'sends a collection changed event' do
+          patch("/v1/objects/#{druid}",
+                params: data,
+                headers:)
+          expect(response).to have_http_status(:ok)
+          description = "Moved from Test Collection (#{current_collection_druid}) " \
+                        "to Test Collection (#{new_collection_druid})"
+          expect(EventFactory).to have_received(:create).with(druid:, event_type: 'collection_changed',
+                                                              data: { who: nil, description:, success: true })
+        end
+      end
+    end
+
+    context 'when invalid' do
       context 'when access mismatch' do
         let(:view) { 'dark' }
         let(:download) { 'none' }
@@ -559,97 +674,70 @@ RSpec.describe 'Update object' do
           expect(response).to have_http_status :bad_request
         end
       end
-    end
 
-    context 'when collection is provided' do
-      let(:structural) { { isMemberOf: ['druid:xx888xx7777'] } }
-
-      let(:data) do
-        <<~JSON
+      context 'with a non-matching druid (Cocina::Models::ValidationError)' do
+        let(:data) do
+          <<~JSON
+            {
+              "cocinaVersion": "#{Cocina::Models::VERSION}",
+              "externalIdentifier": "druid:xs123xx8388",
+              "type":"#{content_type}",
+              "label":"#{label}","version":1,
+              "access":{
+                "view":"#{view}",
+                "download":"#{view}",
+                "copyright":"All rights reserved unless otherwise indicated.",
+                "useAndReproductionStatement":"Property rights reside with the repository..."
+              },
+              "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
+              "description":#{description.to_json},
+              "identification":#{identification.to_json},
+              "structural":{
+                "hasMemberOrders":[{"viewingDirection":"right-to-left"}],
+              }
+            }
+          JSON
+        end
+        let(:description) do
           {
-            "cocinaVersion":"#{Cocina::Models::VERSION}",
-            "externalIdentifier": "#{druid}",
-            "type":"#{Cocina::Models::ObjectType.image}",
-            "label":"#{label}","version":1,
-            "access":{
-              "view":"#{view}",
-              "download":"world",
-              "copyright":"All rights reserved unless otherwise indicated.",
-              "useAndReproductionStatement":"Property rights reside with the repository..."
-            },
-            "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
-            "description":{
-              "title":[{"value":"#{title}"}],
-              "purl":"#{purl}"
-            },
-            "identification":#{identification.to_json},
-            "structural":{"isMemberOf":["druid:xx888xx7777"]}}
-        JSON
+            title: [{ value: title }],
+            purl: 'https://purl.stanford.edu/xs123xx8388'
+          }
+        end
+
+        it 'is a bad request' do
+          patch("/v1/objects/#{druid}",
+                params: data,
+                headers:)
+          expect(response).to have_http_status(:bad_request)
+        end
       end
 
-      it 'creates collection relationship' do
-        patch("/v1/objects/#{druid}",
-              params: data,
-              headers:)
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to equal_cocina_model(Cocina::Models.build(JSON.parse(data)))
-        expect(item.reload.head_version.to_cocina.to_json).to equal_cocina_model(expected)
+      context 'when validation fails' do
+        before do
+          allow(Cocina::ObjectValidator).to receive(:validate).and_raise(Cocina::ValidationError, 'Not on my watch.')
+        end
+
+        it 'is a bad request' do
+          patch("/v1/objects/#{druid}",
+                params: data,
+                headers:)
+          expect(response).to have_http_status(:bad_request)
+        end
       end
-    end
-  end
 
-  context 'when a book is provided' do
-    let(:label) { 'This is my label' }
-    let(:title) { 'This is my title' }
-    let(:expected) do
-      build(:dro, id: druid, type: Cocina::Models::ObjectType.book, label:, title:,
-                  admin_policy_id: 'druid:dd999df4567').new(
-                    identification: { sourceId: 'googlebooks:999999' },
-                    structural: {
-                      hasMemberOrders: [
-                        { viewingDirection: 'right-to-left' }
-                      ],
-                      isMemberOf: ['druid:xx888xx7777']
-                    },
-                    access: { view: 'world', download: 'world' }
-                  )
-    end
-    let(:data) do
-      <<~JSON
-        {
-          "cocinaVersion": "#{Cocina::Models::VERSION}",
-          "externalIdentifier": "#{druid}",
-          "type":"#{Cocina::Models::ObjectType.book}",
-          "label":"#{label}","version":1,
-          "access":{
-            "view":"world",
-            "download":"world"
-          },
-          "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
-          "description":{
-            "title":[{"value":"#{title}"}],
-            "purl":"#{purl}"
-          },
-          "identification":{"sourceId":"googlebooks:999999"},
-          "structural":{
-            "hasMemberOrders":[{"viewingDirection":"right-to-left"}],
-            "isMemberOf":["druid:xx888xx7777"]
-          }}
-      JSON
-    end
-
-    before do
-      allow(AdministrativeTags).to receive(:project).and_return([])
-    end
-
-    it 'registers the book and sets the viewing direction' do
-      patch("/v1/objects/#{druid}",
-            params: data,
-            headers:)
-
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to equal_cocina_model(Cocina::Models.build(JSON.parse(data)))
-      expect(item.reload.head_version.to_cocina.to_json).to equal_cocina_model(expected)
+      context 'when incorrect ETag' do
+        it 'is a stale request and does not save' do
+          patch "/v1/objects/#{druid}",
+                params: data,
+                headers: {
+                  'Authorization' => "Bearer #{jwt}",
+                  'Content-Type' => 'application/json',
+                  'If-Match' => 'W/"BAD LOCK"'
+                }
+          expect(response).to have_http_status(:precondition_failed)
+        end
+      end
     end
   end
 
@@ -804,63 +892,6 @@ RSpec.describe 'Update object' do
         expect(response.body).to equal_cocina_model(Cocina::Models.build(JSON.parse(data)))
         expect(item.reload.head_version.to_cocina.to_json).to equal_cocina_model(expected)
       end
-    end
-  end
-
-  context 'when an embargo is provided' do
-    let(:expected) do
-      build(:dro, id: druid, label: 'This is my label', title: 'This is my title', admin_policy_id: apo_druid,
-                  type: Cocina::Models::ObjectType.book).new(
-                    identification: { sourceId: 'googlebooks:999999' },
-                    structural: {
-                      hasMemberOrders: [
-                        { viewingDirection: 'right-to-left' }
-                      ]
-                    },
-                    access: {
-                      view: 'stanford',
-                      download: 'stanford',
-                      embargo: {
-                        view: 'world',
-                        download: 'world',
-                        releaseDate: '2020-02-29T07:00:00.000+00:00'
-                      }
-                    }
-                  )
-    end
-    let(:data) do
-      <<~JSON
-        {
-          "cocinaVersion": "#{Cocina::Models::VERSION}",
-          "externalIdentifier": "#{druid}",
-          "type":"#{Cocina::Models::ObjectType.book}",
-          "label":"This is my label","version":1,
-          "access":{"view":"stanford","download":"stanford",
-            "embargo":{"view":"world","download":"world","releaseDate":"2020-02-29T07:00:00.000+00:00"}
-          },
-          "administrative":{"hasAdminPolicy":"#{apo_druid}"},
-          "description":{
-            "title":[{"value":"This is my title"}],
-            "purl":"#{purl}"
-          },
-          "identification":{"sourceId":"googlebooks:999999"},
-          "structural":{"hasMemberOrders":[{"viewingDirection":"right-to-left"}]}}
-      JSON
-    end
-    let(:view) { 'stanford' }
-    let(:download) { 'stanford' }
-
-    before do
-      allow(AdministrativeTags).to receive(:project).and_return([])
-    end
-
-    it 'registers the book and sets the rights' do
-      patch("/v1/objects/#{druid}",
-            params: data,
-            headers:)
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to equal_cocina_model(Cocina::Models.build(JSON.parse(data)))
-      expect(item.reload.head_version.to_cocina.to_json).to equal_cocina_model(expected)
     end
   end
 end

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -663,7 +663,7 @@ RSpec.describe 'Update object' do
           description = "Moved from Test Collection (#{current_collection_druid}) " \
                         "to New Collection (#{new_collection_druid})"
           expect(EventFactory).to have_received(:create).with(druid:, event_type: 'collection_changed',
-                                                              data: { who: nil, description:, success: true })
+                                                              data: { who: nil, description: })
         end
       end
 
@@ -698,7 +698,7 @@ RSpec.describe 'Update object' do
           expect(response).to have_http_status(:ok)
           description = "Moved from Test Collection (#{current_collection_druid}) to None ()"
           expect(EventFactory).to have_received(:create).with(druid:, event_type: 'collection_changed',
-                                                              data: { who: nil, description:, success: true })
+                                                              data: { who: nil, description: })
         end
       end
 
@@ -715,7 +715,7 @@ RSpec.describe 'Update object' do
           expect(response).to have_http_status(:ok)
           description = "Moved from None () to Test Collection (#{current_collection_druid})"
           expect(EventFactory).to have_received(:create).with(druid:, event_type: 'collection_changed',
-                                                              data: { who: nil, description:, success: true })
+                                                              data: { who: nil, description: })
         end
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #5373 - record an event during an object update when it is moved from one collection to another

## How was this change tested? 🤨

Specs