### PR TITLE
Adding report for non-URI external identifiers

### DIFF
--- a/app/reports/external_identifier_uris.rb
+++ b/app/reports/external_identifier_uris.rb
@@ -19,11 +19,8 @@ class ExternalIdentifierUris
         AND ro.object_type = 'dro'
     ) Q1
     WHERE
-      external_id IS NOT NULL
-      AND (
-        external_id NOT LIKE 'http%' 
-        OR external_id LIKE 'http%http%'
-      );
+      external_id NOT LIKE 'http%'
+      OR external_id LIKE 'http%http%';
   SQL
 
   def self.report


### PR DESCRIPTION
## Why was this change made? 🤔

Generate a report of FileSet External Identiifers where the value is either not a URL, or multiple URLs concatenated in the same string.

Refs https://github.com/sul-dlss/purl/issues/1454

## How was this change tested? 🤨

Ran on QA.

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



