### PR TITLE
Remove test for item without a main or primary title

### DIFF
--- a/spec/services/indexing/indexers/descriptive_metadata_indexer_title_spec.rb
+++ b/spec/services/indexing/indexers/descriptive_metadata_indexer_title_spec.rb
@@ -55,42 +55,6 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
       end
     end
 
-    context 'with multiple typed titles, none status primary' do
-      # Select first
-      let(:titles) do
-        [
-          {
-            value: 'First',
-            type: 'translated'
-          },
-          {
-            value: 'Second',
-            type: 'alternative'
-          },
-          {
-            value: 'Third',
-            type: 'transliterated'
-          }
-        ]
-      end
-
-      it 'main_title_tenim is first value' do
-        expect(doc['main_title_tenim']).to eq ['First']
-      end
-
-      it 'full_title_tenim is first value' do
-        expect(doc['full_title_tenim']).to eq ['First']
-      end
-
-      it 'additional_titles_tenim is non-first values' do
-        expect(doc['additional_titles_tenim']).to eq %w[Second Third]
-      end
-
-      it 'display_title_ss is first value' do
-        expect(doc['display_title_ss']).to eq 'First'
-      end
-    end
-
     context 'with structuredValue with all parts in common order' do
       let(:titles) do
         [


### PR DESCRIPTION
## Why was this change made? 🤔
I don't believe this test is representative of any real object, making it a bad test


## How was this change tested? 🤨
```SQL
SELECT ro.external_identifier
FROM repository_objects AS ro, repository_object_versions AS rov WHERE
ro.head_version_id = rov.id
AND ro.object_type = 'dro'
AND jsonb_array_length(rov.description #> '{title}') > 1
AND rov.description #>> '{title,0,status}' is NULL
AND rov.description #>> '{title,0,structuredValue}' is NULL
LIMIT 10;

 external_identifier
---------------------
(0 rows)
```

