### PR TITLE
Use object type wasarchive-binary for was shelving logic

### DIFF
--- a/app/jobs/robots/dor_repo/accession/shelve.rb
+++ b/app/jobs/robots/dor_repo/accession/shelve.rb
@@ -24,8 +24,7 @@ module Robots
         end
 
         def was_crawl?
-          # The presence of the wasCrawlPreassemblyWF workflow indicates that this is a crawl.
-          Workflow::Service.workflow?(druid:, workflow_name: 'wasCrawlPreassemblyWF')
+          cocina_object.type == Cocina::Models::ObjectType.webarchive_binary
         end
       end
     end

--- a/spec/jobs/robots/dor_repo/accession/shelve_spec.rb
+++ b/spec/jobs/robots/dor_repo/accession/shelve_spec.rb
@@ -8,12 +8,11 @@ RSpec.describe Robots::DorRepo::Accession::Shelve, type: :robot do
   let(:druid) { 'druid:zz000zz0001' }
   let(:robot) { described_class.new }
 
-  let(:object) { build(:dro, id: druid) }
-  let(:crawl?) { true }
+  let(:object) { build(:dro, id: druid, type:) }
+  let(:type) { Cocina::Models::ObjectType.image }
 
   before do
     allow(CocinaObjectStore).to receive(:find).with(druid).and_return(object)
-    allow(Workflow::Service).to receive(:workflow?).and_return(crawl?)
     allow(WasShelvingService).to receive(:shelve)
     allow(EventFactory).to receive(:create)
   end
@@ -29,8 +28,6 @@ RSpec.describe Robots::DorRepo::Accession::Shelve, type: :robot do
   end
 
   context 'when the object is not a WAS Crawl' do
-    let(:crawl?) { false }
-
     it 'skips the object' do
       expect(perform.status).to eq 'skipped'
       expect(WasShelvingService).not_to have_received(:shelve)
@@ -39,6 +36,8 @@ RSpec.describe Robots::DorRepo::Accession::Shelve, type: :robot do
   end
 
   context 'when the object is a WAS Crawl' do
+    let(:type) { Cocina::Models::ObjectType.webarchive_binary }
+
     it 'shelves the object' do
       expect(perform).to be_nil # no return state defaults to completed.
       expect(WasShelvingService).to have_received(:shelve).with(object)


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #5546 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



