### PR TITLE
Cleanup staging files.

### DIFF
--- a/app/services/cleanup_service.rb
+++ b/app/services/cleanup_service.rb
@@ -70,6 +70,7 @@ class CleanupService
   def cleanup_by_druid
     cleanup_workspace_content(Settings.cleanup.local_workspace_root)
     cleanup_workspace_content(Settings.cleanup.local_assembly_root)
+    cleanup_workspace_content(Settings.cleanup.local_staging_root)
     cleanup_export
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -82,6 +82,7 @@ technical_metadata:
 cleanup:
   local_workspace_root: '/dor/workspace'
   local_assembly_root: '/dor/assembly'
+  local_staging_root: '/sdr-deposit-staging'
   local_export_home: '/dor/export'
   local_backup_path: '/dor/stopped'
 


### PR DESCRIPTION
closes #5370

## Why was this change made? 🤔
H3 is going to be placing file in the staging directory; they need to be cleaned up after accessioning.


## How was this change tested? 🤨
Unit
⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



