### PR TITLE
Update invalid_edtf_date report to look for 'XXXX'

### DIFF
--- a/app/reports/invalid_edtf_dates.rb
+++ b/app/reports/invalid_edtf_dates.rb
@@ -88,6 +88,8 @@ class InvalidEdtfDates
   end
 
   def self.valid_edtf?(date_value)
+    return false if date_value == 'XXXX' # https://github.com/inukshuk/edtf-ruby/issues/41
+
     # edtf! raises error if it can't parse it
     Date.edtf!(date_value) ? true : false
   rescue ArgumentError


### PR DESCRIPTION


## Why was this change made? 🤔
This doesn't appear valid to the EDTF spec, however the EDTF gem still validates it.



