### PR TITLE
Extract fetching out of the indexers. Improve DocumentBuilder tests.

### DIFF
--- a/app/services/indexing/indexers/releasable_indexer.rb
+++ b/app/services/indexing/indexers/releasable_indexer.rb
@@ -4,7 +4,7 @@ module Indexing
   module Indexers
     # Indexes the object's release tags
     class ReleasableIndexer
-      def initialize(cocina:, parent_collections_release_tags: nil, release_tags: nil, **)
+      def initialize(cocina:, parent_collections_release_tags:, release_tags:, **)
         @cocina = cocina
         @parent_collections_release_tags = parent_collections_release_tags
         @release_tags = release_tags
@@ -24,7 +24,7 @@ module Indexing
 
       private
 
-      attr_reader :cocina
+      attr_reader :cocina, :parent_collections_release_tags, :release_tags
 
       def purl_sitemap_release_date
         date_for_tag 'PURL sitemap'
@@ -62,16 +62,6 @@ module Indexing
             result[project] = releases_for_project.max_by(&:date)
           end
         end
-      end
-
-      def parent_collections_release_tags
-        @parent_collections_release_tags ||= collection_druids.index_with do |collection_druid|
-          ReleaseTagService.tags(druid: collection_druid)
-        end
-      end
-
-      def release_tags
-        @release_tags ||= ReleaseTagService.tags(druid: cocina.externalIdentifier)
       end
 
       def tags_from_item

--- a/app/services/indexing/indexers/workflows_indexer.rb
+++ b/app/services/indexing/indexers/workflows_indexer.rb
@@ -6,7 +6,7 @@ module Indexing
     class WorkflowsIndexer
       attr_reader :id
 
-      def initialize(id:, workflows: nil, **)
+      def initialize(id:, workflows:, **)
         @id = id
         @workflows = workflows
       end
@@ -23,10 +23,7 @@ module Indexing
 
       private
 
-      # @return [Array<Workflow::WorkflowResponse>]
-      def workflows
-        @workflows ||= Workflow::Service.workflows(druid: id)
-      end
+      attr_reader :workflows
     end
   end
 end

--- a/app/services/indexing/workflow_fields.rb
+++ b/app/services/indexing/workflow_fields.rb
@@ -87,7 +87,7 @@ module Indexing
         'opened' => 8
       }.freeze
 
-      attr_reader :status_code
+      attr_reader :status_code, :milestones
 
       # @param [String] druid the object identifier
       # @param [String|Integer] version the version identifier
@@ -110,10 +110,6 @@ module Indexing
 
       def display_simplified
         simplified_status_code(STATUS_CODE_DISP_TXT[status_code])
-      end
-
-      def milestones
-        @milestones ||= Workflow::LifecycleService.milestones(druid: druid)
       end
 
       private

--- a/spec/services/indexing/builders/document_builder_spec.rb
+++ b/spec/services/indexing/builders/document_builder_spec.rb
@@ -11,63 +11,27 @@ RSpec.describe Indexing::Builders::DocumentBuilder do
     Cocina::Models.with_metadata(cocina, 'unknown_lock', created: DateTime.parse('Wed, 01 Jan 2020 12:00:01 GMT'),
                                                          modified: DateTime.parse('Thu, 04 Mar 2021 23:05:34 GMT'))
   end
+  let(:cocina) do
+    build(:dro, id: druid).new(
+      structural: {
+        isMemberOf: collections
+      }
+    )
+  end
+  let(:collections) { [] }
   let(:druid) { 'druid:xx999xx9999' }
+  let(:collection_druid) { 'druid:bc999df2323' }
   let(:trace_id) { 'abc123' }
 
-  let(:releasable) do
-    instance_double(Indexing::Indexers::ReleasableIndexer,
-                    to_solr: { 'released_to_ssim' => %w[searchworks earthworks] })
-  end
-  let(:workflows) do
-    instance_double(Indexing::Indexers::WorkflowsIndexer, to_solr: { 'wf_ssim' => ['accessionWF'] })
-  end
-  let(:admin_tags) do
-    instance_double(Indexing::Indexers::AdministrativeTagIndexer, to_solr: { 'tag_ssim' => ['Test : Tag'] })
-  end
-  # rubocop:enable Style/StringHashKeys
-
-  before do
-    allow(Indexing::WorkflowFields).to receive(:for).and_return({ milestones_ssim: %w[foo bar] })
-    allow(Indexing::Indexers::ReleasableIndexer).to receive(:new).and_return(releasable)
-    allow(Indexing::Indexers::WorkflowsIndexer).to receive(:new).and_return(workflows)
-    allow(Indexing::Indexers::AdministrativeTagIndexer).to receive(:new).and_return(admin_tags)
-    allow(AdministrativeTags).to receive(:for).and_return([])
-  end
-
   context 'when the model is an item' do
-    let(:cocina) do
-      build(:dro, id: druid).new(
-        structural: {
-          isMemberOf: collections
-        }
-      )
-    end
-
-    context 'without collections' do
-      let(:collections) { [] }
-
-      it { is_expected.to be_instance_of Indexing::Indexers::CompositeIndexer::Instance }
-    end
-
-    context 'with collections' do
-      let(:related) { build(:collection) }
-      let(:collections) { ['druid:bc999df2323'] }
-
-      before do
-        allow(CocinaObjectStore).to receive(:find).and_return(related)
-      end
-
-      it 'returns indexer' do
-        expect(indexer).to be_instance_of Indexing::Indexers::CompositeIndexer::Instance
-        expect(CocinaObjectStore).to have_received(:find).with(collections.first)
-      end
-    end
+    it { is_expected.to be_instance_of Indexing::Indexers::CompositeIndexer::Instance }
 
     context "with collections that can't be resolved" do
-      let(:collections) { ['druid:bc999df2323'] }
+      let(:collections) { [collection_druid] }
 
       before do
         allow(CocinaObjectStore).to receive(:find).and_raise(CocinaObjectStore::CocinaObjectNotFoundError)
+        allow(Indexing::Indexers::CompositeIndexer::Instance).to receive(:new).and_call_original
       end
 
       it 'logs to honeybadger' do
@@ -75,16 +39,13 @@ RSpec.describe Indexing::Builders::DocumentBuilder do
         expect(indexer).to be_instance_of Indexing::Indexers::CompositeIndexer::Instance
 
         # Ensure that errors are stripped out of parent_collections
-        expect(Indexing::Indexers::AdministrativeTagIndexer).to have_received(:new)
-          .with(cocina: Cocina::Models::DROWithMetadata,
-                id: String,
-                administrative_tags: [],
-                parent_collections: [],
-                parent_collections_release_tags: nil,
-                workflows: nil,
-                release_tags: nil,
-                milestones: nil,
-                trace_id:)
+        expect(Indexing::Indexers::CompositeIndexer::Instance).to have_received(:new)
+          .with(
+            Array, # This is the array of indexers
+            a_hash_including(
+              parent_collections: []
+            )
+          )
         expect(Honeybadger).to have_received(:notify)
           .with('Bad association found on druid:xx999xx9999. druid:bc999df2323 could not be found')
       end
@@ -127,98 +88,73 @@ RSpec.describe Indexing::Builders::DocumentBuilder do
     it { is_expected.to be_instance_of Indexing::Indexers::CompositeIndexer::Instance }
   end
 
-  describe '#to_solr' do
-    subject(:solr_doc) { indexer.to_solr }
-
-    let(:apo_id) { 'druid:bd999bd9999' }
-    let(:apo) { build(:admin_policy, id: apo_id) }
+  describe 'parameters' do
+    let(:administrative_tags) { ['tag1', 'tag2'] }
+    let!(:parent_collection_repository_object) do
+      create(:repository_object, :collection, :with_repository_object_version, external_identifier: collection_druid)
+    end
+    let(:parent_collections) { [parent_collection_repository_object.to_cocina_with_metadata] }
+    let(:collections) { [collection_druid] }
+    let(:milestones) { [{ milestone: 'accessioned' }] }
+    let(:release_tags) { [instance_double(Dor::ReleaseTag)] }
+    let(:parent_collection_release_tags) { [instance_double(Dor::ReleaseTag)] }
+    let(:parent_collections_release_tags) { { collection_druid => parent_collection_release_tags } }
+    let(:workflows) { [instance_double(Workflow::WorkflowResponse)] }
 
     before do
-      allow(CocinaObjectStore).to receive(:find).and_return(apo)
+      allow(Indexing::Indexers::CompositeIndexer::Instance).to receive(:new).and_call_original
+      allow(AdministrativeTags).to receive(:for).with(identifier: druid).and_return(administrative_tags)
     end
 
-    context 'when the model is an item' do
-      let(:cocina) do
-        build(:dro, id: druid, admin_policy_id: apo_id).new(
-          description: {
-            title: [{ value: 'Test obj' }],
-            purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}",
-            subject: [{ type: 'topic', value: 'word' }],
-            event: [
-              {
-                type: 'creation',
-                date: [
-                  {
-                    value: '2021-01-01',
-                    status: 'primary',
-                    encoding: {
-                      code: 'w3cdtf'
-                    },
-                    type: 'creation'
-                  }
-                ]
-              },
-              {
-                type: 'publication',
-                location: [
-                  {
-                    value: 'Moskva'
-                  }
-                ],
-                contributor: [
-                  {
-                    name: [
-                      {
-                        value: 'Izdatelʹstvo "Vesʹ Mir"'
-                      }
-                    ],
-                    type: 'organization',
-                    role: [{ value: 'publisher' }]
-                  }
-                ]
-              }
-            ]
-          }
-        )
-      end
-
-      it 'has required fields' do
-        expect(solr_doc).to include('milestones_ssim', 'wf_ssim', 'tag_ssim')
-
-        expect(solr_doc['originInfo_date_created_tesim']).to eq '2021-01-01'
-        expect(solr_doc['originInfo_publisher_tesim']).to eq 'Izdatelʹstvo "Vesʹ Mir"'
-        expect(solr_doc['originInfo_place_placeTerm_tesim']).to eq 'Moskva'
+    context 'when optional parameters are provided' do
+      it 'uses the provided values' do
+        described_class.for(model: cocina_with_metadata, trace_id:, parent_collections:,
+                            milestones:, parent_collections_release_tags:, release_tags:, workflows:)
+        expect(Indexing::Indexers::CompositeIndexer::Instance).to have_received(:new)
+          .with(
+            Array, # This is the array of indexers
+            {
+              cocina: cocina_with_metadata,
+              id: druid,
+              administrative_tags: administrative_tags,
+              parent_collections:,
+              milestones:,
+              parent_collections_release_tags: { 'druid:bc999df2323' => parent_collection_release_tags },
+              release_tags:,
+              workflows:,
+              trace_id:
+            }
+          )
       end
     end
 
-    context 'when the model is an admin policy' do
-      let(:model) { Dor::AdminPolicyObject.new(pid: druid) }
-      let(:cocina) do
-        build(:admin_policy, id: druid).new(
-          administrative: {
-            hasAdminPolicy: apo_id,
-            hasAgreement: 'druid:bb033gt0615',
-            accessTemplate: { view: 'world', download: 'world' }
-          }
-        )
+    context 'when optional parameters are not provided' do
+      before do
+        allow(Workflow::LifecycleService).to receive(:milestones).with(druid:).and_return(milestones)
+        allow(ReleaseTagService).to receive(:tags).with(druid:).and_return(release_tags)
+        allow(ReleaseTagService).to receive(:tags).with(druid: collection_druid)
+                                                  .and_return(parent_collection_release_tags)
+        allow(Workflow::Service).to receive(:workflows).with(druid:).and_return(workflows)
       end
 
-      it { is_expected.to include('milestones_ssim', 'wf_ssim', 'tag_ssim') }
-    end
-
-    context 'when the model is a hydrus apo' do
-      let(:model) { Hydrus::AdminPolicyObject.new(pid: druid) }
-      let(:cocina) do
-        build(:admin_policy, id: druid).new(
-          administrative: {
-            hasAdminPolicy: apo_id,
-            hasAgreement: 'druid:bb033gt0615',
-            accessTemplate: { view: 'world', download: 'world' }
-          }
-        )
+      it 'fetches them as needed' do
+        indexer
+        expect(Indexing::Indexers::CompositeIndexer::Instance).to have_received(:new)
+          .with(
+            Array, # This is the array of indexers
+            {
+              cocina: cocina_with_metadata,
+              id: druid,
+              administrative_tags: administrative_tags,
+              parent_collections:,
+              milestones:,
+              parent_collections_release_tags:,
+              release_tags:,
+              workflows:,
+              trace_id:
+            }
+          )
       end
-
-      it { is_expected.to include('milestones_ssim', 'wf_ssim', 'tag_ssim') }
     end
   end
 end

--- a/spec/services/indexing/indexers/releasable_indexer_spec.rb
+++ b/spec/services/indexing/indexers/releasable_indexer_spec.rb
@@ -7,303 +7,144 @@ RSpec.describe Indexing::Indexers::ReleasableIndexer do
   let(:release_tags) { [] }
 
   describe 'to_solr' do
-    context 'when release tags are not provided' do
-      let(:doc) do
-        described_class.new(cocina:).to_solr
-      end
+    let(:doc) do
+      described_class.new(cocina:, release_tags:, parent_collections_release_tags:).to_solr
+    end
 
-      before do
-        allow(ReleaseTagService).to receive(:tags).with(druid: cocina.externalIdentifier).and_return(release_tags)
-      end
+    let(:parent_collections_release_tags) { {} }
 
-      context 'with no parent collection' do
-        context 'when multiple releaseTags are present for the same destination' do
-          let(:release_tags) do
-            [
-              Dor::ReleaseTag.new(to: 'Project', release: true, date: '2016-11-16T22:52:35.000+00:00', what: 'self'),
-              Dor::ReleaseTag.new(to: 'Project', release: false, date: '2016-12-21T17:31:18.000+00:00', what: 'self'),
-              Dor::ReleaseTag.new(to: 'Project', release: true, date: '2021-05-12T21:05:21.000+00:00', what: 'self'),
-              Dor::ReleaseTag.new(to: 'test_target', release: true, what: 'self'),
-              Dor::ReleaseTag.new(to: 'test_nontarget', release: false, date: '2016-12-16T22:52:35.000+00:00',
-                                  what: 'self'),
-              Dor::ReleaseTag.new(to: 'test_nontarget', release: true, date: '2016-11-16T22:52:35.000+00:00',
-                                  what: 'self')
-            ]
-          end
-
-          it 'indexes release tags' do
-            expect(doc).to eq('released_to_ssim' => %w[Project test_target])
-          end
+    context 'with no parent collection' do
+      context 'when multiple releaseTags are present for the same destination' do
+        let(:release_tags) do
+          [
+            Dor::ReleaseTag.new(to: 'Project', release: true, date: '2016-11-16T22:52:35.000+00:00', what: 'self'),
+            Dor::ReleaseTag.new(to: 'Project', release: false, date: '2016-12-21T17:31:18.000+00:00', what: 'self'),
+            Dor::ReleaseTag.new(to: 'Project', release: true, date: '2021-05-12T21:05:21.000+00:00', what: 'self'),
+            Dor::ReleaseTag.new(to: 'test_target', release: true, what: 'self'),
+            Dor::ReleaseTag.new(to: 'test_nontarget', release: false, date: '2016-12-16T22:52:35.000+00:00',
+                                what: 'self'),
+            Dor::ReleaseTag.new(to: 'test_nontarget', release: true, date: '2016-11-16T22:52:35.000+00:00',
+                                what: 'self')
+          ]
         end
 
-        context 'when Searchworks, Earthworks, and PURL sitemap tags are present' do
-          let(:release_tags) do
-            [
-              Dor::ReleaseTag.new(to: 'Searchworks', release: true, date: '2021-05-12T21:05:21.000+00:00',
-                                  what: 'self'),
-              Dor::ReleaseTag.new(to: 'Earthworks', release: true, date: '2016-11-16T22:52:35.000+00:00',
-                                  what: 'self'),
-              Dor::ReleaseTag.new(to: 'PURL sitemap', release: true, date: '2023-03-27T10:00:00.000+00:00',
-                                  what: 'self')
-            ]
-          end
-
-          it 'indexes release tags' do
-            expect(doc).to eq(
-              'released_to_ssim' => ['Searchworks', 'Earthworks', 'PURL sitemap'],
-              'released_to_earthworks_dttsi' => '2016-11-16T22:52:35Z',
-              'released_to_searchworks_dttsi' => '2021-05-12T21:05:21Z',
-              'released_to_purl_sitemap_dttsi' => '2023-03-27T10:00:00Z'
-            )
-          end
-        end
-
-        context 'when releaseTags are not present' do
-          let(:release_tags) { [] }
-
-          it 'has no release tags' do
-            expect(doc).to be_empty
-          end
-        end
-
-        context 'when a collection with a collection releaseTag' do
-          let(:release_tags) do
-            [
-              Dor::ReleaseTag.new(to: 'Project', release: true, date: '2016-11-16T22:52:35.000+00:00',
-                                  what: 'collection'),
-              Dor::ReleaseTag.new(to: 'test_target', release: true, what: 'self')
-            ]
-          end
-
-          it 'indexes release tags' do
-            expect(doc).to eq('released_to_ssim' => %w[Project test_target])
-          end
+        it 'indexes release tags' do
+          expect(doc).to eq('released_to_ssim' => %w[Project test_target])
         end
       end
 
-      context 'with a parent collection' do
-        let(:collection_druid) { 'druid:bc123fg4567' }
-        let(:collection_druids) { [collection_druid] }
-        let(:collection_release_tags) { [] }
-
-        before do
-          allow(ReleaseTagService).to receive(:tags).with(druid: collection_druid)
-                                                    .and_return(collection_release_tags)
+      context 'when Searchworks, Earthworks, and PURL sitemap tags are present' do
+        let(:release_tags) do
+          [
+            Dor::ReleaseTag.new(to: 'Searchworks', release: true, date: '2021-05-12T21:05:21.000+00:00',
+                                what: 'self'),
+            Dor::ReleaseTag.new(to: 'Earthworks', release: true, date: '2016-11-16T22:52:35.000+00:00', what: 'self'),
+            Dor::ReleaseTag.new(to: 'PURL sitemap', release: true, date: '2023-03-27T10:00:00.000+00:00',
+                                what: 'self')
+          ]
         end
 
-        context 'when the parent collection has self releaseTags' do
-          let(:release_tags) { [] }
-          let(:collection_release_tags) do
-            [
-              Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00',
-                                  what: 'self')
-            ]
-          end
+        it 'indexes release tags' do
+          expect(doc).to eq(
+            'released_to_ssim' => ['Searchworks', 'Earthworks', 'PURL sitemap'],
+            'released_to_earthworks_dttsi' => '2016-11-16T22:52:35Z',
+            'released_to_searchworks_dttsi' => '2021-05-12T21:05:21Z',
+            'released_to_purl_sitemap_dttsi' => '2023-03-27T10:00:00Z'
+          )
+        end
+      end
 
-          it 'indexes release tags' do
-            expect(doc).to be_empty
-          end
+      context 'when releaseTags are not present' do
+        it 'has no release tags' do
+          expect(doc).to be_empty
+        end
+      end
+
+      context 'when a collection with a collection releaseTag' do
+        let(:release_tags) do
+          [
+            Dor::ReleaseTag.new(to: 'Project', release: true, date: '2016-11-16T22:52:35.000+00:00',
+                                what: 'collection'),
+            Dor::ReleaseTag.new(to: 'test_target', release: true, what: 'self')
+          ]
         end
 
-        context 'when the parent collection has collection releaseTags' do
-          let(:release_tags) { [] }
-          let(:collection_release_tags) do
-            [
-              Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00',
-                                  what: 'collection')
-            ]
-          end
-
-          it 'indexes release tags' do
-            expect(doc).to eq('released_to_ssim' => %w[test_target])
-          end
-        end
-
-        context 'when the parent collection has releaseTags and the item has the same' do
-          let(:release_tags) do
-            [Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00',
-                                 what: 'self')]
-          end
-          let(:collection_release_tags) do
-            [Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00',
-                                 what: 'collection')]
-          end
-
-          it 'indexes release tags' do
-            expect(doc).to eq('released_to_ssim' => %w[test_target])
-          end
-        end
-
-        context 'when the parent collection has release true and item has release false' do
-          let(:release_tags) do
-            [
-              Dor::ReleaseTag.new(to: 'test_target', release: false, date: '2016-12-21T17:31:18.000+00:00',
-                                  what: 'self')
-            ]
-          end
-          let(:collection_release_tags) do
-            [
-              Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00',
-                                  what: 'collection')
-            ]
-          end
-
-          it 'indexes release tags' do
-            expect(doc).to be_empty
-          end
-        end
-
-        context 'when releaseTags are not present' do
-          let(:release_tags) { [] }
-          let(:collection_release_tags) { [] }
-
-          it 'has no release tags' do
-            expect(doc).not_to include('released_to_ssim')
-          end
+        it 'indexes release tags' do
+          expect(doc).to eq('released_to_ssim' => %w[Project test_target])
         end
       end
     end
 
-    context 'when release tags are provided' do
-      let(:doc) do
-        described_class.new(cocina:, release_tags:, parent_collections_release_tags:).to_solr
-      end
+    context 'with a parent collection' do
+      let(:collection_druid) { 'druid:bc123fg4567' }
+      let(:collection_druids) { [collection_druid] }
 
-      let(:parent_collections_release_tags) { {} }
-
-      context 'with no parent collection' do
-        context 'when multiple releaseTags are present for the same destination' do
-          let(:release_tags) do
-            [
-              Dor::ReleaseTag.new(to: 'Project', release: true, date: '2016-11-16T22:52:35.000+00:00', what: 'self'),
-              Dor::ReleaseTag.new(to: 'Project', release: false, date: '2016-12-21T17:31:18.000+00:00', what: 'self'),
-              Dor::ReleaseTag.new(to: 'Project', release: true, date: '2021-05-12T21:05:21.000+00:00', what: 'self'),
-              Dor::ReleaseTag.new(to: 'test_target', release: true, what: 'self'),
-              Dor::ReleaseTag.new(to: 'test_nontarget', release: false, date: '2016-12-16T22:52:35.000+00:00',
-                                  what: 'self'),
-              Dor::ReleaseTag.new(to: 'test_nontarget', release: true, date: '2016-11-16T22:52:35.000+00:00',
-                                  what: 'self')
-            ]
-          end
-
-          it 'indexes release tags' do
-            expect(doc).to eq('released_to_ssim' => %w[Project test_target])
-          end
+      context 'when the parent collection has self releaseTags' do
+        let(:parent_collections_release_tags) do
+          {
+            collection_druid => [Dor::ReleaseTag.new(to: 'test_target', release: true,
+                                                     date: '2016-12-21T17:31:18.000+00:00', what: 'self')]
+          }
         end
 
-        context 'when Searchworks, Earthworks, and PURL sitemap tags are present' do
-          let(:release_tags) do
-            [
-              Dor::ReleaseTag.new(to: 'Searchworks', release: true, date: '2021-05-12T21:05:21.000+00:00',
-                                  what: 'self'),
-              Dor::ReleaseTag.new(to: 'Earthworks', release: true, date: '2016-11-16T22:52:35.000+00:00', what: 'self'),
-              Dor::ReleaseTag.new(to: 'PURL sitemap', release: true, date: '2023-03-27T10:00:00.000+00:00',
-                                  what: 'self')
-            ]
-          end
-
-          it 'indexes release tags' do
-            expect(doc).to eq(
-              'released_to_ssim' => ['Searchworks', 'Earthworks', 'PURL sitemap'],
-              'released_to_earthworks_dttsi' => '2016-11-16T22:52:35Z',
-              'released_to_searchworks_dttsi' => '2021-05-12T21:05:21Z',
-              'released_to_purl_sitemap_dttsi' => '2023-03-27T10:00:00Z'
-            )
-          end
-        end
-
-        context 'when releaseTags are not present' do
-          it 'has no release tags' do
-            expect(doc).to be_empty
-          end
-        end
-
-        context 'when a collection with a collection releaseTag' do
-          let(:release_tags) do
-            [
-              Dor::ReleaseTag.new(to: 'Project', release: true, date: '2016-11-16T22:52:35.000+00:00',
-                                  what: 'collection'),
-              Dor::ReleaseTag.new(to: 'test_target', release: true, what: 'self')
-            ]
-          end
-
-          it 'indexes release tags' do
-            expect(doc).to eq('released_to_ssim' => %w[Project test_target])
-          end
+        it 'indexes release tags' do
+          expect(doc).to be_empty
         end
       end
 
-      context 'with a parent collection' do
-        let(:collection_druid) { 'druid:bc123fg4567' }
-        let(:collection_druids) { [collection_druid] }
-
-        context 'when the parent collection has self releaseTags' do
-          let(:parent_collections_release_tags) do
-            {
-              collection_druid => [Dor::ReleaseTag.new(to: 'test_target', release: true,
-                                                       date: '2016-12-21T17:31:18.000+00:00', what: 'self')]
-            }
-          end
-
-          it 'indexes release tags' do
-            expect(doc).to be_empty
-          end
+      context 'when the parent collection has collection releaseTags' do
+        let(:parent_collections_release_tags) do
+          {
+            collection_druid => [Dor::ReleaseTag.new(to: 'test_target', release: true,
+                                                     date: '2016-12-21T17:31:18.000+00:00', what: 'collection')]
+          }
         end
 
-        context 'when the parent collection has collection releaseTags' do
-          let(:parent_collections_release_tags) do
-            {
-              collection_druid => [Dor::ReleaseTag.new(to: 'test_target', release: true,
-                                                       date: '2016-12-21T17:31:18.000+00:00', what: 'collection')]
-            }
-          end
+        it 'indexes release tags' do
+          expect(doc).to eq('released_to_ssim' => %w[test_target])
+        end
+      end
 
-          it 'indexes release tags' do
-            expect(doc).to eq('released_to_ssim' => %w[test_target])
-          end
+      context 'when the parent collection has releaseTags and the item has the same' do
+        let(:release_tags) do
+          [Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00', what: 'self')]
+        end
+        let(:parent_collections_release_tags) do
+          {
+            collection_druid => [Dor::ReleaseTag.new(to: 'test_target', release: true,
+                                                     date: '2016-12-21T17:31:18.000+00:00',
+                                                     what: 'collection')]
+          }
         end
 
-        context 'when the parent collection has releaseTags and the item has the same' do
-          let(:release_tags) do
-            [Dor::ReleaseTag.new(to: 'test_target', release: true, date: '2016-12-21T17:31:18.000+00:00', what: 'self')]
-          end
-          let(:parent_collections_release_tags) do
-            {
-              collection_druid => [Dor::ReleaseTag.new(to: 'test_target', release: true,
-                                                       date: '2016-12-21T17:31:18.000+00:00',
-                                                       what: 'collection')]
-            }
-          end
+        it 'indexes release tags' do
+          expect(doc).to eq('released_to_ssim' => %w[test_target])
+        end
+      end
 
-          it 'indexes release tags' do
-            expect(doc).to eq('released_to_ssim' => %w[test_target])
-          end
+      context 'when the parent collection has release true and item has release false' do
+        let(:release_tags) do
+          [
+            Dor::ReleaseTag.new(to: 'test_target', release: false, date: '2016-12-21T17:31:18.000+00:00',
+                                what: 'self')
+          ]
+        end
+        let(:parent_collections_release_tags) do
+          {
+            collection_druid => [Dor::ReleaseTag.new(to: 'test_target', release: true,
+                                                     date: '2016-12-21T17:31:18.000+00:00',
+                                                     what: 'collection')]
+          }
         end
 
-        context 'when the parent collection has release true and item has release false' do
-          let(:release_tags) do
-            [
-              Dor::ReleaseTag.new(to: 'test_target', release: false, date: '2016-12-21T17:31:18.000+00:00',
-                                  what: 'self')
-            ]
-          end
-          let(:parent_collections_release_tags) do
-            {
-              collection_druid => [Dor::ReleaseTag.new(to: 'test_target', release: true,
-                                                       date: '2016-12-21T17:31:18.000+00:00',
-                                                       what: 'collection')]
-            }
-          end
-
-          it 'indexes release tags' do
-            expect(doc).to be_empty
-          end
+        it 'indexes release tags' do
+          expect(doc).to be_empty
         end
+      end
 
-        context 'when releaseTags are not present' do
-          it 'has no release tags' do
-            expect(doc).not_to include('released_to_ssim')
-          end
+      context 'when releaseTags are not present' do
+        it 'has no release tags' do
+          expect(doc).not_to include('released_to_ssim')
         end
       end
     end

--- a/spec/services/indexing/indexers/workflows_indexer_spec.rb
+++ b/spec/services/indexing/indexers/workflows_indexer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 RSpec.describe Indexing::Indexers::WorkflowsIndexer do
-  let(:indexer) { described_class.new(id: 'druid:ab123cd4567') }
+  let(:indexer) { described_class.new(id: 'druid:ab123cd4567', workflows:) }
 
   describe '#to_solr' do
     let(:solr_doc) { indexer.to_solr }
@@ -112,10 +112,9 @@ RSpec.describe Indexing::Indexers::WorkflowsIndexer do
       ] }
     end
 
+    let(:workflows) { Dor::Services::Response::Workflows.new(xml: Nokogiri::XML(xml)).workflows }
+
     before do
-      allow(Workflow::Service).to receive(:workflows).with(druid: 'druid:ab123cd4567').and_return(
-        Dor::Services::Response::Workflows.new(xml: Nokogiri::XML(xml)).workflows
-      )
       allow(Workflow::TemplateService).to receive(:template)
         .with(workflow_name: 'accessionWF').and_return(accession_json)
       allow(Workflow::TemplateService).to receive(:template)

--- a/spec/services/indexing/workflow_fields_spec.rb
+++ b/spec/services/indexing/workflow_fields_spec.rb
@@ -3,9 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Indexing::WorkflowFields do
-  let(:doc) { described_class.for(druid:, version:) }
+  let(:doc) { described_class.for(druid:, version:, milestones:) }
   let(:druid) { 'druid:ab123cd4567' }
   let(:version) { 4 }
+  let(:milestones) { [] }
 
   context 'with milestones' do
     let(:milestones) do
@@ -65,14 +66,10 @@ RSpec.describe Indexing::WorkflowFields do
 
   describe Indexing::WorkflowFields::Status do
     subject(:instance) do
-      described_class.new(druid:, version: version)
+      described_class.new(druid:, version: version, milestones:)
     end
 
     let(:version) { '2' }
-
-    before do
-      allow(Workflow::LifecycleService).to receive(:milestones).and_return(milestones)
-    end
 
     describe '#display' do
       subject(:status) { instance.display }


### PR DESCRIPTION
## Why was this change made? 🤔
* Make DocumentBuilder responsible for any lookups, since values can also be passed into DocumentBuilder.
* DocumentBuilder tests were not useful and incomplete.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



