### PR TITLE
Remove obsolete SSL configuration

### DIFF
--- a/config/initializers/ssl.rb
+++ b/config/initializers/ssl.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-# By default Ruby 2.5 tries to use SSLv23.
-# This sometimes causes this error:
-#   OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A
-#
-# See: https://stackoverflow.com/questions/9175151/connecting-using-https-to-a-server-with-a-certificate-signed-by-a-ca-i-created/9262269#9262269
-
-OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ssl_version] = 'TLSv1_2'


### PR DESCRIPTION


## Why was this change made? 🤔

Calling this in ruby 4.0 causes;
  can't modify frozen Hash: {verify_mode: 1, verify_hostname: true, options: 2147614800}

## How was this change tested? 🤨
unit
