### PR TITLE
Do not replace useAndReproductionStatement when releasing embargo.

### DIFF
--- a/app/services/embargo_release_service.rb
+++ b/app/services/embargo_release_service.rb
@@ -67,9 +67,8 @@ class EmbargoReleaseService
   def access_props_for(cocina_object)
     # Copy access > embargo > useAndReproductionStatement, view, download, location, controlledDigitalLending
     # to access > Remove access > embargo
-    access_props = cocina_object.access.to_h.except(:view, :download, :location, :controlledDigitalLending,
-                                                    :useAndReproductionStatement)
-    access_props.merge!(access_props[:embargo].except(:releaseDate))
+    access_props = cocina_object.access.to_h.except(:view, :download, :location, :controlledDigitalLending)
+    access_props.merge!(access_props[:embargo].except(:releaseDate, :useAndReproductionStatement))
     # Remove embargo
     access_props.delete(:embargo)
     access_props

--- a/spec/services/embargo_release_service_spec.rb
+++ b/spec/services/embargo_release_service_spec.rb
@@ -134,11 +134,13 @@ RSpec.describe EmbargoReleaseService do
         Cocina::Models::DROAccess.new({
                                         view: 'citation-only',
                                         download: 'none',
+                                        useAndReproductionStatement: 'Free!',
                                         embargo: {
                                           releaseDate: DateTime.parse('2029-02-28'),
                                           view: 'world',
                                           download: 'world',
-                                          useAndReproductionStatement: 'Free!'
+                                          # use and reproduction statement should not be moved.
+                                          useAndReproductionStatement: 'Ignore me'
                                         }
                                       }).to_h
       end
@@ -167,11 +169,11 @@ RSpec.describe EmbargoReleaseService do
         Cocina::Models::DROAccess.new({
                                         view: 'citation-only',
                                         download: 'none',
+                                        useAndReproductionStatement: 'Free!',
                                         embargo: {
                                           releaseDate: DateTime.parse('2029-02-28'),
                                           view: 'citation-only',
-                                          download: 'none',
-                                          useAndReproductionStatement: 'Free!'
+                                          download: 'none'
                                         }
                                       }).to_h
       end
@@ -204,11 +206,11 @@ RSpec.describe EmbargoReleaseService do
         Cocina::Models::DROAccess.new({
                                         view: 'citation-only',
                                         download: 'none',
+                                        useAndReproductionStatement: 'Free!',
                                         embargo: {
                                           releaseDate: DateTime.parse('2029-02-28'),
                                           view: 'citation-only',
-                                          download: 'none',
-                                          useAndReproductionStatement: 'Free!'
+                                          download: 'none'
                                         }
                                       }).to_h
       end


### PR DESCRIPTION
refs https://github.com/sul-dlss/hungry-hungry-hippo/issues/1566

## Why was this change made? 🤔
Per @andrewjbtw only rights should be changed as part of embargo. This was causing roundtripping errors in H3.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



