### PR TITLE
Separate release tag service from public metadata release tag service.

### DIFF
--- a/app/controllers/release_tags_controller.rb
+++ b/app/controllers/release_tags_controller.rb
@@ -16,15 +16,15 @@ class ReleaseTagsController < ApplicationController
     end
 
     json = if params[:public]
-             ReleaseTagService.for_public_metadata(cocina_object: @cocina_object)
+             PublicMetadataReleaseTagService.for_public_metadata(cocina_object: @cocina_object)
            else
-             ReleaseTagService.item_tags(cocina_object: @cocina_object)
+             ReleaseTagService.tags(druid: @cocina_object.externalIdentifier)
            end
     render json: json
   end
 
   def create
-    ReleaseTagService.create(cocina_object: @cocina_object, tag: new_tag)
+    ReleaseTagService.create(druid: @cocina_object.externalIdentifier, tag: new_tag)
     head :created
   end
 

--- a/app/services/catalog/marc_856_generator.rb
+++ b/app/services/catalog/marc_856_generator.rb
@@ -127,7 +127,7 @@ module Catalog
 
       collections.each do |collection_druid|
         collection = CocinaObjectStore.find(collection_druid)
-        next unless ReleaseTagService.released_to_searchworks?(cocina_object: collection)
+        next unless PublicMetadataReleaseTagService.released_to_searchworks?(cocina_object: collection)
 
         catalog_link = collection.identification&.catalogLinks&.find { |link| link.catalog == catalog }
         collection_info << { code: 'x',

--- a/app/services/indexing/indexers/releasable_indexer.rb
+++ b/app/services/indexing/indexers/releasable_indexer.rb
@@ -51,7 +51,7 @@ module Indexing
 
       def tags_from_collection
         parent_collections.each_with_object({}) do |collection, result|
-          ReleaseTagService.item_tags(cocina_object: collection)
+          ReleaseTagService.tags(druid: collection.externalIdentifier)
                            .select { |tag| tag.what == 'collection' }
                            .group_by(&:to).map do |project, releases_for_project|
             result[project] = releases_for_project.max_by(&:date)
@@ -60,7 +60,7 @@ module Indexing
       end
 
       def release_tags
-        @release_tags ||= ReleaseTagService.item_tags(cocina_object: cocina)
+        @release_tags ||= ReleaseTagService.tags(druid: cocina.externalIdentifier)
       end
 
       def tags_from_item

--- a/app/services/public_metadata_release_tag_service.rb
+++ b/app/services/public_metadata_release_tag_service.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Shows release tags for public metadata. This replaces parts of https://github.com/sul-dlss/dor-services/blob/main/lib/dor/models/concerns/releaseable.rb
+class PublicMetadataReleaseTagService
+  # Retrieve the release tags for an item and all the collections that it is a part of
+  #
+  # Determine projects in which an item is released
+  # @param cocina_object [Cocina::Models::DRO, Cocina::Models::Collection] the object to list release tags for
+  # @return [Array<Dor::ReleaseTag>]
+  def self.for_public_metadata(...)
+    new(...).for_public_metadata
+  end
+
+  def self.released_to_searchworks?(...)
+    new(...).for_public_metadata
+            .find { |tag| tag.to.casecmp?('Searchworks') }&.release || false
+  end
+
+  def initialize(cocina_object:)
+    @cocina_object = cocina_object
+  end
+
+  # Determine projects in which an item is released
+  # @return [Array<Dor::ReleaseTag>]
+  def for_public_metadata
+    # For each release target, item tags trump collection tags
+    grouped_latest_tags(collection_tags).merge(grouped_latest_tags(item_tags)).values
+  end
+
+  private
+
+  attr_reader :cocina_object
+
+  def collection_tags
+    tags = collection_druids.flat_map do |collection_druid|
+      ReleaseTagService.tags(druid: collection_druid)
+    end
+    tags.select { |tag| tag.what == 'collection' }
+  end
+
+  def collection_druids
+    return [] unless cocina_object.dro?
+
+    cocina_object.structural.isMemberOf
+  end
+
+  def item_tags
+    ReleaseTagService.tags(druid: cocina_object.externalIdentifier)
+  end
+
+  def grouped_latest_tags(release_tags)
+    # Group by release target
+    grouped_tags = release_tags.group_by(&:to)
+    # For each release target, select the most recent release tag
+    grouped_tags.transform_values { |tags| tags.max_by(&:date) }
+  end
+end

--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -51,7 +51,7 @@ module Publish
     end
 
     def release_tags_on_success
-      tags = ReleaseTagService.for_public_metadata(cocina_object: public_cocina)
+      tags = PublicMetadataReleaseTagService.for_public_metadata(cocina_object: public_cocina)
       actions = { index: [], delete: [] }.tap do |releases|
         tags.each do |tag|
           releases[tag.release ? :index : :delete] << tag.to

--- a/app/services/release_tag_service.rb
+++ b/app/services/release_tag_service.rb
@@ -2,72 +2,14 @@
 
 # Shows and creates release tags. This replaces parts of https://github.com/sul-dlss/dor-services/blob/main/lib/dor/models/concerns/releaseable.rb
 class ReleaseTagService
-  # Retrieve the release tags for an item and all the collections that it is a part of
-  #
-  # Determine projects in which an item is released
-  # @param cocina_object [Cocina::Models::DRO, Cocina::Models::Collection] the object to list release tags for
-  # @return [Array<Dor::ReleaseTag>]
-  def self.for_public_metadata(cocina_object:)
-    new(cocina_object).for_public_metadata
-  end
-
   # Retrieve the release tags for an item
-  def self.item_tags(cocina_object:)
-    new(cocina_object).item_tags
-  end
-
-  def self.released_to_searchworks?(cocina_object:)
-    new(cocina_object).for_public_metadata
-                      .find { |tag| tag.to.casecmp?('Searchworks') }&.release || false
-  end
-
-  # Creates ReleaseTag model objects.
-  # @param cocina_object [Cocina::Models::DRO, Cocina::Models::Collection] the object to add to
-  # @param [Dor::ReleaseTag] tag
-  def self.create(cocina_object:, tag:)
-    ReleaseTag.from_cocina(druid: cocina_object.externalIdentifier, tag:).save!
-  end
-
-  def initialize(cocina_object)
-    @cocina_object = cocina_object
-  end
-
-  attr_reader :cocina_object
-
-  # Determine projects in which an item is released
-  # @return [Array<Dor::ReleaseTag>]
-  def for_public_metadata
-    # For each release target, item tags trump collection tags
-    grouped_latest_tags(collection_tags).merge(grouped_latest_tags(item_tags)).values
-  end
-
-  def item_tags
-    tags_for(cocina_object.externalIdentifier)
-  end
-
-  private
-
-  def tags_for(druid)
+  def self.tags(druid:)
     ReleaseTag.where(druid:).map(&:to_cocina)
   end
 
-  def collection_tags
-    tags = collection_druids.flat_map do |collection_druid|
-      tags_for(collection_druid)
-    end
-    tags.select { |tag| tag.what == 'collection' }
-  end
-
-  def collection_druids
-    return [] unless cocina_object.dro?
-
-    cocina_object.structural.isMemberOf
-  end
-
-  def grouped_latest_tags(release_tags)
-    # Group by release target
-    grouped_tags = release_tags.group_by(&:to)
-    # For each release target, select the most recent release tag
-    grouped_tags.transform_values { |tags| tags.max_by(&:date) }
+  # Creates ReleaseTag model objects.
+  # @param [Dor::ReleaseTag] tag
+  def self.create(druid:, tag:)
+    ReleaseTag.from_cocina(druid:, tag:).save!
   end
 end

--- a/spec/services/catalog/folio_writer_spec.rb
+++ b/spec/services/catalog/folio_writer_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Catalog::FolioWriter do
     before do
       allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
       allow(FolioClient).to receive(:edit_marc_json).and_yield(folio_response_json).and_return(nil)
-      allow(ReleaseTagService).to receive(:released_to_searchworks?).and_return(release_data)
+      allow(PublicMetadataReleaseTagService).to receive(:released_to_searchworks?).and_return(release_data)
       allow(FolioClient).to receive_messages(fetch_instance_info: instance_record, fetch_marc_hash: source_record)
       allow(Honeybadger).to receive(:notify)
     end

--- a/spec/services/catalog/marc856_generator_spec.rb
+++ b/spec/services/catalog/marc856_generator_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Catalog::Marc856Generator do
   end
 
   before do
-    allow(ReleaseTagService).to receive(:released_to_searchworks?).and_return(release_data)
+    allow(PublicMetadataReleaseTagService).to receive(:released_to_searchworks?).and_return(release_data)
   end
 
   describe '.create' do

--- a/spec/services/indexing/indexers/releasable_indexer_spec.rb
+++ b/spec/services/indexing/indexers/releasable_indexer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Indexing::Indexers::ReleasableIndexer do
   let(:release_tags) { [] }
 
   before do
-    allow(ReleaseTagService).to receive(:item_tags).with(cocina_object: cocina).and_return(release_tags)
+    allow(ReleaseTagService).to receive(:tags).with(druid: cocina.externalIdentifier).and_return(release_tags)
   end
 
   describe 'to_solr' do
@@ -80,7 +80,7 @@ RSpec.describe Indexing::Indexers::ReleasableIndexer do
             'released_to_searchworks_dttsi' => '2021-05-12T21:05:21Z'
           )
           # rubocop:enable Style/StringHashKeys
-          expect(ReleaseTagService).not_to have_received(:item_tags)
+          expect(ReleaseTagService).not_to have_received(:tags)
         end
       end
 
@@ -116,8 +116,8 @@ RSpec.describe Indexing::Indexers::ReleasableIndexer do
       let(:collection_release_tags) { [] }
 
       before do
-        allow(ReleaseTagService).to receive(:item_tags).with(cocina_object: collection)
-                                                       .and_return(collection_release_tags)
+        allow(ReleaseTagService).to receive(:tags).with(druid: collection_druid)
+                                                  .and_return(collection_release_tags)
       end
 
       context 'when the parent collection has self releaseTags' do

--- a/spec/services/public_metadata_release_tag_service_spec.rb
+++ b/spec/services/public_metadata_release_tag_service_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PublicMetadataReleaseTagService do
+  let(:cocina_object) do
+    build(:dro, id: druid, collection_ids:)
+  end
+  let(:apo_id) { 'druid:qv648vd4392' }
+  let(:collection_druid) { 'druid:xh235dd9059' }
+  let(:druid) { 'druid:bb004bn8654' }
+  let(:collection_ids) { [] }
+
+  describe '.for_public_metadata' do
+    subject(:releases) { described_class.for_public_metadata(cocina_object:) }
+
+    context 'when item has self tags' do
+      let!(:searchworks_self_release_tag) { create(:release_tag, druid:, released_to: 'Searchworks', what: 'self') }
+      let!(:earthworks_self_release_tag) { create(:release_tag, druid:, released_to: 'Earthworks', what: 'self') }
+
+      it 'returns the list of release tags' do
+        expect(releases).to eq [
+          searchworks_self_release_tag.to_cocina,
+          earthworks_self_release_tag.to_cocina
+        ]
+      end
+    end
+
+    context 'when item has multiple self tags' do
+      let!(:self_release_tag) { create(:release_tag, druid:, released_to: 'Searchworks', what: 'self') }
+
+      before do
+        create(:release_tag, druid:, released_to: 'Searchworks', what: 'self', created_at: 1.day.ago)
+      end
+
+      it 'returns the most recent tag' do
+        expect(releases).to eq [
+          self_release_tag.to_cocina
+        ]
+      end
+    end
+
+    context 'when a collection has a self tag' do
+      let(:collection_ids) { [collection_druid] }
+
+      before do
+        create(:release_tag, druid: collection_druid, released_to: 'Searchworks', what: 'self')
+      end
+
+      it 'ignores the collection self tag' do
+        expect(releases).to eq []
+      end
+    end
+
+    context 'when a collection has a collection tag' do
+      let(:collection_ids) { [collection_druid] }
+
+      let!(:collection_release_tag) do
+        create(:release_tag, druid: collection_druid, released_to: 'Searchworks', what: 'collection')
+      end
+
+      it 'returns the collection tag' do
+        expect(releases).to eq [collection_release_tag.to_cocina]
+      end
+    end
+
+    context 'when a collection has a collection tag (created first) and the item has a self tag' do
+      let(:collection_ids) { [collection_druid] }
+
+      let!(:self_release_tag) { create(:release_tag, druid:, released_to: 'Searchworks', what: 'self') }
+
+      before do
+        create(:release_tag, druid: collection_druid, released_to: 'Searchworks', what: 'collection',
+                             created_at: 1.day.ago)
+      end
+
+      it 'prioritizes the item self tag' do
+        expect(releases).to eq [self_release_tag.to_cocina]
+      end
+    end
+
+    context 'when a collection has a collection tag and the item has a self tag (created first)' do
+      let(:collection_ids) { [collection_druid] }
+
+      let!(:self_release_tag) do
+        create(:release_tag, druid:, released_to: 'Searchworks', what: 'self', created_at: 1.day.ago)
+      end
+
+      before do
+        create(:release_tag, druid: collection_druid, released_to: 'Searchworks', what: 'collection')
+      end
+
+      it 'prioritizes the item self tag' do
+        expect(releases).to eq [self_release_tag.to_cocina]
+      end
+    end
+  end
+
+  describe '.released_to_searchworks?' do
+    subject { described_class.released_to_searchworks?(cocina_object:) }
+
+    context 'when release_data tag has release to=Searchworks and value is true' do
+      before do
+        create(:release_tag, druid:, released_to: 'Searchworks', release: true)
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when release_data tag has release to=searchworks (all lowercase) and value is true' do
+      before do
+        create(:release_tag, druid:, released_to: 'searchworks', release: true)
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when release_data tag has release to=SearchWorks (camelcase) and value is true' do
+      before do
+        create(:release_tag, druid:, released_to: 'SearchWorks', release: true)
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when release_data tag has release to=Searchworks and value is false' do
+      before do
+        create(:release_tag, druid:, released_to: 'Searchworks', release: false)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when there are no release tags at all' do
+      it { is_expected.to be false }
+    end
+
+    context 'when there are non searchworks related release tags' do
+      before do
+        create(:release_tag, druid:, released_to: 'Revs', release: true)
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Publish::MetadataTransferService do
       allow(Publish::PublicCocinaService).to receive(:create).and_return(public_cocina)
       allow(Publish::TransferStager).to receive(:copy)
       allow(PurlFetcher::Client::ReleaseTags).to receive(:release)
-      allow(ReleaseTagService).to receive(:for_public_metadata).and_return([searchworks_release_tag,
-                                                                            earthworks_release_tag])
+      allow(PublicMetadataReleaseTagService).to receive(:for_public_metadata).and_return([searchworks_release_tag,
+                                                                                          earthworks_release_tag])
     end
 
     context 'when a collection' do

--- a/spec/services/release_tag_service_spec.rb
+++ b/spec/services/release_tag_service_spec.rb
@@ -3,203 +3,27 @@
 require 'rails_helper'
 
 RSpec.describe ReleaseTagService do
-  let(:releases) { described_class.new(cocina_object) }
-  let(:cocina_object) do
-    build(:dro, id: druid, collection_ids:).new(
-      administrative: {
-        hasAdminPolicy: apo_id
-      }
-    )
-  end
-  let(:apo_id) { 'druid:qv648vd4392' }
-  let(:collection_druid) { 'druid:xh235dd9059' }
   let(:druid) { 'druid:bb004bn8654' }
-  let(:collection_ids) { [] }
-
-  describe '.for_public_metadata' do
-    subject(:releases) { described_class.for_public_metadata(cocina_object:) }
-
-    context 'when item has self tags' do
-      let!(:searchworks_self_release_tag) { create(:release_tag, druid:, released_to: 'Searchworks', what: 'self') }
-      let!(:earthworks_self_release_tag) { create(:release_tag, druid:, released_to: 'Earthworks', what: 'self') }
-
-      it 'returns the list of release tags' do
-        expect(releases).to eq [
-          searchworks_self_release_tag.to_cocina,
-          earthworks_self_release_tag.to_cocina
-        ]
-      end
-    end
-
-    context 'when item has multiple self tags' do
-      let!(:self_release_tag) { create(:release_tag, druid:, released_to: 'Searchworks', what: 'self') }
-
-      before do
-        create(:release_tag, druid:, released_to: 'Searchworks', what: 'self', created_at: 1.day.ago)
-      end
-
-      it 'returns the most recent tag' do
-        expect(releases).to eq [
-          self_release_tag.to_cocina
-        ]
-      end
-    end
-
-    context 'when a collection has a self tag' do
-      let(:collection_ids) { [collection_druid] }
-
-      before do
-        create(:release_tag, druid: collection_druid, released_to: 'Searchworks', what: 'self')
-      end
-
-      it 'ignores the collection self tag' do
-        expect(releases).to eq []
-      end
-    end
-
-    context 'when a collection has a collection tag' do
-      let(:collection_ids) { [collection_druid] }
-
-      let!(:collection_release_tag) do
-        create(:release_tag, druid: collection_druid, released_to: 'Searchworks', what: 'collection')
-      end
-
-      it 'returns the collection tag' do
-        expect(releases).to eq [collection_release_tag.to_cocina]
-      end
-    end
-
-    context 'when a collection has a collection tag (created first) and the item has a self tag' do
-      let(:collection_ids) { [collection_druid] }
-
-      let!(:self_release_tag) { create(:release_tag, druid:, released_to: 'Searchworks', what: 'self') }
-
-      before do
-        create(:release_tag, druid: collection_druid, released_to: 'Searchworks', what: 'collection',
-                             created_at: 1.day.ago)
-      end
-
-      it 'prioritizes the item self tag' do
-        expect(releases).to eq [self_release_tag.to_cocina]
-      end
-    end
-
-    context 'when a collection has a collection tag and the item has a self tag (created first)' do
-      let(:collection_ids) { [collection_druid] }
-
-      let!(:self_release_tag) do
-        create(:release_tag, druid:, released_to: 'Searchworks', what: 'self', created_at: 1.day.ago)
-      end
-
-      before do
-        create(:release_tag, druid: collection_druid, released_to: 'Searchworks', what: 'collection')
-      end
-
-      it 'prioritizes the item self tag' do
-        expect(releases).to eq [self_release_tag.to_cocina]
-      end
-    end
-  end
-
-  describe '.released_to_searchworks?' do
-    subject { described_class.released_to_searchworks?(cocina_object:) }
-
-    context 'when release_data tag has release to=Searchworks and value is true' do
-      before do
-        create(:release_tag, druid:, released_to: 'Searchworks', release: true)
-      end
-
-      it { is_expected.to be true }
-    end
-
-    context 'when release_data tag has release to=searchworks (all lowercase) and value is true' do
-      before do
-        create(:release_tag, druid:, released_to: 'searchworks', release: true)
-      end
-
-      it { is_expected.to be true }
-    end
-
-    context 'when release_data tag has release to=SearchWorks (camelcase) and value is true' do
-      before do
-        create(:release_tag, druid:, released_to: 'SearchWorks', release: true)
-      end
-
-      it { is_expected.to be true }
-    end
-
-    context 'when release_data tag has release to=Searchworks and value is false' do
-      before do
-        create(:release_tag, druid:, released_to: 'Searchworks', release: false)
-      end
-
-      it { is_expected.to be false }
-    end
-
-    context 'when there are no release tags at all' do
-      it { is_expected.to be false }
-    end
-
-    context 'when there are non searchworks related release tags' do
-      before do
-        create(:release_tag, druid:, released_to: 'Revs', release: true)
-      end
-
-      it { is_expected.to be false }
-    end
-  end
 
   describe '.create' do
-    subject(:create_tag) { described_class.create(cocina_object:, tag:) }
+    subject(:create_tag) { described_class.create(druid:, tag:) }
 
     let(:tag) { Dor::ReleaseTag.new(to: 'Earthworks', what: 'self', who: 'cathy', date: 2.days.ago.iso8601) }
-
-    let(:cocina_release_tags) do
-      [
-        {
-          who: 'carrickr',
-          what: 'collection',
-          date: '2015-01-06T23:33:47.000+00:00',
-          to: 'Revs',
-          release: true
-        },
-        {
-          who: 'carrickr',
-          what: 'self',
-          date: '2015-01-06T23:33:54.000+00:00',
-          to: 'Revs',
-          release: true
-        },
-        {
-          who: 'carrickr',
-          what: 'self',
-          date: '2015-01-06T23:40:01.000+00:00',
-          to: 'Revs',
-          release: false
-        }
-      ]
-    end
-
-    before do
-      allow(CocinaObjectStore).to receive(:store)
-    end
 
     it 'adds another release tag and' do
       expect { create_tag }.to change { ReleaseTag.where(druid:).count }.by(1)
     end
   end
 
-  describe '.item_tags' do
-    subject(:releases) { described_class.item_tags(cocina_object:) }
+  describe '.tags' do
+    subject(:releases) { described_class.tags(druid:) }
 
-    context 'when ReleaseTag objects exist for this item' do
-      let!(:release_tag) { create(:release_tag) }
+    let!(:release_tag) { create(:release_tag, druid:) }
 
-      it 'returns release tags from the ReleaseTag objects' do
-        expect(releases).to eq [
-          release_tag.to_cocina
-        ]
-      end
+    it 'returns release tags from the ReleaseTag objects' do
+      expect(releases).to eq [
+        release_tag.to_cocina
+      ]
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Having these together as a single service required all operations to provide a cocina object. However, it was only really needed for some. This is because it was mixing multiple responsibilities. This splits them out.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



