### PR TITLE
Use batch reindexing jobs instead of rolling indexer to reindex everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,33 +101,13 @@ Cron check-ins are configured in the following locations:
 3. `config/settings/production.yml` in `shared_configs`: This contains the actual check-in keys.
 4. HB notification page: Check-ins are configured per project in HB. To configure a check-in, the cron schedule will be needed, which can be found with `bundle exec whenever`. After a check-in is created, the check-in key will be available. (If the URL is `https://api.honeybadger.io/v1/check_in/rkIdpB` then the check-in key will be `rkIdpB`).
 
-## Rolling (Re)Indexer
+## Reindexing all objects
 
-(This runs here so it has efficient access to the cocina for each object.)
+A full reindex can be invoked with `bundle exec rake indexer:reindex_jobs`.
 
-This helps keep the index fresh by reindexing the oldest data. It is managed as a systemd service. To interact with it from your machine, you can use Capistrano:
+This will enqueue a number of `BatchReindexJob`s.
 
-```shell
-$ cap ENV rolling_indexer:status
-$ cap ENV rolling_indexer:start
-$ cap ENV rolling_indexer:stop
-$ cap ENV rolling_indexer:restart
-```
-
-Or if you're on a server that has the `rolling_indexer` capistrano role, use systemd commands:
-
-```shell
-$ sudo systemctl status rolling-index
-$ sudo systemctl start rolling-index
-$ sudo systemctl stop rolling-index
-$ sudo systemctl restart rolling-index
-```
-
-**NOTE 1**: The rolling indexer is automatically restarted during deployments.
-
-**NOTE 2**: The rolling indexer runs only on one node per environment. Conventionally, this is the `-a` node, but for production, it is dor-services-worker-prod-b.
-
-**NOTE 3**: The rolling indexer logs to `{capistrano_shared_dir}/log/rolling_indexer.log`
+A full reindex is scheduled to happen periodically to make sure that all objects have the latest indexing.
 
 ## Robots
 

--- a/app/jobs/batch_reindex_job.rb
+++ b/app/jobs/batch_reindex_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Reindexes a batch of objects.
+class BatchReindexJob < ApplicationJob
+  queue_as 'batch_reindex'
+
+  def perform(druids)
+    start_time = Time.zone.now
+    solr_docs = []
+    RepositoryObject.includes(:head_version).where(external_identifier: druids).find_each do |repository_object|
+      solr_docs << Indexing::Builders::DocumentBuilder.for(
+        model: repository_object.head_version.to_cocina_with_metadata,
+        trace_id: Indexer.trace_id_for(druid: repository_object.external_identifier)
+      ).to_solr
+    end
+    solr_conn.add(solr_docs, add_attributes: { commitWithin: 500 })
+    log_duration(start_time:, druids:)
+  end
+
+  def solr_conn
+    RSolr.connect(timeout: 120, open_timeout: 120, url: Settings.solr.url)
+  end
+
+  def log_duration(start_time:, druids:)
+    batch_duration = Time.zone.now - start_time
+    Rails.logger.info("Batch reindexed #{druids.size} objects in #{batch_duration.round(0)} secs " \
+                      "(#{(batch_duration / druids.size).round(2)} secs / object)")
+  end
+end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -107,6 +107,7 @@ namespace :rolling_indexer do
   end
 end
 
+# TODO: Fully remove rolling_indexer from deploy. See https://github.com/sul-dlss/dor-services-app/issues/5517
 after 'deploy:starting', 'rolling_indexer:stop'
-after 'deploy:published', 'rolling_indexer:start'
+# after 'deploy:published', 'rolling_indexer:start'
 after 'deploy:failed', 'rolling_indexer:restart'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -45,7 +45,7 @@ every :day, at: '2:16am' do
 end
 
 # Run this an on off minute to avoid Google Books every 15 minutes
-every :day, at: '8:35pm' do
+every :day, at: '6:35am' do
   set :check_in, Settings.honeybadger_checkins.missing_druids
   rake_hb 'missing_druids:unindexed_objects'
 end
@@ -53,4 +53,9 @@ end
 every 6.hours do
   set :check_in, Settings.honeybadger_checkins.workflow_monitor
   runner_hb 'Workflow::Monitor.monitor'
+end
+
+# TODO: Add HB check-in. See https://github.com/sul-dlss/dor-services-app/issues/5517
+every :friday, at: '8:00pm' do
+  rake_hb 'indexer:reindex_jobs'
 end

--- a/lib/tasks/indexer.rake
+++ b/lib/tasks/indexer.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :indexer do
+  desc 'Reindex all objects in jobs'
+  task :reindex_jobs, %i[batch_size] => :environment do |_task, args|
+    druids = RepositoryObject.pluck(:external_identifier)
+
+    batches = druids.each_slice(args.batch_size&.to_i || 100)
+
+    batches.each do |batch|
+      BatchReindexJob.perform_later(batch)
+    end
+  end
+end

--- a/spec/jobs/batch_reindex_job_spec.rb
+++ b/spec/jobs/batch_reindex_job_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BatchReindexJob do
+  subject(:perform) do
+    described_class.perform_now([repository_object.external_identifier, 'druid:bc123cd4567'])
+  end
+
+  let(:repository_object) { create(:repository_object, :with_repository_object_version) }
+
+  let(:conn) { instance_double(RSolr::Client, add: nil) }
+  let(:indexer) { double(Indexing::Indexers::CompositeIndexer, to_solr: solr_doc) } # rubocop:disable RSpec/VerifiedDoubles
+  let(:solr_doc) { { id: repository_object.external_identifier } }
+
+  before do
+    allow(RSolr).to receive(:connect).and_return(conn)
+    allow(Indexing::Builders::DocumentBuilder).to receive(:for).and_return(indexer)
+  end
+
+  it 'indexes' do
+    perform
+    expect(conn).to have_received(:add).with([solr_doc], add_attributes: { commitWithin: 500 })
+    expect(Indexing::Builders::DocumentBuilder).to have_received(:for).once.with(
+      model: repository_object.head_version.to_cocina_with_metadata,
+      trace_id: String
+    )
+  end
+end


### PR DESCRIPTION
refs #5518

## Why was this change made? 🤔
* Make it easier to reindex everything, in support of making changes to the solr schema.
* Use our normal machinery (jobs, cron) instead of daemon.
* Make reindexing more deterministic (it runs according to the schedule).

## How was this change tested? 🤨
QA
⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



