### PR TITLE
If a non DOI URL is used as a related work, use it as title

### DIFF
--- a/app/services/cocina/to_datacite/related_resource.rb
+++ b/app/services/cocina/to_datacite/related_resource.rb
@@ -109,7 +109,7 @@ module Cocina
       end
 
       def related_item_title
-        @related_item_title ||= preferred_citation || other_title || related_item_doi
+        @related_item_title ||= preferred_citation || other_title || related_item_doi || related_item_identifier_url
       end
 
       # example cocina relatedResource:

--- a/spec/services/cocina/to_datacite/related_resource_spec.rb
+++ b/spec/services/cocina/to_datacite/related_resource_spec.rb
@@ -97,7 +97,8 @@ RSpec.describe Cocina::ToDatacite::RelatedResource do
         relatedItemType: 'Other',
         relationType: 'References',
         relatedItemIdentifier: 'https://example.com/resource',
-        relatedItemIdentifierType: 'URL'
+        relatedItemIdentifierType: 'URL',
+        titles: [{ title: 'https://example.com/resource' }]
       )
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Datacite updates are missing the title if a non-DOI URL is provided as a related work.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



