### PR TITLE
make spec more complete

### DIFF
--- a/spec/requests/start_accession_spec.rb
+++ b/spec/requests/start_accession_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Start Accession or Re-accession an object (with versioning)' do
     end
 
     context 'with context' do
-      let(:workflow_context) { { 'requireOCR' => true } }
+      let(:workflow_context) { { 'requireOCR' => true, 'ocrLanguages' => ['Russian'] } }
 
       it 'sends workflow context' do
         post "/v1/objects/#{druid}/accession?#{params.to_query}",


### PR DESCRIPTION
## Why was this change made? 🤔

Same as https://github.com/sul-dlss/dor-services-client/pull/557 for DSA

Just verifying that languages come through as an array (for OCR work in the workflow context).  The expectation below the change should verify it comes back out again as a hash.

Part of the investigation of https://github.com/sul-dlss/common-accessioning/issues/1495
