### PR TITLE
Drop use of XML for workflows for internal operations.

### DIFF
--- a/app/services/indexing/indexers/workflow_indexer.rb
+++ b/app/services/indexing/indexers/workflow_indexer.rb
@@ -37,7 +37,7 @@ module Indexing
       end
 
       def processes
-        @processes ||= definition_process_names.map do |process_name|
+        @processes ||= definition_process_names.filter_map do |process_name|
           workflow.process_for_recent_version(name: process_name)
         end
       end

--- a/app/services/indexing/indexers/workflow_process_indexer.rb
+++ b/app/services/indexing/indexers/workflow_process_indexer.rb
@@ -13,7 +13,7 @@ module Indexing
 
       # @param [WorkflowSolrDocument] solr_doc
       # @param [String] workflow_name
-      # @param [Dor::Services::Response::Process] process containing data for a process in a workflow for an object
+      # @param [Workflow::ProcessResponse] process containing data for a process in a workflow for an object
       def initialize(solr_doc:, workflow_name:, process:)
         @solr_doc = solr_doc
         @workflow_name = workflow_name

--- a/app/services/indexing/indexers/workflows_indexer.rb
+++ b/app/services/indexing/indexers/workflows_indexer.rb
@@ -23,7 +23,7 @@ module Indexing
 
       private
 
-      # @return [Array<Workflow::Response::Workflows>]
+      # @return [Array<Workflow::WorkflowResponse>]
       def workflows
         @workflows ||= Workflow::Service.workflows(druid: id)
       end

--- a/app/services/workflow/batch_service.rb
+++ b/app/services/workflow/batch_service.rb
@@ -25,21 +25,8 @@ module Workflow
 
     def build_workflows(druid:, steps:)
       steps_by_workflow = steps.group_by(&:workflow)
-      xml = Nokogiri::XML::Builder.new do |builder|
-        builder.workflows(objectId: druid) do
-          steps_by_workflow.each do |workflow_name, steps|
-            build_workflow(builder:, workflow_name:, steps:, druid:)
-          end
-        end
-      end.to_xml
-      Dor::Services::Response::Workflows.new(xml: Nokogiri::XML(xml)).workflows
-    end
-
-    def build_workflow(builder:, workflow_name:, steps:, druid:)
-      builder.workflow(id: workflow_name, objectId: druid) do
-        steps.each do |step|
-          builder.process(**step.attributes_for_process)
-        end
+      steps_by_workflow.map do |workflow_name, steps|
+        Workflow::WorkflowResponse.new(druid:, workflow_name:, steps:)
       end
     end
   end

--- a/app/services/workflow/process_response.rb
+++ b/app/services/workflow/process_response.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Workflow
+  # Adapts a WorkflowStep to a Dor::Services::Response::Process
+  class ProcessResponse
+    def initialize(step:)
+      @step = step
+    end
+
+    delegate :status, :elapsed, :attempts, :lifecycle, :note, :lane_id, :context, to: :step
+
+    def name
+      step.process
+    end
+
+    def datetime
+      step.updated_at.to_time.iso8601
+    end
+
+    def error_message
+      step.error_msg
+    end
+
+    def workflow_name
+      step.workflow
+    end
+
+    def pid
+      step.druid
+    end
+
+    private
+
+    attr_reader :step
+  end
+end

--- a/app/services/workflow/workflow_response.rb
+++ b/app/services/workflow/workflow_response.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Workflow
+  # Model for a workflow.
+  # Equivalent to Dor::Services::Response::Workflow, but without the XML.
+  class WorkflowResponse
+    def initialize(druid:, workflow_name:, steps:)
+      @steps = steps
+      @druid = druid
+      @workflow_name = workflow_name
+    end
+
+    attr_reader :druid, :workflow_name, :steps
+
+    def pid
+      druid
+    end
+
+    # Check if there are any processes for the provided version.
+    # @param [Integer] version the version we are checking for.
+    def active_for?(version:)
+      versions.include?(version)
+    end
+
+    def error_count
+      @error_count ||= steps_for_latest_version.count { |step| step.status == 'error' }
+    end
+
+    # Returns the process for the most recent version that matches the given name:
+    def process_for_recent_version(name:)
+      step = steps_for_latest_version.find { |step| step.process == name }
+      return unless step
+
+      ProcessResponse.new(step:)
+    end
+
+    delegate :empty?, to: :steps
+
+    # Check if all processes are skipped or complete for the provided version.
+    # @param [Integer] version the version we are checking for.
+    def complete_for?(version:)
+      incomplete_processes_for(version: version).empty?
+    end
+
+    def complete?
+      complete_for?(version: latest_version)
+    end
+
+    def incomplete_processes_for(version:)
+      steps_for_version(version: version).filter_map do |step|
+        next if %w[skipped completed].include?(step.status)
+
+        ProcessResponse.new(step:)
+      end
+    end
+
+    def incomplete_processes
+      incomplete_processes_for(version: latest_version)
+    end
+
+    private
+
+    def versions
+      @versions ||= steps_by_version.keys
+    end
+
+    def latest_version
+      @latest_version ||= versions.max
+    end
+
+    def steps_for_latest_version
+      steps_for_version(version: latest_version)
+    end
+
+    def steps_for_version(version:)
+      steps_by_version[version] || []
+    end
+
+    def steps_by_version
+      @steps_by_version ||= {}.tap do |hash|
+        steps.each do |step|
+          hash[step.version] ||= []
+          hash[step.version] << step
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/workflow_steps.rb
+++ b/spec/factories/workflow_steps.rb
@@ -16,6 +16,12 @@ FactoryBot.define do
       completed_at { Time.zone.now }
     end
 
+    trait :error do
+      status { 'error' }
+      completed_at { Time.zone.now }
+      error_msg { 'Something went wrong' }
+    end
+
     trait :with_ocr_context do
       after(:create) do |step|
         create(:version_context, druid: step.druid, version: step.version)

--- a/spec/jobs/batch_reindex_job_spec.rb
+++ b/spec/jobs/batch_reindex_job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe BatchReindexJob do
     expect(Indexing::Builders::DocumentBuilder).to have_received(:for).once.with(
       model: repository_object.head_version.to_cocina_with_metadata,
       trace_id: String,
-      workflows: [an_instance_of(Dor::Services::Response::Workflow)]
+      workflows: [an_instance_of(Workflow::WorkflowResponse)]
     )
   end
 end

--- a/spec/services/workflow/batch_service_spec.rb
+++ b/spec/services/workflow/batch_service_spec.rb
@@ -9,28 +9,14 @@ RSpec.describe Workflow::BatchService do
   describe '#workflows' do
     subject(:workflows) { described_class.workflows(druids: [druid1, druid2]) }
 
-    let(:xml1) do
-      <<~XML
-        <?xml version="1.0"?>
-        <workflow id="accessionWF" objectId="druid:bb033gt0615">
-          <process version="1" note="" lifecycle="" laneId="default" elapsed="" attempts="0" datetime="2025-07-22T21:35:36+00:00" context="{&quot;requireOCR&quot;:true,&quot;requireTranscript&quot;:true}" status="waiting" name="start-accession"/>
-        </workflow>
-      XML
-    end
-
-    let(:xml2) do
-      <<~XML
-        <?xml version="1.0"?>
-        <workflow id="accessionWF" objectId="druid:bc033gt0616">
-          <process version="2" note="" lifecycle="" laneId="default" elapsed="" attempts="0" datetime="2025-07-22T21:35:36+00:00" context="{&quot;requireOCR&quot;:true,&quot;requireTranscript&quot;:true}" status="waiting" name="start-accession"/>
-          <process version="1" note="" lifecycle="" laneId="default" elapsed="" attempts="0" datetime="2025-07-22T21:35:36+00:00" context="{&quot;requireOCR&quot;:true,&quot;requireTranscript&quot;:true}" status="waiting" name="start-accession"/>
-        </workflow>
-      XML
+    let!(:steps) do
+      [
+        create(:workflow_step, :with_ocr_context, druid: druid1, updated_at: '2025-07-22T21:35:36+00:00',
+                                                  status: 'waiting')
+      ]
     end
 
     before do
-      create(:workflow_step, :with_ocr_context, druid: druid1, updated_at: '2025-07-22T21:35:36+00:00',
-                                                status: 'waiting')
       create(:workflow_step, :with_ocr_context, druid: druid2, updated_at: '2025-07-22T21:35:36+00:00', version: 2)
       create(:workflow_step, :with_ocr_context, druid: druid2, updated_at: '2025-07-22T21:35:36+00:00',
                                                 status: 'waiting')
@@ -42,11 +28,11 @@ RSpec.describe Workflow::BatchService do
       expect(workflows).to be_a(Hash)
       expect(workflows.size).to eq 2
       expect(workflows[druid1].size).to eq 1
-      expect(workflows[druid1].first).to be_a(Dor::Services::Response::Workflow)
-      expect(workflows[druid1].first.xml).to be_equivalent_to xml1
+      workflow = workflows[druid1].first
+      expect(workflow.workflow_name).to eq 'accessionWF'
+      expect(workflow).to be_a(Workflow::WorkflowResponse)
+      expect(workflow.steps).to eq steps
       expect(workflows[druid2].size).to eq 2
-      expect(workflows[druid2].first).to be_a(Dor::Services::Response::Workflow)
-      expect(workflows[druid2].first.xml).to be_equivalent_to xml2
     end
   end
 end

--- a/spec/services/workflow/service_spec.rb
+++ b/spec/services/workflow/service_spec.rb
@@ -8,24 +8,19 @@ RSpec.describe Workflow::Service do
   describe '#workflows' do
     subject(:workflows) { described_class.workflows(druid:) }
 
-    let(:xml) do
-      <<~XML
-        <?xml version="1.0"?>
-        <workflow id="accessionWF" objectId="druid:bb033gt0615">
-          <process version="1" note="" lifecycle="" laneId="default" elapsed="" attempts="0" datetime="2025-07-22T21:35:36+00:00" context="{&quot;requireOCR&quot;:true,&quot;requireTranscript&quot;:true}" status="waiting" name="start-accession"/>
-        </workflow>
-      XML
-    end
-
-    before do
-      create(:workflow_step, :with_ocr_context, druid:, updated_at: '2025-07-22T21:35:36+00:00', status: 'waiting')
+    let!(:steps) do
+      [
+        create(:workflow_step, :with_ocr_context, druid:, updated_at: '2025-07-22T21:35:36+00:00', status: 'waiting')
+      ]
     end
 
     it 'returns workflows' do
       expect(workflows).to be_a(Array)
       expect(workflows.size).to eq 1
-      expect(workflows.first).to be_a(Dor::Services::Response::Workflow)
-      expect(workflows.first.xml).to be_equivalent_to xml
+      workflow = workflows.first
+      expect(workflow).to be_a(Workflow::WorkflowResponse)
+      expect(workflow.workflow_name).to eq 'accessionWF'
+      expect(workflow.steps).to eq steps
     end
   end
 

--- a/spec/services/workflow/workflow_response_spec.rb
+++ b/spec/services/workflow/workflow_response_spec.rb
@@ -1,0 +1,254 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# These specs are adapted from the specs for Dor::Services::Response::Workflow.
+RSpec.describe Workflow::WorkflowResponse do
+  subject(:workflow_response) { described_class.new(druid:, workflow_name:, steps:) }
+
+  let(:druid) { 'druid:mw971zk1113' }
+  let(:workflow_name) { 'assemblyWF' }
+  let(:steps) { [] }
+
+  describe '#pid' do
+    subject { workflow_response.pid }
+
+    it { is_expected.to eq 'druid:mw971zk1113' }
+  end
+
+  describe '#workflow_name' do
+    subject { workflow_response.workflow_name }
+
+    it { is_expected.to eq 'assemblyWF' }
+  end
+
+  describe '#complete?' do
+    subject { workflow_response.complete? }
+
+    context 'when all steps are complete' do
+      let(:xml) do
+        <<~XML
+          <workflow repository="dor" objectId="druid:mw971zk1113" id="assemblyWF">
+            <process version="1" laneId="default" elapsed="0.0" attempts="1" datetime="2013-02-18T14:40:25-0800" status="completed" name="start-assembly"/>
+            <process version="1" laneId="default" elapsed="0.509" attempts="1" datetime="2013-02-18T14:42:24-0800" status="completed" name="jp2-create"/>
+          </workflow>
+        XML
+      end
+
+      let(:steps) do
+        [
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly'),
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'jp2-create')
+        ]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when some steps are not complete' do
+      let(:steps) do
+        [
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly'),
+          build(:workflow_step, druid:, workflow: workflow_name, process: 'jp2-create')
+        ]
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#complete_for?' do
+    let(:steps) do
+      [
+        build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly'),
+        build(:workflow_step, druid:, workflow: workflow_name, process: 'jp2-create'),
+        build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly', version: 2),
+        build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'jp2-create', version: 2)
+      ]
+    end
+
+    context 'when all steps are complete' do
+      it 'returns true' do
+        expect(workflow_response.complete_for?(version: 2)).to be true
+      end
+    end
+
+    context 'when some steps are not complete' do
+      it 'returns false' do
+        expect(workflow_response.complete_for?(version: 1)).to be false
+      end
+    end
+  end
+
+  describe '#active_for?' do
+    subject { workflow_response.active_for?(version: 2) }
+
+    context 'when the workflow has not been instantiated for the given version' do
+      let(:steps) do
+        [
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly'),
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'jp2-create')
+        ]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the workflow has been instantiated for the given version' do
+      let(:steps) do
+        [
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly'),
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'jp2-create'),
+          build(:workflow_step, druid:, workflow: workflow_name, process: 'jp2-create', version: 2)
+        ]
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#empty?' do
+    subject { workflow_response.empty? }
+
+    context 'when there are steps' do
+      let(:steps) do
+        [
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly')
+        ]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when there are no steps' do
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#error_count' do
+    subject(:error_count) { workflow_response.error_count }
+
+    context 'when errors present in latest version' do
+      let(:steps) do
+        [
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly'),
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'jp2-create'),
+          build(:workflow_step, :error, druid:, workflow: workflow_name, process: 'jp2-create', version: 2)
+        ]
+      end
+
+      it { is_expected.to eq(1) }
+    end
+
+    context 'when no errors present in latest version' do
+      let(:steps) do
+        [
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly'),
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'jp2-create')
+        ]
+      end
+
+      it { is_expected.to eq(0) }
+    end
+
+    context 'when errors in earlier versions' do
+      let(:steps) do
+        [
+          build(:workflow_step, :error, druid:, workflow: workflow_name, process: 'start-assembly', version: 1),
+          build(:workflow_step, :error, druid:, workflow: workflow_name, process: 'jp2-create', version: 1),
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'jp2-create', version: 2)
+        ]
+      end
+
+      it { is_expected.to eq(0) }
+    end
+  end
+
+  describe '#process_for_recent_version' do
+    subject(:process) { workflow_response.process_for_recent_version(name: 'jp2-create') }
+
+    context 'when the workflow has not been instantiated for the given version' do
+      let(:steps) do
+        [
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly'),
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'jp2-create')
+        ]
+      end
+
+      it 'returns a process' do
+        expect(process).to be_a Workflow::ProcessResponse
+        expect(process.status).to eq 'completed'
+        expect(process.name).to eq 'jp2-create'
+      end
+    end
+
+    context 'when the workflow has been instantiated for the given version' do
+      let(:steps) do
+        [
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly', version: 1),
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'jp2-create', version: 1),
+          build(:workflow_step, :error, druid:, workflow: workflow_name, process: 'jp2-create', version: 2)
+        ]
+      end
+
+      it 'returns a process' do
+        expect(process).to be_a Workflow::ProcessResponse
+        expect(process.status).to eq 'error'
+        expect(process.error_message).to eq 'Something went wrong'
+        expect(process.name).to eq 'jp2-create'
+      end
+    end
+  end
+
+  describe '#incomplete_processes' do
+    subject(:processes) { workflow_response.incomplete_processes }
+
+    context 'when all steps are complete' do
+      let(:steps) do
+        [
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly'),
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'jp2-create')
+        ]
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when some steps are not complete' do
+      let(:steps) do
+        [
+          build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly'),
+          build(:workflow_step, druid:, workflow: workflow_name, process: 'jp2-create')
+        ]
+      end
+
+      it 'returns the incomplete processes' do
+        expect(processes.size).to eq 1
+        expect(processes.first.name).to eq 'jp2-create'
+      end
+    end
+  end
+
+  describe '#incomplete_processes_for' do
+    let(:steps) do
+      [
+        build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly', version: 1),
+        build(:workflow_step, druid:, workflow: workflow_name, process: 'jp2-create', version: 1),
+        build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly', version: 2),
+        build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'jp2-create', version: 2)
+      ]
+    end
+
+    context 'when all steps are complete' do
+      it 'returns empty' do
+        expect(workflow_response.incomplete_processes_for(version: 2)).to be_empty
+      end
+    end
+
+    context 'when some steps are not complete' do
+      it 'returns false' do
+        expect(workflow_response.incomplete_processes_for(version: 1).size).to eq 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
refs #5515

## Why was this change made? 🤔
Our successors will not know what XML is.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



