### PR TITLE
Do not index release tags for dark objects.

### DIFF
--- a/app/services/indexing/indexers/releasable_indexer.rb
+++ b/app/services/indexing/indexers/releasable_indexer.rb
@@ -15,7 +15,7 @@ module Indexing
 
       # @return [Hash] the partial solr document for releasable concerns
       def to_solr
-        return {} if tags.blank?
+        return {} if tags.blank? || Cocina::Support.dark?(cocina)
 
         {
           'released_to_ssim' => tags.map(&:to).uniq,

--- a/spec/services/indexing/indexers/releasable_indexer_spec.rb
+++ b/spec/services/indexing/indexers/releasable_indexer_spec.rb
@@ -2,9 +2,10 @@
 
 require 'rails_helper'
 RSpec.describe Indexing::Indexers::ReleasableIndexer do
-  let(:cocina) { build(:dro).new(structural: { isMemberOf: collection_druids }) }
+  let(:cocina) { build(:dro).new(structural: { isMemberOf: collection_druids }, access:) }
   let(:collection_druids) { [] }
   let(:release_tags) { [] }
+  let(:access) { { view: 'world', download: 'world' } }
 
   describe 'to_solr' do
     let(:doc) do
@@ -146,6 +147,20 @@ RSpec.describe Indexing::Indexers::ReleasableIndexer do
         it 'has no release tags' do
           expect(doc).not_to include('released_to_ssim')
         end
+      end
+    end
+
+    context 'when item is dark' do
+      let(:release_tags) do
+        [
+          Dor::ReleaseTag.new(to: 'Searchworks', release: true, date: '2021-05-12T21:05:21.000+00:00',
+                              what: 'self')
+        ]
+      end
+      let(:access) { { view: 'dark', download: 'none' } }
+
+      it 'does not index release tags' do
+        expect(doc).to be_empty
       end
     end
   end


### PR DESCRIPTION
closes #5584

## Why was this change made? 🤔
Dark objects are not actually released.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



