### PR TITLE
Adds workflow rake task. Refactors rabbit publishing and indexing when updating next step.

### DIFF
--- a/app/services/next_step_service.rb
+++ b/app/services/next_step_service.rb
@@ -16,7 +16,21 @@ class NextStepService
   # @param [WorkflowStep] step
   # @return [ActiveRecord::Relation] a list of WorkflowSteps that have been enqueued
   def enqueue_next_steps(step:)
-    find_next(step:)
+    next_steps = find_next(step:)
+    if last_accession_step?(step)
+      # https://github.com/sul-dlss/argo/issues/3817
+      # Theory is that many commits to solr are not being executed in the correct order, resulting in
+      # older data being indexed last.  This is an attempt to force a delay when indexing the very
+      # last step of the accessionWF.
+      sleep 1
+
+      # In theory, notifications should be sent for every step.
+      # However, currently consumers only care about the end-accession step.
+      Notifications::WorkflowStepUpdated.publish(step:)
+    end
+
+    Indexer.reindex_later(druid: step.druid)
+    next_steps
   end
 
   private
@@ -57,5 +71,9 @@ class NextStepService
 
     parser = WorkflowTemplateParser.new(doc)
     parser.processes.index_by(&:name)
+  end
+
+  def last_accession_step?(step)
+    step.workflow == 'accessionWF' && step.process == 'end-accession' && step.status == 'completed'
   end
 end

--- a/app/services/rabbit_factory.rb
+++ b/app/services/rabbit_factory.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Factory for initializing global RabbitMQ connection and channel.
+class RabbitFactory
+  # rubocop:disable Style/GlobalVars
+  def self.start_global
+    $rabbitmq_connection = Bunny.new(hostname: Settings.rabbitmq.hostname,
+                                     vhost: Settings.rabbitmq.vhost,
+                                     username: Settings.rabbitmq.username,
+                                     password: Settings.rabbitmq.password)
+    $rabbitmq_connection.start
+
+    $rabbitmq_channel = $rabbitmq_connection.create_channel
+  end
+  # rubocop:enable Style/GlobalVars
+end

--- a/app/services/workflow_creator.rb
+++ b/app/services/workflow_creator.rb
@@ -48,10 +48,6 @@ class WorkflowCreator
 
     # Enqueue next steps
     NextStepService.enqueue_next_steps(step: first_step)
-
-    # In theory, notifications should be sent for every step.
-    # However, currently consumers only care about the end-accession step so not sending here.
-    # Notifications::WorkflowStepUpdated.publish(step: first_step)
   end
 
   def workflow_attributes(process)

--- a/app/services/workflow_process_service.rb
+++ b/app/services/workflow_process_service.rb
@@ -88,20 +88,6 @@ class WorkflowProcessService
 
     # Enqueue next steps
     NextStepService.enqueue_next_steps(step:)
-
-    if last_accession_step?(step)
-      # https://github.com/sul-dlss/argo/issues/3817
-      # Theory is that many commits to solr are not being executed in the correct order, resulting in
-      # older data being indexed last.  This is an attempt to force a delay when indexing the very
-      # last step of the accessionWF.
-      sleep 1
-
-      # In theory, notifications should be sent for every step.
-      # However, currently consumers only care about the end-accession step.
-      Notifications::WorkflowStepUpdated.publish(step:)
-    end
-
-    Indexer.reindex_later(druid: druid)
   end
 
   def find_step_for_process
@@ -115,10 +101,6 @@ class WorkflowProcessService
     end
 
     query.first
-  end
-
-  def last_accession_step?(step)
-    step.workflow == 'accessionWF' && step.process == 'end-accession' && step.status == 'completed'
   end
 
   def check_step_exists!(step)

--- a/config/initializers/bunny_connection_after_fork.rb
+++ b/config/initializers/bunny_connection_after_fork.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Since we're using Passenger, we need to (re)establish our RabbitMQ connection
+# after Passenger forks a new process. Otherwise we can end up with errors like:
+#   Bunny::ConnectionClosedError: Trying to send frame through a closed connection.
+#
+# See http://rubybunny.info/articles/connecting.html#using_bunny_with_passenger
+# rubocop:disable Style/GlobalVars
+if defined?(PhusionPassenger) # otherwise it breaks rake commands if you put this in an initializer
+  PhusionPassenger.on_event(:starting_worker_process) do |forked|
+    if forked
+      # We're in a smart spawning mode
+      # Now is a good time to connect to RabbitMQ
+      RabbitFactory.start_global
+    end
+  end
+
+  PhusionPassenger.on_event(:stopping_worker_process) do
+    $rabbitmq_connection&.close
+  end
+end
+# rubocop:enable Style/GlobalVars

--- a/lib/tasks/workflow.rake
+++ b/lib/tasks/workflow.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :workflow do
+  desc 'Update a workflow step'
+  task :step, %i[druid workflow process version status] => :environment do |_task, args|
+    # This initializes rabbit, which is needed since rake task isn't run in Phusion Passenger.
+    RabbitFactory.start_global
+
+    step = WorkflowStep.find_by(
+      druid: args[:druid],
+      workflow: args[:workflow],
+      process: args[:process],
+      version: args[:version]
+    )
+
+    raise 'Workflow step does not already exist' if step.nil?
+
+    step.update(status: args[:status], error_msg: nil)
+    puts("Setting #{args[:process]} to #{args[:status]}")
+
+    # Enqueue next steps
+    NextStepService.enqueue_next_steps(step:)
+  end
+end

--- a/spec/services/next_step_service_spec.rb
+++ b/spec/services/next_step_service_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe NextStepService do
   describe '.enqueue_next_steps' do
     subject(:next_steps) { described_class.enqueue_next_steps(step:) }
 
+    before do
+      allow(QueueService).to receive(:enqueue)
+      allow(Notifications::WorkflowStepUpdated).to receive(:publish)
+      allow(Indexer).to receive(:reindex_later)
+      allow_any_instance_of(described_class).to receive(:sleep) # rubocop:disable RSpec/AnyInstance
+    end
+
     context "when there is a step that isn't complete" do
       let(:step) do
         create(:workflow_step,
@@ -32,12 +39,36 @@ RSpec.describe NextStepService do
                version: 1,
                status: 'waiting',
                active_version: true)
-        allow(QueueService).to receive(:enqueue)
       end
 
       it 'returns a list of unblocked statuses' do
         expect(next_steps).to eq [ready]
         expect(QueueService).to have_received(:enqueue).with(ready)
+        expect(Notifications::WorkflowStepUpdated).not_to have_received(:publish)
+        expect(Indexer).to have_received(:reindex_later).with(druid: step.druid)
+      end
+    end
+
+    context 'when step is last accession step' do
+      let(:step) do
+        create(:workflow_step,
+               process: 'end-accession',
+               version: 1,
+               status: 'completed',
+               active_version: true)
+      end
+
+      before do
+        allow(QueueService).to receive(:enqueue)
+        allow(Notifications::WorkflowStepUpdated).to receive(:publish)
+        allow(Indexer).to receive(:reindex_later)
+      end
+
+      it 'returns a list of unblocked statuses' do
+        expect(next_steps).to eq []
+        expect(QueueService).not_to have_received(:enqueue)
+        expect(Notifications::WorkflowStepUpdated).to have_received(:publish).with(step:)
+        expect(Indexer).to have_received(:reindex_later).with(druid: step.druid)
       end
     end
 


### PR DESCRIPTION
closes #5432 

## Why was this change made? 🤔
Andrew uses this rake task. Same logic for publishing / indexing was in 3 places.


## How was this change tested? 🤨
Unit, QA.

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



