### PR TITLE
Reindex after creating release tag.

### DIFF
--- a/app/controllers/release_tags_controller.rb
+++ b/app/controllers/release_tags_controller.rb
@@ -24,7 +24,7 @@ class ReleaseTagsController < ApplicationController
   end
 
   def create
-    ReleaseTagService.create(druid: @cocina_object.externalIdentifier, tag: new_tag)
+    ReleaseTagService.create(cocina_object: @cocina_object, tag: new_tag)
     head :created
   end
 

--- a/app/services/release_tag_service.rb
+++ b/app/services/release_tag_service.rb
@@ -9,7 +9,9 @@ class ReleaseTagService
 
   # Creates ReleaseTag model objects.
   # @param [Dor::ReleaseTag] tag
-  def self.create(druid:, tag:)
-    ReleaseTag.from_cocina(druid:, tag:).save!
+  # @param [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata] cocina_object
+  def self.create(tag:, cocina_object:)
+    ReleaseTag.from_cocina(druid: cocina_object.externalIdentifier, tag:).save!
+    Indexer.reindex(cocina_object: cocina_object)
   end
 end

--- a/spec/requests/release_tags_spec.rb
+++ b/spec/requests/release_tags_spec.rb
@@ -83,17 +83,21 @@ RSpec.describe 'Operations on release tags' do
       build(:dro, id: druid)
     end
 
-    context 'when succeessful' do
-      let(:data) do
-        tag.to_json
-      end
+    let(:data) do
+      tag.to_json
+    end
 
-      it 'creates a tag' do
-        post "/v1/objects/#{druid}/release_tags",
-             headers: auth_headers.merge('Content-Type' => 'application/json'),
-             params: data
-        expect(response).to have_http_status :created
-      end
+    before do
+      allow(ReleaseTagService).to receive(:create)
+    end
+
+    it 'creates a tag' do
+      post "/v1/objects/#{druid}/release_tags",
+           headers: auth_headers.merge('Content-Type' => 'application/json'),
+           params: data
+      expect(response).to have_http_status :created
+      expect(ReleaseTagService).to have_received(:create).with(cocina_object: cocina_object_with_metadata,
+                                                               tag: an_instance_of(Dor::ReleaseTag))
     end
   end
 end

--- a/spec/services/release_tag_service_spec.rb
+++ b/spec/services/release_tag_service_spec.rb
@@ -6,12 +6,18 @@ RSpec.describe ReleaseTagService do
   let(:druid) { 'druid:bb004bn8654' }
 
   describe '.create' do
-    subject(:create_tag) { described_class.create(druid:, tag:) }
+    subject(:create_tag) { described_class.create(cocina_object:, tag:) }
 
     let(:tag) { Dor::ReleaseTag.new(to: 'Earthworks', what: 'self', who: 'cathy', date: 2.days.ago.iso8601) }
+    let(:cocina_object) { instance_double(Cocina::Models::DROWithMetadata, externalIdentifier: druid) }
 
-    it 'adds another release tag and' do
+    before do
+      allow(Indexer).to receive(:reindex)
+    end
+
+    it 'adds another release tag and reindexes' do
       expect { create_tag }.to change { ReleaseTag.where(druid:).count }.by(1)
+      expect(Indexer).to have_received(:reindex).with(cocina_object:)
     end
   end
 


### PR DESCRIPTION
closes #5557

## Why was this change made? 🤔
So that an Argo user doesn't need to reindex to see latest.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



