### PR TITLE
Revert "Remove legacy facet fields."

### DIFF
--- a/app/services/indexing/indexers/administrative_tag_indexer.rb
+++ b/app/services/indexing/indexers/administrative_tag_indexer.rb
@@ -15,10 +15,11 @@ module Indexing
       end
 
       # @return [Hash] the partial solr document for administrative tags
-      def to_solr # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+      def to_solr # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         solr_doc = {
           'tag_ssim' => [],
           'tag_text_unstemmed_im' => [],
+          'exploded_nonproject_tag_ssim' => [], # TODO: Remove
           'exploded_nonproject_tag_ssimdv' => []
         }
         administrative_tags.each do |tag|
@@ -29,6 +30,8 @@ module Indexing
           solr_doc['tag_text_unstemmed_im'] << tag # for Argo search
 
           # exploded tags are for hierarchical facets in Argo
+          # TODO: Remove exploded_nonproject_tag_ssim
+          solr_doc['exploded_nonproject_tag_ssim'] += explode_tag_hierarchy(tag) unless prefix == 'project'
           solr_doc['exploded_nonproject_tag_ssimdv'] += explode_tag_hierarchy(tag) unless prefix == 'project'
 
           next if rest.blank?
@@ -41,6 +44,8 @@ module Indexing
 
           next unless prefix == 'project'
 
+          solr_doc['exploded_project_tag_ssim'] ||= [] # TODO: Remove
+          solr_doc['exploded_project_tag_ssim'] += explode_tag_hierarchy(rest.strip) # TODO: Remove
           solr_doc['exploded_project_tag_ssimdv'] ||= []
           solr_doc['exploded_project_tag_ssimdv'] += explode_tag_hierarchy(rest.strip)
         end

--- a/app/services/indexing/indexers/basic_indexer.rb
+++ b/app/services/indexing/indexers/basic_indexer.rb
@@ -14,13 +14,15 @@ module Indexing
       end
 
       # @return [Hash] the partial solr document for basic data
-      def to_solr # rubocop:disable Metrics/AbcSize
+      def to_solr # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         {}.tap do |solr_doc|
           solr_doc[:id] = cocina.externalIdentifier
           solr_doc['trace_id_ss'] = trace_id
+          solr_doc['current_version_isi'] = cocina.version # TODO: Remove
           solr_doc['current_version_ipsidv'] = cocina.version # Argo Facet field "Version"
           solr_doc['obj_label_tesim'] = cocina.label
 
+          solr_doc['modified_latest_dttsi'] = modified_latest # TODO: Remove
           solr_doc['modified_latest_dtpsidv'] = modified_latest
           solr_doc['created_at_dttsi'] = created_at
 
@@ -34,6 +36,7 @@ module Indexing
           solr_doc['is_governed_by_ssim'] = "info:fedora/#{cocina.administrative.hasAdminPolicy}"
 
           # Used so that DSA can generate public XML whereas a constituent can find the virtual object it is part of.
+          solr_doc['has_constituents_ssim'] = virtual_object_constituents # TODO: Remove
           solr_doc['has_constituents_ssimdv'] = virtual_object_constituents
         end.merge(Indexing::WorkflowFields.for(druid: cocina.externalIdentifier, version: cocina.version, milestones:))
            .transform_keys(&:to_s)

--- a/app/services/indexing/indexers/collection_title_indexer.rb
+++ b/app/services/indexing/indexers/collection_title_indexer.rb
@@ -12,12 +12,14 @@ module Indexing
       end
 
       # @return [Hash] the partial solr document for collection title concerns
-      def to_solr
+      def to_solr # rubocop:disable Metrics/AbcSize
         {}.tap do |solr_doc|
           parent_collections.each do |collection_obj|
             coll_title = Cocina::Models::Builders::TitleBuilder.build(collection_obj.description.title)
             next if coll_title.blank?
 
+            solr_doc['collection_title_ssim'] ||= [] # TODO: Remove
+            solr_doc['collection_title_ssim'] << coll_title # TODO: Remove
             solr_doc['collection_title_ssimdv'] ||= []
             solr_doc['collection_title_ssimdv'] << coll_title
             solr_doc['collection_title_tesim'] ||= []

--- a/app/services/indexing/indexers/default_object_rights_indexer.rb
+++ b/app/services/indexing/indexers/default_object_rights_indexer.rb
@@ -17,6 +17,7 @@ module Indexing
         {
           'use_statement_ssim' => use_statement,
           'copyright_ssim' => copyright,
+          'rights_descriptions_ssim' => 'dark', # TODO: Remove
           'rights_descriptions_ssimdv' => 'dark',
           'default_rights_descriptions_ssim' => Cocina::Models::Builders::RightsDescriptionBuilder.build(cocina)
         }

--- a/app/services/indexing/indexers/descriptive_metadata_indexer.rb
+++ b/app/services/indexing/indexers/descriptive_metadata_indexer.rb
@@ -45,9 +45,11 @@ module Indexing
           'author_text_nostem_im' => author_primary, # primary author tokenized but not stemmed
           'author_display_ss' => author_primary, # used for author display in Argo
           'contributor_text_nostem_im' => author_all, # author names should be tokenized but not stemmed
+          'contributor_orcids_ssim' => orcids, # TODO: Remove
           'contributor_orcids_ssimdv' => orcids,
 
           # topic
+          'topic_ssim' => stanford_mods_record.topic_facet&.uniq, # TODO: Remove
           'topic_ssimdv' => stanford_mods_record.topic_facet&.uniq,
           'topic_tesim' => stemmable_topics,
 
@@ -55,14 +57,21 @@ module Indexing
           'originInfo_date_created_tesim' => creation_date,
           'originInfo_publisher_tesim' => publisher_name,
           'originInfo_place_placeTerm_tesim' => event_place, # do we want this?
+          'sw_pub_date_facet_ssi' => stanford_mods_record.pub_year_int.to_s, # TODO: Remove
           'sw_pub_date_facet_ssidv' => stanford_mods_record.pub_year_int.to_s, # SW Date facet
 
           # SW facets plus a friend facet
+          'sw_format_ssim' => sw_format, # TODO: Remove
           'sw_format_ssimdv' => sw_format, # SW Resource Type facet
+          'mods_typeOfResource_ssim' => resource_type, # TODO: Remove
           'mods_typeOfResource_ssimdv' => resource_type, # MODS Resource Type facet
+          'sw_genre_ssim' => stanford_mods_record.sw_genre, # TODO: Remove
           'sw_genre_ssimdv' => stanford_mods_record.sw_genre, # SW Genre facet
+          'sw_language_ssim' => stanford_mods_record.sw_language_facet, # TODO: Remove
           'sw_language_ssimdv' => stanford_mods_record.sw_language_facet, # SW Language facet
+          'sw_subject_temporal_ssim' => stanford_mods_record.era_facet, # TODO: Remove
           'sw_subject_temporal_ssimdv' => stanford_mods_record.era_facet, # SW Era facet
+          'sw_subject_geographic_ssim' => subject_geographic, # TODO: Remove
           'sw_subject_geographic_ssimdv' => subject_geographic, # SW Region facet
 
           # all the descriptive data that we want to search on, with different flavors for better recall and precision

--- a/app/services/indexing/indexers/embargo_metadata_indexer.rb
+++ b/app/services/indexing/indexers/embargo_metadata_indexer.rb
@@ -17,6 +17,7 @@ module Indexing
           embargo_release_date = embargo_release_date(cocina)
           if embargo_release_date.present?
             solr_doc['embargo_status_ssim'] = ['embargoed']
+            solr_doc['embargo_release_dtsim'] = [embargo_release_date.utc.iso8601] # TODO: Remove
             solr_doc['embargo_release_dtpsimdv'] = [embargo_release_date.utc.iso8601]
           end
         end

--- a/app/services/indexing/indexers/identifiable_indexer.rb
+++ b/app/services/indexing/indexers/identifiable_indexer.rb
@@ -28,7 +28,10 @@ module Indexing
           # TODO: Remove https://github.com/sul-dlss/dor-services-app/issues/5537
           add_apo_titles(solr_doc, cocina.administrative.hasAdminPolicy)
 
-          solr_doc['metadata_source_ssimdv'] = identity_metadata_sources unless cocina.admin_policy?
+          unless cocina.admin_policy?
+            solr_doc['metadata_source_ssim'] = identity_metadata_sources # TODO: Remove
+            solr_doc['metadata_source_ssimdv'] = identity_metadata_sources
+          end
           solr_doc['druid_prefixed_ssi'] = cocina.externalIdentifier
           solr_doc['druid_bare_ssi'] = cocina.externalIdentifier.delete_prefix('druid:')
         end
@@ -81,13 +84,15 @@ module Indexing
       end
 
       # TODO: Remove https://github.com/sul-dlss/dor-services-app/issues/5537
-      def add_apo_titles(solr_doc, admin_policy_id)
+      def add_apo_titles(solr_doc, admin_policy_id) # rubocop:disable Metrics/AbcSize
         row = populate_cache(admin_policy_id)
         title = row['related_obj_title']
         if row['is_from_hydrus']
           solr_doc['hydrus_apo_title_ssim'] ||= []
           solr_doc['hydrus_apo_title_ssim'] << title
         else
+          solr_doc['nonhydrus_apo_title_ssim'] ||= [] # TODO: Remove
+          solr_doc['nonhydrus_apo_title_ssim'] << title # TODO: Remove
           solr_doc['nonhydrus_apo_title_ssimdv'] ||= []
           solr_doc['nonhydrus_apo_title_ssimdv'] << title
         end

--- a/app/services/indexing/indexers/identity_metadata_indexer.rb
+++ b/app/services/indexing/indexers/identity_metadata_indexer.rb
@@ -11,22 +11,26 @@ module Indexing
       end
 
       # @return [Hash] the partial solr document for identityMetadata
-      def to_solr
+      def to_solr # rubocop:disable Metrics/AbcSize
         if object_type == 'adminPolicy' || cocina_object.identification.blank?
           return {
+            'objectType_ssim' => [object_type], # TODO: Remove
             'objectType_ssimdv' => [object_type]
           }
         end
 
         {
+          'objectType_ssim' => [object_type], # TODO: Remove
           'objectType_ssimdv' => [object_type],
           'identifier_ssim' => prefixed_identifiers, # sourceid, barcode, folio_instance_hrid for display
           'identifier_tesim' => prefixed_identifiers, # ditto ^^, for search, tokenized (can search prefix and value
           # as separate tokens)
+          'barcode_id_ssim' => [barcode].compact, # TODO: Remove
           'barcode_id_ssimdv' => [barcode].compact,
           'source_id_ssi' => source_id, # for search and display (reports, track_sheet)
           'source_id_text_nostem_i' => source_id, # for search, tokenized per request from accessioneers
           'folio_instance_hrid_ssim' => [folio_instance_hrid].compact,
+          'doi_ssim' => [doi].compact, # TODO: Remove
           'doi_ssimdv' => [doi].compact
         }
       end

--- a/app/services/indexing/indexers/object_files_indexer.rb
+++ b/app/services/indexing/indexers/object_files_indexer.rb
@@ -24,14 +24,17 @@ module Indexing
       end
 
       # @return [Hash] the partial solr document for files in the object
-      def to_solr
+      def to_solr # rubocop:disable Metrics/AbcSize
         {
+          'content_type_ssim' => type(cocina.type), # TODO: Remove
           'content_type_ssimdv' => type(cocina.type),
+          'content_file_mimetypes_ssim' => files.map(&:hasMimeType).uniq, # TODO: Remove
           'content_file_mimetypes_ssimdv' => files.map(&:hasMimeType).uniq,
           'content_file_count_itsi' => files.size,
           'shelved_content_file_count_itsi' => shelved_files.size,
           'resource_count_itsi' => file_sets.size,
           'preserved_size_dbtsi' => preserved_size, # double (trie) to support very large sizes
+          'content_file_roles_ssim' => files.filter_map(&:use), # TODO: Remove
           'content_file_roles_ssimdv' => files.filter_map(&:use),
           # first_shelved_image is neither indexed nor multiple
           'first_shelved_image_ss' => first_shelved_image

--- a/app/services/indexing/indexers/releasable_indexer.rb
+++ b/app/services/indexing/indexers/releasable_indexer.rb
@@ -19,8 +19,11 @@ module Indexing
 
         {
           'released_to_ssim' => tags.map(&:to).uniq,
+          'released_to_searchworks_dttsi' => searchworks_release_date, # TODO: Remove
           'released_to_searchworks_dtpsidv' => searchworks_release_date,
+          'released_to_earthworks_dttsi' => earthworks_release_date, # TODO: Remove
           'released_to_earthworks_dtpsidv' => earthworks_release_date,
+          'released_to_purl_sitemap_dttsi' => purl_sitemap_release_date, # TODO: Remove
           'released_to_purl_sitemap_dtpsidv' => purl_sitemap_release_date
         }.compact
       end

--- a/app/services/indexing/indexers/rights_metadata_indexer.rb
+++ b/app/services/indexing/indexers/rights_metadata_indexer.rb
@@ -36,7 +36,9 @@ module Indexing
         {
           'copyright_ssim' => cocina.access.copyright,
           'use_statement_ssim' => cocina.access.useAndReproductionStatement,
+          'use_license_machine_ssi' => license, # TODO: Remove
           'use_license_machine_ssidv' => license,
+          'rights_descriptions_ssim' => rights_description, # TODO: Remove
           'rights_descriptions_ssimdv' => rights_description
         }.compact
       end

--- a/app/services/indexing/workflow_fields.rb
+++ b/app/services/indexing/workflow_fields.rb
@@ -34,6 +34,7 @@ module Indexing
       solr_doc['status_ssi'] = status.display
 
       # This is used for Argo's "Processing Status" facet
+      solr_doc['processing_status_text_ssi'] = status.display_simplified # TODO: Remove
       solr_doc['processing_status_text_ssidv'] = status.display_simplified
     end
 
@@ -44,16 +45,20 @@ module Indexing
       end
     end
 
-    def add_sortable_milestones(solr_doc)
+    def add_sortable_milestones(solr_doc) # rubocop:disable Metrics/AbcSize
       sortable_milestones.each do |milestone, unordered_dates|
         dates = unordered_dates.sort
         # create the published_dttsi and published_day fields and the like
         dates.each do |date|
+          solr_doc["#{milestone}_dttsim"] ||= [] # TODO: Remove
+          solr_doc["#{milestone}_dttsim"] << date unless solr_doc["#{milestone}_dttsim"].include?(date) # TODO: Remove
           solr_doc["#{milestone}_dtpsimdv"] ||= []
           solr_doc["#{milestone}_dtpsimdv"] << date unless solr_doc["#{milestone}_dtpsimdv"].include?(date)
         end
         # fields for OAI havester to sort on: _dttsi is trie date +stored +indexed (single valued, i.e. sortable)
         # TODO: we really only need accessioned_earliest and registered_earliest
+        solr_doc["#{milestone}_earliest_dttsi"] = dates.first # TODO: Remove
+        solr_doc["#{milestone}_latest_dttsi"] = dates.last # TODO: Remove
         solr_doc["#{milestone}_earliest_dtpsidv"] = dates.first
         solr_doc["#{milestone}_latest_dtpsidv"] = dates.last
       end

--- a/app/services/indexing/workflow_solr_document.rb
+++ b/app/services/indexing/workflow_solr_document.rb
@@ -6,18 +6,24 @@ module Indexing
     WORKFLOW_SOLR = 'wf_ssim'
     # field that indexes workflow name, process status then process name
     WORKFLOW_WPS_SOLR = 'wf_wps_ssimdv'
+    WORKFLOW_WPS_SOLR_REMOVE = 'wf_wps_ssim' # TODO: Remove
     # field that indexes workflow name, process name then process status
     WORKFLOW_WSP_SOLR = 'wf_wsp_ssimdv'
+    WORKFLOW_WSP_SOLR_REMOVE = 'wf_wsp_ssim' # TODO: Remove
     # field that indexes process status, workflowname then process name
     WORKFLOW_SWP_SOLR = 'wf_swp_ssimdv'
+    WORKFLOW_SWP_SOLR_REMOVE = 'wf_swp_ssim' # TODO: Remove
     WORKFLOW_ERROR_SOLR = 'wf_error_ssim'
     WORKFLOW_STATUS_SOLR = 'workflow_status_ssim'
 
     KEYS_TO_MERGE = [
       WORKFLOW_SOLR,
       WORKFLOW_WPS_SOLR,
+      WORKFLOW_WPS_SOLR_REMOVE,
       WORKFLOW_WSP_SOLR,
+      WORKFLOW_WSP_SOLR_REMOVE,
       WORKFLOW_SWP_SOLR,
+      WORKFLOW_SWP_SOLR_REMOVE,
       WORKFLOW_STATUS_SOLR,
       WORKFLOW_ERROR_SOLR
     ].freeze
@@ -31,6 +37,8 @@ module Indexing
       data[WORKFLOW_SOLR] += [wf_name]
       data[WORKFLOW_WPS_SOLR] += [wf_name]
       data[WORKFLOW_WSP_SOLR] += [wf_name]
+      data[WORKFLOW_WPS_SOLR_REMOVE] += [wf_name]
+      data[WORKFLOW_WSP_SOLR_REMOVE] += [wf_name]
     end
 
     def status=(status)
@@ -44,16 +52,19 @@ module Indexing
     # Add to the field that indexes workflow name, process status then process name
     def add_wps(*messages)
       data[WORKFLOW_WPS_SOLR] += messages
+      data[WORKFLOW_WPS_SOLR_REMOVE] += messages
     end
 
     # Add to the field that indexes workflow name, process name then process status
     def add_wsp(*messages)
       data[WORKFLOW_WSP_SOLR] += messages
+      data[WORKFLOW_WSP_SOLR_REMOVE] += messages
     end
 
     # Add to the field that indexes process status, workflow name then process name
     def add_swp(*messages)
       data[WORKFLOW_SWP_SOLR] += messages
+      data[WORKFLOW_SWP_SOLR_REMOVE] += messages
     end
 
     # Add the processes data_time attribute to the solr document

--- a/spec/requests/show_user_version_solr_spec.rb
+++ b/spec/requests/show_user_version_solr_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Show single user version' do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(id: druid)
+      expect(response.parsed_body).to include(rights_descriptions_ssim: ['world', 'dark (file)']) # TODO: Remove
       expect(response.parsed_body).to include(rights_descriptions_ssimdv: ['world', 'dark (file)'])
     end
   end

--- a/spec/requests/show_version_solr_spec.rb
+++ b/spec/requests/show_version_solr_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe 'Show solr for an object version' do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(id: druid)
+      expect(response.parsed_body).to include(rights_descriptions_ssim: ['world', 'dark (file)']) # TODO: Remove
       expect(response.parsed_body).to include(rights_descriptions_ssimdv: ['world', 'dark (file)'])
     end
   end

--- a/spec/services/indexing/indexers/administrative_tag_indexer_spec.rb
+++ b/spec/services/indexing/indexers/administrative_tag_indexer_spec.rb
@@ -27,12 +27,20 @@ RSpec.describe Indexing::Indexers::AdministrativeTagIndexer do
     end
 
     it 'indexes exploded tags' do
+      expect(document['exploded_nonproject_tag_ssim']) # TODO: Remove
+        .to contain_exactly('Google Books', 'Google Books : Phase 1', 'Google Books',
+                            'Google Books : Scan source STANFORD', 'Registered By',
+                            'Registered By : blalbrit', 'DPG', 'DPG : Beautiful Books',
+                            'DPG : Beautiful Books : Octavo',
+                            'DPG : Beautiful Books : Octavo : newpri', 'Remediated By', 'Remediated By : 4.15.4')
       expect(document['exploded_nonproject_tag_ssimdv'])
         .to contain_exactly('Google Books', 'Google Books : Phase 1', 'Google Books',
                             'Google Books : Scan source STANFORD', 'Registered By',
                             'Registered By : blalbrit', 'DPG', 'DPG : Beautiful Books',
                             'DPG : Beautiful Books : Octavo',
                             'DPG : Beautiful Books : Octavo : newpri', 'Remediated By', 'Remediated By : 4.15.4')
+      expect(document['exploded_project_tag_ssim']).to contain_exactly('Beautiful Books', 'Rare Books', # TODO: Remove
+                                                                       'Rare Books : Very Old Books')
       expect(document['exploded_project_tag_ssimdv']).to contain_exactly('Beautiful Books', 'Rare Books',
                                                                          'Rare Books : Very Old Books')
       expect(document).not_to have_key('exploded_registered_by_tag_ssim')

--- a/spec/services/indexing/indexers/basic_indexer_spec.rb
+++ b/spec/services/indexing/indexers/basic_indexer_spec.rb
@@ -36,13 +36,16 @@ RSpec.describe Indexing::Indexers::BasicIndexer do
       it 'makes a solr doc' do
         expect(doc).to eq(
           'obj_label_tesim' => 'item label',
+          'current_version_isi' => 4, # TODO: Remove
           'current_version_ipsidv' => 4,
           'milestones_ssim' => %w[foo bar],
+          'has_constituents_ssim' => nil, # TODO: Remove
           'has_constituents_ssimdv' => nil,
           'governed_by_ssim' => 'druid:vv888vv8888',
           'member_of_collection_ssim' => ['druid:bb777bb7777', 'druid:dd666dd6666'],
           'is_governed_by_ssim' => 'info:fedora/druid:vv888vv8888', # TODO: Remove https://github.com/sul-dlss/dor-services-app/issues/5532
           'is_member_of_collection_ssim' => ['info:fedora/druid:bb777bb7777', 'info:fedora/druid:dd666dd6666'], # TODO: Remove https://github.com/sul-dlss/dor-services-app/issues/5532 # rubocop:disable Layout/LineLength
+          'modified_latest_dttsi' => '2021-03-04T23:05:34Z', # TODO: Remove
           'modified_latest_dtpsidv' => '2021-03-04T23:05:34Z',
           'created_at_dttsi' => '2020-01-01T12:00:01Z',
           'id' => 'druid:xx999xx9999',
@@ -59,13 +62,16 @@ RSpec.describe Indexing::Indexers::BasicIndexer do
       it 'makes a solr doc' do
         expect(doc).to eq(
           'obj_label_tesim' => 'item label',
+          'current_version_isi' => 4, # TODO: Remove
           'current_version_ipsidv' => 4,
           'milestones_ssim' => %w[foo bar],
           'is_governed_by_ssim' => 'info:fedora/druid:vv888vv8888', # TODO: Remove https://github.com/sul-dlss/dor-services-app/issues/5532
           'is_member_of_collection_ssim' => [], # TODO: Remove https://github.com/sul-dlss/dor-services-app/issues/5532
           'governed_by_ssim' => 'druid:vv888vv8888',
           'member_of_collection_ssim' => [],
+          'has_constituents_ssim' => nil, # TODO: Remove
           'has_constituents_ssimdv' => nil,
+          'modified_latest_dttsi' => '2021-03-04T23:05:34Z', # TODO: Remove
           'modified_latest_dtpsidv' => '2021-03-04T23:05:34Z',
           'created_at_dttsi' => '2020-01-01T12:00:01Z',
           'id' => 'druid:xx999xx9999',
@@ -82,13 +88,16 @@ RSpec.describe Indexing::Indexers::BasicIndexer do
       it 'makes a solr doc' do
         expect(doc).to eq(
           'obj_label_tesim' => 'item label',
+          'current_version_isi' => 4, # TODO: Remove
           'current_version_ipsidv' => 4,
           'milestones_ssim' => %w[foo bar],
+          'has_constituents_ssim' => ['druid:bb777bb7777', 'druid:dd666dd6666'], # TODO: Remove
           'has_constituents_ssimdv' => ['druid:bb777bb7777', 'druid:dd666dd6666'],
           'is_governed_by_ssim' => 'info:fedora/druid:vv888vv8888', # TODO: Remove https://github.com/sul-dlss/dor-services-app/issues/5532
           'is_member_of_collection_ssim' => [], # TODO: Remove https://github.com/sul-dlss/dor-services-app/issues/5532
           'governed_by_ssim' => 'druid:vv888vv8888',
           'member_of_collection_ssim' => [],
+          'modified_latest_dttsi' => '2021-03-04T23:05:34Z', # TODO: Remove
           'modified_latest_dtpsidv' => '2021-03-04T23:05:34Z',
           'created_at_dttsi' => '2020-01-01T12:00:01Z',
           'id' => 'druid:xx999xx9999',

--- a/spec/services/indexing/indexers/collection_title_indexer_spec.rb
+++ b/spec/services/indexing/indexers/collection_title_indexer_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Indexing::Indexers::CollectionTitleIndexer do
       let(:collections) { [] }
 
       it "doesn't raise an error" do
+        expect(doc['collection_title_ssim']).to be_nil # TODO: Remove
         expect(doc['collection_title_ssimdv']).to be_nil
         expect(doc['collection_title_tesim']).to be_nil
       end
@@ -27,6 +28,7 @@ RSpec.describe Indexing::Indexers::CollectionTitleIndexer do
       let(:collection) { build(:collection, id: collection_druid, title: 'Collection test object') }
 
       it 'generates collection title fields' do
+        expect(doc['collection_title_ssim'].first).to eq 'Collection test object' # TODO: Remove
         expect(doc['collection_title_ssimdv'].first).to eq 'Collection test object'
         expect(doc['collection_title_tesim'].first).to eq 'Collection test object'
       end

--- a/spec/services/indexing/indexers/composite_indexer_spec.rb
+++ b/spec/services/indexing/indexers/composite_indexer_spec.rb
@@ -42,12 +42,15 @@ RSpec.describe Indexing::Indexers::CompositeIndexer do
         'full_title_tenim' => ['Test item'],
         'display_title_ss' => 'Test item',
         'apo_title_ssimdv' => ['test admin policy'],
+        'nonhydrus_apo_title_ssim' => ['test admin policy'], # TODO: Remove
         # TODO: Remove https://github.com/sul-dlss/dor-services-app/issues/5537
         'nonhydrus_apo_title_ssimdv' => ['test admin policy'],
         'apo_title_ssim' => ['test admin policy'],
+        'metadata_source_ssim' => ['DOR'], # TODO: Remove
         'metadata_source_ssimdv' => ['DOR'],
         'druid_bare_ssi' => 'mx123ms3333',
         'druid_prefixed_ssi' => 'druid:mx123ms3333',
+        'topic_ssim' => ['word'], # TODO: Remove
         'topic_ssimdv' => ['word'],
         'topic_tesim' => ['word']
       )

--- a/spec/services/indexing/indexers/default_object_rights_indexer_spec.rb
+++ b/spec/services/indexing/indexers/default_object_rights_indexer_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Indexing::Indexers::DefaultObjectRightsIndexer do
       expect(doc).to match a_hash_including('use_statement_ssim' =>
         'Rights are owned by Stanford University Libraries.')
       expect(doc).to match a_hash_including('copyright_ssim' => 'Additional copyright info')
+      expect(doc).to match a_hash_including('rights_descriptions_ssim' => 'dark') # TODO: Remove
       expect(doc).to match a_hash_including('rights_descriptions_ssimdv' => 'dark')
       expect(doc).to match a_hash_including('default_rights_descriptions_ssim' => ['location: spec'])
       # rubocop:enable Style/StringHashKeys

--- a/spec/services/indexing/indexers/descriptive_metadata_indexer_format_spec.rb
+++ b/spec/services/indexing/indexers/descriptive_metadata_indexer_format_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Book']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Book'])
       end
     end
@@ -62,6 +63,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on genre' do
+        expect(doc).to include('sw_format_ssim' => ['Dataset']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Dataset'])
       end
     end
@@ -84,6 +86,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Archive/Manuscript']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Archive/Manuscript'])
       end
     end
@@ -106,6 +109,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Map']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Map'])
       end
     end
@@ -128,6 +132,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Archive/Manuscript']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Archive/Manuscript'])
       end
     end
@@ -150,6 +155,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Video']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Video'])
       end
     end
@@ -172,6 +178,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Music score']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Music score'])
       end
     end
@@ -194,6 +201,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Software/Multimedia']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Software/Multimedia'])
       end
     end
@@ -220,6 +228,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on cartographic resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Map']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Map'])
       end
     end
@@ -247,6 +256,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on dataset genre' do
+        expect(doc).to include('sw_format_ssim' => ['Dataset']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Dataset'])
       end
     end
@@ -269,6 +279,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Music recording']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Music recording'])
       end
     end
@@ -291,6 +302,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Sound recording']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Sound recording'])
       end
     end
@@ -313,6 +325,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Sound recording']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Sound recording'])
       end
     end
@@ -335,6 +348,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Image']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Image'])
       end
     end
@@ -367,6 +381,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type and issuance' do
+        expect(doc).to include('sw_format_ssim' => ['Book']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Book'])
       end
     end
@@ -410,6 +425,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type and issuance' do
+        expect(doc).to include('sw_format_ssim' => ['Book']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Book'])
       end
     end
@@ -446,6 +462,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type and issuance' do
+        expect(doc).to include('sw_format_ssim' => ['Book']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Book'])
       end
     end
@@ -472,6 +489,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on manuscript resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Archive/Manuscript']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Archive/Manuscript'])
       end
     end
@@ -504,6 +522,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type and issuance' do
+        expect(doc).to include('sw_format_ssim' => ['Journal/Periodical']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Journal/Periodical'])
       end
     end
@@ -536,6 +555,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type and issuance' do
+        expect(doc).to include('sw_format_ssim' => ['Journal/Periodical']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Journal/Periodical'])
       end
     end
@@ -569,6 +589,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type and frequency' do
+        expect(doc).to include('sw_format_ssim' => ['Journal/Periodical']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Journal/Periodical'])
       end
     end
@@ -612,6 +633,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type and issuance' do
+        expect(doc).to include('sw_format_ssim' => ['Journal/Periodical']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Journal/Periodical'])
       end
     end
@@ -655,6 +677,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type and issuance' do
+        expect(doc).to include('sw_format_ssim' => ['Journal/Periodical']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Journal/Periodical'])
       end
     end
@@ -699,6 +722,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type and frequency' do
+        expect(doc).to include('sw_format_ssim' => ['Journal/Periodical']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Journal/Periodical'])
       end
     end
@@ -738,6 +762,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type and issuance' do
+        expect(doc).to include('sw_format_ssim' => ['Journal/Periodical']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Journal/Periodical'])
       end
     end
@@ -777,6 +802,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type and issuance' do
+        expect(doc).to include('sw_format_ssim' => ['Journal/Periodical']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Journal/Periodical'])
       end
     end
@@ -817,6 +843,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type and frequency' do
+        expect(doc).to include('sw_format_ssim' => ['Journal/Periodical']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Journal/Periodical'])
       end
     end
@@ -844,6 +871,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type and genre' do
+        expect(doc).to include('sw_format_ssim' => ['Archived website']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Archived website'])
       end
     end
@@ -866,6 +894,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'defaults to Book format' do
+        expect(doc).to include('sw_format_ssim' => ['Book']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Book'])
       end
     end
@@ -892,6 +921,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Book']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Book'])
       end
     end
@@ -914,6 +944,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Object']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Object'])
       end
     end
@@ -944,6 +975,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns formats based on all resource types and genres' do
+        expect(doc).to include('sw_format_ssim' => %w[Map Image Dataset]) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => %w[Map Image Dataset])
       end
     end
@@ -966,6 +998,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'does not assign a format' do
+        expect(doc).not_to include('sw_format_ssim') # TODO: Remove
         expect(doc).not_to include('sw_format_ssimdv')
       end
     end
@@ -987,6 +1020,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'does not assign a format' do
+        expect(doc).not_to include('sw_format_ssim') # TODO: Remove
         expect(doc).not_to include('sw_format_ssimdv')
       end
     end
@@ -1013,6 +1047,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format once' do
+        expect(doc).to include('sw_format_ssim' => ['Archive/Manuscript']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Archive/Manuscript'])
       end
     end
@@ -1042,6 +1077,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on mapped resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Music score']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Music score'])
       end
     end
@@ -1071,6 +1107,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns format based on mapped resource type' do
+        expect(doc).to include('sw_format_ssim' => ['Music score']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Music score'])
       end
     end
@@ -1121,6 +1158,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'assigns formats based on resource types' do
+        expect(doc).to include('sw_format_ssim' => ['Sound recording', 'Book']) # TODO: Remove
         expect(doc).to include('sw_format_ssimdv' => ['Sound recording', 'Book'])
       end
     end

--- a/spec/services/indexing/indexers/descriptive_metadata_indexer_genre_spec.rb
+++ b/spec/services/indexing/indexers/descriptive_metadata_indexer_genre_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'uses genre value' do
-        expect(doc).to include('sw_genre_ssimdv' => ['photographs'])
+        expect(doc).to include('sw_genre_ssim' => ['photographs'])
       end
     end
 
@@ -59,6 +59,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'uses both genre values' do
+        expect(doc).to include('sw_genre_ssim' => %w[photographs ambrotypes]) # TODO: Remove
         expect(doc).to include('sw_genre_ssimdv' => %w[photographs ambrotypes])
       end
     end
@@ -89,6 +90,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'uses both genre values' do
+        expect(doc).to include('sw_genre_ssim' => %w[photographs фотографии]) # TODO: Remove
         expect(doc).to include('sw_genre_ssimdv' => %w[photographs фотографии])
       end
     end
@@ -112,6 +114,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'retains capitalization in Solr' do
+        expect(doc).to include('sw_genre_ssim' => ['Photographs']) # TODO: Remove
         expect(doc).to include('sw_genre_ssimdv' => ['Photographs'])
       end
     end
@@ -134,6 +137,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'retains capitalization in Solr' do
+        expect(doc).to include('sw_genre_ssim' => ['Thesis', 'Thesis/Dissertation']) # TODO: Remove
         expect(doc).to include('sw_genre_ssimdv' => ['Thesis', 'Thesis/Dissertation'])
       end
     end
@@ -156,6 +160,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'retains capitalization in Solr' do
+        expect(doc).to include('sw_genre_ssim' => ['Conference Publication', 'Conference proceedings']) # TODO: Remove
         expect(doc).to include('sw_genre_ssimdv' => ['Conference Publication', 'Conference proceedings'])
       end
     end
@@ -178,6 +183,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'retains capitalization in Solr' do
+        expect(doc).to include('sw_genre_ssim' => ['Government publication', 'Government document']) # TODO: Remove
         expect(doc).to include('sw_genre_ssimdv' => ['Government publication', 'Government document'])
       end
     end
@@ -200,6 +206,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'retains capitalization in Solr' do
+        expect(doc).to include('sw_genre_ssim' => ['technical report', 'Technical report']) # TODO: Remove
         expect(doc).to include('sw_genre_ssimdv' => ['technical report', 'Technical report'])
       end
     end
@@ -226,6 +233,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'doc does not include sw_genre_ssim' do
+        expect(doc).not_to include('sw_genre_ssim') # TODO: Remove
         expect(doc).not_to include('sw_genre_ssimdv')
       end
     end

--- a/spec/services/indexing/indexers/descriptive_metadata_indexer_language_spec.rb
+++ b/spec/services/indexing/indexers/descriptive_metadata_indexer_language_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'translates code to term' do
+        expect(doc).to include('sw_language_ssim' => ['English']) # TODO: Remove
         expect(doc).to include('sw_language_ssimdv' => ['English'])
       end
     end
@@ -60,6 +61,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'translates code to term' do
+        expect(doc).to include('sw_language_ssim' => ['English']) # TODO: Remove
         expect(doc).to include('sw_language_ssimdv' => ['English'])
       end
     end
@@ -84,6 +86,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'includes language term' do
+        expect(doc).to include('sw_language_ssim' => ['English']) # TODO: Remove
         expect(doc).to include('sw_language_ssimdv' => ['English'])
       end
     end
@@ -108,6 +111,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'does not include a value' do
+        expect(doc).not_to include('sw_language_ssim') # TODO: Remove
         expect(doc).not_to include('sw_language_ssimdv')
       end
     end
@@ -132,6 +136,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'does not include a value' do
+        expect(doc).not_to include('sw_language_ssim') # TODO: Remove
         expect(doc).not_to include('sw_language_ssimdv')
       end
     end
@@ -157,6 +162,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'translates code to term' do
+        expect(doc).to include('sw_language_ssim' => ['English, Old (ca. 450-1100)']) # TODO: Remove
         expect(doc).to include('sw_language_ssimdv' => ['English, Old (ca. 450-1100)'])
       end
     end
@@ -182,6 +188,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'includes text value' do
+        expect(doc).to include('sw_language_ssim' => ['English, Old (ca. 450-1100)']) # TODO: Remove
         expect(doc).to include('sw_language_ssimdv' => ['English, Old (ca. 450-1100)'])
       end
     end
@@ -207,6 +214,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'does not include a value' do
+        expect(doc).not_to include('sw_language_ssim') # TODO: Remove
         expect(doc).not_to include('sw_language_ssimdv')
       end
     end
@@ -232,6 +240,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'translates code to term' do
+        expect(doc).to include('sw_language_ssim' => ['American Sign Language']) # TODO: Remove
         expect(doc).to include('sw_language_ssimdv' => ['American Sign Language'])
       end
     end
@@ -256,6 +265,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'defaults to the searchworks language vocabulary' do
+        expect(doc).to include('sw_language_ssim' => ['English']) # TODO: Remove
         expect(doc).to include('sw_language_ssimdv' => ['English'])
       end
     end
@@ -277,6 +287,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'includes language term' do
+        expect(doc).to include('sw_language_ssim' => ['English']) # TODO: Remove
         expect(doc).to include('sw_language_ssimdv' => ['English'])
       end
     end
@@ -309,6 +320,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'translates language code to term' do
+        expect(doc).to include('sw_language_ssim' => ['English']) # TODO: Remove
         expect(doc).to include('sw_language_ssimdv' => ['English'])
       end
     end
@@ -336,6 +348,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'does not include a value' do
+        expect(doc).not_to include('sw_language_ssim') # TODO: Remove
         expect(doc).not_to include('sw_language_ssimdv')
       end
     end
@@ -382,6 +395,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'translates language code to term and drops duplicate' do
+        expect(doc).to include('sw_language_ssim' => ['Chinese']) # TODO: Remove
         expect(doc).to include('sw_language_ssimdv' => ['Chinese'])
       end
     end
@@ -414,6 +428,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'includes all languages' do
+        expect(doc).to include('sw_language_ssim' => %w[English Russian]) # TODO: Remove
         expect(doc).to include('sw_language_ssimdv' => %w[English Russian])
       end
     end
@@ -439,6 +454,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'translates code to term' do
+        expect(doc).to include('sw_language_ssim' => ['English']) # TODO: Remove
         expect(doc).to include('sw_language_ssimdv' => ['English'])
       end
     end
@@ -464,6 +480,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'translates code to term' do
+        expect(doc).to include('sw_language_ssim' => ['American Sign Language']) # TODO: Remove
         expect(doc).to include('sw_language_ssimdv' => ['American Sign Language'])
       end
     end
@@ -487,6 +504,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'translates code to term' do
+        expect(doc).to include('sw_language_ssim' => ['English']) # TODO: Remove
         expect(doc).to include('sw_language_ssimdv' => ['English'])
       end
     end
@@ -510,6 +528,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'translates code to term' do
+        expect(doc).to include('sw_language_ssim' => ['American Sign Language']) # TODO: Remove
         expect(doc).to include('sw_language_ssimdv' => ['American Sign Language'])
       end
     end

--- a/spec/services/indexing/indexers/descriptive_metadata_indexer_pub_year_1e_spec.rb
+++ b/spec/services/indexing/indexers/descriptive_metadata_indexer_pub_year_1e_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects date with status primary' do
+        expect(doc).to include('sw_pub_date_facet_ssi' => '2020') # TODO: Remove
         expect(doc).to include('sw_pub_date_facet_ssidv' => '2020')
       end
     end
@@ -72,6 +73,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects date with type publication' do
+        expect(doc).to include('sw_pub_date_facet_ssi' => '2020') # TODO: Remove
         expect(doc).to include('sw_pub_date_facet_ssidv' => '2020')
       end
     end
@@ -102,6 +104,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects first date with type publication' do
+        expect(doc).to include('sw_pub_date_facet_ssi' => '2019') # TODO: Remove
         expect(doc).to include('sw_pub_date_facet_ssidv' => '2019')
       end
     end
@@ -132,6 +135,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects date with type creation or production' do
+        expect(doc).to include('sw_pub_date_facet_ssi' => '2020') # TODO: Remove
         expect(doc).to include('sw_pub_date_facet_ssidv' => '2020')
       end
     end
@@ -163,6 +167,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects first date with type creation or production' do
+        expect(doc).to include('sw_pub_date_facet_ssi' => '2019') # TODO: Remove
         expect(doc).to include('sw_pub_date_facet_ssidv' => '2019')
       end
     end
@@ -192,6 +197,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects date with type capture' do
+        expect(doc).to include('sw_pub_date_facet_ssi' => '2020') # TODO: Remove
         expect(doc).to include('sw_pub_date_facet_ssidv' => '2020')
       end
     end
@@ -222,6 +228,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects first date with type capture' do
+        expect(doc).to include('sw_pub_date_facet_ssi' => '2019') # TODO: Remove
         expect(doc).to include('sw_pub_date_facet_ssidv' => '2019')
       end
     end
@@ -252,6 +259,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects the earliest date' do
+        expect(doc).to include('sw_pub_date_facet_ssi' => '2019') # TODO: Remove
         expect(doc).to include('sw_pub_date_facet_ssidv' => '2019')
       end
     end

--- a/spec/services/indexing/indexers/descriptive_metadata_indexer_pub_year_spec.rb
+++ b/spec/services/indexing/indexers/descriptive_metadata_indexer_pub_year_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'uses value with status primary' do
+        expect(doc).to include('sw_pub_date_facet_ssi' => '1940') # TODO: Remove
         expect(doc).to include('sw_pub_date_facet_ssidv' => '1940')
       end
 
@@ -89,6 +90,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         end
 
         it 'uses value with status primary' do
+          expect(doc).to include('sw_pub_date_facet_ssi' => '1940') # TODO: Remove
           expect(doc).to include('sw_pub_date_facet_ssidv' => '1940')
         end
       end
@@ -133,6 +135,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         end
 
         it 'uses parallelEvent date status primary with type publication' do
+          expect(doc).to include('sw_pub_date_facet_ssi' => '1999') # TODO: Remove
           expect(doc).to include('sw_pub_date_facet_ssidv' => '1999')
         end
       end
@@ -178,6 +181,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'uses value from type publication' do
+        expect(doc).to include('sw_pub_date_facet_ssi' => '2018') # TODO: Remove
         expect(doc).to include('sw_pub_date_facet_ssidv' => '2018')
       end
 
@@ -230,6 +234,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         end
 
         it 'uses value from first date of structuredValue' do
+          expect(doc).to include('sw_pub_date_facet_ssi' => '1940') # TODO: Remove
           expect(doc).to include('sw_pub_date_facet_ssidv' => '1940')
         end
       end
@@ -298,6 +303,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         end
 
         it 'uses first publication date of parallelValue of type publication' do
+          expect(doc).to include('sw_pub_date_facet_ssi' => '2020') # TODO: Remove
           expect(doc).to include('sw_pub_date_facet_ssidv' => '2020')
         end
       end
@@ -325,6 +331,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'uses first year of 1980-1984' do
+        expect(doc).to include('sw_pub_date_facet_ssi' => '1980') # TODO: Remove
         expect(doc).to include('sw_pub_date_facet_ssidv' => '1980')
       end
 
@@ -362,6 +369,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         end
 
         it 'uses first year of structuredValue' do
+          expect(doc).to include('sw_pub_date_facet_ssi' => '1980') # TODO: Remove
           expect(doc).to include('sw_pub_date_facet_ssidv' => '1980')
         end
       end
@@ -421,6 +429,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         end
 
         it 'uses first publication date of parallelValue' do
+          expect(doc).to include('sw_pub_date_facet_ssi' => '1966') # TODO: Remove
           expect(doc).to include('sw_pub_date_facet_ssidv' => '1966')
         end
       end
@@ -464,6 +473,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'uses creation date' do
+        expect(doc).to include('sw_pub_date_facet_ssi' => '1940') # TODO: Remove
         expect(doc).to include('sw_pub_date_facet_ssidv' => '1940')
       end
 
@@ -503,6 +513,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         end
 
         it 'uses creation date with status primary' do
+          expect(doc).to include('sw_pub_date_facet_ssi' => '1940') # TODO: Remove
           expect(doc).to include('sw_pub_date_facet_ssidv' => '1940')
         end
       end
@@ -547,6 +558,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         end
 
         it 'uses value from parallelEvent date status primary with type publication' do
+          expect(doc).to include('sw_pub_date_facet_ssi' => '1999') # TODO: Remove
           expect(doc).to include('sw_pub_date_facet_ssidv' => '1999')
         end
       end
@@ -592,6 +604,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'uses value with date of type creation from event type of creation' do
+        expect(doc).to include('sw_pub_date_facet_ssi' => '2018') # TODO: Remove
         expect(doc).to include('sw_pub_date_facet_ssidv' => '2018')
       end
 
@@ -644,6 +657,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         end
 
         it 'uses first date of structuredValue of type creation from event of type creation' do
+          expect(doc).to include('sw_pub_date_facet_ssi' => '1940') # TODO: Remove
           expect(doc).to include('sw_pub_date_facet_ssidv' => '1940')
         end
       end
@@ -712,6 +726,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         end
 
         it 'uses first publication date of parallelValue of type publication' do
+          expect(doc).to include('sw_pub_date_facet_ssi' => '2020') # TODO: Remove
           expect(doc).to include('sw_pub_date_facet_ssidv' => '2020')
         end
       end
@@ -739,6 +754,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'uses first year of 1980-1984 from date with type creation' do
+        expect(doc).to include('sw_pub_date_facet_ssi' => '1980') # TODO: Remove
         expect(doc).to include('sw_pub_date_facet_ssidv' => '1980')
       end
 
@@ -776,6 +792,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         end
 
         it 'uses first year of structuredValue for date of type creation' do
+          expect(doc).to include('sw_pub_date_facet_ssi' => '1980') # TODO: Remove
           expect(doc).to include('sw_pub_date_facet_ssidv' => '1980')
         end
       end
@@ -835,6 +852,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         end
 
         it 'uses first publication date of parallelValue' do
+          expect(doc).to include('sw_pub_date_facet_ssi' => '1966') # TODO: Remove
           expect(doc).to include('sw_pub_date_facet_ssidv' => '1966')
         end
       end

--- a/spec/services/indexing/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/services/indexing/indexers/descriptive_metadata_indexer_spec.rb
@@ -402,11 +402,17 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         'descriptive_tiv' => all_search_text,
         'descriptive_teiv' => all_search_text,
         'descriptive_text_nostem_i' => all_search_text,
+        'sw_language_ssim' => ['English'], # TODO: Remove
         'sw_language_ssimdv' => ['English'],
+        'sw_format_ssim' => ['Book'], # TODO: Remove
         'sw_format_ssimdv' => ['Book'],
+        'mods_typeOfResource_ssim' => ['text'], # TODO: Remove
         'mods_typeOfResource_ssimdv' => ['text'],
+        'sw_subject_temporal_ssim' => ['1800-1900'], # TODO: Remove
         'sw_subject_temporal_ssimdv' => ['1800-1900'],
+        'sw_subject_geographic_ssim' => ['Europe'], # TODO: Remove
         'sw_subject_geographic_ssimdv' => ['Europe'],
+        'sw_pub_date_facet_ssi' => '1911', # TODO: Remove
         'sw_pub_date_facet_ssidv' => '1911',
         'author_display_ss' => 'George, Henry, 1839-1897',
         'author_text_nostem_im' => 'George, Henry, 1839-1897',
@@ -418,9 +424,12 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         'display_title_ss' => 'The complete works of Henry George, Part 1',
         # 'originInfo_date_created_tesim' => '', # not populated by the example; see indexer_spec instead
         'originInfo_publisher_tesim' => 'Doubleday, Page',
+        'topic_ssim' => %w[Economics cats], # TODO: Remove
         'topic_ssimdv' => %w[Economics cats],
         'topic_tesim' => %w[cats Economics],
         'originInfo_place_placeTerm_tesim' => 'Garden City, N. Y',
+        'contributor_orcids_ssim' => ['https://orcid.org/0000-1111-2222-3333', # TODO: Remove
+                                      'https://sandbox.orcid.org/1111-2222-3333-4444', 'https://orcid.org/0000-0001-5321-289X'],
         'contributor_orcids_ssimdv' => ['https://orcid.org/0000-1111-2222-3333',
                                         'https://sandbox.orcid.org/1111-2222-3333-4444', 'https://orcid.org/0000-0001-5321-289X']
       )

--- a/spec/services/indexing/indexers/descriptive_metadata_indexer_subject_geographic_spec.rb
+++ b/spec/services/indexing/indexers/descriptive_metadata_indexer_subject_geographic_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects geographic subject' do
+        expect(doc).to include('sw_subject_geographic_ssim' => ['Europe']) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => ['Europe'])
       end
     end
@@ -59,6 +60,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects geographic subjects' do
+        expect(doc).to include('sw_subject_geographic_ssim' => %w[Europe Africa]) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => %w[Europe Africa])
       end
     end
@@ -89,6 +91,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects geographic subject from complex subject' do
+        expect(doc).to include('sw_subject_geographic_ssim' => ['Europe']) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => ['Europe'])
       end
     end
@@ -118,6 +121,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects geographic subjects from parallelValue' do
+        expect(doc).to include('sw_subject_geographic_ssim' => %w[Russia Россия]) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => %w[Russia Россия])
       end
     end
@@ -164,6 +168,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects geographic subject from complex subject' do
+        expect(doc).to include('sw_subject_geographic_ssim' => %w[Russia Россия]) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => %w[Russia Россия])
       end
     end
@@ -206,6 +211,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'dedupes the value' do
+        expect(doc).to include('sw_subject_geographic_ssim' => ['Europe']) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => ['Europe'])
       end
     end
@@ -234,6 +240,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'maps the code to text' do
+        expect(doc).to include('sw_subject_geographic_ssim' => ['Russia (Federation)']) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => ['Russia (Federation)'])
       end
     end
@@ -266,6 +273,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'maps the code to text' do
+        expect(doc).not_to include('sw_subject_geographic_ssim') # TODO: Remove
         expect(doc).not_to include('sw_subject_geographic_ssimdv')
         # HB notification has been temporarily removed.
         # expect(Honeybadger).to have_received(:notify)
@@ -294,6 +302,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'maps the code to text' do
+        expect(doc).not_to include('sw_subject_geographic_ssim') # TODO: Remove
         expect(doc).not_to include('sw_subject_geographic_ssimdv')
       end
     end
@@ -319,6 +328,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'maps the code to text' do
+        expect(doc).to include('sw_subject_geographic_ssim' => ['Russia (Federation)']) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => ['Russia (Federation)'])
       end
     end
@@ -344,6 +354,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'maps the code to text' do
+        expect(doc).not_to include('sw_subject_geographic_ssim') # TODO: Remove
         expect(doc).not_to include('sw_subject_geographic_ssimdv')
       end
     end
@@ -369,6 +380,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'ignores the code' do
+        expect(doc).not_to include('sw_subject_geographic_ssim') # TODO: Remove
         expect(doc).not_to include('sw_subject_geographic_ssimdv')
       end
     end
@@ -391,6 +403,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'ignores the code' do
+        expect(doc).not_to include('sw_subject_geographic_ssim') # TODO: Remove
         expect(doc).not_to include('sw_subject_geographic_ssimdv')
       end
     end
@@ -417,6 +430,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'includes term once' do
+        expect(doc).to include('sw_subject_geographic_ssim' => ['Russia (Federation)']) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => ['Russia (Federation)'])
       end
     end
@@ -443,6 +457,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'includes both terms' do
+        expect(doc).to include('sw_subject_geographic_ssim' => ['Russia', 'Russia (Federation)']) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => ['Russia', 'Russia (Federation)'])
       end
     end
@@ -479,6 +494,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'constructs the value' do
+        expect(doc).to include('sw_subject_geographic_ssim' => ['North America Canada Vancouver']) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => ['North America Canada Vancouver'])
       end
     end
@@ -502,6 +518,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'drops the punctuation' do
+        expect(doc).to include('sw_subject_geographic_ssim' => ['Europe']) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => ['Europe'])
       end
     end
@@ -532,6 +549,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'drops the punctuation' do
+        expect(doc).to include('sw_subject_geographic_ssim' => ['Europe']) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => ['Europe'])
       end
     end
@@ -561,6 +579,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'drops the punctuation' do
+        expect(doc).to include('sw_subject_geographic_ssim' => %w[Russia Россия]) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => %w[Russia Россия])
       end
     end
@@ -607,6 +626,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'drops the punctuation' do
+        expect(doc).to include('sw_subject_geographic_ssim' => %w[Russia Россия]) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => %w[Russia Россия])
       end
     end
@@ -629,6 +649,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'does not drop the punctuation' do
+        expect(doc).to include('sw_subject_geographic_ssim' => ['Europe.']) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => ['Europe.'])
       end
     end
@@ -655,6 +676,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'drops the punctuation before deduping' do
+        expect(doc).to include('sw_subject_geographic_ssim' => ['Europe']) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => ['Europe'])
       end
     end
@@ -680,6 +702,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'drops the punctuation' do
+        expect(doc).to include('sw_subject_geographic_ssim' => ['Russia (Federation)']) # TODO: Remove
         expect(doc).to include('sw_subject_geographic_ssimdv' => ['Russia (Federation)'])
       end
     end

--- a/spec/services/indexing/indexers/descriptive_metadata_indexer_subject_temporal_spec.rb
+++ b/spec/services/indexing/indexers/descriptive_metadata_indexer_subject_temporal_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects temporal subject' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century'])
       end
     end
@@ -59,6 +60,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects temporal subjects' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century', '15th century']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century', '15th century'])
       end
     end
@@ -90,6 +92,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects both temporal subjects in range' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century', '15th century']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century', '15th century'])
       end
     end
@@ -115,6 +118,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects temporal subject' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['1400']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['1400'])
       end
     end
@@ -145,6 +149,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects temporal subject from complex subject' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century'])
       end
     end
@@ -180,6 +185,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects temporal subject range from complex subject' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century', '15th century']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century', '15th century'])
       end
     end
@@ -210,6 +216,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects temporal subjects from parallelValue' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century', 'XIVieme siecle']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century', 'XIVieme siecle'])
       end
     end
@@ -257,6 +264,8 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects temporal subject range from parallelValue' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century', '15th century', 'XIVieme siecle',
+                                                              'XVieme siecle']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century', '15th century', 'XIVieme siecle',
                                                                 'XVieme siecle'])
       end
@@ -304,6 +313,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects temporal subjects from complex subjects' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century', 'XIVieme siecle']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century', 'XIVieme siecle'])
       end
     end
@@ -358,6 +368,8 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects temporal range from complex subjects' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century', '15th century', 'XIVieme siecle',
+                                                              'XVieme siecle']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century', '15th century', 'XIVieme siecle',
                                                                 'XVieme siecle'])
       end
@@ -401,6 +413,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'drops duplicate value' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century', '14th century']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century', '14th century'])
       end
     end
@@ -424,6 +437,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'drops punctuation' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century'])
       end
     end
@@ -455,6 +469,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'drops punctuation' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century', '15th century']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century', '15th century'])
       end
     end
@@ -485,6 +500,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'drops punctuation' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century'])
       end
     end
@@ -520,6 +536,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'drops punctuation' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century', '15th century']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century', '15th century'])
       end
     end
@@ -550,6 +567,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'drops punctuation' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century', 'XIVieme siecle']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century', 'XIVieme siecle'])
       end
     end
@@ -596,6 +614,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'drops punctuation' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century', 'XIVieme siecle']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century', 'XIVieme siecle'])
       end
     end
@@ -650,6 +669,8 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'drops punctuation' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century', '15th century', 'XIVieme siecle',
+                                                              'XVieme siecle']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century', '15th century', 'XIVieme siecle',
                                                                 'XVieme siecle'])
       end
@@ -673,6 +694,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'does not drop punctuation' do
+        expect(doc).to include('sw_subject_temporal_ssim' => ['14th century.']) # TODO: Remove
         expect(doc).to include('sw_subject_temporal_ssimdv' => ['14th century.'])
       end
     end

--- a/spec/services/indexing/indexers/descriptive_metadata_indexer_subject_topic_spec.rb
+++ b/spec/services/indexing/indexers/descriptive_metadata_indexer_subject_topic_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects topic from subject' do
+        expect(doc).to include('topic_ssim' => ['Cats']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['Cats'])
         expect(doc).to include('topic_tesim' => ['Cats'])
       end
@@ -62,6 +63,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects topics from multiple subjects' do
+        expect(doc).to include('topic_ssim' => %w[Cats Birds]) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => %w[Cats Birds])
         expect(doc).to include('topic_tesim' => %w[Cats Birds])
       end
@@ -92,6 +94,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects topics from subjects in parallelValue' do
+        expect(doc).to include('topic_ssim' => %w[Cats Chats]) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => %w[Cats Chats])
         expect(doc).to include('topic_tesim' => %w[Cats Chats])
       end
@@ -123,6 +126,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects topic part from complex subject' do
+        expect(doc).to include('topic_ssim' => ['Cats']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['Cats'])
         expect(doc).to include('topic_tesim' => ['Cats'])
       end
@@ -166,6 +170,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects topic parts from multiple complex subjects' do
+        expect(doc).to include('topic_ssim' => %w[Cats Birds]) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => %w[Cats Birds])
         expect(doc).to include('topic_tesim' => %w[Cats Birds])
       end
@@ -197,6 +202,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects topic parts from complex subject' do
+        expect(doc).to include('topic_ssim' => ['Cats', 'Homes and haunts']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['Cats', 'Homes and haunts'])
         expect(doc).to include('topic_tesim' => ['Cats', 'Homes and haunts'])
       end
@@ -240,6 +246,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects topic parts from complex subjects and dedupes' do
+        expect(doc).to include('topic_ssim' => ['Cats', 'Homes and haunts', 'Birds']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['Cats', 'Homes and haunts', 'Birds'])
         expect(doc).to include('topic_tesim' => ['Cats', 'Homes and haunts', 'Birds'])
       end
@@ -287,6 +294,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects topic parts from complex subjects in parallelValue' do
+        expect(doc).to include('topic_ssim' => %w[Cats Chats]) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => %w[Cats Chats])
         expect(doc).to include('topic_tesim' => %w[Cats Chats])
       end
@@ -334,6 +342,8 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects topic parts from complex subjects in parallelValue' do
+        # TODO: Remove
+        expect(doc).to include('topic_ssim' => ['Cats', 'Homes and haunts', 'Chats', 'Maisons et repaires'])
         expect(doc).to include('topic_ssimdv' => ['Cats', 'Homes and haunts', 'Chats', 'Maisons et repaires'])
         expect(doc).to include('topic_tesim' => ['Cats', 'Homes and haunts', 'Chats', 'Maisons et repaires'])
       end
@@ -358,6 +368,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects name from subject for topic_ssim' do
+        expect(doc).to include('topic_ssim' => ['Sayers, Dorothy L.']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['Sayers, Dorothy L.'])
         expect(doc).not_to include('topic_tesim')
       end
@@ -387,6 +398,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects name from subject for topic_ssim' do
+        expect(doc).to include('topic_ssim' => ['Sayers, Dorothy L.']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['Sayers, Dorothy L.'])
         expect(doc).not_to include('topic_tesim')
       end
@@ -426,6 +438,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'constructs name subject for topic_ssim' do
+        expect(doc).to include('topic_ssim' => ['Sayers, Dorothy, L.']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['Sayers, Dorothy, L.'])
         expect(doc).not_to include('topic_tesim')
       end
@@ -456,6 +469,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects name subjects from parallelValue for topic_ssimdv' do
+        expect(doc).to include('topic_ssim' => %w[SFU СФУ]) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => %w[SFU СФУ])
         expect(doc).not_to include('topic_tesim')
       end
@@ -512,6 +526,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'constructs names from subjects in parallelValue for topic_ssim' do
+        expect(doc).to include('topic_ssim' => ['Sayers, Dorothy, L.', 'Сэйерс, Дороти, Л.']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['Sayers, Dorothy, L.', 'Сэйерс, Дороти, Л.'])
         expect(doc).not_to include('topic_tesim')
       end
@@ -556,6 +571,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'constructs name subject for topic_ssim and selects topic subject' do
+        expect(doc['topic_ssim']).to contain_exactly('Sayers, Dorothy, L.', 'Homes and haunts') # TODO: Remove
         expect(doc['topic_ssimdv']).to contain_exactly('Sayers, Dorothy, L.', 'Homes and haunts')
         expect(doc).to include('topic_tesim' => ['Homes and haunts'])
       end
@@ -587,6 +603,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects name and title subjects for topic_ssim' do
+        expect(doc['topic_ssim']).to contain_exactly('Sayers, Dorothy L.', 'Gaudy night') # TODO: Remove
         expect(doc['topic_ssimdv']).to contain_exactly('Sayers, Dorothy L.', 'Gaudy night')
         expect(doc).not_to include('topic_tesim')
       end
@@ -610,6 +627,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects title subject for topic_ssim' do
+        expect(doc).to include('topic_ssim' => ['Gaudy night']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['Gaudy night'])
         expect(doc).not_to include('topic_tesim')
       end
@@ -655,6 +673,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'constructs title subject for topic_ssim' do
+        expect(doc).to include('topic_ssim' => ['The title with a subtitle part 1 part the first']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['The title with a subtitle part 1 part the first'])
         expect(doc).not_to include('topic_tesim')
       end
@@ -685,6 +704,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects title subjects from parallelValue for topic_ssim' do
+        expect(doc).to include('topic_ssim' => ['The master and Margarita', 'Мастер и Маргарита']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['The master and Margarita', 'Мастер и Маргарита'])
         expect(doc).not_to include('topic_tesim')
       end
@@ -733,6 +753,8 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'constructs title subjects from parallelValue for topic_ssim' do
+        # TODO: Remove
+        expect(doc).to include('topic_ssim' => ['The master and Margarita a novel', 'Мастер и Маргарита роман'])
         expect(doc).to include('topic_ssimdv' => ['The master and Margarita a novel', 'Мастер и Маргарита роман'])
         expect(doc).not_to include('topic_tesim')
       end
@@ -773,6 +795,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'constructs title subject for topic_ssim' do
+        expect(doc).to include('topic_ssim' => ['The master and Margarita a novel']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['The master and Margarita a novel'])
         expect(doc).not_to include('topic_tesim')
       end
@@ -796,6 +819,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects occupation subject for topic_ssim' do
+        expect(doc).to include('topic_ssim' => ['Calligraphers']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['Calligraphers'])
         expect(doc).not_to include('topic_tesim')
       end
@@ -826,6 +850,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'selects occupation subjects from parallelValue for topic_ssim' do
+        expect(doc).to include('topic_ssim' => %w[Calligraphers Каллиграфы]) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => %w[Calligraphers Каллиграфы])
         expect(doc).not_to include('topic_tesim')
       end
@@ -850,6 +875,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'strips trailing punctuation from subject for topic_ssimdv' do
+        expect(doc).to include('topic_ssim' => ['Cats']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['Cats'])
         expect(doc).to include('topic_tesim' => ['Cats,'])
       end
@@ -881,6 +907,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'strips trailing punctuation and space from parts of complex subject for topic_ssimdv' do
+        expect(doc).to include('topic_ssim' => ['Cats', 'Homes and haunts']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['Cats', 'Homes and haunts'])
         expect(doc).to include('topic_tesim' => ['Cats \\', 'Homes and haunts ;'])
       end
@@ -911,6 +938,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'strips trailing punctuation from parts of parallelValue for topic_ssimdv' do
+        expect(doc).to include('topic_ssim' => %w[Cats Chats]) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => %w[Cats Chats])
         expect(doc).to include('topic_tesim' => ['Cats,', 'Chats,'])
       end
@@ -958,6 +986,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'strips trailing punctuation from topic parts of complex subject in parallelValue for topic_ssimdv' do
+        expect(doc).to include('topic_ssim' => %w[Cats Chats]) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => %w[Cats Chats])
         expect(doc).to include('topic_tesim' => ['Cats;', 'Chats \\'])
       end
@@ -981,6 +1010,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'does not strip trailing period' do
+        expect(doc).to include('topic_ssim' => ['Cats.']) # TODO: Remove
         expect(doc).to include('topic_ssimdv' => ['Cats.'])
         expect(doc).to include('topic_tesim' => ['Cats.'])
       end

--- a/spec/services/indexing/indexers/descriptive_metadata_indexer_type_of_resource_spec.rb
+++ b/spec/services/indexing/indexers/descriptive_metadata_indexer_type_of_resource_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'includes value' do
+        expect(doc).to include('mods_typeOfResource_ssim' => ['text']) # TODO: Remove
         expect(doc).to include('mods_typeOfResource_ssimdv' => ['text'])
       end
     end
@@ -68,6 +69,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'includes values' do
+        expect(doc).to include('mods_typeOfResource_ssim' => ['text', 'still image']) # TODO: Remove
         expect(doc).to include('mods_typeOfResource_ssimdv' => ['text', 'still image'])
       end
     end
@@ -94,6 +96,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'does not include value' do
+        expect(doc).not_to include('mods_typeOfResource_ssim') # TODO: Remove
         expect(doc).not_to include('mods_typeOfResource_ssimdv')
       end
     end
@@ -120,6 +123,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'does not includes value' do
+        expect(doc).not_to include('mods_typeOfResource_ssim') # TODO: Remove
         expect(doc).not_to include('mods_typeOfResource_ssimdv')
       end
     end
@@ -142,6 +146,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'does not includes value' do
+        expect(doc).not_to include('mods_typeOfResource_ssim') # TODO: Remove
         expect(doc).not_to include('mods_typeOfResource_ssimdv')
       end
     end
@@ -166,6 +171,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
 
       it 'includes value' do
+        expect(doc).to include('mods_typeOfResource_ssim' => ['text']) # TODO: Remove
         expect(doc).to include('mods_typeOfResource_ssimdv' => ['text'])
       end
     end

--- a/spec/services/indexing/indexers/embargo_metadata_indexer_spec.rb
+++ b/spec/services/indexing/indexers/embargo_metadata_indexer_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Indexing::Indexers::EmbargoMetadataIndexer do
 
       it 'sets both embargo fields in Solr doc' do
         expect(doc).to eq(
+          'embargo_release_dtsim' => ['2024-06-05T22:00:00Z'], # TODO: Remove
           'embargo_release_dtpsimdv' => ['2024-06-05T22:00:00Z'],
           'embargo_status_ssim' => ['embargoed']
         )
@@ -47,6 +48,7 @@ RSpec.describe Indexing::Indexers::EmbargoMetadataIndexer do
       # rubocop:disable Style/StringHashKeys
       it 'Solr doc has embargo fields' do
         expect(doc).to eq(
+          'embargo_release_dtsim' => ['2020-06-05T22:00:00Z'], # TODO: Remove
           'embargo_release_dtpsimdv' => ['2020-06-05T22:00:00Z'],
           'embargo_status_ssim' => ['embargoed']
         )

--- a/spec/services/indexing/indexers/identifiable_indexer_spec.rb
+++ b/spec/services/indexing/indexers/identifiable_indexer_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Indexing::Indexers::IdentifiableIndexer do
         expect(doc['apo_title_ssimdv'].first).to eq apo_id
         expect(doc['apo_title_ssim'].first).to eq apo_id # TODO: Remove https://github.com/sul-dlss/dor-services-app/issues/5537
         expect(doc['nonhydrus_apo_title_ssimdv'].first).to eq apo_id # TODO: Remove https://github.com/sul-dlss/dor-services-app/issues/5537
+        expect(doc['nonhydrus_apo_title_ssim'].first).to eq apo_id # TODO: Remove
       end
     end
 
@@ -64,9 +65,11 @@ RSpec.describe Indexing::Indexers::IdentifiableIndexer do
         expect(doc['apo_title_ssimdv'].first).to eq 'collection title'
         expect(doc['apo_title_ssim'].first).to eq 'collection title' # TODO: Remove https://github.com/sul-dlss/dor-services-app/issues/5537
         expect(doc['nonhydrus_apo_title_ssimdv'].first).to eq 'collection title' # TODO: Remove https://github.com/sul-dlss/dor-services-app/issues/5537
+        expect(doc['nonhydrus_apo_title_ssim'].first).to eq 'collection title' # TODO: Remove
       end
 
       it 'indexes metadata sources' do
+        expect(doc).to match a_hash_including('metadata_source_ssim' => %w[Folio]) # TODO: Remove
         expect(doc).to match a_hash_including('metadata_source_ssimdv' => %w[Folio])
       end
     end
@@ -75,6 +78,7 @@ RSpec.describe Indexing::Indexers::IdentifiableIndexer do
       let(:identification) { { sourceId: 'sul:1234' } }
 
       it 'indexes metadata sources' do
+        expect(doc).to match a_hash_including('metadata_source_ssim' => ['DOR']) # TODO: Remove
         expect(doc).to match a_hash_including('metadata_source_ssimdv' => ['DOR'])
       end
     end
@@ -92,6 +96,7 @@ RSpec.describe Indexing::Indexers::IdentifiableIndexer do
       end
 
       it 'indexes metadata sources' do
+        expect(doc).to match a_hash_including('metadata_source_ssim' => ['DOR']) # TODO: Remove
         expect(doc).to match a_hash_including('metadata_source_ssimdv' => ['DOR'])
       end
     end
@@ -100,6 +105,7 @@ RSpec.describe Indexing::Indexers::IdentifiableIndexer do
       let(:cocina_item) { build(:dro, id: druid, admin_policy_id: apo_id) }
 
       it 'indexes metadata sources' do
+        expect(doc).to match a_hash_including('metadata_source_ssim' => ['DOR']) # TODO: Remove
         expect(doc).to match a_hash_including('metadata_source_ssimdv' => ['DOR'])
       end
     end

--- a/spec/services/indexing/indexers/identity_metadata_indexer_spec.rb
+++ b/spec/services/indexing/indexers/identity_metadata_indexer_spec.rb
@@ -48,14 +48,17 @@ RSpec.describe Indexing::Indexers::IdentityMetadataIndexer do
 
       it 'has the fields used by argo' do
         expect(doc).to include(
+          'barcode_id_ssim' => ['36105049267078'], # TODO: Remove
           'barcode_id_ssimdv' => ['36105049267078'],
           'folio_instance_hrid_ssim' => ['a129483625'],
           'identifier_ssim' => ['google:STANFORD_342837261527', 'barcode:36105049267078',
                                 'folio:a129483625'],
           'identifier_tesim' => ['google:STANFORD_342837261527', 'barcode:36105049267078',
                                  'folio:a129483625'],
+          'objectType_ssim' => ['item'], # TODO: Remove
           'objectType_ssimdv' => ['item'],
           'source_id_ssi' => 'google:STANFORD_342837261527',
+          'doi_ssim' => ['10.25740/yr775yn6440'], # TODO: Remove
           'doi_ssimdv' => ['10.25740/yr775yn6440']
         )
       end
@@ -69,9 +72,11 @@ RSpec.describe Indexing::Indexers::IdentityMetadataIndexer do
       # rubocop:disable Style/StringHashKeys
       it 'has the fields used by argo' do
         expect(doc).to include(
+          'barcode_id_ssim' => [], # TODO: Remove
           'barcode_id_ssimdv' => [],
           'identifier_ssim' => ['sul:1234'],
           'identifier_tesim' => ['sul:1234'],
+          'objectType_ssim' => ['agreement'], # TODO: Remove
           'objectType_ssimdv' => ['agreement'],
           'source_id_ssi' => 'sul:1234',
           'source_id_text_nostem_i' => 'sul:1234'
@@ -104,10 +109,12 @@ RSpec.describe Indexing::Indexers::IdentityMetadataIndexer do
       # rubocop:disable Style/StringHashKeys
       it 'has the fields used by argo' do
         expect(doc).to include(
+          'barcode_id_ssim' => [], # TODO: Remove
           'barcode_id_ssimdv' => [],
           'folio_instance_hrid_ssim' => ['a129483625'],
           'identifier_ssim' => ['google:STANFORD_342837261527', 'folio:a129483625'],
           'identifier_tesim' => ['google:STANFORD_342837261527', 'folio:a129483625'],
+          'objectType_ssim' => ['collection'], # TODO: Remove
           'objectType_ssimdv' => ['collection'],
           'source_id_ssi' => 'google:STANFORD_342837261527',
           'source_id_text_nostem_i' => 'google:STANFORD_342837261527'

--- a/spec/services/indexing/indexers/object_files_indexer_spec.rb
+++ b/spec/services/indexing/indexers/object_files_indexer_spec.rb
@@ -170,8 +170,11 @@ RSpec.describe Indexing::Indexers::ObjectFilesIndexer do
 
       it 'has the fields used by argo' do
         expect(doc).to include(
+          'content_type_ssim' => 'map', # TODO: Remove
           'content_type_ssimdv' => 'map',
+          'content_file_mimetypes_ssim' => ['image/jp2', 'image/gif', 'image/tiff'], # TODO: Remove
           'content_file_mimetypes_ssimdv' => ['image/jp2', 'image/gif', 'image/tiff'],
+          'content_file_roles_ssim' => ['derivative'], # TODO: Remove
           'content_file_roles_ssimdv' => ['derivative'],
           'shelved_content_file_count_itsi' => 1,
           'resource_count_itsi' => 1,
@@ -272,7 +275,9 @@ RSpec.describe Indexing::Indexers::ObjectFilesIndexer do
 
       it 'has the fields used by argo' do
         expect(doc).to include(
+          'content_type_ssim' => 'map', # TODO: Remove
           'content_type_ssimdv' => 'map',
+          'content_file_mimetypes_ssim' => [], # TODO: Remove
           'content_file_mimetypes_ssimdv' => [],
           'shelved_content_file_count_itsi' => 0,
           'resource_count_itsi' => 0,

--- a/spec/services/indexing/indexers/releasable_indexer_spec.rb
+++ b/spec/services/indexing/indexers/releasable_indexer_spec.rb
@@ -47,8 +47,11 @@ RSpec.describe Indexing::Indexers::ReleasableIndexer do
         it 'indexes release tags' do
           expect(doc).to eq(
             'released_to_ssim' => ['Searchworks', 'Earthworks', 'PURL sitemap'],
+            'released_to_earthworks_dttsi' => '2016-11-16T22:52:35Z', # TODO: Remove
             'released_to_earthworks_dtpsidv' => '2016-11-16T22:52:35Z',
+            'released_to_searchworks_dttsi' => '2021-05-12T21:05:21Z', # TODO: Remove
             'released_to_searchworks_dtpsidv' => '2021-05-12T21:05:21Z',
+            'released_to_purl_sitemap_dttsi' => '2023-03-27T10:00:00Z', # TODO: Remove
             'released_to_purl_sitemap_dtpsidv' => '2023-03-27T10:00:00Z'
           )
         end

--- a/spec/services/indexing/indexers/rights_metadata_indexer_spec.rb
+++ b/spec/services/indexing/indexers/rights_metadata_indexer_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe Indexing::Indexers::RightsMetadataIndexer do
         expect(doc).to include(
           'copyright_ssim' => 'Copyright © World Trade Organization',
           'use_statement_ssim' => 'Official WTO documents are free for public use.',
+          'use_license_machine_ssi' => 'CC0-1.0', # TODO: Remove
           'use_license_machine_ssidv' => 'CC0-1.0',
+          'rights_descriptions_ssim' => 'world', # TODO: Remove
           'rights_descriptions_ssimdv' => 'world'
         )
       end
@@ -43,7 +45,9 @@ RSpec.describe Indexing::Indexers::RightsMetadataIndexer do
         expect(doc).to include(
           'copyright_ssim' => 'Copyright © World Trade Organization',
           'use_statement_ssim' => 'Official WTO documents are free for public use.',
+          'use_license_machine_ssi' => 'CC0-1.0', # TODO: Remove
           'use_license_machine_ssidv' => 'CC0-1.0',
+          'rights_descriptions_ssim' => 'dark', # TODO: Remove
           'rights_descriptions_ssimdv' => 'dark'
         )
       end
@@ -74,11 +78,576 @@ RSpec.describe Indexing::Indexers::RightsMetadataIndexer do
       expect(doc).to include(
         'copyright_ssim' => 'Copyright © World Trade Organization',
         'use_statement_ssim' => 'Official WTO documents are free for public use.',
+        'use_license_machine_ssi' => 'CC0-1.0', # TODO: Remove
         'use_license_machine_ssidv' => 'CC0-1.0',
+        'rights_descriptions_ssim' => ['world'], # TODO: Remove
         'rights_descriptions_ssimdv' => ['world']
       )
     end
     # rubocop:enable Style/StringHashKeys
+
+    describe 'rights descriptions (to remove)' do # TODO: Remove
+      subject { doc['rights_descriptions_ssim'] }
+
+      let(:structural) do
+        {
+          contains: [
+            {
+              type: Cocina::Models::FileSetType.page,
+              externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/d906da21-aca1-4b95-b7d1-c14c23cd93e6',
+              label: 'Page 1',
+              version: 5,
+              structural: {
+                contains: [
+                  {
+                    type: Cocina::Models::ObjectType.file,
+                    externalIdentifier: 'https://cocina.sul.stanford.edu/file/4d88213d-f150-45ae-a58a-08b1045db2a0',
+                    label: '50807230_0001.jp2',
+                    filename: '50807230_0001.jp2',
+                    size: 3_575_822,
+                    version: 5,
+                    hasMimeType: 'image/jp2',
+                    hasMessageDigests: [
+                      {
+                        type: 'sha1',
+                        digest: '0a089200032d209e9b3e7f7768dd35323a863fcc'
+                      },
+                      {
+                        type: 'md5',
+                        digest: 'c99fae3c4c53e40824e710440f08acb9'
+                      }
+                    ],
+                    access: file_access,
+                    administrative: {
+                      publish: false,
+                      sdrPreserve: false,
+                      shelve: false
+                    },
+                    presentation: {}
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      end
+
+      context 'when citation only' do
+        let(:access) do
+          {
+            view: 'citation-only',
+            download: 'none'
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'dark',
+            download: 'none'
+          }
+        end
+
+        it { is_expected.to eq ['citation'] }
+      end
+
+      context 'when controlled digital lending' do
+        let(:access) do
+          {
+            view: 'stanford',
+            download: 'none',
+            controlledDigitalLending: true
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'stanford',
+            download: 'none',
+            controlledDigitalLending: false
+          }
+        end
+
+        it { is_expected.to eq 'controlled digital lending' }
+      end
+
+      context 'when dark' do
+        let(:access) do
+          {
+            view: 'dark',
+            download: 'none'
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'dark',
+            download: 'none'
+          }
+        end
+
+        it { is_expected.to eq ['dark'] }
+      end
+
+      context 'when location' do
+        context 'when downloadable' do
+          let(:access) do
+            {
+              view: 'location-based',
+              download: 'location-based',
+              location: 'spec'
+            }
+          end
+
+          let(:file_access) do
+            {
+              view: 'location-based',
+              download: 'location-based',
+              location: 'spec'
+            }
+          end
+
+          it { is_expected.to eq ['location: spec'] }
+        end
+
+        context 'when not downloadable' do
+          let(:access) do
+            {
+              view: 'location-based',
+              download: 'none',
+              location: 'spec'
+            }
+          end
+
+          let(:file_access) do
+            {
+              view: 'location-based',
+              download: 'none',
+              location: 'spec'
+            }
+          end
+
+          it { is_expected.to eq ['location: spec (no-download)'] }
+        end
+      end
+
+      context 'when world readable and location download' do
+        let(:access) do
+          {
+            view: 'world',
+            download: 'location-based',
+            location: 'spec'
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'world',
+            download: 'location-based',
+            location: 'spec'
+          }
+        end
+
+        it { is_expected.to eq ['world (no-download)', 'location: spec'] }
+      end
+
+      context 'when stanford readable and location download' do
+        let(:access) do
+          {
+            view: 'stanford',
+            download: 'location-based',
+            location: 'spec'
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'stanford',
+            download: 'location-based',
+            location: 'spec'
+          }
+        end
+
+        it { is_expected.to eq ['stanford (no-download)', 'location: spec'] }
+      end
+
+      context 'when world readable and no-download' do
+        let(:access) do
+          {
+            view: 'world',
+            download: 'none'
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'world',
+            download: 'none'
+          }
+        end
+
+        it { is_expected.to eq ['world (no-download)'] }
+      end
+
+      context 'when stanford readable and no-download' do
+        let(:access) do
+          {
+            view: 'stanford',
+            download: 'none',
+            controlledDigitalLending: false
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'stanford',
+            download: 'none',
+            controlledDigitalLending: false
+          }
+        end
+
+        it { is_expected.to eq ['stanford (no-download)'] }
+      end
+
+      context 'when stanford, dark (file)' do
+        # via https://argo.stanford.edu/view/druid:hz651dj0129
+        let(:access) do
+          {
+            view: 'stanford',
+            download: 'stanford'
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'dark',
+            download: 'none'
+          }
+        end
+
+        it { is_expected.to eq ['stanford', 'dark (file)'] }
+      end
+
+      context 'when stanford, world (file)' do
+        # Via https://argo.stanford.edu/view/druid:bb142ws0723
+        let(:structural) do
+          {
+            contains: [
+              {
+                type: Cocina::Models::FileSetType.page,
+                externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/d906da21-aca1-4b95-b7d1-c14c23cd93e6',
+                label: 'Page 1',
+                version: 5,
+                structural: {
+                  contains: [
+                    {
+                      type: Cocina::Models::ObjectType.file,
+                      externalIdentifier: 'https://cocina.sul.stanford.edu/file/4d88213d-f150-45ae-a58a-08b1045db2a0',
+                      label: '50807230_0001.jp2',
+                      filename: '50807230_0001.jp2',
+                      size: 3_575_822,
+                      version: 5,
+                      hasMimeType: 'image/jp2',
+                      hasMessageDigests: [
+                        {
+                          type: 'sha1',
+                          digest: '0a089200032d209e9b3e7f7768dd35323a863fcc'
+                        },
+                        {
+                          type: 'md5',
+                          digest: 'c99fae3c4c53e40824e710440f08acb9'
+                        }
+                      ],
+                      access: file_access,
+                      administrative: {
+                        publish: false,
+                        sdrPreserve: false,
+                        shelve: false
+                      },
+                      presentation: {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        end
+        let(:access) do
+          {
+            view: 'stanford',
+            download: 'stanford'
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'world',
+            download: 'world'
+          }
+        end
+
+        it { is_expected.to eq ['stanford', 'world (file)'] }
+      end
+
+      context 'when citation, world (file)' do
+        # https://argo.stanford.edu/view/druid:mq506jn2183
+        let(:structural) do
+          {
+            contains: [
+              {
+                type: Cocina::Models::FileSetType.page,
+                externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/d906da21-aca1-4b95-b7d1-c14c23cd93e6',
+                label: 'Page 1',
+                version: 5,
+                structural: {
+                  contains: [
+                    {
+                      type: Cocina::Models::ObjectType.file,
+                      externalIdentifier: 'https://cocina.sul.stanford.edu/file/4d88213d-f150-45ae-a58a-08b1045db2a0',
+                      label: '50807230_0001.jp2',
+                      filename: '50807230_0001.jp2',
+                      size: 3_575_822,
+                      version: 5,
+                      hasMimeType: 'image/jp2',
+                      hasMessageDigests: [
+                        {
+                          type: 'sha1',
+                          digest: '0a089200032d209e9b3e7f7768dd35323a863fcc'
+                        },
+                        {
+                          type: 'md5',
+                          digest: 'c99fae3c4c53e40824e710440f08acb9'
+                        }
+                      ],
+                      access: file_access,
+                      administrative: {
+                        publish: false,
+                        sdrPreserve: false,
+                        shelve: false
+                      },
+                      presentation: {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        end
+
+        let(:access) do
+          {
+            view: 'citation-only',
+            download: 'none'
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'world',
+            download: 'world'
+          }
+        end
+
+        it { is_expected.to eq ['citation', 'world (file)'] }
+      end
+
+      context 'when world (no-download), stanford (no-download) (file)' do
+        # via https://argo.stanford.edu/view/druid:cb810hh5010
+        let(:structural) do
+          {
+            contains: [
+              {
+                type: Cocina::Models::FileSetType.page,
+                externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/d906da21-aca1-4b95-b7d1-c14c23cd93e6',
+                label: 'Page 1',
+                version: 5,
+                structural: {
+                  contains: [
+                    {
+                      type: Cocina::Models::ObjectType.file,
+                      externalIdentifier: 'https://cocina.sul.stanford.edu/file/4d88213d-f150-45ae-a58a-08b1045db2a0',
+                      label: '50807230_0001.jp2',
+                      filename: '50807230_0001.jp2',
+                      size: 3_575_822,
+                      version: 5,
+                      hasMimeType: 'image/jp2',
+                      hasMessageDigests: [
+                        {
+                          type: 'sha1',
+                          digest: '0a089200032d209e9b3e7f7768dd35323a863fcc'
+                        },
+                        {
+                          type: 'md5',
+                          digest: 'c99fae3c4c53e40824e710440f08acb9'
+                        }
+                      ],
+                      access: file_access,
+                      administrative: {
+                        publish: false,
+                        sdrPreserve: false,
+                        shelve: false
+                      },
+                      presentation: {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        end
+        let(:access) do
+          {
+            view: 'world',
+            download: 'none'
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'stanford',
+            download: 'none',
+            controlledDigitalLending: false
+          }
+        end
+
+        it { is_expected.to eq ['world (no-download)', 'stanford (no-download) (file)'] }
+      end
+
+      context 'when two object level access. stanford, world (no-download), and world (file)' do
+        # via https://argo.stanford.edu/view/druid:bd336ff4952
+        let(:structural) do
+          {
+            contains: [
+              {
+                type: Cocina::Models::FileSetType.page,
+                externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/d906da21-aca1-4b95-b7d1-c14c23cd93e6',
+                label: 'Page 1',
+                version: 5,
+                structural: {
+                  contains: [
+                    {
+                      type: Cocina::Models::ObjectType.file,
+                      externalIdentifier: 'https://cocina.sul.stanford.edu/file/4d88213d-f150-45ae-a58a-08b1045db2a0',
+                      label: '50807230_0001.jp2',
+                      filename: '50807230_0001.jp2',
+                      size: 3_575_822,
+                      version: 5,
+                      hasMimeType: 'image/jp2',
+                      hasMessageDigests: [
+                        {
+                          type: 'sha1',
+                          digest: '0a089200032d209e9b3e7f7768dd35323a863fcc'
+                        },
+                        {
+                          type: 'md5',
+                          digest: 'c99fae3c4c53e40824e710440f08acb9'
+                        }
+                      ],
+                      access: file_access,
+                      administrative: {
+                        publish: false,
+                        sdrPreserve: false,
+                        shelve: false
+                      },
+                      presentation: {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        end
+        let(:access) do
+          {
+            view: 'world',
+            download: 'stanford'
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'world',
+            download: 'world'
+          }
+        end
+
+        it { is_expected.to eq ['stanford', 'world (no-download)', 'world (file)'] }
+      end
+
+      context 'when file level access has a read location' do
+        let(:access) do
+          {
+            view: 'citation-only',
+            download: 'none'
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'location-based',
+            download: 'none',
+            location: 'm&m'
+          }
+        end
+
+        it { is_expected.to eq ['citation', 'location: m&m (no-download) (file)'] }
+      end
+
+      context 'when file level access has stanford and a download location' do
+        let(:access) do
+          {
+            view: 'citation-only',
+            download: 'none'
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'stanford',
+            download: 'location-based',
+            location: 'm&m'
+          }
+        end
+
+        it { is_expected.to eq ['citation', 'stanford (no-download) (file)', 'location: m&m (file)'] }
+      end
+
+      context 'when file level access has world and a download location' do
+        let(:access) do
+          {
+            view: 'citation-only',
+            download: 'none'
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'world',
+            download: 'location-based',
+            location: 'm&m'
+          }
+        end
+
+        it { is_expected.to eq ['citation', 'world (no-download) (file)', 'location: m&m (file)'] }
+      end
+
+      context 'when file level access has world and stanford download' do
+        let(:access) do
+          {
+            view: 'citation-only',
+            download: 'none'
+          }
+        end
+
+        let(:file_access) do
+          {
+            view: 'world',
+            download: 'stanford'
+          }
+        end
+
+        it { is_expected.to eq ['citation', 'world (no-download) (file)', 'stanford (file)'] }
+      end
+    end
 
     describe 'rights descriptions' do
       subject { doc['rights_descriptions_ssimdv'] }

--- a/spec/services/indexing/workflow_fields_spec.rb
+++ b/spec/services/indexing/workflow_fields_spec.rb
@@ -39,14 +39,23 @@ RSpec.describe Indexing::WorkflowFields do
     it 'includes the semicolon delimited version, an earliest published date and a status' do
       # published date should be the first published date
       expect(doc['status_ssi']).to eq 'v4 In accessioning (described, published)'
+      expect(doc['processing_status_text_ssi']).to eq 'In accessioning' # TODO: Remove
       expect(doc['processing_status_text_ssidv']).to eq 'In accessioning'
+      expect(doc).to match a_hash_including('opened_dttsim' => including('2012-11-07T00:21:02Z')) # TODO: Remove
       expect(doc).to match a_hash_including('opened_dtpsimdv' => including('2012-11-07T00:21:02Z'))
+      expect(doc['published_earliest_dttsi']).to eq('2012-01-27T05:06:54Z') # TODO: Remove
       expect(doc['published_earliest_dtpsidv']).to eq('2012-01-27T05:06:54Z')
+      expect(doc['published_latest_dttsi']).to eq('2012-11-07T00:59:39Z') # TODO: Remove
       expect(doc['published_latest_dtpsidv']).to eq('2012-11-07T00:59:39Z')
+      expect(doc['published_dttsim'].first).to eq(doc['published_earliest_dttsi']) # TODO: Remove
+      expect(doc['published_dttsim'].last).to eq(doc['published_latest_dttsi']) # TODO: Remove
+      expect(doc['published_dttsim'].size).to eq(3) # TODO: Remove
       expect(doc['published_dtpsimdv'].first).to eq(doc['published_earliest_dtpsidv'])
       expect(doc['published_dtpsimdv'].last).to eq(doc['published_latest_dtpsidv'])
       expect(doc['published_dtpsimdv'].size).to eq(3) # not 4 because 1 deduplicated value removed!
+      expect(doc['opened_earliest_dttsi']).to eq('2012-10-29T23:30:07Z') # TODO: Remove
       expect(doc['opened_earliest_dtpsidv']).to eq('2012-10-29T23:30:07Z') #  2012-10-29T16:30:07-0700
+      expect(doc['opened_latest_dttsi']).to eq('2012-11-07T00:21:02Z') # TODO: Remove
       expect(doc['opened_latest_dtpsidv']).to eq('2012-11-07T00:21:02Z') #  2012-11-06T16:21:02-0800
     end
 


### PR DESCRIPTION
This reverts commit 9cb2ae5d5344c21dcdf38c0e0acb0d2f249d3644.

## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



