### PR TITLE
Uses local workflow services in DSA robots.

### DIFF
--- a/app/jobs/robots/robot.rb
+++ b/app/jobs/robots/robot.rb
@@ -8,7 +8,62 @@ module Robots
     end
 
     def object_client
-      raise 'Object Client should not be used from a DSA robot'
+      raise '.object_client should not be used from a DSA robot'
+    end
+
+    private
+
+    def workflow
+      @workflow ||= RobotWorkflow.new(workflow_name: workflow_name, process: process, druid:)
+    end
+
+    # This encapsulates the workflow operations that lyber-core does.
+    # This implementation uses local services instead of the dor-services-client.
+    # It should have the same interface as LyberCore::Workflow.
+    class RobotWorkflow
+      def initialize(workflow_name:, process:, druid:)
+        @workflow_name = workflow_name
+        @process = process
+        @druid = druid
+      end
+
+      def object_workflow
+        raise '.object_workflow should not be used from a DSA robot'
+      end
+
+      def workflow_process
+        raise '.workflow_process should not be used from a DSA robot'
+      end
+
+      # @return [Dor::Services::Response::Workflow] for druid/workflow/step on which this instance was initialized
+      def workflow_response
+        @workflow_response ||= Workflow::Service.workflow(druid:, workflow_name: workflow_name)
+      end
+
+      # @return [Dor::Services::Response::Process] for druid/workflow/step on which this instance was initialized
+      def process_response
+        @process_response ||= workflow_response.process_for_recent_version(name: process)
+      end
+
+      def start!(note)
+        Workflow::ProcessService.update(druid:, workflow_name:, process:, status: 'started', note:, elapsed: 1.0)
+      end
+
+      def complete!(status, elapsed, note)
+        Workflow::ProcessService.update(druid:, workflow_name:, process:, status:, note:, elapsed:)
+      end
+
+      def retrying!
+        Workflow::ProcessService.update(druid:, workflow_name:, process:, status: 'retrying', note: nil, elapsed: 1.0)
+      end
+
+      def error!(error_msg, error_text)
+        Workflow::ProcessService.update_error(druid:, workflow_name:, process:, error_msg:, error_text:)
+      end
+
+      delegate :context, :status, :lane_id, to: :process_response
+
+      attr_reader :workflow_name, :process, :druid
     end
   end
 end

--- a/spec/jobs/robots/dor_repo/accession/sdr_ingest_transfer_spec.rb
+++ b/spec/jobs/robots/dor_repo/accession/sdr_ingest_transfer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Robots::DorRepo::Accession::SdrIngestTransfer, type: :robot do
 
   let(:druid) { 'druid:zz000zz0001' }
   let(:robot) { described_class.new }
-  let(:workflow_service) { instance_double(Dor::Workflow::Client) }
+  let(:workflow) { instance_double(Dor::Workflow::Response::Workflow, process_for_recent_version: process) }
   let(:process) { instance_double(Dor::Workflow::Response::Process, lane_id: 'low') }
   let(:object) { build(:dro, id: druid) }
 
@@ -15,8 +15,8 @@ RSpec.describe Robots::DorRepo::Accession::SdrIngestTransfer, type: :robot do
     allow(CocinaObjectStore).to receive(:find).with(druid).and_return(object)
     allow(PreservationIngestService).to receive(:transfer)
     allow(Workflow::Service).to receive(:create)
-    allow(Dor::Workflow::Client).to receive(:new).and_return(workflow_service)
-    allow(workflow_service).to receive(:process).and_return(process)
+    allow(Workflow::Service).to receive(:workflow).with(druid:,
+                                                        workflow_name: 'accessionWF').and_return(workflow)
   end
 
   it 'preserves the object' do

--- a/spec/jobs/robots/robot_spec.rb
+++ b/spec/jobs/robots/robot_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# A test robot.
+class TestRobot < Robots::Robot
+  def initialize
+    super('testWF', 'test-step')
+  end
+
+  def perform_work; end
+end
+
+RSpec.describe Robots::Robot do
+  subject(:robot) { TestRobot.new }
+
+  describe '#object_client' do
+    it 'raises an error' do
+      expect { robot.object_client }.to raise_error(RuntimeError, '.object_client should not be used from a DSA robot')
+    end
+  end
+
+  describe '#perform' do
+    let(:robot_workflow) { instance_double(Robots::Robot::RobotWorkflow, status: 'queued', start!: true, complete!: true) }
+
+    before do
+      allow(Robots::Robot::RobotWorkflow).to receive(:new).and_return(robot_workflow)
+    end
+
+    it 'invokes a RobotWorkflow' do
+      robot.perform('druid:gv054hp4128')
+      expect(robot.send(:workflow)).to be robot_workflow
+      expect(Robots::Robot::RobotWorkflow).to have_received(:new).with(workflow_name: 'testWF', process: 'test-step',
+                                                                       druid: 'druid:gv054hp4128')
+      expect(robot_workflow).to have_received(:start!).with(Socket.gethostname)
+      expect(robot_workflow).to have_received(:complete!).with('completed', Float, Socket.gethostname)
+    end
+  end
+
+  describe Robots::Robot::RobotWorkflow do
+    subject(:workflow) do
+      described_class.new(workflow_name: 'testWF', process: 'test-step', druid: 'druid:gv054hp4128')
+    end
+
+    let(:workflow_response) { instance_double(Dor::Workflow::Response::Workflow, process_for_recent_version: process_response) }
+    let(:process_response) { instance_double(Dor::Workflow::Response::Process, name: 'test-step', status: 'waiting', lane_id: 'low', context: { foo: 'bar' }) }
+
+    before do
+      allow(Workflow::Service).to receive(:workflow).and_return(workflow_response)
+      allow(Workflow::ProcessService).to receive(:update)
+      allow(Workflow::ProcessService).to receive(:update_error)
+    end
+
+    describe '.object_workflow' do
+      it 'raises an error' do
+        expect { workflow.object_workflow }.to raise_error(RuntimeError)
+      end
+    end
+
+    describe '.workflow_process' do
+      it 'raises an error' do
+        expect { workflow.workflow_process }.to raise_error(RuntimeError)
+      end
+    end
+
+    describe '.workflow_response' do
+      it 'returns the workflow response for the given druid and workflow name' do
+        expect(workflow.workflow_response).to eq(workflow_response)
+        expect(Workflow::Service).to have_received(:workflow).with(druid: 'druid:gv054hp4128', workflow_name: 'testWF')
+      end
+    end
+
+    describe '.process_response' do
+      it 'returns the process response for the given process name' do
+        expect(workflow.process_response).to eq(process_response)
+        expect(workflow_response).to have_received(:process_for_recent_version).with(name: 'test-step')
+      end
+    end
+
+    describe '.start!' do
+      it 'updates the workflow process status to started' do
+        workflow.start!('Starting workflow')
+        expect(Workflow::ProcessService).to have_received(:update)
+          .with(druid: 'druid:gv054hp4128', workflow_name: 'testWF',
+                process: 'test-step', status: 'started', note: 'Starting workflow', elapsed: 1.0)
+      end
+    end
+
+    describe '.complete!' do
+      it 'updates the workflow process status to completed' do
+        workflow.complete!('completed', 1.0, 'Workflow completed successfully')
+        expect(Workflow::ProcessService).to have_received(:update)
+          .with(druid: 'druid:gv054hp4128', workflow_name: 'testWF',
+                process: 'test-step', status: 'completed', note: 'Workflow completed successfully', elapsed: 1.0)
+      end
+    end
+
+    describe '.retrying!' do
+      it 'updates the workflow process status to retrying' do
+        workflow.retrying!
+        expect(Workflow::ProcessService).to have_received(:update)
+          .with(druid: 'druid:gv054hp4128', workflow_name: 'testWF',
+                process: 'test-step', status: 'retrying', note: nil, elapsed: 1.0)
+      end
+    end
+
+    describe '.error!' do
+      it 'updates the workflow process status to error' do
+        workflow.error!('An error occurred', 'Detailed error information')
+        expect(Workflow::ProcessService).to have_received(:update_error)
+          .with(druid: 'druid:gv054hp4128', workflow_name: 'testWF',
+                process: 'test-step', error_msg: 'An error occurred', error_text: 'Detailed error information')
+      end
+    end
+
+    describe '.status' do
+      it 'returns the status of the process response' do
+        expect(workflow.status).to eq('waiting')
+      end
+    end
+
+    describe '.lane_id' do
+      it 'returns the lane_id of the process response' do
+        expect(workflow.lane_id).to eq('low')
+      end
+    end
+
+    describe '.context' do
+      it 'returns the context of the process response' do
+        expect(workflow.context).to eq({ foo: 'bar' })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔
The default for a robot is to invoke workflow operations via DSC. For robots running within DSA, workflow operations can be invoked directly.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



