### PR TITLE
Skip update marc

### DIFF
--- a/app/jobs/robots/dor_repo/release/update_marc.rb
+++ b/app/jobs/robots/dor_repo/release/update_marc.rb
@@ -10,9 +10,10 @@ module Robots
         end
 
         def perform_work
-          # temporarily skip update-marc during winter closure 2025, post-FOLIO update
+          # temporarily skip update-marc step during winter closure 2025, post-FOLIO update
+          # to be reverted Jan 5, 2026
           LyberCore::ReturnState.new(status: :skipped,
-                                     note: 'Orcid works are not supported on non-Item objects')
+                                     note: 'Skipping during FOLIO update winter closure 2025')
           # Catalog::UpdateMarc856RecordService.update(cocina_object,
           #                                            thumbnail_service: ThumbnailService.new(cocina_object))
         end

--- a/spec/jobs/robots/dor_repo/release/update_marc_spec.rb
+++ b/spec/jobs/robots/dor_repo/release/update_marc_spec.rb
@@ -19,8 +19,9 @@ RSpec.describe Robots::DorRepo::Release::UpdateMarc, type: :robot do
 
   it 'updates the MARC record for the object' do
     expect { perform }.not_to raise_error
-    expect(Catalog::UpdateMarc856RecordService).to have_received(:update).with(object,
-                                                                               thumbnail_service: thumbnail_service)
-    expect(ThumbnailService).to have_received(:new).with(object)
+    expect(perform).to have_attributes(status: 'skipped')
+    # expect(Catalog::UpdateMarc856RecordService).to have_received(:update).with(object,
+    #                                                                            thumbnail_service: thumbnail_service)
+    # expect(ThumbnailService).to have_received(:new).with(object)
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Temporarily skip update-marc in releaseWF until after winter closure.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



