### PR TITLE
Default to null in openapi

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1186,7 +1186,6 @@ paths:
           required: false
           schema:
             type: string
-            default: nil
       requestBody:
         required: true
         content:
@@ -1383,14 +1382,12 @@ paths:
           required: false
           schema:
             type: string
-            default: nil
         - name: who
           in: query
           description: The sunetid of the person making the change
           required: false
           schema:
             type: string
-            default: nil
       requestBody:
         required: true
         content:
@@ -1545,8 +1542,7 @@ paths:
           content:
             application/json:
               schema:
-                type:
-                  object
+                type: object
         "404":
           description: Workflow template not found for given ID/name
           content:
@@ -2165,15 +2161,15 @@ components:
     DOI:
       description: Digital Object Identifier (https://www.doi.org)
       oneOf:
-        - $ref: '#/components/schemas/RepositoryDOI'
-        - $ref: '#/components/schemas/PreregisteredRepositoryDOI'
-        - $ref: '#/components/schemas/LibrariesDOI'
-        - $ref: '#/components/schemas/DOIExceptions'
+        - $ref: "#/components/schemas/RepositoryDOI"
+        - $ref: "#/components/schemas/PreregisteredRepositoryDOI"
+        - $ref: "#/components/schemas/LibrariesDOI"
+        - $ref: "#/components/schemas/DOIExceptions"
     DOIExceptions:
       type: string
       description: "The DOI (Digital Object Identifier, https://www.doi.org) pattern for objects in SDR that do not adhere to any of the other DOI patterns in the spec. This is a short list of known exceptions only. Please note that DOIs are *not* case-sensitive, so we allow for uppercase and lowercase letters with these exceptions."
       pattern: '^10\.25936\/[jJ][mM]709[hH][cC]8700|10\.18735\/4[nN][sS][eE]-8871|10\.18735\/952[xX]-[wW]447|10\.18735\/0[mM][wW]1-[qQ][qQ]72$'
-      example: '10.18735/0mw1-qq72'
+      example: "10.18735/0mw1-qq72"
     DRO:
       description: Domain-defined abstraction of a 'work'. Digital Repository Objects' abstraction is describable for our domain’s purposes, i.e. for management needs within our system.
       type: object
@@ -2930,9 +2926,9 @@ components:
       nullable: true
     LibrariesDOI:
       type: string
-      description: 'The DOI (Digital Object Identifier, https://www.doi.org) pattern for works registered by Stanford Libraries outside of SDR workflows. Please note that DOIs are *not* case-sensitive so both cases of letters should be permitted.'
+      description: "The DOI (Digital Object Identifier, https://www.doi.org) pattern for works registered by Stanford Libraries outside of SDR workflows. Please note that DOIs are *not* case-sensitive so both cases of letters should be permitted."
       pattern: '^10\.25936\/[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}$'
-      example: '10.25936/629T-bx79'
+      example: "10.25936/629T-bx79"
     License:
       description: The license governing reuse of the DRO. Should be an IRI for known licenses (i.e. CC, RightsStatement.org URI, etc.).
       type: string
@@ -3063,9 +3059,9 @@ components:
       example: "L11403803"
     PreregisteredRepositoryDOI:
       type: string
-      description: 'The DOI (Digital Object Identifier, https://www.doi.org) pattern for DOIs registered before an SDR object has been registered---i.e., before it has a druid, which is a common pattern as of 2025. Please note that DOIs are *not* case-sensitive so both cases of letters should be permitted.'
+      description: "The DOI (Digital Object Identifier, https://www.doi.org) pattern for DOIs registered before an SDR object has been registered---i.e., before it has a druid, which is a common pattern as of 2025. Please note that DOIs are *not* case-sensitive so both cases of letters should be permitted."
       pattern: '^10\.(25740|80343)\/[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}$'
-      example: '10.80343/12qF-5243'
+      example: "10.80343/12qF-5243"
     Presentation:
       description: Presentation data for the File.
       type: object
@@ -3092,48 +3088,49 @@ components:
           description: The relationship of the related resource to the described resource.
           type: string
         dataCiteRelationType:
-          description: The DataCite relationType describing the relationship from the related resource to the described resource.
+          description:
+            The DataCite relationType describing the relationship from the related resource to the described resource.
             See https://datacite-metadata-schema.readthedocs.io/en/4.6/appendices/appendix-1/relationType
           type: string
           enum:
-            - 'IsCitedBy'
-            - 'Cites'
-            - 'IsSupplementTo'
-            - 'IsSupplementedBy'
-            - 'IsContinuedBy'
-            - 'Continues'
-            - 'Describes'
-            - 'IsDescribedBy'
-            - 'HasMetadata'
-            - 'IsMetadataFor'
-            - 'HasVersion'
-            - 'IsVersionOf'
-            - 'IsNewVersionOf'
-            - 'IsPreviousVersionOf'
-            - 'IsPartOf'
-            - 'HasPart'
-            - 'IsPublishedIn'
-            - 'IsReferencedBy'
-            - 'References'
-            - 'IsDocumentedBy'
-            - 'Documents'
-            - 'IsCompiledBy'
-            - 'Compiles'
-            - 'IsVariantFormOf'
-            - 'IsOriginalFormOf'
-            - 'IsIdenticalTo'
-            - 'IsReviewedBy'
-            - 'Reviews'
-            - 'IsDerivedFrom'
-            - 'IsSourceOf'
-            - 'IsRequiredBy'
-            - 'Requires'
-            - 'Obsoletes'
-            - 'IsObsoletedBy'
-            - 'IsCollectedBy'
-            - 'Collects'
-            - 'IsTranslationOf'
-            - 'HasTranslation'
+            - "IsCitedBy"
+            - "Cites"
+            - "IsSupplementTo"
+            - "IsSupplementedBy"
+            - "IsContinuedBy"
+            - "Continues"
+            - "Describes"
+            - "IsDescribedBy"
+            - "HasMetadata"
+            - "IsMetadataFor"
+            - "HasVersion"
+            - "IsVersionOf"
+            - "IsNewVersionOf"
+            - "IsPreviousVersionOf"
+            - "IsPartOf"
+            - "HasPart"
+            - "IsPublishedIn"
+            - "IsReferencedBy"
+            - "References"
+            - "IsDocumentedBy"
+            - "Documents"
+            - "IsCompiledBy"
+            - "Compiles"
+            - "IsVariantFormOf"
+            - "IsOriginalFormOf"
+            - "IsIdenticalTo"
+            - "IsReviewedBy"
+            - "Reviews"
+            - "IsDerivedFrom"
+            - "IsSourceOf"
+            - "IsRequiredBy"
+            - "Requires"
+            - "Obsoletes"
+            - "IsObsoletedBy"
+            - "IsCollectedBy"
+            - "Collects"
+            - "IsTranslationOf"
+            - "HasTranslation"
         status:
           description: Status of the related resource relative to other related resources.
           type: string
@@ -3239,7 +3236,7 @@ components:
       type: string
       description: "The DOI (Digital Object Identifier, https://www.doi.org) pattern for SDR objects, based on the object's repository identifier. Permits both production and text prefixes to be used to account for objects in different SDR environments. Please note that while DOIs are *not* case-sensitive, we constrain the DOIs we mint for SDR to lowercase for consistency."
       pattern: '^10\.(25740|80343)\/[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}$'
-      example: '10.25740/bc123df4567'
+      example: "10.25740/bc123df4567"
     RequestAdminPolicy:
       description: Same as an AdminPolicy, but doesn't have an externalIdentifier as one will be created
       type: object


### PR DESCRIPTION

## Why was this change made? 🤔
nil means the string "nil". Yaml uses null. The openapi validator does not allow setting null as the default.  I think that means it is implied as null

Fixes #5702 


## How was this change tested? 🤨
ci

