### PR TITLE
Release-publish robot does not release for a registered item.

### DIFF
--- a/app/jobs/robots/dor_repo/release/release_publish.rb
+++ b/app/jobs/robots/dor_repo/release/release_publish.rb
@@ -18,7 +18,7 @@ module Robots
           end
 
           # Ensure that item has been published before releasing.
-          raise PublishNotCompleteError unless published_milestone_present?
+          raise PublishNotCompleteError unless Publish::Item.new(druid:).published?
 
           PurlFetcher::Client::ReleaseTags.release(
             druid:,
@@ -37,12 +37,6 @@ module Robots
 
         def dark?
           Cocina::Support.dark?(cocina_object)
-        end
-
-        def published_milestone_present?
-          # Use Publish::Item to get the version being published.
-          publish_item = Publish::Item.new(druid:)
-          Workflow::LifecycleService.milestone?(druid:, milestone_name: 'published', version: publish_item.version)
         end
       end
     end

--- a/app/services/publish/item.rb
+++ b/app/services/publish/item.rb
@@ -37,6 +37,13 @@ module Publish
       user_version.present?
     end
 
+    # @return [Boolean] whether the item has been published for the published version
+    def published?
+      return false if repository_object_version.nil?
+
+      Workflow::LifecycleService.milestone?(druid:, milestone_name: 'published', version: version)
+    end
+
     delegate :version, to: :repository_object_version
 
     attr_reader :druid, :user_version


### PR DESCRIPTION
closes #5620

## Why was this change made? 🤔
Registered items haven't been published to PURL so they can't be released.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



