### PR TITLE
Use direct db queries to get workflow state

### DIFF
--- a/app/services/workflow_state_batch_service.rb
+++ b/app/services/workflow_state_batch_service.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Service for retrieving the workflow state of a batch of objects.
+class WorkflowStateBatchService
+  def self.accessioning_druids(...)
+    new(...).accessioning_druids
+  end
+
+  def self.accessioned_druids(...)
+    new(...).accessioned_druids
+  end
+
+  def self.assembling_druids(...)
+    new(...).assembling_druids
+  end
+
+  def initialize(druids:)
+    @druids = druids
+  end
+
+  # @return [Array<String>] list of druids that are currently accessioning
+  def accessioning_druids
+    WorkflowStep.where(druid: druids, active_version: true, workflow: 'accessionWF')
+                .incomplete
+                .where.not(process: 'end-accession')
+                .select(:druid).distinct.pluck(:druid)
+  end
+
+  # @return [Array<String>] list of druids that have been accessioned
+  def accessioned_druids
+    WorkflowStep.where(druid: druids, lifecycle: 'accessioned')
+                .complete
+                .select(:druid).distinct.pluck(:druid)
+  end
+
+  # rubocop:disable Rails/WhereNotWithMultipleConditions, Metrics/AbcSize
+  # @return [Array<String>] list of druids that are currently assembling
+  def assembling_druids
+    # For any of the assembly workflows, are they are incomplete workflow steps for the active version,
+    # ignoring certain final steps that might not be complete yet.
+    WorkflowStep
+      .where(druid: druids, active_version: true,
+             workflow: %w[assemblyWF wasCrawlPreassemblyWF wasSeedPreassemblyWF
+                          gisDeliveryWF ocrWF speechToTextWF gisAssemblyWF])
+      .incomplete
+      .where.not(workflow: 'assemblyWF', process: 'accessioning-initiate')
+      .where.not(workflow: 'wasCrawlPreassemblyWF', process: 'end-was-crawl-preassembly')
+      .where.not(workflow: 'wasSeedPreassemblyWF', process: 'end-was-seed-preassembly')
+      .where.not(workflow: 'gisDeliveryWF', process: 'start-accession-workflow')
+      .where.not(workflow: 'ocrWF', process: 'end-ocr')
+      .where.not(workflow: 'speechToTextWF', process: 'end-stt')
+      .select(:druid).distinct.pluck(:druid)
+  end
+  # rubocop:enable Rails/WhereNotWithMultipleConditions, Metrics/AbcSize
+
+  private
+
+  attr_reader :druids
+end

--- a/spec/requests/versions_spec.rb
+++ b/spec/requests/versions_spec.rb
@@ -279,11 +279,6 @@ RSpec.describe 'Operations regarding object versions' do
       end
 
       context 'when the object is not found' do
-        # before do
-        #   allow(VersionBatchStatusService).to receive(:new).and_raise(CocinaObjectStore::CocinaObjectNotFoundError,
-        #                                                               'Object not found')
-        # end
-
         it 'returns a not found error' do
           get '/v1/objects/druid:mx123qw2323/versions/status',
               headers: { 'Authorization' => "Bearer #{jwt}" }
@@ -364,11 +359,9 @@ RSpec.describe 'Operations regarding object versions' do
           .with(druid: druids[1], version: 2,
                 workflow_state_service: workflow_state_service2).and_return(version_service2)
         allow(WorkflowStateService).to receive(:new)
-          .with(druid: druids[0],
-                version: 1).and_return(workflow_state_service1)
+          .with(druid: druids[0], version: 1).and_return(workflow_state_service1)
         allow(WorkflowStateService).to receive(:new)
-          .with(druid: druids[1],
-                version: 2).and_return(workflow_state_service2)
+          .with(druid: druids[1], version: 2).and_return(workflow_state_service2)
       end
 
       it 'returns the version status for the provided druids' do

--- a/spec/services/workflow_state_batch_service_spec.rb
+++ b/spec/services/workflow_state_batch_service_spec.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# rubocop:disable Rails/SkipsModelValidations
+RSpec.describe WorkflowStateBatchService do
+  before do
+    allow(Settings.enabled_features).to receive(:local_wf).and_return(true)
+    allow(QueueService).to receive(:enqueue)
+  end
+
+  describe '.accessioning_druids' do
+    subject(:accessioning_druids) do
+      described_class.accessioning_druids(druids: [accessioning_druid, missing_druid, accessioned_druid,
+                                                   accessioning_druid_with_ignored_step])
+    end
+
+    let(:accessioned_druid) { 'druid:bb033gt0615' }
+    let(:accessioning_druid) { 'druid:bb033gt0616' }
+    let(:missing_druid) { 'druid:bb033gt0617' }
+    let(:accessioning_druid_with_ignored_step) { 'druid:bb033gt0618' }
+
+    before do
+      # accessioned
+      WorkflowService.create(druid: accessioned_druid, workflow_name: 'accessionWF', version: 1)
+      WorkflowStep.where(druid: accessioned_druid, active_version: true,
+                         workflow: 'accessionWF').update_all(status: 'completed')
+      # accessioning (with some steps completed)
+      WorkflowService.create(druid: accessioning_druid, workflow_name: 'accessionWF', version: 1)
+      WorkflowStep.where(druid: accessioning_druid, active_version: true,
+                         workflow: 'accessionWF').order(:id).limit(4).update_all(status: 'completed')
+      # accessioning with all completed except the last step
+      WorkflowService.create(druid: accessioning_druid_with_ignored_step, workflow_name: 'accessionWF', version: 1)
+      WorkflowStep.where(druid: accessioning_druid_with_ignored_step, active_version: true,
+                         workflow: 'accessionWF').where.not(process: 'end-accession').update_all(status: 'completed')
+    end
+
+    it 'returns the accessioning druids' do
+      expect(accessioning_druids).to contain_exactly(accessioning_druid)
+    end
+  end
+
+  describe '.accessioned_druids' do
+    subject(:accessioned_druids) do
+      described_class.accessioned_druids(druids: [accessioned_druid, missing_druid, accessioning_druid])
+    end
+
+    let(:accessioned_druid) { 'druid:bb033gt0615' }
+    let(:accessioning_druid) { 'druid:bb033gt0616' }
+    let(:missing_druid) { 'druid:bb033gt0617' }
+
+    before do
+      create(:workflow_step, druid: accessioned_druid, workflow: 'accessionWF', active_version: true,
+                             process: 'end-accession', lifecycle: 'accessioned', status: 'completed')
+      create(:workflow_step, druid: accessioning_druid, workflow: 'accessionWF', active_version: true,
+                             process: 'end-accession', lifecycle: 'accessioned', status: 'waiting')
+    end
+
+    it 'returns the accessioned druids' do
+      expect(accessioned_druids).to contain_exactly(accessioned_druid)
+    end
+  end
+
+  describe '.assembling_druids' do
+    subject(:assembling_druids) do
+      described_class.assembling_druids(
+        druids: [
+          assembling_druid, missing_druid, assembled_druid, assembling_druid_with_ignored_step,
+          was_crawl_preassembling_druid, was_crawl_preassembled_druid, was_crawl_preassembling_druid_with_ignored_step,
+          was_seed_preassembling_druid, was_seed_preassembled_druid, was_seed_preassembling_druid_with_ignored_step,
+          gis_delivering_druid, gis_delivered_druid, gis_delivering_druid_with_ignored_step,
+          ocring_druid, ocred_druid, ocring_druid_with_ignored_step,
+          stting_druid, stted_druid, stting_druid_with_ignored_step,
+          gis_assembling_druid, gis_assembled_druid
+        ]
+      )
+    end
+
+    let(:missing_druid) { 'druid:bb033gt0615' }
+    let(:assembling_druid) { 'druid:bc033gt0615' }
+    let(:assembled_druid) { 'druid:bc033gt0616' }
+    let(:assembling_druid_with_ignored_step) { 'druid:bc033gt0617' }
+    let(:was_crawl_preassembling_druid) { 'druid:bd033gt0615' }
+    let(:was_crawl_preassembled_druid) { 'druid:bd033gt0616' }
+    let(:was_crawl_preassembling_druid_with_ignored_step) { 'druid:bd033gt0617' }
+    let(:was_seed_preassembling_druid) { 'druid:bf033gt0615' }
+    let(:was_seed_preassembled_druid) { 'druid:bf033gt0616' }
+    let(:was_seed_preassembling_druid_with_ignored_step) { 'druid:bf033gt0617' }
+    let(:gis_delivering_druid) { 'druid:bg033gt0615' }
+    let(:gis_delivered_druid) { 'druid:bg033gt0616' }
+    let(:gis_delivering_druid_with_ignored_step) { 'druid:bg033gt0617' }
+    let(:ocring_druid) { 'druid:bh033gt0615' }
+    let(:ocred_druid) { 'druid:bh033gt0616' }
+    let(:ocring_druid_with_ignored_step) { 'druid:bh033gt0617' }
+    let(:stting_druid) { 'druid:bj033gt0615' }
+    let(:stted_druid) { 'druid:bj033gt0616' }
+    let(:stting_druid_with_ignored_step) { 'druid:bj033gt0617' }
+    let(:gis_assembling_druid) { 'druid:bk033gt0615' }
+    let(:gis_assembled_druid) { 'druid:bk033gt0616' }
+
+    before do
+      # assembling
+      WorkflowService.create(druid: assembling_druid, workflow_name: 'assemblyWF', version: 1)
+      WorkflowStep.where(druid: assembling_druid, active_version: true,
+                         workflow: 'assemblyWF').order(:id).limit(4).update_all(status: 'completed')
+      # assembled
+      WorkflowService.create(druid: assembled_druid, workflow_name: 'assemblyWF', version: 1)
+      WorkflowStep.where(druid: assembled_druid, active_version: true,
+                         workflow: 'assemblyWF').update_all(status: 'completed')
+      # assembling with all completed except the last step
+      WorkflowService.create(druid: assembling_druid_with_ignored_step, workflow_name: 'assemblyWF', version: 1)
+      WorkflowStep.where(druid: assembling_druid_with_ignored_step, active_version: true,
+                         workflow: 'assemblyWF').where.not(process: 'accessioning-initiate')
+                  .update_all(status: 'completed')
+
+      # wasCrawlPreassemblyWF assembling
+      WorkflowService.create(druid: was_crawl_preassembling_druid, workflow_name: 'wasCrawlPreassemblyWF', version: 1)
+      # wasCrawlPreassemblyWF assembled
+      WorkflowService.create(druid: was_crawl_preassembled_druid, workflow_name: 'wasCrawlPreassemblyWF', version: 1)
+      WorkflowStep.where(druid: was_crawl_preassembled_druid, active_version: true,
+                         workflow: 'wasCrawlPreassemblyWF').update_all(status: 'completed')
+      # wasCrawlPreassemblyWF assembling with all completed except the last step
+      WorkflowService.create(druid: was_crawl_preassembling_druid_with_ignored_step,
+                             workflow_name: 'wasCrawlPreassemblyWF', version: 1)
+      WorkflowStep.where(druid: was_crawl_preassembling_druid_with_ignored_step, active_version: true,
+                         workflow: 'wasCrawlPreassemblyWF').where.not(process: 'end-was-crawl-preassembly')
+                  .update_all(status: 'completed')
+
+      # wasSeedPreassemblyWF assembling
+      WorkflowService.create(druid: was_seed_preassembling_druid, workflow_name: 'wasSeedPreassemblyWF', version: 1)
+      # wasSeedPreassemblyWF assembled
+      WorkflowService.create(druid: was_seed_preassembled_druid, workflow_name: 'wasSeedPreassemblyWF', version: 1)
+      WorkflowStep.where(druid: was_seed_preassembled_druid, active_version: true,
+                         workflow: 'wasSeedPreassemblyWF').update_all(status: 'completed')
+      # wasSeedPreassemblyWF assembling with all completed except the last step
+      WorkflowService.create(druid: was_seed_preassembling_druid_with_ignored_step,
+                             workflow_name: 'wasSeedPreassemblyWF', version: 1)
+      WorkflowStep.where(druid: was_seed_preassembling_druid_with_ignored_step, active_version: true,
+                         workflow: 'wasSeedPreassemblyWF').where.not(process: 'end-was-seed-preassembly')
+                  .update_all(status: 'completed')
+
+      # gisDeliveryWF delivering
+      WorkflowService.create(druid: gis_delivering_druid, workflow_name: 'gisDeliveryWF', version: 1)
+      WorkflowStep.where(druid: gis_delivering_druid, active_version: true,
+                         workflow: 'gisDeliveryWF').order(:id).limit(2).update_all(status: 'completed')
+      # gisDeliveryWF delivered
+      WorkflowService.create(druid: gis_delivered_druid, workflow_name: 'gisDeliveryWF', version: 1)
+      WorkflowStep.where(druid: gis_delivered_druid, active_version: true,
+                         workflow: 'gisDeliveryWF').update_all(status: 'completed')
+      # gisDeliveryWF delivering with all completed except the last step
+      WorkflowService.create(druid: gis_delivering_druid_with_ignored_step, workflow_name: 'gisDeliveryWF', version: 1)
+      WorkflowStep.where(druid: gis_delivering_druid_with_ignored_step, active_version: true,
+                         workflow: 'gisDeliveryWF').where.not(process: 'start-accession-workflow')
+                  .update_all(status: 'completed')
+
+      # ocrWF ocring
+      WorkflowService.create(druid: ocring_druid, workflow_name: 'ocrWF', version: 1)
+      WorkflowStep.where(druid: ocring_druid, active_version: true,
+                         workflow: 'ocrWF').order(:id).limit(2).update_all(status: 'completed')
+      # ocrWF ocred
+      WorkflowService.create(druid: ocred_druid, workflow_name: 'ocrWF', version: 1)
+      WorkflowStep.where(druid: ocred_druid, active_version: true,
+                         workflow: 'ocrWF').update_all(status: 'completed')
+      # ocrWF ocring with all completed except the last step
+      WorkflowService.create(druid: ocring_druid_with_ignored_step, workflow_name: 'ocrWF', version: 1)
+      WorkflowStep.where(druid: ocring_druid_with_ignored_step, active_version: true,
+                         workflow: 'ocrWF').where.not(process: 'end-ocr')
+                  .update_all(status: 'completed')
+
+      # speechToTextWF stting
+      WorkflowService.create(druid: stting_druid, workflow_name: 'speechToTextWF', version: 1)
+      WorkflowStep.where(druid: stting_druid, active_version: true,
+                         workflow: 'speechToTextWF').order(:id).limit(2).update_all(status: 'completed')
+      # speechToTextWF stted
+      WorkflowService.create(druid: stted_druid, workflow_name: 'speechToTextWF', version: 1)
+      WorkflowStep.where(druid: stted_druid, active_version: true,
+                         workflow: 'speechToTextWF').update_all(status: 'completed')
+      # speechToTextWF stting with all completed except the last step
+      WorkflowService.create(druid: stting_druid_with_ignored_step, workflow_name: 'speechToTextWF', version: 1)
+      WorkflowStep.where(druid: stting_druid_with_ignored_step, active_version: true,
+                         workflow: 'speechToTextWF').where.not(process: 'end-stt')
+                  .update_all(status: 'completed')
+
+      # gisAssemblyWF assembling
+      WorkflowService.create(druid: gis_assembling_druid, workflow_name: 'gisAssemblyWF', version: 1)
+      WorkflowStep.where(druid: gis_assembling_druid, active_version: true,
+                         workflow: 'gisAssemblyWF').order(:id).limit(4).update_all(status: 'completed')
+      # gisAssemblyWF assembled
+      WorkflowService.create(druid: gis_assembled_druid, workflow_name: 'gisAssemblyWF', version: 1)
+      WorkflowStep.where(druid: gis_assembled_druid, active_version: true,
+                         workflow: 'gisAssemblyWF').update_all(status: 'completed')
+    end
+
+    it 'returns the assembling druids' do
+      expect(assembling_druids).to contain_exactly(assembling_druid, was_crawl_preassembling_druid,
+                                                   was_seed_preassembling_druid, gis_delivering_druid,
+                                                   ocring_druid, stting_druid, gis_assembling_druid)
+    end
+  end
+end
+# rubocop:enable Rails/SkipsModelValidations

--- a/spec/services/workflow_state_service_spec.rb
+++ b/spec/services/workflow_state_service_spec.rb
@@ -3,272 +3,350 @@
 require 'rails_helper'
 
 RSpec.describe WorkflowStateService do
-  subject(:workflow_state) { described_class.new(druid:, version:) }
+  subject(:workflow_state) { described_class.new(druid:, version: nil) }
 
   let(:druid) { 'druid:xz456jk0987' }
-  let(:version) { 1 }
-  let(:workflow_service) { instance_double(WorkflowService) }
+  let(:workflow_state_batch_service) do
+    instance_double(WorkflowStateBatchService, accessioned_druids:, accessioning_druids:, assembling_druids:)
+  end
+  let(:accessioned_druids) { [] }
+  let(:accessioning_druids) { [] }
+  let(:assembling_druids) { [] }
 
   before do
-    allow(WorkflowService).to receive(:new).and_return(workflow_service)
+    allow(WorkflowStateBatchService).to receive(:new).and_return(workflow_state_batch_service)
   end
 
   describe '.accessioned?' do
-    context 'when the object is accessioned' do
+    context 'when local workflow is enabled' do
       before do
-        allow(WorkflowLifecycleService).to receive(:milestone?).and_return(true)
+        allow(Settings.enabled_features).to receive(:local_wf).and_return(true)
       end
 
-      it 'returns true' do
-        expect(workflow_state).to be_accessioned
-        expect(WorkflowLifecycleService).to have_received(:milestone?).with(druid: druid, milestone_name: 'accessioned')
+      context 'when the object is accessioned' do
+        let(:accessioned_druids) { [druid] }
+
+        it 'returns true' do
+          expect(workflow_state).to be_accessioned
+        end
+      end
+
+      context 'when the object is not accessioned' do
+        it 'returns false' do
+          expect(workflow_state).not_to be_accessioned
+        end
       end
     end
 
-    context 'when the object is not accessioned' do
-      before do
-        allow(WorkflowLifecycleService).to receive(:milestone?).and_return(false)
+    context 'when local workflow is not enabled' do
+      context 'when the object is accessioned' do
+        before do
+          allow(WorkflowLifecycleService).to receive(:milestone?).and_return(true)
+        end
+
+        it 'returns true' do
+          expect(workflow_state).to be_accessioned
+          expect(WorkflowLifecycleService).to have_received(:milestone?).with(druid: druid,
+                                                                              milestone_name: 'accessioned')
+        end
       end
 
-      it 'returns false' do
-        expect(workflow_state).not_to be_accessioned
+      context 'when the object is not accessioned' do
+        before do
+          allow(WorkflowLifecycleService).to receive(:milestone?).and_return(false)
+        end
+
+        it 'returns false' do
+          expect(workflow_state).not_to be_accessioned
+        end
       end
     end
   end
 
   describe '.accessioning?' do
-    let(:accession_wf_response) do
-      instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'accessionWF')
-    end
-    let(:process) { instance_double(Dor::Workflow::Response::Process, name: process_name) }
+    context 'when local workflow is enabled' do
+      before do
+        allow(Settings.enabled_features).to receive(:local_wf).and_return(true)
+      end
 
-    before do
-      allow(workflow_service).to receive(:workflow).and_return(accession_wf_response)
+      context 'when the object is accessioning' do
+        let(:accessioning_druids) { [druid] }
+
+        it 'returns true' do
+          expect(workflow_state).to be_accessioning
+        end
+      end
+
+      context 'when the object is not accessioning' do
+        it 'returns false' do
+          expect(workflow_state).not_to be_accessioning
+        end
+      end
     end
 
-    context 'when there is an active accessioningWF with a non-ignored step' do
-      let(:process_name) { 'publish' } # or any other step in accessionWF except for end-accession
+    context 'when local workflow is not enabled' do
+      let(:accession_wf_response) do
+        instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'accessionWF')
+      end
+      let(:process) { instance_double(Dor::Workflow::Response::Process, name: process_name) }
+      let(:workflow_service) { instance_double(WorkflowService) }
 
       before do
-        allow(accession_wf_response).to receive_messages(active_for?: true,
-                                                         incomplete_processes_for: [
-                                                           process, process
-                                                         ])
+        allow(WorkflowService).to receive(:new).and_return(workflow_service)
+        allow(workflow_service).to receive(:workflow).and_return(accession_wf_response)
       end
 
-      it 'returns true' do
-        expect(workflow_state).to be_accessioning
-        expect(workflow_service).to have_received(:workflow).with(workflow_name: 'accessionWF')
+      context 'when there is an active accessioningWF with a non-ignored step' do
+        let(:process_name) { 'publish' } # or any other step in accessionWF except for end-accession
+
+        before do
+          allow(accession_wf_response).to receive_messages(active_for?: true,
+                                                           incomplete_processes_for: [
+                                                             process, process
+                                                           ])
+        end
+
+        it 'returns true' do
+          expect(workflow_state).to be_accessioning
+          expect(workflow_service).to have_received(:workflow).with(workflow_name: 'accessionWF')
+        end
       end
-    end
 
-    context 'when there is an active accessioningWF with an ignored step' do
-      let(:process_name) { 'end-accession' } # this step is ignored in the check for active accessioning steps
+      context 'when there is an active accessioningWF with an ignored step' do
+        let(:process_name) { 'end-accession' } # this step is ignored in the check for active accessioning steps
 
-      before do
-        allow(accession_wf_response).to receive_messages(active_for?: true,
-                                                         incomplete_processes_for: [
-                                                           process, process
-                                                         ])
+        before do
+          allow(accession_wf_response).to receive_messages(active_for?: true,
+                                                           incomplete_processes_for: [
+                                                             process, process
+                                                           ])
+        end
+
+        it 'returns false' do
+          expect(workflow_state).not_to be_accessioning
+        end
       end
 
-      it 'returns false' do
-        expect(workflow_state).not_to be_accessioning
-      end
-    end
-
-    context 'when there is not an active accessioningWF' do
-      it 'returns false' do
-        expect(workflow_state).not_to be_accessioning
+      context 'when there is not an active accessioningWF' do
+        it 'returns false' do
+          expect(workflow_state).not_to be_accessioning
+        end
       end
     end
   end
 
   describe '.assembling?' do
-    let(:assembly_wf_response) do
-      instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'assemblyWF')
-    end
-    let(:was_crawl_preassembly_wf_response) do
-      instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'wasCrawlPreassemblyWF')
-    end
-    let(:was_seed_preassembly_wf_response) do
-      instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'wasSeedPreassemblyWF')
-    end
-    let(:gis_delivery_wf_response) do
-      instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'gisDeliveryWF')
-    end
-    let(:gis_assembly_wf_response) do
-      instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'gisAssemblyWF')
-    end
-    let(:ocr_wf_response) do
-      instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'ocrWF')
-    end
-    let(:stt_wf_response) do
-      instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'speechToTextWF')
-    end
-    let(:workflow_responses) do
-      instance_double(Dor::Workflow::Response::Workflows, workflows: [
-                        assembly_wf_response, was_crawl_preassembly_wf_response, was_seed_preassembly_wf_response,
-                        gis_delivery_wf_response, gis_assembly_wf_response, ocr_wf_response, stt_wf_response
-                      ])
-    end
-    let(:process) { instance_double(Dor::Workflow::Response::Process, name: 'arbitrary') }
-
-    before do
-      allow(workflow_service).to receive(:workflow).with(workflow_name: 'assemblyWF').and_return(assembly_wf_response)
-      allow(workflow_service).to receive(:workflow).with(workflow_name: 'wasCrawlPreassemblyWF')
-                                                   .and_return(was_crawl_preassembly_wf_response)
-      allow(workflow_service).to receive(:workflow).with(workflow_name: 'wasSeedPreassemblyWF')
-                                                   .and_return(was_seed_preassembly_wf_response)
-      allow(workflow_service).to receive(:workflow).with(workflow_name: 'gisDeliveryWF')
-                                                   .and_return(gis_delivery_wf_response)
-      allow(workflow_service).to receive(:workflow).with(workflow_name: 'gisAssemblyWF')
-                                                   .and_return(gis_assembly_wf_response)
-      allow(workflow_service).to receive(:workflow).with(workflow_name: 'ocrWF').and_return(ocr_wf_response)
-      allow(workflow_service).to receive(:workflow).with(workflow_name: 'speechToTextWF').and_return(stt_wf_response)
-    end
-
-    context 'when there is an active assemblyWF' do
+    context 'when local workflow is enabled' do
       before do
-        allow(assembly_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [process, process])
+        allow(Settings.enabled_features).to receive(:local_wf).and_return(true)
       end
 
-      it 'returns true' do
-        expect(workflow_state).to be_assembling
-      end
-    end
+      context 'when the object is assembling' do
+        let(:assembling_druids) { [druid] }
 
-    context 'when there is an active wasCrawlPreassemblyWF' do
-      before do
-        allow(was_crawl_preassembly_wf_response).to receive_messages(active_for?: true,
-                                                                     incomplete_processes_for: [
-                                                                       process, process
-                                                                     ])
+        it 'returns true' do
+          expect(workflow_state).to be_assembling
+        end
       end
 
-      it 'returns true' do
-        expect(workflow_state).to be_assembling
+      context 'when the object is not assembling' do
+        it 'returns false' do
+          expect(workflow_state).not_to be_assembling
+        end
       end
     end
 
-    context 'when there is an active wasSeedPreassemblyWF' do
-      before do
-        allow(was_seed_preassembly_wf_response).to receive_messages(active_for?: true,
-                                                                    incomplete_processes_for: [
-                                                                      process, process
-                                                                    ])
+    context 'when local workflow is not enabled' do
+      let(:assembly_wf_response) do
+        instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'assemblyWF')
       end
-
-      it 'returns true' do
-        expect(workflow_state).to be_assembling
+      let(:was_crawl_preassembly_wf_response) do
+        instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'wasCrawlPreassemblyWF')
       end
-    end
-
-    context 'when there is an active gisDeliveryWF (multiple processes)' do
-      before do
-        allow(gis_delivery_wf_response).to receive_messages(active_for?: true,
-                                                            incomplete_processes_for: [
-                                                              process, process
-                                                            ])
+      let(:was_seed_preassembly_wf_response) do
+        instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'wasSeedPreassemblyWF')
       end
-
-      it 'returns true' do
-        expect(workflow_state).to be_assembling
+      let(:gis_delivery_wf_response) do
+        instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'gisDeliveryWF')
       end
-    end
-
-    context 'when there is an active gisDeliveryWF (single wrong process)' do
-      let(:process) { instance_double(Dor::Workflow::Response::Process, name: 'not-the-step') }
+      let(:gis_assembly_wf_response) do
+        instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'gisAssemblyWF')
+      end
+      let(:ocr_wf_response) do
+        instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'ocrWF')
+      end
+      let(:stt_wf_response) do
+        instance_double(Dor::Workflow::Response::Workflow, active_for?: false, workflow_name: 'speechToTextWF')
+      end
+      let(:workflow_responses) do
+        instance_double(Dor::Workflow::Response::Workflows, workflows: [
+                          assembly_wf_response, was_crawl_preassembly_wf_response, was_seed_preassembly_wf_response,
+                          gis_delivery_wf_response, gis_assembly_wf_response, ocr_wf_response, stt_wf_response
+                        ])
+      end
+      let(:process) { instance_double(Dor::Workflow::Response::Process, name: 'arbitrary') }
+      let(:workflow_service) { instance_double(WorkflowService) }
 
       before do
-        allow(gis_delivery_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [process])
+        allow(WorkflowService).to receive(:new).and_return(workflow_service)
+        allow(workflow_service).to receive(:workflow).with(workflow_name: 'assemblyWF').and_return(assembly_wf_response)
+        allow(workflow_service).to receive(:workflow).with(workflow_name: 'wasCrawlPreassemblyWF')
+                                                     .and_return(was_crawl_preassembly_wf_response)
+        allow(workflow_service).to receive(:workflow).with(workflow_name: 'wasSeedPreassemblyWF')
+                                                     .and_return(was_seed_preassembly_wf_response)
+        allow(workflow_service).to receive(:workflow).with(workflow_name: 'gisDeliveryWF')
+                                                     .and_return(gis_delivery_wf_response)
+        allow(workflow_service).to receive(:workflow).with(workflow_name: 'gisAssemblyWF')
+                                                     .and_return(gis_assembly_wf_response)
+        allow(workflow_service).to receive(:workflow).with(workflow_name: 'ocrWF').and_return(ocr_wf_response)
+        allow(workflow_service).to receive(:workflow).with(workflow_name: 'speechToTextWF').and_return(stt_wf_response)
       end
 
-      it 'returns true' do
-        expect(workflow_state).to be_assembling
-      end
-    end
+      context 'when there is an active assemblyWF' do
+        before do
+          allow(assembly_wf_response).to receive_messages(active_for?: true,
+                                                          incomplete_processes_for: [
+                                                            process, process
+                                                          ])
+        end
 
-    context 'when there is an active gisAssemblyWF' do
-      before do
-        allow(gis_assembly_wf_response).to receive_messages(active_for?: true, complete_for?: false)
-      end
-
-      it 'returns true' do
-        expect(workflow_state).to be_assembling
-      end
-    end
-
-    context 'when there is an active ocrWF' do
-      before do
-        allow(ocr_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [process, process])
+        it 'returns true' do
+          expect(workflow_state).to be_assembling
+        end
       end
 
-      it 'returns true' do
-        expect(workflow_state).to be_assembling
-      end
-    end
+      context 'when there is an active wasCrawlPreassemblyWF' do
+        before do
+          allow(was_crawl_preassembly_wf_response).to receive_messages(active_for?: true,
+                                                                       incomplete_processes_for: [
+                                                                         process, process
+                                                                       ])
+        end
 
-    context 'when there is an active speechToTextWF' do
-      before do
-        allow(stt_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [process, process])
-      end
-
-      it 'returns true' do
-        expect(workflow_state).to be_assembling
-      end
-    end
-
-    context 'when only ignored steps are incomplete' do
-      let(:accessioning_initiate_process) do
-        instance_double(Dor::Workflow::Response::Process, name: 'accessioning-initiate')
-      end
-      let(:end_was_crawl_process) do
-        instance_double(Dor::Workflow::Response::Process, name: 'end-was-crawl-preassembly')
-      end
-      let(:end_was_seed_process) { instance_double(Dor::Workflow::Response::Process, name: 'end-was-seed-preassembly') }
-      let(:start_accession_process) do
-        instance_double(Dor::Workflow::Response::Process, name: 'start-accession-workflow')
-      end
-      let(:end_ocr_process) { instance_double(Dor::Workflow::Response::Process, name: 'end-ocr') }
-      let(:end_stt_process) { instance_double(Dor::Workflow::Response::Process, name: 'end-stt') }
-
-      before do
-        allow(assembly_wf_response).to receive_messages(active_for?: true,
-                                                        incomplete_processes_for: [accessioning_initiate_process])
-        allow(was_crawl_preassembly_wf_response).to receive_messages(active_for?: true,
-                                                                     incomplete_processes_for: [end_was_crawl_process])
-        allow(was_seed_preassembly_wf_response).to receive_messages(active_for?: true,
-                                                                    incomplete_processes_for: [end_was_seed_process])
-        allow(gis_delivery_wf_response).to receive_messages(active_for?: true,
-                                                            incomplete_processes_for: [start_accession_process])
-        allow(ocr_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [end_ocr_process])
-        allow(stt_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [end_stt_process])
+        it 'returns true' do
+          expect(workflow_state).to be_assembling
+        end
       end
 
-      it 'returns false' do
-        expect(workflow_state).not_to be_assembling
-      end
-    end
+      context 'when there is an active wasSeedPreassemblyWF' do
+        before do
+          allow(was_seed_preassembly_wf_response).to receive_messages(active_for?: true,
+                                                                      incomplete_processes_for: [
+                                                                        process, process
+                                                                      ])
+        end
 
-    context 'when there are no incomplete steps' do
-      before do
-        allow(assembly_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [])
-        allow(was_crawl_preassembly_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [])
-        allow(was_seed_preassembly_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [])
-        allow(gis_delivery_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [])
-        allow(ocr_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [])
-        allow(stt_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [])
+        it 'returns true' do
+          expect(workflow_state).to be_assembling
+        end
       end
 
-      it 'returns false' do
-        expect(workflow_state).not_to be_assembling
-      end
-    end
+      context 'when there is an active gisDeliveryWF (multiple processes)' do
+        before do
+          allow(gis_delivery_wf_response).to receive_messages(active_for?: true,
+                                                              incomplete_processes_for: [
+                                                                process, process
+                                                              ])
+        end
 
-    context 'when there are no assembly workflows' do
-      it 'returns false' do
-        expect(workflow_state).not_to be_assembling
+        it 'returns true' do
+          expect(workflow_state).to be_assembling
+        end
+      end
+
+      context 'when there is an active gisDeliveryWF (single wrong process)' do
+        let(:process) { instance_double(Dor::Workflow::Response::Process, name: 'not-the-step') }
+
+        before do
+          allow(gis_delivery_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [process])
+        end
+
+        it 'returns true' do
+          expect(workflow_state).to be_assembling
+        end
+      end
+
+      context 'when there is an active gisAssemblyWF' do
+        before do
+          allow(gis_assembly_wf_response).to receive_messages(active_for?: true, complete_for?: false)
+        end
+
+        it 'returns true' do
+          expect(workflow_state).to be_assembling
+        end
+      end
+
+      context 'when there is an active ocrWF' do
+        before do
+          allow(ocr_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [process, process])
+        end
+
+        it 'returns true' do
+          expect(workflow_state).to be_assembling
+        end
+      end
+
+      context 'when there is an active speechToTextWF' do
+        before do
+          allow(stt_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [process, process])
+        end
+
+        it 'returns true' do
+          expect(workflow_state).to be_assembling
+        end
+      end
+
+      context 'when only ignored steps are incomplete' do
+        let(:accessioning_initiate_process) do
+          instance_double(Dor::Workflow::Response::Process, name: 'accessioning-initiate')
+        end
+        let(:end_was_crawl_process) do
+          instance_double(Dor::Workflow::Response::Process, name: 'end-was-crawl-preassembly')
+        end
+        let(:end_was_seed_process) { instance_double(Dor::Workflow::Response::Process, name: 'end-was-seed-preassembly') }
+        let(:start_accession_process) do
+          instance_double(Dor::Workflow::Response::Process, name: 'start-accession-workflow')
+        end
+        let(:end_ocr_process) { instance_double(Dor::Workflow::Response::Process, name: 'end-ocr') }
+        let(:end_stt_process) { instance_double(Dor::Workflow::Response::Process, name: 'end-stt') }
+
+        before do
+          allow(assembly_wf_response).to receive_messages(active_for?: true,
+                                                          incomplete_processes_for: [accessioning_initiate_process])
+          allow(was_crawl_preassembly_wf_response)
+            .to receive_messages(active_for?: true, incomplete_processes_for: [end_was_crawl_process])
+          allow(was_seed_preassembly_wf_response).to receive_messages(active_for?: true,
+                                                                      incomplete_processes_for: [end_was_seed_process])
+          allow(gis_delivery_wf_response).to receive_messages(active_for?: true,
+                                                              incomplete_processes_for: [start_accession_process])
+          allow(ocr_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [end_ocr_process])
+          allow(stt_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [end_stt_process])
+        end
+
+        it 'returns false' do
+          expect(workflow_state).not_to be_assembling
+        end
+      end
+
+      context 'when there are no incomplete steps' do
+        before do
+          allow(assembly_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [])
+          allow(was_crawl_preassembly_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [])
+          allow(was_seed_preassembly_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [])
+          allow(gis_delivery_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [])
+          allow(ocr_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [])
+          allow(stt_wf_response).to receive_messages(active_for?: true, incomplete_processes_for: [])
+        end
+
+        it 'returns false' do
+          expect(workflow_state).not_to be_assembling
+        end
+      end
+
+      context 'when there are no assembly workflows' do
+        it 'returns false' do
+          expect(workflow_state).not_to be_assembling
+        end
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔
So that there is only one approach to getting workflow state.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



