### PR TITLE
Make preserved size field a document value field.

### DIFF
--- a/app/services/indexing/indexers/object_files_indexer.rb
+++ b/app/services/indexing/indexers/object_files_indexer.rb
@@ -31,7 +31,7 @@ module Indexing
           'content_file_count_itsi' => files.size,
           'shelved_content_file_count_itsi' => shelved_files.size,
           'resource_count_itsi' => file_sets.size,
-          'preserved_size_lpsi' => preserved_size, # long to support very large sizes
+          'preserved_size_lpsidv' => preserved_size, # long to support very large sizes
           'preserved_size_dbtsi' => preserved_size, # TODO: remove https://github.com/sul-dlss/dor-services-app/issues/5604
           'human_preserved_size_ss' => ActiveSupport::NumberHelper.number_to_human_size(preserved_size),
           'content_file_roles_ssimdv' => files.filter_map(&:use),

--- a/spec/services/indexing/indexers/object_files_indexer_spec.rb
+++ b/spec/services/indexing/indexers/object_files_indexer_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Indexing::Indexers::ObjectFilesIndexer do
           'resource_count_itsi' => 1,
           'content_file_count_itsi' => 4,
           'first_shelved_image_ss' => 'gw177fc7976_05_0001.jp2',
-          'preserved_size_lpsi' => 168_404_723,
+          'preserved_size_lpsidv' => 168_404_723,
           'preserved_size_dbtsi' => 168_404_723, # TODO: remove https://github.com/sul-dlss/dor-services-app/issues/5604
           'human_preserved_size_ss' => '161 MB'
         )
@@ -264,7 +264,7 @@ RSpec.describe Indexing::Indexers::ObjectFilesIndexer do
 
       it 'ignores the nil sizes without erroring' do
         expect(doc).to include(
-          'preserved_size_lpsi' => 4_128_877,
+          'preserved_size_lpsidv' => 4_128_877,
           'preserved_size_dbtsi' => 4_128_877, # TODO: remove https://github.com/sul-dlss/dor-services-app/issues/5604
           'human_preserved_size_ss' => '3.94 MB'
         )
@@ -281,7 +281,7 @@ RSpec.describe Indexing::Indexers::ObjectFilesIndexer do
           'shelved_content_file_count_itsi' => 0,
           'resource_count_itsi' => 0,
           'content_file_count_itsi' => 0,
-          'preserved_size_lpsi' => 0,
+          'preserved_size_lpsidv' => 0,
           'preserved_size_dbtsi' => 0, # TODO: remove https://github.com/sul-dlss/dor-services-app/issues/5604
           'human_preserved_size_ss' => '0 Bytes'
         )


### PR DESCRIPTION
## Why was this change made? 🤔
```
Information for cause: RSolr::Error::Http (RSolr::Error::Http - 400 Bad Request
Error: Can't calculate stats on a PointField without docValues
```


## How was this change tested? 🤨
Unit
⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



