### PR TITLE
Use repository object created_at date when creating Cocina with metadata

### DIFF
--- a/app/models/repository_object_version.rb
+++ b/app/models/repository_object_version.rb
@@ -34,9 +34,17 @@ class RepositoryObjectVersion < ApplicationRecord
     end
   end
 
+  # NOTE: Always use the repository object's created_at timestamp, not the
+  #       version's. In practice, this date is indexed and used in Argo to show
+  #       the created date for the object itself; we use the modified date
+  #       to show in Purl when a version was made.
   def to_cocina_with_metadata
-    Cocina::Models.with_metadata(to_cocina, repository_object.external_lock, created: created_at.utc,
-                                                                             modified: updated_at.utc)
+    Cocina::Models.with_metadata(
+      to_cocina,
+      repository_object.external_lock,
+      created: repository_object.created_at.utc,
+      modified: updated_at.utc
+    )
   end
 
   # Legacy RepositoryObjectVersions don't have cocina.

--- a/spec/factories/repository_objects.rb
+++ b/spec/factories/repository_objects.rb
@@ -6,6 +6,8 @@ FactoryBot.define do
     external_identifier { generate(:unique_druid) }
     source_id { "sul:#{SecureRandom.uuid}" }
     lock { 1 }
+    created_at { Time.current }
+    updated_at { Time.current }
   end
 
   trait :admin_policy do

--- a/spec/services/notifications/object_created_spec.rb
+++ b/spec/services/notifications/object_created_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Notifications::ObjectCreated do
   let(:topic) { instance_double(Bunny::Exchange, publish: true) }
 
   let(:model) do
-    create(:repository_object, :with_repository_object_version, object_type) do |repo_obj|
-      repo_obj.head_version.update(created_at:, updated_at:)
+    create(:repository_object, :with_repository_object_version, object_type, created_at:) do |repo_obj|
+      repo_obj.head_version.update(updated_at:)
     end
   end
 


### PR DESCRIPTION
I assume @andrewjbtw may want to hold this until it can be thoroughly tested in QA to ensure it doesn't have unexpected side effects.

# Why was this change made?

Fixes sul-dlss/argo#4984

# How was this change tested?

- [x] CI
- [x] QA (approved by Andrew)

