### PR TITLE
Index file size as a long point.

### DIFF
--- a/app/services/indexing/indexers/object_files_indexer.rb
+++ b/app/services/indexing/indexers/object_files_indexer.rb
@@ -31,7 +31,8 @@ module Indexing
           'content_file_count_itsi' => files.size,
           'shelved_content_file_count_itsi' => shelved_files.size,
           'resource_count_itsi' => file_sets.size,
-          'preserved_size_dbtsi' => preserved_size, # double (trie) to support very large sizes
+          'preserved_size_lpsi' => preserved_size, # long to support very large sizes
+          'preserved_size_dbtsi' => preserved_size, # TODO: remove https://github.com/sul-dlss/dor-services-app/issues/5604
           'human_preserved_size_ss' => ActiveSupport::NumberHelper.number_to_human_size(preserved_size),
           'content_file_roles_ssimdv' => files.filter_map(&:use),
           'first_shelved_image_ss' => first_shelved_image

--- a/spec/services/indexing/indexers/object_files_indexer_spec.rb
+++ b/spec/services/indexing/indexers/object_files_indexer_spec.rb
@@ -177,7 +177,8 @@ RSpec.describe Indexing::Indexers::ObjectFilesIndexer do
           'resource_count_itsi' => 1,
           'content_file_count_itsi' => 4,
           'first_shelved_image_ss' => 'gw177fc7976_05_0001.jp2',
-          'preserved_size_dbtsi' => 168_404_723,
+          'preserved_size_lpsi' => 168_404_723,
+          'preserved_size_dbtsi' => 168_404_723, # TODO: remove https://github.com/sul-dlss/dor-services-app/issues/5604
           'human_preserved_size_ss' => '161 MB'
         )
       end
@@ -263,7 +264,8 @@ RSpec.describe Indexing::Indexers::ObjectFilesIndexer do
 
       it 'ignores the nil sizes without erroring' do
         expect(doc).to include(
-          'preserved_size_dbtsi' => 4_128_877,
+          'preserved_size_lpsi' => 4_128_877,
+          'preserved_size_dbtsi' => 4_128_877, # TODO: remove https://github.com/sul-dlss/dor-services-app/issues/5604
           'human_preserved_size_ss' => '3.94 MB'
         )
       end
@@ -279,7 +281,8 @@ RSpec.describe Indexing::Indexers::ObjectFilesIndexer do
           'shelved_content_file_count_itsi' => 0,
           'resource_count_itsi' => 0,
           'content_file_count_itsi' => 0,
-          'preserved_size_dbtsi' => 0,
+          'preserved_size_lpsi' => 0,
+          'preserved_size_dbtsi' => 0, # TODO: remove https://github.com/sul-dlss/dor-services-app/issues/5604
           'human_preserved_size_ss' => '0 Bytes'
         )
       end


### PR DESCRIPTION
~**HOLD PENDING ADDING LONG POINT TO SOLR SCHEMA**~

closes #5603

## Why was this change made? 🤔
The existing field is a double. This doesn't export correctly to CSV without casting it.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



