### PR TITLE
Fetch release tags in batch.

### DIFF
--- a/app/services/indexing/builders/document_builder.rb
+++ b/app/services/indexing/builders/document_builder.rb
@@ -56,9 +56,10 @@ module Indexing
         @@parent_collections = {} # rubocop:disable Style/ClassVars
       end
 
-      def initialize(model:, workflows: nil, trace_id: SecureRandom.uuid)
+      def initialize(model:, workflows: nil, release_tags: nil, trace_id: SecureRandom.uuid)
         @model = model
         @workflows = workflows
+        @release_tags = release_tags
         @trace_id = trace_id
       end
 
@@ -69,6 +70,7 @@ module Indexing
                                          workflows:,
                                          parent_collections:,
                                          administrative_tags:,
+                                         release_tags:,
                                          trace_id:)
       rescue StandardError => e
         Honeybadger.notify('[DATA ERROR] Unexpected indexing exception',
@@ -81,7 +83,7 @@ module Indexing
 
       private
 
-      attr_reader :model, :workflow_client, :trace_id, :workflows
+      attr_reader :model, :workflow_client, :trace_id, :workflows, :release_tags
 
       def id
         model.externalIdentifier

--- a/app/services/indexing/indexers/releasable_indexer.rb
+++ b/app/services/indexing/indexers/releasable_indexer.rb
@@ -6,9 +6,10 @@ module Indexing
     class ReleasableIndexer
       attr_reader :cocina, :parent_collections
 
-      def initialize(cocina:, parent_collections:, **)
+      def initialize(cocina:, parent_collections:, release_tags: nil, **)
         @cocina = cocina
         @parent_collections = parent_collections
+        @release_tags = release_tags
       end
 
       # @return [Hash] the partial solr document for releasable concerns
@@ -58,9 +59,12 @@ module Indexing
         end
       end
 
+      def release_tags
+        @release_tags ||= ReleaseTagService.item_tags(cocina_object: cocina)
+      end
+
       def tags_from_item
-        ReleaseTagService.item_tags(cocina_object: cocina)
-                         .group_by(&:to).transform_values do |releases_for_project|
+        release_tags.group_by(&:to).transform_values do |releases_for_project|
           releases_for_project.max_by(&:date)
         end
       end

--- a/spec/jobs/batch_reindex_job_spec.rb
+++ b/spec/jobs/batch_reindex_job_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe BatchReindexJob do
   let(:conn) { instance_double(RSolr::Client, add: nil) }
   let(:indexer) { double(Indexing::Indexers::CompositeIndexer, to_solr: solr_doc) } # rubocop:disable RSpec/VerifiedDoubles
   let(:solr_doc) { { id: repository_object.external_identifier } }
+  let!(:release_tag) { create(:release_tag, druid:) }
 
   before do
     allow(RSolr).to receive(:connect).and_return(conn)
@@ -26,7 +27,8 @@ RSpec.describe BatchReindexJob do
     expect(Indexing::Builders::DocumentBuilder).to have_received(:for).once.with(
       model: repository_object.head_version.to_cocina_with_metadata,
       trace_id: String,
-      workflows: [an_instance_of(Workflow::WorkflowResponse)]
+      workflows: [an_instance_of(Workflow::WorkflowResponse)],
+      release_tags: [release_tag.to_cocina]
     )
   end
 end

--- a/spec/services/indexing/builders/document_builder_spec.rb
+++ b/spec/services/indexing/builders/document_builder_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe Indexing::Builders::DocumentBuilder do
                 administrative_tags: [],
                 parent_collections: [],
                 workflows: nil,
+                release_tags: nil,
                 trace_id:)
         expect(Honeybadger).to have_received(:notify)
           .with('Bad association found on druid:xx999xx9999. druid:bc999df2323 could not be found')

--- a/spec/services/indexing/indexers/releasable_indexer_spec.rb
+++ b/spec/services/indexing/indexers/releasable_indexer_spec.rb
@@ -16,7 +16,11 @@ RSpec.describe Indexing::Indexers::ReleasableIndexer do
   end
 
   describe 'to_solr' do
-    let(:doc) { described_class.new(cocina:, parent_collections:).to_solr }
+    let(:doc) do
+      described_class.new(cocina:, parent_collections:, release_tags: provided_release_tags).to_solr
+    end
+
+    let(:provided_release_tags) { release_tags }
 
     context 'with no parent collection' do
       let(:parent_collections) { [] }
@@ -59,6 +63,24 @@ RSpec.describe Indexing::Indexers::ReleasableIndexer do
             'released_to_purl_sitemap_dttsi' => '2023-03-27T10:00:00Z'
           )
           # rubocop:enable Style/StringHashKeys
+        end
+      end
+
+      context 'when release tags are provided' do
+        let(:provided_release_tags) do
+          [
+            Dor::ReleaseTag.new(to: 'Searchworks', release: true, date: '2021-05-12T21:05:21.000+00:00', what: 'self')
+          ]
+        end
+
+        it 'indexes release tags' do
+          # rubocop:disable Style/StringHashKeys
+          expect(doc).to eq(
+            'released_to_ssim' => ['Searchworks'],
+            'released_to_searchworks_dttsi' => '2021-05-12T21:05:21Z'
+          )
+          # rubocop:enable Style/StringHashKeys
+          expect(ReleaseTagService).not_to have_received(:item_tags)
         end
       end
 


### PR DESCRIPTION
refs #5518

## Why was this change made? 🤔
Fetching in batch is faster than fetching one at a time.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



