### PR TITLE
Enable local_wf by default.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,7 @@ enabled_features:
   create_ur_admin_policy: false
   datacite_update: false
   orcid_update: true
-  local_wf: false
+  local_wf: true
 
 # Ur Admin Policy
 ur_admin_policy:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -2,3 +2,6 @@ catalog:
   folio:
     max_lookup_tries: 3
     sleep_seconds: 0
+
+enabled_features:
+  local_wf: false


### PR DESCRIPTION
## Why was this change made? 🤔
So that docker images are built using local workflow. This will allow removing the workflow server images from Argo, etc.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



