### PR TITLE
Bumping cocina-models version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'rails', '~> 8.0.0'
 
 # DLSS/domain-specific dependencies
-gem 'cocina-models', '~> 0.103.0'
+gem 'cocina-models', '~> 0.104.0'
 gem 'datacite', '~> 0.6'
 gem 'dor-workflow-client', '~> 7.8'
 gem 'druid-tools', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.103.2)
+    cocina-models (0.104.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -171,9 +171,9 @@ GEM
       ed25519
     docile (1.4.1)
     domain_name (0.6.20240107)
-    dor-services-client (15.11.0)
+    dor-services-client (15.12.0)
       activesupport (>= 7.0.0)
-      cocina-models (~> 0.103.2)
+      cocina-models (~> 0.104.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -618,7 +618,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.103.0)
+  cocina-models (~> 0.104.0)
   committee
   config
   connection_pool

--- a/openapi.yml
+++ b/openapi.yml
@@ -2796,6 +2796,49 @@ components:
         type:
           description: The relationship of the related resource to the described resource.
           type: string
+        dataCiteRelationType:
+          description: The DataCite relationType describing the relationship from the related resource to the described resource.
+            See https://datacite-metadata-schema.readthedocs.io/en/4.6/appendices/appendix-1/relationType
+          type: string
+          enum:
+            - 'IsCitedBy'
+            - 'Cites'
+            - 'IsSupplementTo'
+            - 'IsSupplementedBy'
+            - 'IsContinuedBy'
+            - 'Continues'
+            - 'Describes'
+            - 'IsDescribedBy'
+            - 'HasMetadata'
+            - 'IsMetadataFor'
+            - 'HasVersion'
+            - 'IsVersionOf'
+            - 'IsNewVersionOf'
+            - 'IsPreviousVersionOf'
+            - 'IsPartOf'
+            - 'HasPart'
+            - 'IsPublishedIn'
+            - 'IsReferencedBy'
+            - 'References'
+            - 'IsDocumentedBy'
+            - 'Documents'
+            - 'IsCompiledBy'
+            - 'Compiles'
+            - 'IsVariantFormOf'
+            - 'IsOriginalFormOf'
+            - 'IsIdenticalTo'
+            - 'IsReviewedBy'
+            - 'Reviews'
+            - 'IsDerivedFrom'
+            - 'IsSourceOf'
+            - 'IsRequiredBy'
+            - 'Requires'
+            - 'Obsoletes'
+            - 'IsObsoletedBy'
+            - 'IsCollectedBy'
+            - 'Collects'
+            - 'IsTranslationOf'
+            - 'HasTranslation'
         status:
           description: Status of the related resource relative to other related resources.
           type: string


### PR DESCRIPTION
## Why was this change made? 🤔
To support cocina-models 0.104.0 with `dataCiteRelationType`.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



