### PR TITLE
Update moab-versioning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       ed25519
     docile (1.4.1)
     domain_name (0.6.20240107)
-    dor-services-client (15.15.1)
+    dor-services-client (15.15.2)
       activesupport (>= 7.0.0)
       cocina-models (~> 0.104.1)
       deprecation
@@ -250,7 +250,7 @@ GEM
       activesupport (>= 6.1)
     graphiql-rails (1.10.5)
       railties
-    graphql (2.5.10)
+    graphql (2.5.11)
       base64
       fiber-storage
       logger
@@ -319,7 +319,7 @@ GEM
     marcel (1.0.4)
     mini_mime (1.1.5)
     minitest (5.25.5)
-    moab-versioning (6.1.0)
+    moab-versioning (6.1.1)
       druid-tools (>= 1.0.0)
       json
       nokogiri
@@ -486,7 +486,7 @@ GEM
     rspec-support (3.13.4)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.77.0)
+    rubocop (1.78.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)


### PR DESCRIPTION
## Why was this change made? 🤔

Update moab-versioning, and a few other things. The hope is this will help address errors where `reset_bag()` isn't working correctly on the WEKA NFS backed `/dor` volume:

https://app.honeybadger.io/projects/50568/faults/121577651/01JZRJ18HMNY6YYA8A95HDHE9X?page=0

## How was this change tested? 🤨

Unit tests and preassembly integration tests.
