### PR TITLE
Change sidekiq config for active jobs.

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,9 +2,6 @@
 
 # Common superclass for all jobs
 class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
-
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
+  # See config/initializers/sidekiq.rb for explanation.
+  sidekiq_options pool: REDIS
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -13,6 +13,9 @@ Sidekiq.configure_server do |config|
   end
 end
 
+# The redis instance is also set in ApplicationJob.
+# This is because we were encountering issues with active jobs
+# getting enqueued to the wrong Redis instance.
 Sidekiq.configure_client do |config|
   config.redis = { url: Settings.redis_url }
 end


### PR DESCRIPTION
refs https://github.com/sul-dlss/argo/issues/4653

## Why was this change made? 🤔
To try to ensure that the correct redis instance is used for Active Jobs.


## How was this change tested? 🤨
stage

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



