### PR TITLE
Remove hb alert when out of reindex retries.

### DIFF
--- a/app/jobs/reindex_job.rb
+++ b/app/jobs/reindex_job.rb
@@ -7,14 +7,7 @@ class ReindexJob < ApplicationJob
   queue_as :default
 
   # ~3 seconds, ~18 seconds, ~83 seconds. If this fails, Sidekiq retries are not used.
-  retry_on DeadLockError, attempts: 3, wait: :polynomially_longer, queue: :low do |job, _error|
-    # Only notify Honeybadger when we're giving up
-    Honeybadger.notify('ReindexJob::DeadLockError out of retries', context: {
-                         druid: job.arguments.first[:druid],
-                         trace_id: job.arguments.first[:trace_id],
-                         attempts: job.executions
-                       })
-  end
+  retry_on DeadLockError, attempts: 3, wait: :polynomially_longer, queue: :low
   sidekiq_options retry: false
 
   # @param [String] druid


### PR DESCRIPTION
## Why was this change made? 🤔
Extraneous alerts in stage.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



