### PR TITLE
Use cocina display to get the title

### DIFF
--- a/app/services/goobi_service.rb
+++ b/app/services/goobi_service.rb
@@ -170,10 +170,8 @@ class GoobiService
 
   def title_or_label
     if cocina_obj.description
-      desc_ng_xml = Cocina::Models::Mapping::ToMods::Description.transform(cocina_obj.description,
-                                                                           cocina_obj.externalIdentifier)
-      title_element = ModsUtils.primary_title_info(desc_ng_xml)
-      return title_element.content.strip if title_element.respond_to?(:content) && title_element.content.present?
+      main_title = CocinaDisplay::CocinaRecord.new(cocina_obj.to_h.with_indifferent_access).main_title
+      return main_title if main_title
     end
 
     cocina_obj.label

--- a/app/services/mods_utils.rb
+++ b/app/services/mods_utils.rb
@@ -2,19 +2,6 @@
 
 # Functions for querying MODS XML
 class ModsUtils
-  # @param [Nokogiri::Document] ng_xml
-  # @return [Nokogiri::Element]
-  def self.primary_title_info(ng_xml)
-    title_info = ng_xml.xpath('//mods:mods/mods:titleInfo[not(@type)]',
-                              mods: Cocina::Models::Mapping::FromMods::Description::DESC_METADATA_NS).first
-    title_info ||= ng_xml.xpath('//mods:mods/mods:titleInfo[@usage="primary"]',
-                                mods: Cocina::Models::Mapping::FromMods::Description::DESC_METADATA_NS).first
-    title_info ||= ng_xml.xpath('//mods:mods/mods:titleInfo',
-                                mods: Cocina::Models::Mapping::FromMods::Description::DESC_METADATA_NSS).first
-
-    title_info
-  end
-
   def self.label(ng_xml)
     ng_xml.root.add_namespace_definition('mods', 'http://www.loc.gov/mods/v3')
     ng_xml.xpath('/mods:mods/mods:titleInfo[1]')

--- a/spec/services/goobi_service_spec.rb
+++ b/spec/services/goobi_service_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe GoobiService do
   describe '#title_or_label' do
     subject(:title_or_label) { Nokogiri::XML(goobi.send(:xml_request)).xpath('//title').first.content }
 
-    context 'when MODS title is present' do
+    context 'when description is present' do
       let(:description) do
         {
           title: [


### PR DESCRIPTION
Instead of converting cocina to mods and then looking for it.

## Why was this change made? 🤔
Why convert to XML?


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



