### PR TITLE
Adds workflow monitor.

### DIFF
--- a/app/services/workflow_monitor.rb
+++ b/app/services/workflow_monitor.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Monitors stuck workflows
+class WorkflowMonitor
+  # Look for "queued" steps that are more than 24 hours old
+  # and "started" steps that are more than 48 hours old
+  def self.monitor
+    new.monitor
+  end
+
+  def monitor
+    monitor_queued_steps
+    monitor_started_steps
+  end
+
+  private
+
+  def monitor_started_steps
+    steps = WorkflowStep.started
+                        .where(WorkflowStep.arel_table[:updated_at].lt(48.hours.ago))
+                        .order(:druid, :version)
+                        .limit(1000)
+
+    return if steps.count.zero?
+
+    Honeybadger.notify('Workflow step(s) has been running for more than 48 hours. Perhaps there is a problem.',
+                       context: context_from(steps))
+  end
+
+  def monitor_queued_steps
+    queued = WorkflowStep.queued
+                         .where(WorkflowStep.arel_table[:updated_at].lt(24.hours.ago))
+                         .order(:druid, :version)
+                         .limit(1000)
+    return if queued.count.zero?
+
+    Honeybadger.notify('Workflow step(s) have been queued for more than 24 hours. Perhaps there is a ' \
+                       'problem with the robots.', context: context_from(queued))
+  end
+
+  def context_from(steps)
+    { steps: steps.map do |step|
+      { druid: step.druid, version: step.version, workflow: step.workflow, process: step.process }
+    end }
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -33,6 +33,9 @@ env 'RAILS_LOG_LEVEL', 'warn'
 job_type :rake_hb,
          'cd :path && :environment_variable=:environment bundle exec rake --silent ":task" :output && curl --silent https://api.honeybadger.io/v1/check_in/:check_in'
 
+job_type :runner_hb,
+         "cd :path && bin/rails runner -e :environment ':task' :output && curl --silent https://api.honeybadger.io/v1/check_in/:check_in"
+
 # Suppress warnings to avoid unnecessary cron emails.
 env 'RUBYOPT', '-W0'
 
@@ -45,4 +48,9 @@ end
 every :day, at: '8:35pm' do
   set :check_in, Settings.honeybadger_checkins.missing_druids
   rake_hb 'missing_druids:unindexed_objects'
+end
+
+every 6.hours do
+  set :check_in, Settings.honeybadger_checkins.workflow_monitor
+  runner_hb 'WorkflowMonitor.monitor'
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -128,8 +128,9 @@ sidekiq:
                          # see https://github.com/sidekiq/sidekiq/wiki/Monitoring#monitoring-queue-latency
 
 honeybadger_checkins:
-  embargo_release: foo
-  missing_druids: bar
+  embargo_release: ~
+  missing_druids: ~
+  workflow_monitor: ~
 
 orcid:
   client_id: ~

--- a/spec/services/workflow_monitor_spec.rb
+++ b/spec/services/workflow_monitor_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WorkflowMonitor do
+  before do
+    allow(Honeybadger).to receive(:notify)
+
+    # On deck
+    create(:workflow_step,
+           druid: stale.druid,
+           process: 'publish',
+           version: 1,
+           status: 'waiting',
+           active_version: true)
+
+    create(:workflow_step,
+           druid: completed.druid,
+           process: 'publish',
+           version: 2,
+           status: 'waiting',
+           active_version: true)
+
+    # Started
+    create(:workflow_step,
+           druid: stale_started.druid,
+           process: 'publish',
+           version: 1,
+           status: 'waiting',
+           active_version: true)
+  end
+
+  describe '.monitor' do
+    let(:stale) do
+      create(:workflow_step,
+             process: 'start-accession',
+             version: 1,
+             status: 'queued',
+             active_version: true,
+             updated_at: 2.days.ago)
+    end
+
+    let(:completed) do
+      create(:workflow_step,
+             process: 'start-accession',
+             version: 2,
+             status: 'completed',
+             active_version: true,
+             updated_at: 1.day.ago)
+    end
+
+    let(:stale_started) do
+      create(:workflow_step,
+             process: 'start-accession',
+             version: 3,
+             status: 'started',
+             active_version: true,
+             updated_at: 2.days.ago)
+    end
+
+    it 'reports to Honeybadger' do
+      described_class.monitor
+      expect(Honeybadger).to have_received(:notify).exactly(2).times
+
+      expect(Honeybadger).to have_received(:notify)
+        .with('Workflow step(s) has been running for more than 48 hours. Perhaps there is a problem.',
+              context: { steps: [{ druid: stale_started.druid, version: stale_started.version,
+                                   workflow: stale_started.workflow, process: stale_started.process }] })
+
+      expect(Honeybadger).to have_received(:notify)
+        .with('Workflow step(s) have been queued for more than 24 hours. Perhaps there is a problem with the robots.',
+              context: { steps: [{ druid: stale.druid, version: stale.version, workflow: stale.workflow,
+                                   process: stale.process }] })
+    end
+  end
+end


### PR DESCRIPTION
refs #5433

## Why was this change made? 🤔
It lets us know when workflow is broken.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



