### PR TITLE
add workflow-status route

### DIFF
--- a/app/controllers/workflow_processes_controller.rb
+++ b/app/controllers/workflow_processes_controller.rb
@@ -2,6 +2,11 @@
 
 # Controller for workflow processes
 class WorkflowProcessesController < WorkflowApplicationController
+  def show
+    status = workflow_client.workflow_status(druid:, workflow:, process: workflow_process)
+    render json: { status: }
+  end
+
   def update # rubocop:disable Metrics/AbcSize
     if status == 'error'
       workflow_client.update_error_status(druid:, workflow:, process: workflow_process, error_msg: params[:error_msg],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,7 @@ Rails.application.routes.draw do
           post '', to: 'workflows#create'
         end
 
-        resources :processes, only: %i[update], controller: 'workflow_processes'
+        resources :processes, only: %i[show update], controller: 'workflow_processes'
       end
 
       resources :lifecycles, only: %i[index], controller: 'workflow_lifecycles'

--- a/openapi.yml
+++ b/openapi.yml
@@ -37,7 +37,7 @@ tags:
   - name: workspaces
     description: Operations about workspaces
   - name: workflows
-    description: Operations about workflows    
+    description: Operations about workflows
 paths:
   /v1/about:
     get:
@@ -1586,7 +1586,7 @@ paths:
           description: Name of the workflow to create
           required: true
           schema:
-            type: string            
+            type: string
         - name: version
           in: query
           description: The version of the object to create the workflow for
@@ -1606,7 +1606,7 @@ paths:
               properties:
                 context:
                   type: object
-                  additionalProperties: true            
+                  additionalProperties: true
   "/v1/objects/{object_id}/workflows/{workflow}/skip_all":
     post:
       tags:
@@ -1641,6 +1641,39 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
   "/v1/objects/{object_id}/workflows/{workflow}/processes/{process}":
+    get:
+      tags:
+        - workflows
+      summary: Get the status of a workflow process (step) for this object.
+      operationId: "workflow_processes#show"
+      responses:
+        "200":
+          description: Ok
+        "404":
+          description: Object, workflow, or process not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: object_id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: "#/components/schemas/Druid"
+        - name: workflow
+          in: path
+          description: Name of the workflow to update
+          required: true
+          schema:
+            type: string
+        - name: process
+          in: path
+          description: Name of the workflow step to return status for (e.g. "shelve")
+          required: true
+          schema:
+            type: string
     put:
       tags:
         - workflows
@@ -1679,7 +1712,7 @@ paths:
           description: Name of the workflow to update
           required: true
           schema:
-            type: string            
+            type: string
         - name: process
           in: path
           description: Name of the workflow step to update (e.g. "shelve")
@@ -1710,7 +1743,7 @@ paths:
                 error_message:
                   type: string
               required:
-                - status                
+                - status
 components:
   schemas:
     Access:

--- a/spec/requests/get_workflow_process_spec.rb
+++ b/spec/requests/get_workflow_process_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Get a workflow process status' do
+  let(:workflow_client) { instance_double(Dor::Workflow::Client, workflow_status:) }
+
+  let(:druid) { 'druid:mx123qw2323' }
+  let(:workflow_status) { 'completed' }
+
+  before do
+    allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+  end
+
+  it 'returns the status' do
+    get "/v1/objects/#{druid}/workflows/accessionWF/processes/shelve",
+        headers: { 'Authorization' => "Bearer #{jwt}" },
+        as: :json
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to eq({ status: workflow_status }.to_json)
+    expect(workflow_client).to have_received(:workflow_status)
+      .with(druid:, workflow: 'accessionWF', process: 'shelve')
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Add the route which allows to fetch the status of a single workflow step, ie. lets us call this: https://github.com/sul-dlss/dor-workflow-client/blob/main/lib/dor/workflow/client/workflow_routes.rb#L70-L78

## How was this change tested? 🤨

Specs