### PR TITLE
Bumps cocina-models to 0.109.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '~> 8.0.0'
 
 # DLSS/domain-specific dependencies
 gem 'cocina_display'
-gem 'cocina-models', '~> 0.108.0'
+gem 'cocina-models', '~> 0.109.0'
 gem 'datacite', '~> 0.6'
 gem 'dor-services-client' # Used for Dor::Services::Response::* classes
 gem 'druid-tools', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.108.3)
+    cocina-models (0.109.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -172,9 +172,9 @@ GEM
       ed25519
     docile (1.4.1)
     domain_name (0.6.20240107)
-    dor-services-client (15.25.2)
+    dor-services-client (15.25.3)
       activesupport (>= 7.0.0)
-      cocina-models (~> 0.108.2)
+      cocina-models (~> 0.109.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -620,7 +620,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.108.0)
+  cocina-models (~> 0.109.0)
   cocina_display
   committee
   config


### PR DESCRIPTION
## Why was this change made? 🤔
To keep in sync with cocina-models.


## How was this change tested? 🤨
To keep in sync with cocina-models.




