### PR TITLE
Stop returning skipped workflow names from TemplateService.

### DIFF
--- a/app/services/indexing/workflow_solr_document.rb
+++ b/app/services/indexing/workflow_solr_document.rb
@@ -113,7 +113,7 @@ module Indexing
     end
 
     def skip_wps_workflow?
-      SKIP_WPS_WORKFLOWS.include?(wf_name)
+      Settings.skip_workflows.include?(wf_name)
     end
   end
 end

--- a/app/services/workflow/template_service.rb
+++ b/app/services/workflow/template_service.rb
@@ -15,8 +15,9 @@ module Workflow
     def templates
       @templates ||= begin
         files = Dir.glob("#{Workflow::TemplateLoader::WORKFLOWS_DIR}/*.xml")
-        files.map do |file|
-          file.sub(%r{#{Workflow::TemplateLoader::WORKFLOWS_DIR}/([^/]*).xml}, '\1')
+        files.filter_map do |file|
+          name = file.sub(%r{#{Workflow::TemplateLoader::WORKFLOWS_DIR}/([^/]*).xml}, '\1')
+          name if Settings.skip_workflows.exclude?(name)
         end.sort
       end
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -140,3 +140,22 @@ mais_orcid:
 
 indexer:
   logging: false
+
+# These are workflows that are either deprecated or are very minimal workflows.
+# They are omitted from indexing in wps field by WorkflowSolrDocument
+# and are not returned by Workflow::TemplateService.templates.
+# Note that some of these workflows are still in use and are still indexed in other fields.
+skip_workflows:
+  -accession2WF
+  -sdrMigrationWF
+  -dpgImageWF
+  -sdrAuditWF
+  -swIndexWF
+  -googleScannedBookWF
+  -eemsAccessionWF
+  -gisDiscoveryWF
+  -etdSubmitWF
+  -hydrusAssemblyWF
+  -disseminationWF
+  -registrationWF
+  -versioningWF

--- a/spec/services/workflow/template_service_spec.rb
+++ b/spec/services/workflow/template_service_spec.rb
@@ -38,32 +38,20 @@ RSpec.describe Workflow::TemplateService do
     it 'returns a list of workflow template names' do
       expect(described_class.templates).to eq(
         %w[
-          accession2WF
           accessionWF
           assemblyWF
           captionWF
           digitizationWF
-          disseminationWF
-          dpgImageWF
-          eemsAccessionWF
-          etdSubmitWF
           gisAssemblyWF
           gisDeliveryWF
           goobiWF
-          googleScannedBookWF
-          hydrusAssemblyWF
           ocrWF
           preservationAuditWF
           preservationIngestWF
-          registrationWF
           releaseWF
-          sdrAuditWF
           sdrIngestWF
-          sdrMigrationWF
           sdrRecoveryWF
           speechToTextWF
-          swIndexWF
-          versioningWF
           wasCrawlDisseminationWF
           wasCrawlPreassemblyWF
           wasDisseminationWF


### PR DESCRIPTION
## Why was this change made? 🤔
This will cause them to be omitted in locations like the Argo workflow grid.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



