### PR TITLE
Stop caching parent collections. Fetch parent collections and parent collection tags in batch.

### DIFF
--- a/app/jobs/batch_reindex_job.rb
+++ b/app/jobs/batch_reindex_job.rb
@@ -7,10 +7,9 @@ class BatchReindexJob < ApplicationJob
   def perform(druids)
     @druids = druids
     start_time = Time.zone.now
-    solr_docs = []
-    RepositoryObject.includes(:head_version).where(external_identifier: druids).find_each do |repository_object|
+    solr_docs = repository_objects.map do |repository_object|
       Honeybadger.context(druid: repository_object.external_identifier)
-      solr_docs << build_solr_doc(repository_object:)
+      build_solr_doc(repository_object:)
     end
     solr_conn.add(solr_docs, add_attributes: { commitWithin: 500 })
     log_duration(start_time:, druids:)
@@ -19,6 +18,29 @@ class BatchReindexJob < ApplicationJob
   private
 
   attr_reader :druids
+
+  def repository_objects
+    @repository_objects ||= RepositoryObject.includes(:head_version).where(external_identifier: druids).to_a
+  end
+
+  # @return [Array<String>] all collection druids referenced by the objects in the batch
+  def collection_druids
+    @collection_druids ||= repository_objects.flat_map do |repository_object|
+      collection_druids_from(repository_object:)
+    end.uniq
+  end
+
+  # @return [Hash<String, Cocina::Models::Collection>] map of collection druid to collection cocina object
+  def collection_cocina_object_map
+    @collection_cocina_object_map ||= {}.tap do |map|
+      RepositoryObject.includes(:head_version)
+                      .where(external_identifier: collection_druids)
+                      .find_each do |collection_repository_object|
+        map[collection_repository_object.external_identifier] =
+          collection_repository_object.head_version.to_cocina_with_metadata
+      end
+    end
+  end
 
   def solr_conn
     RSolr.connect(timeout: 120, open_timeout: 120, url: Settings.solr.url)
@@ -36,7 +58,7 @@ class BatchReindexJob < ApplicationJob
 
   def release_tags_map
     @release_tags_map ||= {}.tap do |map|
-      ReleaseTag.where(druid: druids).find_each do |tag|
+      ReleaseTag.where(druid: druids + collection_druids).find_each do |tag|
         map[tag.druid] ||= []
         map[tag.druid] << tag.to_cocina
       end
@@ -51,9 +73,27 @@ class BatchReindexJob < ApplicationJob
     Indexing::Builders::DocumentBuilder.for(
       model: repository_object.head_version.to_cocina_with_metadata,
       workflows: workflows_map[repository_object.external_identifier],
-      release_tags: release_tags_map[repository_object.external_identifier] || [],
-      milestones: milestones_map[repository_object.external_identifier] || [],
+      release_tags: release_tags_map.fetch(repository_object.external_identifier, []),
+      milestones: milestones_map.fetch(repository_object.external_identifier, []),
+      parent_collections: parent_collections_for(repository_object:),
+      parent_collections_release_tags: parent_collections_release_tags_for(repository_object:),
       trace_id: Indexer.trace_id_for(druid: repository_object.external_identifier)
     ).to_solr
+  end
+
+  def collection_druids_from(repository_object:)
+    repository_object.head_version.structural.fetch('isMemberOf', [])
+  end
+
+  def parent_collections_for(repository_object:)
+    collection_druids_from(repository_object:).map do |collection_druid|
+      collection_cocina_object_map[collection_druid]
+    end
+  end
+
+  def parent_collections_release_tags_for(repository_object:)
+    collection_druids_from(repository_object:).flat_map do |collection_druid|
+      release_tags_map.fetch(collection_druid, [])
+    end
   end
 end

--- a/spec/services/indexing/builders/document_builder_spec.rb
+++ b/spec/services/indexing/builders/document_builder_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe Indexing::Builders::DocumentBuilder do
   # rubocop:enable Style/StringHashKeys
 
   before do
-    described_class.reset_parent_collections
     allow(Indexing::WorkflowFields).to receive(:for).and_return({ milestones_ssim: %w[foo bar] })
     allow(Indexing::Indexers::ReleasableIndexer).to receive(:new).and_return(releasable)
     allow(Indexing::Indexers::WorkflowsIndexer).to receive(:new).and_return(workflows)
@@ -64,24 +63,6 @@ RSpec.describe Indexing::Builders::DocumentBuilder do
       end
     end
 
-    context 'with a cached collections' do
-      let(:related) { build(:collection) }
-      let(:collections) { ['druid:bc999df2323'] }
-
-      before do
-        allow(CocinaObjectStore).to receive(:find).and_return(related)
-        described_class.for(
-          model: cocina_with_metadata,
-          trace_id:
-        )
-      end
-
-      it 'uses the cached collection' do
-        expect(indexer).to be_instance_of Indexing::Indexers::CompositeIndexer::Instance
-        expect(CocinaObjectStore).to have_received(:find).with(collections.first)
-      end
-    end
-
     context "with collections that can't be resolved" do
       let(:collections) { ['druid:bc999df2323'] }
 
@@ -99,6 +80,7 @@ RSpec.describe Indexing::Builders::DocumentBuilder do
                 id: String,
                 administrative_tags: [],
                 parent_collections: [],
+                parent_collections_release_tags: nil,
                 workflows: nil,
                 release_tags: nil,
                 milestones: nil,

--- a/spec/services/indexing/indexers/releasable_indexer_spec.rb
+++ b/spec/services/indexing/indexers/releasable_indexer_spec.rb
@@ -2,195 +2,311 @@
 
 require 'rails_helper'
 RSpec.describe Indexing::Indexers::ReleasableIndexer do
-  let(:cocina) { build(:dro).new(administrative:) }
-  let(:administrative) do
-    {
-      hasAdminPolicy: apo_id
-    }
-  end
-  let(:apo_id) { 'druid:gf999hb9999' }
+  let(:cocina) { build(:dro).new(structural: { isMemberOf: collection_druids }) }
+  let(:collection_druids) { [] }
   let(:release_tags) { [] }
 
-  before do
-    allow(ReleaseTagService).to receive(:tags).with(druid: cocina.externalIdentifier).and_return(release_tags)
-  end
-
   describe 'to_solr' do
-    let(:doc) do
-      described_class.new(cocina:, parent_collections:, release_tags: provided_release_tags).to_solr
-    end
-
-    let(:provided_release_tags) { release_tags }
-
-    context 'with no parent collection' do
-      let(:parent_collections) { [] }
-
-      context 'when multiple releaseTags are present for the same destination' do
-        let(:release_tags) do
-          [
-            Dor::ReleaseTag.new(to: 'Project', release: true, date: '2016-11-16T22:52:35.000+00:00', what: 'self'),
-            Dor::ReleaseTag.new(to: 'Project', release: false, date: '2016-12-21T17:31:18.000+00:00', what: 'self'),
-            Dor::ReleaseTag.new(to: 'Project', release: true, date: '2021-05-12T21:05:21.000+00:00', what: 'self'),
-            Dor::ReleaseTag.new(to: 'test_target', release: true, what: 'self'),
-            Dor::ReleaseTag.new(to: 'test_nontarget', release: false, date: '2016-12-16T22:52:35.000+00:00',
-                                what: 'self'),
-            Dor::ReleaseTag.new(to: 'test_nontarget', release: true, date: '2016-11-16T22:52:35.000+00:00',
-                                what: 'self')
-          ]
-        end
-
-        it 'indexes release tags' do
-          expect(doc).to eq('released_to_ssim' => %w[Project test_target])
-          # rubocop:enable Style/StringHashKeys
-        end
+    context 'when release tags are not provided' do
+      let(:doc) do
+        described_class.new(cocina:).to_solr
       end
-
-      context 'when Searchworks, Earthworks, and PURL sitemap tags are present' do
-        let(:release_tags) do
-          [
-            Dor::ReleaseTag.new(to: 'Searchworks', release: true, date: '2021-05-12T21:05:21.000+00:00', what: 'self'),
-            Dor::ReleaseTag.new(to: 'Earthworks', release: true, date: '2016-11-16T22:52:35.000+00:00', what: 'self'),
-            Dor::ReleaseTag.new(to: 'PURL sitemap', release: true, date: '2023-03-27T10:00:00.000+00:00', what: 'self')
-          ]
-        end
-
-        it 'indexes release tags' do
-          # rubocop:disable Style/StringHashKeys
-          expect(doc).to eq(
-            'released_to_ssim' => ['Searchworks', 'Earthworks', 'PURL sitemap'],
-            'released_to_earthworks_dttsi' => '2016-11-16T22:52:35Z',
-            'released_to_searchworks_dttsi' => '2021-05-12T21:05:21Z',
-            'released_to_purl_sitemap_dttsi' => '2023-03-27T10:00:00Z'
-          )
-          # rubocop:enable Style/StringHashKeys
-        end
-      end
-
-      context 'when release tags are provided' do
-        let(:provided_release_tags) do
-          [
-            Dor::ReleaseTag.new(to: 'Searchworks', release: true, date: '2021-05-12T21:05:21.000+00:00', what: 'self')
-          ]
-        end
-
-        it 'indexes release tags' do
-          # rubocop:disable Style/StringHashKeys
-          expect(doc).to eq(
-            'released_to_ssim' => ['Searchworks'],
-            'released_to_searchworks_dttsi' => '2021-05-12T21:05:21Z'
-          )
-          # rubocop:enable Style/StringHashKeys
-          expect(ReleaseTagService).not_to have_received(:tags)
-        end
-      end
-
-      context 'when releaseTags are not present' do
-        let(:release_tags) { [] }
-
-        it 'has no release tags' do
-          expect(doc).to be_empty
-        end
-      end
-
-      context 'when a collection with a collection releaseTag' do
-        let(:release_tags) do
-          [
-            Dor::ReleaseTag.new(to: 'Project', release: true, date: '2016-11-16T22:52:35.000+00:00',
-                                what: 'collection'),
-            Dor::ReleaseTag.new(to: 'test_target', release: true, what: 'self')
-          ]
-        end
-
-        it 'indexes release tags' do
-          expect(doc).to eq('released_to_ssim' => %w[Project test_target]) # rubocop:disable Style/StringHashKeys
-        end
-      end
-    end
-
-    context 'with a parent collection' do
-      let(:parent_collections) { [collection] }
-      let(:collection) do
-        instance_double(Cocina::Models::Collection, externalIdentifier: collection_druid)
-      end
-      let(:collection_druid) { 'druid:bc123fg4567' }
-      let(:collection_release_tags) { [] }
 
       before do
-        allow(ReleaseTagService).to receive(:tags).with(druid: collection_druid)
-                                                  .and_return(collection_release_tags)
+        allow(ReleaseTagService).to receive(:tags).with(druid: cocina.externalIdentifier).and_return(release_tags)
       end
 
-      context 'when the parent collection has self releaseTags' do
-        let(:release_tags) { [] }
-        let(:collection_release_tags) do
-          [
-            Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00', what: 'self')
-          ]
+      context 'with no parent collection' do
+        context 'when multiple releaseTags are present for the same destination' do
+          let(:release_tags) do
+            [
+              Dor::ReleaseTag.new(to: 'Project', release: true, date: '2016-11-16T22:52:35.000+00:00', what: 'self'),
+              Dor::ReleaseTag.new(to: 'Project', release: false, date: '2016-12-21T17:31:18.000+00:00', what: 'self'),
+              Dor::ReleaseTag.new(to: 'Project', release: true, date: '2021-05-12T21:05:21.000+00:00', what: 'self'),
+              Dor::ReleaseTag.new(to: 'test_target', release: true, what: 'self'),
+              Dor::ReleaseTag.new(to: 'test_nontarget', release: false, date: '2016-12-16T22:52:35.000+00:00',
+                                  what: 'self'),
+              Dor::ReleaseTag.new(to: 'test_nontarget', release: true, date: '2016-11-16T22:52:35.000+00:00',
+                                  what: 'self')
+            ]
+          end
+
+          it 'indexes release tags' do
+            expect(doc).to eq('released_to_ssim' => %w[Project test_target])
+          end
         end
 
-        it 'indexes release tags' do
-          expect(doc).to be_empty
+        context 'when Searchworks, Earthworks, and PURL sitemap tags are present' do
+          let(:release_tags) do
+            [
+              Dor::ReleaseTag.new(to: 'Searchworks', release: true, date: '2021-05-12T21:05:21.000+00:00',
+                                  what: 'self'),
+              Dor::ReleaseTag.new(to: 'Earthworks', release: true, date: '2016-11-16T22:52:35.000+00:00',
+                                  what: 'self'),
+              Dor::ReleaseTag.new(to: 'PURL sitemap', release: true, date: '2023-03-27T10:00:00.000+00:00',
+                                  what: 'self')
+            ]
+          end
+
+          it 'indexes release tags' do
+            expect(doc).to eq(
+              'released_to_ssim' => ['Searchworks', 'Earthworks', 'PURL sitemap'],
+              'released_to_earthworks_dttsi' => '2016-11-16T22:52:35Z',
+              'released_to_searchworks_dttsi' => '2021-05-12T21:05:21Z',
+              'released_to_purl_sitemap_dttsi' => '2023-03-27T10:00:00Z'
+            )
+          end
+        end
+
+        context 'when releaseTags are not present' do
+          let(:release_tags) { [] }
+
+          it 'has no release tags' do
+            expect(doc).to be_empty
+          end
+        end
+
+        context 'when a collection with a collection releaseTag' do
+          let(:release_tags) do
+            [
+              Dor::ReleaseTag.new(to: 'Project', release: true, date: '2016-11-16T22:52:35.000+00:00',
+                                  what: 'collection'),
+              Dor::ReleaseTag.new(to: 'test_target', release: true, what: 'self')
+            ]
+          end
+
+          it 'indexes release tags' do
+            expect(doc).to eq('released_to_ssim' => %w[Project test_target])
+          end
         end
       end
 
-      context 'when the parent collection has collection releaseTags' do
-        let(:release_tags) { [] }
-        let(:collection_release_tags) do
-          [
-            Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00',
-                                what: 'collection')
-          ]
-        end
-
-        it 'indexes release tags' do
-          # rubocop:disable Style/StringHashKeys
-          expect(doc).to eq('released_to_ssim' => %w[test_target])
-          # rubocop:enable Style/StringHashKeys
-        end
-      end
-
-      context 'when the parent collection has releaseTags and the item has the same' do
-        let(:release_tags) do
-          [Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00', what: 'self')]
-        end
-        let(:collection_release_tags) do
-          [Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00',
-                               what: 'collection')]
-        end
-
-        it 'indexes release tags' do
-          # rubocop:disable Style/StringHashKeys
-          expect(doc).to eq('released_to_ssim' => %w[test_target])
-          # rubocop:enable Style/StringHashKeys
-        end
-      end
-
-      context 'when the parent collection has release true and item has release false' do
-        let(:release_tags) do
-          [
-            Dor::ReleaseTag.new(to: 'test_target', release: false, date: '2016-12-21T17:31:18.000+00:00', what: 'self')
-          ]
-        end
-        let(:collection_release_tags) do
-          [
-            Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00',
-                                what: 'collection')
-          ]
-        end
-
-        it 'indexes release tags' do
-          expect(doc).to be_empty
-        end
-      end
-
-      context 'when releaseTags are not present' do
-        let(:release_tags) { [] }
+      context 'with a parent collection' do
+        let(:collection_druid) { 'druid:bc123fg4567' }
+        let(:collection_druids) { [collection_druid] }
         let(:collection_release_tags) { [] }
 
-        it 'has no release tags' do
-          expect(doc).not_to include('released_to_ssim')
+        before do
+          allow(ReleaseTagService).to receive(:tags).with(druid: collection_druid)
+                                                    .and_return(collection_release_tags)
+        end
+
+        context 'when the parent collection has self releaseTags' do
+          let(:release_tags) { [] }
+          let(:collection_release_tags) do
+            [
+              Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00',
+                                  what: 'self')
+            ]
+          end
+
+          it 'indexes release tags' do
+            expect(doc).to be_empty
+          end
+        end
+
+        context 'when the parent collection has collection releaseTags' do
+          let(:release_tags) { [] }
+          let(:collection_release_tags) do
+            [
+              Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00',
+                                  what: 'collection')
+            ]
+          end
+
+          it 'indexes release tags' do
+            expect(doc).to eq('released_to_ssim' => %w[test_target])
+          end
+        end
+
+        context 'when the parent collection has releaseTags and the item has the same' do
+          let(:release_tags) do
+            [Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00',
+                                 what: 'self')]
+          end
+          let(:collection_release_tags) do
+            [Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00',
+                                 what: 'collection')]
+          end
+
+          it 'indexes release tags' do
+            expect(doc).to eq('released_to_ssim' => %w[test_target])
+          end
+        end
+
+        context 'when the parent collection has release true and item has release false' do
+          let(:release_tags) do
+            [
+              Dor::ReleaseTag.new(to: 'test_target', release: false, date: '2016-12-21T17:31:18.000+00:00',
+                                  what: 'self')
+            ]
+          end
+          let(:collection_release_tags) do
+            [
+              Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00',
+                                  what: 'collection')
+            ]
+          end
+
+          it 'indexes release tags' do
+            expect(doc).to be_empty
+          end
+        end
+
+        context 'when releaseTags are not present' do
+          let(:release_tags) { [] }
+          let(:collection_release_tags) { [] }
+
+          it 'has no release tags' do
+            expect(doc).not_to include('released_to_ssim')
+          end
+        end
+      end
+    end
+
+    context 'when release tags are provided' do
+      let(:doc) do
+        described_class.new(cocina:, release_tags:, parent_collections_release_tags:).to_solr
+      end
+
+      let(:parent_collections_release_tags) { {} }
+
+      context 'with no parent collection' do
+        context 'when multiple releaseTags are present for the same destination' do
+          let(:release_tags) do
+            [
+              Dor::ReleaseTag.new(to: 'Project', release: true, date: '2016-11-16T22:52:35.000+00:00', what: 'self'),
+              Dor::ReleaseTag.new(to: 'Project', release: false, date: '2016-12-21T17:31:18.000+00:00', what: 'self'),
+              Dor::ReleaseTag.new(to: 'Project', release: true, date: '2021-05-12T21:05:21.000+00:00', what: 'self'),
+              Dor::ReleaseTag.new(to: 'test_target', release: true, what: 'self'),
+              Dor::ReleaseTag.new(to: 'test_nontarget', release: false, date: '2016-12-16T22:52:35.000+00:00',
+                                  what: 'self'),
+              Dor::ReleaseTag.new(to: 'test_nontarget', release: true, date: '2016-11-16T22:52:35.000+00:00',
+                                  what: 'self')
+            ]
+          end
+
+          it 'indexes release tags' do
+            expect(doc).to eq('released_to_ssim' => %w[Project test_target])
+          end
+        end
+
+        context 'when Searchworks, Earthworks, and PURL sitemap tags are present' do
+          let(:release_tags) do
+            [
+              Dor::ReleaseTag.new(to: 'Searchworks', release: true, date: '2021-05-12T21:05:21.000+00:00',
+                                  what: 'self'),
+              Dor::ReleaseTag.new(to: 'Earthworks', release: true, date: '2016-11-16T22:52:35.000+00:00', what: 'self'),
+              Dor::ReleaseTag.new(to: 'PURL sitemap', release: true, date: '2023-03-27T10:00:00.000+00:00',
+                                  what: 'self')
+            ]
+          end
+
+          it 'indexes release tags' do
+            expect(doc).to eq(
+              'released_to_ssim' => ['Searchworks', 'Earthworks', 'PURL sitemap'],
+              'released_to_earthworks_dttsi' => '2016-11-16T22:52:35Z',
+              'released_to_searchworks_dttsi' => '2021-05-12T21:05:21Z',
+              'released_to_purl_sitemap_dttsi' => '2023-03-27T10:00:00Z'
+            )
+          end
+        end
+
+        context 'when releaseTags are not present' do
+          it 'has no release tags' do
+            expect(doc).to be_empty
+          end
+        end
+
+        context 'when a collection with a collection releaseTag' do
+          let(:release_tags) do
+            [
+              Dor::ReleaseTag.new(to: 'Project', release: true, date: '2016-11-16T22:52:35.000+00:00',
+                                  what: 'collection'),
+              Dor::ReleaseTag.new(to: 'test_target', release: true, what: 'self')
+            ]
+          end
+
+          it 'indexes release tags' do
+            expect(doc).to eq('released_to_ssim' => %w[Project test_target])
+          end
+        end
+      end
+
+      context 'with a parent collection' do
+        let(:collection_druid) { 'druid:bc123fg4567' }
+        let(:collection_druids) { [collection_druid] }
+
+        context 'when the parent collection has self releaseTags' do
+          let(:parent_collections_release_tags) do
+            {
+              collection_druid => [Dor::ReleaseTag.new(to: 'test_target', release: true,
+                                                       date: '2016-12-21T17:31:18.000+00:00', what: 'self')]
+            }
+          end
+
+          it 'indexes release tags' do
+            expect(doc).to be_empty
+          end
+        end
+
+        context 'when the parent collection has collection releaseTags' do
+          let(:parent_collections_release_tags) do
+            {
+              collection_druid => [Dor::ReleaseTag.new(to: 'test_target', release: true,
+                                                       date: '2016-12-21T17:31:18.000+00:00', what: 'collection')]
+            }
+          end
+
+          it 'indexes release tags' do
+            expect(doc).to eq('released_to_ssim' => %w[test_target])
+          end
+        end
+
+        context 'when the parent collection has releaseTags and the item has the same' do
+          let(:release_tags) do
+            [Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00', what: 'self')]
+          end
+          let(:parent_collections_release_tags) do
+            {
+              collection_druid => [Dor::ReleaseTag.new(to: 'test_target', release: true,
+                                                       date: '2016-12-21T17:31:18.000+00:00',
+                                                       what: 'collection')]
+            }
+          end
+
+          it 'indexes release tags' do
+            expect(doc).to eq('released_to_ssim' => %w[test_target])
+          end
+        end
+
+        context 'when the parent collection has release true and item has release false' do
+          let(:release_tags) do
+            [
+              Dor::ReleaseTag.new(to: 'test_target', release: false, date: '2016-12-21T17:31:18.000+00:00',
+                                  what: 'self')
+            ]
+          end
+          let(:parent_collections_release_tags) do
+            {
+              collection_druid => [Dor::ReleaseTag.new(to: 'test_target', release: true,
+                                                       date: '2016-12-21T17:31:18.000+00:00',
+                                                       what: 'collection')]
+            }
+          end
+
+          it 'indexes release tags' do
+            expect(doc).to be_empty
+          end
+        end
+
+        context 'when releaseTags are not present' do
+          it 'has no release tags' do
+            expect(doc).not_to include('released_to_ssim')
+          end
         end
       end
     end
   end
+  # rubocop:enable Style/StringHashKeys
 end


### PR DESCRIPTION
refs #5518
closes https://github.com/sul-dlss/argo/issues/4653

## Why was this change made? 🤔
* Caching parent collections was causing collection titles not to be updated when they were changed.
* Faster re-indexing.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



