### PR TITLE
Change strategy for HB alerting for reindexing deadlocks.

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -9,6 +9,7 @@ exceptions:
 stage:
   exceptions:
     ignore:
+      - 'ReindexJob::DeadLockError'
       - 'PreservationIngestService::VersionMismatchError'      
 insights:
   enabled: false


### PR DESCRIPTION
closes #5487

## Why was this change made? 🤔
We were getting too many alerts.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



