### PR TITLE
Create releaseWF when creating release tag.

### DIFF
--- a/app/services/release_tag_service.rb
+++ b/app/services/release_tag_service.rb
@@ -13,5 +13,6 @@ class ReleaseTagService
   def self.create(tag:, cocina_object:)
     ReleaseTag.from_cocina(druid: cocina_object.externalIdentifier, tag:).save!
     Indexer.reindex(cocina_object: cocina_object)
+    Workflow::Service.create(name: 'releaseWF', druid: cocina_object.externalIdentifier, version: cocina_object.version)
   end
 end

--- a/spec/services/release_tag_service_spec.rb
+++ b/spec/services/release_tag_service_spec.rb
@@ -9,15 +9,18 @@ RSpec.describe ReleaseTagService do
     subject(:create_tag) { described_class.create(cocina_object:, tag:) }
 
     let(:tag) { Dor::ReleaseTag.new(to: 'Earthworks', what: 'self', who: 'cathy', date: 2.days.ago.iso8601) }
-    let(:cocina_object) { instance_double(Cocina::Models::DROWithMetadata, externalIdentifier: druid) }
+    let(:cocina_object) { instance_double(Cocina::Models::DROWithMetadata, externalIdentifier: druid, version: 2) }
 
     before do
       allow(Indexer).to receive(:reindex)
+      allow(Workflow::Service).to receive(:create)
     end
 
-    it 'adds another release tag and reindexes' do
+    it 'adds another release tag' do
       expect { create_tag }.to change { ReleaseTag.where(druid:).count }.by(1)
       expect(Indexer).to have_received(:reindex).with(cocina_object:)
+      expect(Workflow::Service).to have_received(:create).with(name: 'releaseWF',
+                                                               druid:, version: 2)
     end
   end
 


### PR DESCRIPTION
closes #5586

## Why was this change made? 🤔
This should be a responsibility of DSA, not Argo.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



