### PR TITLE
Do not re-raise deadlock errors in reindex job

### DIFF
--- a/app/jobs/reindex_job.rb
+++ b/app/jobs/reindex_job.rb
@@ -6,8 +6,11 @@ class ReindexJob < ApplicationJob
 
   queue_as :low
 
-  # ~3 seconds, ~18 seconds, ~83 seconds. If this fails, Sidekiq retries are not used.
-  retry_on DeadLockError, attempts: 3, wait: :polynomially_longer, queue: :low
+  # Retry at ~3 seconds, ~18 seconds, ~83 seconds. If all attempts fail, the error is swallowed not bubbled up.
+  retry_on DeadLockError, attempts: 3, wait: :polynomially_longer, queue: :low do |_job, _error|
+    nil # do nothing
+  end
+  # ActiveJob retries are used instead of Sidekiq retries
   sidekiq_options retry: false
 
   # @param [String] druid


### PR DESCRIPTION
# Why was this change made?

Fixes #5693

This is adding excessive noise to server logs.

# How was this change tested?

CI, rigged up a temporary test job locally using a subset of the reindex job code to make sure the traceback is not logged.

