### PR TITLE
Upgrade to latest cocina-models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '~> 8.0.0'
 
 # DLSS/domain-specific dependencies
 gem 'cocina_display'
-gem 'cocina-models', '~> 0.109.0'
+gem 'cocina-models', '~> 0.110.1'
 gem 'datacite', '~> 0.6'
 gem 'dor-services-client' # Used for Dor::Services::Response::* classes
 gem 'druid-tools', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.109.0)
+    cocina-models (0.110.1)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -119,9 +119,10 @@ GEM
       edtf
       equivalent-xml
       i18n
+      json_schemer (~> 2.0)
       jsonpath
+      marc (~> 1.3)
       nokogiri
-      openapi_parser (~> 1.0)
       super_diff
       thor
       zeitwerk (~> 2.1)
@@ -132,9 +133,9 @@ GEM
       i18n
       janeway-jsonpath (~> 0.6)
       zeitwerk (~> 2.7)
-    committee (5.0.0)
+    committee (5.6.1)
       json_schema (~> 0.14, >= 0.14.3)
-      openapi_parser (~> 1.0)
+      openapi_parser (~> 2.0)
       rack (>= 1.5)
     concurrent-ruby (1.3.6)
     config (5.6.1)
@@ -172,9 +173,9 @@ GEM
       ed25519
     docile (1.4.1)
     domain_name (0.6.20240107)
-    dor-services-client (15.26.0)
+    dor-services-client (15.27.1)
       activesupport (>= 7.0.0)
-      cocina-models (~> 0.109.0)
+      cocina-models (~> 0.110.1)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -366,7 +367,7 @@ GEM
       version_gem (~> 1.1, >= 1.1.9)
     okcomputer (1.19.1)
       benchmark
-    openapi_parser (1.0.0)
+    openapi_parser (2.3.1)
     optimist (3.2.1)
     ostruct (0.6.3)
     parallel (1.27.0)
@@ -620,7 +621,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.109.0)
+  cocina-models (~> 0.110.1)
   cocina_display
   committee
   config

--- a/app/services/refresh_description_from_catalog.rb
+++ b/app/services/refresh_description_from_catalog.rb
@@ -30,11 +30,12 @@ class RefreshDescriptionFromCatalog
     return Failure() unless identifiers.any?
 
     if Settings.enabled_features.use_marc
-      marc = marc_service.marc
-      return Failure() if marc.nil?
+      marc_hash = marc_service.marc
+      return Failure() if marc_hash.nil?
 
-      description_props = Cocina::Models::Mapping::FromMarc::Description.props(marc:, druid:,
-                                                                               label: cocina_object.label)
+      marc = MARC::Record.new_from_hash(marc_hash)
+
+      description_props = Cocina::Models::Mapping::FromMarc::Description.props(marc:, druid:)
     else
       return Failure() if marc_service.mods.nil?
 

--- a/spec/requests/administrative_tags_spec.rb
+++ b/spec/requests/administrative_tags_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Administrative tags' do
              headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status(:bad_request)
         expect(response.body)
-          .to eq('{"errors":[{"title":"bad request","detail":"param is missing or the value is empty or invalid: administrative_tags"}]}') # rubocop:disable Layout/LineLength
+          .to eq('{"errors":[{"status":"bad_request","detail":"\"Content-Type\" request header must be set to \"application/json\"."}]}') # rubocop:disable Layout/LineLength
       end
     end
 
@@ -189,7 +189,7 @@ RSpec.describe 'Administrative tags' do
             headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status(:bad_request)
         expect(response.body)
-          .to eq('{"errors":[{"title":"bad request","detail":"param is missing or the value is empty or invalid: administrative_tag"}]}') # rubocop:disable Layout/LineLength
+          .to eq('{"errors":[{"status":"bad_request","detail":"\"Content-Type\" request header must be set to \"application/json\"."}]}') # rubocop:disable Layout/LineLength
       end
     end
 

--- a/spec/requests/metadata_refresh_spec.rb
+++ b/spec/requests/metadata_refresh_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe 'Refresh metadata' do
         post '/v1/objects/druid:mk420bs7601/refresh_metadata',
              headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status(:unprocessable_content)
-        expect(response.body).to match('missing required parameters: title')
+        expect(response.body).to match('missing required properties: title')
       end
     end
   end

--- a/spec/services/refresh_description_from_catalog_spec.rb
+++ b/spec/services/refresh_description_from_catalog_spec.rb
@@ -147,11 +147,27 @@ RSpec.describe RefreshDescriptionFromCatalog do
       end
 
       context 'when reading from Folio' do
+        let(:today) { Time.zone.now.strftime('%Y-%m-%d') }
+
         it 'gets the data from Folio and returns success' do
           expect(refresh.success?).to be(true)
           expect(refresh.value!.description_props).to eq({
                                                            title: [{ value: 'Gaudy night' }],
-                                                           purl: Purl.for(druid:)
+                                                           purl: Purl.for(druid:),
+                                                           note: [
+                                                             {
+                                                               value: 'by Dorothy L. Sayers.',
+                                                               type: 'statement of responsibility'
+                                                             }
+                                                           ],
+                                                           adminMetadata: {
+                                                             note: [
+                                                               {
+                                                                 value: "Converted from MARC to Cocina #{today}",
+                                                                 type: 'record origin'
+                                                               }
+                                                             ]
+                                                           }
                                                          })
           expect(Catalog::MarcService).to have_received(:new).with(folio_instance_hrid: 'a123')
         end


### PR DESCRIPTION
This also upgrades committee.


## Why was this change made? 🤔
So that we can change to using json_schemer for json validation.


## How was this change tested? 🤨
ci

