### PR TITLE
Add reliable push config for Sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -21,3 +21,5 @@ end
 ROBOT_SIDEKIQ_CLIENT = Sidekiq::Client.new(
   pool: ConnectionPool.new { Redis.new(url: Settings.robots_redis_url) }
 )
+
+Sidekiq::Client.reliable_push! unless Rails.env.test?


### PR DESCRIPTION
## Why was this change made? 🤔
Reliability when there are redis network issues.

This is the same config as currently in workflow server.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



