### PR TITLE
Index the searchworks format from MARC

### DIFF
--- a/app/models/marc_cache_entry.rb
+++ b/app/models/marc_cache_entry.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
+# Stores MARC records in a database table
+# We use this for indexing (namely for sw_format_ssimdv)
 class MarcCacheEntry < ApplicationRecord
+  def marc
+    @marc ||= MARC::Record.new_from_hash(JSON.parse(marc_data))
+  end
 end

--- a/app/services/catalog/folio_reader.rb
+++ b/app/services/catalog/folio_reader.rb
@@ -41,7 +41,7 @@ module Catalog
       updated_marc.fields << MARC::ControlField.new('003', 'FOLIO')
 
       # Cache the MARC, so that we can use it for creating the Argo index without having to fetch it again.
-      MarcCacheEntry.upsert({ folio_hrid: folio_instance_hrid, marc_data: updated_marc.to_hash.to_json }, # rubocop:disable Rails/SkipsModelValidations
+      MarcCacheEntry.upsert({ folio_hrid: folio_instance_hrid, marc_data: updated_marc.to_json_string }, # rubocop:disable Rails/SkipsModelValidations
                             unique_by: :index_marc_cache_entries_on_folio_hrid)
       updated_marc
     end

--- a/app/services/indexer.rb
+++ b/app/services/indexer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Indexes a Cocina object.
+# Indexes a Cocina object into Solr for use by Argo.
 class Indexer
   # @param [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata]
   def self.reindex(cocina_object:, trace_id: nil)

--- a/app/services/indexing/indexers/descriptive_metadata_indexer.rb
+++ b/app/services/indexing/indexers/descriptive_metadata_indexer.rb
@@ -36,8 +36,10 @@ module Indexing
           'originInfo_place_placeTerm_tesim' => event_place, # do we want this?
           'publication_year_ssidv' => cocina_display_record.pub_year_int&.to_s,
 
-          # SW facets plus a friend facet
+          # sw_resource_type_ssimdv is deprecated and will be replaced by sw_format_ssimdv
           'sw_resource_type_ssimdv' => cocina_display_record.searchworks_resource_types,
+          # SW facets plus a friend facet
+          'sw_format_ssimdv' => Indexers::SearchworksFormatIndexer.value(cocina_display_record: cocina_display_record),
           'mods_typeOfResource_ssimdv' => resource_type, # MODS Resource Type facet
           'genre_ssimdv' => cocina_display_record.genres,
           'sw_language_names_ssimdv' => cocina_display_record.searchworks_language_names,

--- a/app/services/indexing/indexers/searchworks_format_indexer.rb
+++ b/app/services/indexing/indexers/searchworks_format_indexer.rb
@@ -1,0 +1,547 @@
+# frozen_string_literal: true
+
+module Indexing
+  module Indexers
+    # Creates the Searchworks format field, used for the format facet.
+    # For records that have a folio_id, we'll look for the marc data and use
+    # this logic:
+    # https://github.com/sul-dlss/searchworks_traject_indexer/blob/93e091eec3d195e92a3ec8229338c47cfe300475/lib/traject/config/folio_format_config.rb#L13
+    # except we ignore any logic that depends on holdings.
+    # Otherwise, if there is no hrid, we'll use this logic:
+    # https://github.com/sul-dlss/searchworks_traject_indexer/blob/8994c9ee01d21ded323434ec0ac0407f8f18a310/lib/traject/config/sdr_config.rb#L209-L224
+    class SearchworksFormatIndexer # rubocop:disable Metrics/ClassLength
+      def self.value(cocina_display_record:)
+        new(cocina_display_record:).value
+      end
+
+      def initialize(cocina_display_record:)
+        @cocina_display_record = cocina_display_record
+      end
+
+      attr_reader :cocina_display_record
+
+      def value
+        if marc_record
+          value_from_marc
+        else
+          cocina_display_record.searchworks_resource_types
+        end
+      end
+
+      def value_from_marc
+        @record = { 'format_hsim' => [] }
+        add_folio_format_fields
+        @record['format_hsim']
+      end
+
+      # This is copied verbatim from https://github.com/sul-dlss/searchworks_traject_indexer/blob/93e091eec3d195e92a3ec8229338c47cfe300475/lib/traject/config/folio_format_config.rb#L13
+      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
+      def add_folio_format_fields # rubocop:disable Metrics/CyclomaticComplexity
+        to_field 'format_hsim',
+                 condition(
+                   leader?(byte: 6, values: %w[p t d f]),
+                   literal('Archive/Manuscript')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   leader?(byte: 6, value: 'a'),
+                   leader?(byte: 7, value: 'c'),
+                   literal('Archive/Manuscript')
+                 )
+
+        to_field 'format_hsim',
+                 condition(
+                   marc_subfield_contains?('245', subfield: 'h', values: ['manuscript', 'manuscript/digital']),
+                   literal('Archive/Manuscript')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   leader?(byte: 6, values: %w[a t]),
+                   leader?(byte: 7, values: %w[a m]),
+                   literal('Book')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   leader?(byte: 7, value: 's'),
+                   control_field_byte?('008', byte: 21, value: 'm'),
+                   literal('Book')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('006', { byte: 0, value: 's' }, { byte: 4, value: 'm' }),
+                   literal('Book')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   leader?(byte: 7, values: %w[i s]),
+                   control_field_byte?('008', byte: 21, value: 'd'),
+                   literal('Database')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('006', { byte: 0, value: 's' }, { byte: 4, value: 'd' }),
+                   literal('Database')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   leader?(byte: 6, value: 'm'),
+                   control_field_byte?('008', byte: 26, value: 'j'),
+                   literal('Database')
+                 )
+
+        # Statistical code is 'Database'
+        # to_field 'format_hsim' do |record, accumulator, _context|
+        #   accumulator << 'Database' if record.statistical_codes.any? { |stat_code| stat_code['name'] == 'Database' }
+        # end
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   leader?(byte: 6, value: 'm'),
+                   control_field_byte?('008', byte: 26, value: 'a'),
+                   literal('Dataset')
+                 )
+
+        # to_field 'format_hsim' do |record, acc, _ctx|
+        #   acc << 'Equipment' if record.respond_to?(:holdings) && record.holdings.any? do |h|
+        #     h.dig('holdingsType', 'name') == 'Equipment'
+        #   end
+        # end
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   leader?(byte: 6, value: 'k'),
+                   control_field_byte?('008', byte: 33, value: /[aciklnopst 0-9|]/),
+                   literal('Image')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   leader?(byte: 6, value: 'g'),
+                   control_field_byte?('008', byte: 33, value: /[ aciklnopst]/),
+                   literal('Image')
+                 )
+
+        image_terms = ['art original', 'digital graphic', 'slide', 'slides', 'chart', 'art reproduction', 'graphic',
+                       'technical drawing', 'flash card', 'transparency', 'activity card', 'picture',
+                       'graphic/digital graphic', 'diapositives']
+
+        to_field 'format_hsim',
+                 condition(
+                   marc_subfield_contains?('245', subfield: 'h', values: image_terms),
+                   literal('Image')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('007', byte: 0, values: %w[k r]),
+                   marc_subfield_contains?('245', subfield: 'h', value: 'kit'),
+                   literal('Image')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('007', { byte: 0, value: 'k' }, { byte: 1, values: %w[g h r v] }),
+                   literal_multiple('Image', 'Image|Photo')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('007', { byte: 0, value: 'k' }, { byte: 1, value: 'k' }),
+                   literal_multiple('Image', 'Image|Poster')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('007', { byte: 0, value: 'g' }, { byte: 1, value: 's' }),
+                   literal_multiple('Image', 'Image|Slide')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   leader?(byte: 7, value: 's'),
+                   control_field_byte?('008', byte: 21, value: /[\\ gjpst|]/),
+                   literal('Journal/Periodical')
+                 )
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('006', { byte: 0, value: 's' }, { byte: 4, value: /[\\ gjpst|]/ }),
+                   literal('Journal/Periodical')
+                 )
+
+        to_field 'format_hsim',
+                 condition(
+                   marc_subfield_contains?('590', subfield: 'a', value: 'MARCit brief record'),
+                   literal('Journal/Periodical')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   leader?(byte: 7, values: %w[s i]),
+                   control_field_byte?('008', byte: 21, value: 'l'),
+                   literal('Loose-leaf')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('006', { byte: 0, value: 's' }, { byte: 4, value: 'l' }),
+                   literal('Loose-leaf')
+                 )
+
+        to_field 'format_hsim',
+                 condition(
+                   leader?(byte: 6, values: %w[e f]),
+                   literal('Map')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   marc_subfield_contains?('245', subfield: 'h', value: 'kit'),
+                   control_field_byte?('007', byte: 0, values: %w[a d]),
+                   literal('Map')
+                 )
+
+        to_field 'format_hsim',
+                 condition(
+                   control_field_byte?('007', byte: 0, value: 'd'),
+                   literal_multiple('Map', 'Map|Globe')
+                 )
+
+        to_field 'format_hsim',
+                 condition(
+                   control_field_byte?('007', byte: 0, value: 'r'),
+                   literal_multiple('Map', 'Map|Remote-sensing image')
+                 )
+
+        to_field 'format_hsim',
+                 condition(
+                   control_field_byte?('007', byte: 0, value: 'r'),
+                   literal_multiple('Map', 'Map|Remote-sensing image')
+                 )
+
+        to_field 'format_hsim',
+                 condition(
+                   control_field_byte?('007', byte: 0, value: 'h'),
+                   literal_multiple('Microform')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   marc_subfield_contains?('245', subfield: 'h', value: 'microform'),
+                   literal('Microform')
+                 )
+
+        to_field 'format_hsim',
+                 condition(
+                   leader?(byte: 6, values: %w[c d]),
+                   literal('Music score')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   marc_subfield_contains?('245', subfield: 'h', value: 'kit'),
+                   control_field_byte?('007', byte: 0, value: 'q'),
+                   literal('Music score')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   leader?(byte: 7, value: 's'),
+                   control_field_byte?('008', byte: 21, value: 'n'),
+                   literal('Newspaper')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('006', { byte: 0, value: 's' }, { byte: 4, value: 'n' }),
+                   literal('Newspaper')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   leader?(byte: 6, value: 'r'),
+                   literal('Object')
+                 )
+
+        # This condition contains negative logic to exclude certain values.
+        # This pattern differs from the custom macros we wrote for other blocks, so it is written out longhand.
+        to_field 'format_hsim' do |record, accumulator, _context|
+          leader = record.leader
+          next unless leader && leader.length > 6 && leader[6] == 'm'
+
+          field008 = record['008']
+          excluded_values = %w[a g j]
+          byte26 = field008.value[26] if field008
+          accumulator << 'Software/Multimedia' if field008.nil? || byte26.nil? || !excluded_values.include?(byte26) # rubocop:disable Rails/NegateInclude
+        end
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   marc_subfield_contains?('245', subfield: 'h', value: 'kit'),
+                   control_field_byte?('007', byte: 0, value: 'c'),
+                   literal('Software/Multimedia')
+                 )
+
+        to_field 'format_hsim',
+                 condition(
+                   leader?(byte: 6, values: %w[i j]),
+                   literal('Sound recording')
+                 )
+
+        to_field 'format_hsim',
+                 condition(
+                   control_field_byte?('006', byte: 0, values: %w[i j]),
+                   literal('Sound recording')
+                 )
+
+        to_field 'format_hsim',
+                 condition(
+                   marc_subfield_contains?('245', subfield: 'h', value: 'sound recording'),
+                   literal('Sound recording')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('007', { byte: 0, value: 's' }, { byte: 3, value: 'b' }),
+                   literal_multiple('Sound recording', 'Sound recording|Vinyl disc') # 33 rpm disc (vinyl LP)')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('007', { byte: 0, value: 's' }, { byte: 3, value: 'c' }),
+                   literal_multiple('Sound recording', 'Sound recording|Vinyl disc') # 45 rpm disc (vinyl)')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('007', { byte: 0, value: 's' }, { byte: 3, value: 'd' }),
+                   literal_multiple('Sound recording', 'Sound recording|78 rpm disc (shellac)')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('007', { byte: 0, value: 's' }, { byte: 6, value: 'j' }),
+                   literal_multiple('Sound recording', 'Sound recording|Audiocassette')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('007', { byte: 0, value: 's' }, { byte: 3, value: 'f' }),
+                   literal_multiple('Sound recording', 'Sound recording|CD')
+                 )
+        piano_roll_terms = ['piano roll', 'organ roll', 'audio roll']
+
+        to_field 'format_hsim',
+                 condition(
+                   marc_subfield_contains?('338', subfield: 'a', values: piano_roll_terms),
+                   literal_multiple('Sound recording', 'Sound recording|Piano/Organ roll')
+                 )
+
+        to_field 'format_hsim',
+                 condition(
+                   marc_subfield_contains?('300', subfield: 'a', values: piano_roll_terms),
+                   literal_multiple('Sound recording', 'Sound recording|Piano/Organ roll')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   leader?(byte: 6, value: 'g'),
+                   control_field_byte?('006', byte: 4, value: /[ |fmv0-9]/),
+                   literal('Video/Film')
+                 )
+        video_terms = ['videorecording', 'video recording', 'videorecordings', 'video recordings', 'motion picture',
+                       'filmstrip', 'videodisc', 'videocassette']
+
+        to_field 'format_hsim',
+                 condition(
+                   marc_subfield_contains?('245', subfield: 'n', values: video_terms),
+                   literal(
+                     'Video/Film'
+                   )
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   marc_subfield_contains?('245', subfield: 'h', value: 'kit'),
+                   control_field_byte?('007', byte: 0, values: %w[g m v]),
+                   literal('Video/Film')
+                 )
+
+        # TODO: Video/Film|Online video
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('007', { byte: 0, value: 'v' }, { byte: 4, value: 's' }),
+                   literal_multiple('Video/Film', 'Video/Film|Blu-ray')
+                 )
+
+        blu_ray_terms = ['Bluray', 'Blu-ray', 'Blu ray']
+
+        to_field 'format_hsim',
+                 condition(
+                   marc_subfield_contains?('538', subfield: 'a', values: blu_ray_terms),
+                   literal_multiple('Video/Film', 'Video/Film|Blu-ray')
+                 )
+
+        # to_field 'format_hsim' do |record, acc, _ctx|
+        #   if record.holdings.any? { |h| h['callNumber']&.include?('BLU-RAY') }
+        #     acc << 'Video/Film'
+        #     acc << 'Video/Film|Blu-ray'
+        #   end
+        # end
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('007', { byte: 0, value: 'v' }, { byte: 4, value: 'v' }),
+                   literal_multiple('Video/Film', 'Video/Film|DVD')
+                 )
+
+        to_field 'format_hsim',
+                 condition(
+                   marc_subfield_contains?('538', subfield: 'a', value: 'DVD'),
+                   literal_multiple('Video/Film', 'Video/Film|DVD')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('007', { byte: 0, value: 'v' }, { byte: 4, value: 'g' }),
+                   literal_multiple('Video/Film', 'Video/Film|DVD') # Laser disc
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('007', { byte: 0, value: 'v' }, { byte: 4, values: %w[a i j] }),
+                   literal_multiple('Video/Film', 'Video/Film|Videocassette') # Beta
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('007', { byte: 0, value: 'v' }, { byte: 4, value: 'b' }),
+                   literal_multiple('Video/Film', 'Video/Film|Videocassette') # VHS
+                 )
+
+        to_field 'format_hsim',
+                 condition(
+                   marc_subfield_contains?('538', subfield: 'a', value: 'VHS'),
+                   literal_multiple('Video/Film', 'Video/Film|Videocassette') # VHS
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('007', { byte: 0, value: 'v' }, { byte: 4, value: 'q' }),
+                   literal_multiple('Video/Film', 'Video/Film|Videocassette') # Hi-8 mm
+                 )
+
+        to_field 'format_hsim',
+                 condition(
+                   control_field_byte?('007', byte: 0, value: 'm'),
+                   literal_multiple('Video/Film', 'Video/Film|Film reel')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   marc_subfield_contains?('655', subfield: 'a', value: 'Video game'),
+                   literal('Video game')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   leader?(byte: 6, value: 'm'),
+                   control_field_byte?('008', byte: 26, value: 'g'),
+                   literal('Video game')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   leader?(byte: 7, value: 's'),
+                   control_field_byte?('008', byte: 21, values: %w[h w]),
+                   literal('Website')
+                 )
+
+        to_field 'format_hsim',
+                 all_conditions(
+                   control_field_byte?('006', { byte: 0, value: 's' }, { byte: 4, values: %w[h w] }),
+                   literal('Website')
+                 )
+
+        # TODO: Website|Archived website
+      end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
+
+      def marc_record
+        @marc_record ||= MarcCacheEntry.find_by(folio_hrid:)&.marc if folio_hrid
+      end
+
+      # These methods mimic the Traject API
+      def to_field(field_name, value = nil)
+        if block_given?
+          # debugger
+          yield marc_record, @record[field_name]
+        elsif value
+          Array(value).each { @record[field_name] << it }
+        end
+      end
+
+      def leader?(byte:, value: nil, values: nil)
+        value_at_byte = marc_record&.leader&.[](byte)
+
+        if value
+          value_at_byte == value
+        elsif values
+          values.include?(value_at_byte)
+        end
+      end
+
+      def literal(value)
+        value
+      end
+
+      def literal_multiple(*values)
+        values
+      end
+
+      def condition(test, value)
+        value if test
+      end
+
+      def all_conditions(*tests, value)
+        value if tests.all?
+      end
+
+      def marc_subfield_contains?(tag, subfield:, values: nil, value: nil) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+        values ||= [value]
+        field = marc_record&.fields&.find { |field| field.tag == tag }
+        field&.subfields&.any? do |sf|
+          sf.code == subfield && values.any? { sf.value.downcase.include?(it.downcase) }
+        end
+      end
+
+      def control_field_byte?(tag, *filters) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity
+        field = marc_record.fields&.find { |field| field.tag == tag }
+        return false unless field
+
+        filters.all? do |filter|
+          value_at_byte = field.value.[](filter[:byte])
+          case filter[:value]
+          when String
+            value_at_byte == filter[:value]
+          when Regexp
+            filter[:value].match? value_at_byte
+          else
+            filter[:values]&.any?(value_at_byte)
+          end
+        end
+      end
+
+      delegate :folio_hrid, to: :cocina_display_record
+    end
+  end
+end

--- a/spec/services/indexing/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/services/indexing/indexers/descriptive_metadata_indexer_spec.rb
@@ -409,6 +409,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         'descriptive_text_nostem_i' => all_search_text,
         'sw_language_names_ssimdv' => ['English'],
         'sw_resource_type_ssimdv' => ['Book'],
+        'sw_format_ssimdv' => ['Book'],
         'mods_typeOfResource_ssimdv' => ['text'],
         'subject_place_ssimdv' => ['Europe'],
         'genre_ssimdv' => ['Photographs'],

--- a/spec/services/indexing/indexers/searchworks_format_indexer_spec.rb
+++ b/spec/services/indexing/indexers/searchworks_format_indexer_spec.rb
@@ -1,0 +1,386 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Indexing::Indexers::SearchworksFormatIndexer do
+  subject(:value) { described_class.value(cocina_display_record:) }
+
+  context 'without hrid' do
+    let(:cocina_display_record) do
+      instance_double(CocinaDisplay::CocinaRecord, folio_hrid: nil,
+                                                   searchworks_resource_types: ['Archived website', 'manuscript'])
+    end
+
+    it { is_expected.to eq ['Archived website', 'manuscript'] }
+  end
+
+  context 'with hrid but no cached marc' do
+    let(:cocina_display_record) do
+      instance_double(CocinaDisplay::CocinaRecord, folio_hrid: 'a123',
+                                                   searchworks_resource_types: ['Archived website', 'manuscript'])
+    end
+
+    it { is_expected.to eq ['Archived website', 'manuscript'] }
+  end
+
+  context 'with hrid and cached marc' do
+    let(:cocina_display_record) do
+      instance_double(CocinaDisplay::CocinaRecord, folio_hrid: 'a123')
+    end
+
+    let(:result) { { field => value } }
+    let(:field) { 'field' }
+
+    before do
+      MarcCacheEntry.create(folio_hrid: 'a123', marc_data: record.to_json_string)
+    end
+
+    # These scenarios are copied from:
+    # https://github.com/sul-dlss/searchworks_traject_indexer/blob/93e091eec3d195e92a3ec8229338c47cfe300475/spec/lib/traject/config/folio_format_config_spec.rb#L22
+    context 'when record is a Manuscript' do
+      context 'when leader[6] = p' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = 'p1952cpm  2200457Ia 4500'
+          end
+        end
+
+        it 'maps to Archive/Manuscript' do
+          expect(result[field]).to eq ['Archive/Manuscript']
+        end
+      end
+
+      context 'when leader[6] = a and leader[7] = c' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = 'p1952cac  2200457Ia 4500'
+          end
+        end
+
+        it 'maps to Archive/Manuscript' do
+          expect(result[field]).to eq ['Archive/Manuscript']
+        end
+      end
+
+      context 'when 245h contains manuscript or manuscript/digital' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '01952c d  2200457Ia 4500'
+            # We expect [manuscript] to be in brackets in the string
+            r.append(MARC::DataField.new('245', '1', ' ',
+                                         MARC::Subfield.new('a', 'manuscript: 245h'),
+                                         MARC::Subfield.new('h', '[manuscript/digital]')))
+          end
+        end
+
+        it 'maps to Archive/Manuscript' do
+          expect(result[field]).to eq ['Archive/Manuscript']
+        end
+      end
+    end
+
+    context 'when record is a Book' do
+      context 'when leader[6] = a and leader[7] = m' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = 'p1952cam  2200457Ia 4500'
+          end
+        end
+
+        it 'maps to Book' do
+          expect(result[field]).to eq ['Book']
+        end
+      end
+
+      context 'when leader[7] = s and 008[21] = m' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = 'p1952cas  2200457Ia 4500'
+            r.append(MARC::ControlField.new('008', '000000000000000000000m000000000000000000'))
+          end
+        end
+
+        it 'maps to Book' do
+          expect(result[field]).to eq ['Book']
+        end
+      end
+
+      context 'when 006[0] = s and 006[4] = m' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.append(MARC::ControlField.new('006', 's000m00000000000000'))
+          end
+        end
+
+        it 'maps to Book' do
+          expect(result[field]).to eq ['Book']
+        end
+      end
+    end
+
+    context 'when record is a Database' do
+      context 'when leader[7] = s and 008[21] = d' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '0000000s0000000000000000'
+            r.append(MARC::ControlField.new('008', '000000000000000000000d000000000000000000'))
+          end
+        end
+
+        it 'maps to Database' do
+          expect(result[field]).to eq ['Database']
+        end
+      end
+
+      context 'when 006[0] = s and 006[4] = d' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.append(MARC::ControlField.new('006', 's000d00000000000000'))
+          end
+        end
+
+        it 'maps to Database' do
+          expect(result[field]).to eq ['Database']
+        end
+      end
+
+      context 'when leader[6] = m and 008[26] = j' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000m00000000000000000'
+            r.append(MARC::ControlField.new('008', '00000000000000000000000000j00000000000'))
+          end
+        end
+
+        it 'maps to Database' do
+          expect(result[field]).to eq ['Database']
+        end
+      end
+    end
+
+    context 'when record is a Dataset' do
+      context 'when leader[6] = m and 008[26] = a' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000m00000000000000000'
+            r.append(MARC::ControlField.new('008', '00000000000000000000000000a00000000000'))
+          end
+        end
+
+        it 'maps to Dataset' do
+          expect(result[field]).to eq ['Dataset']
+        end
+      end
+    end
+
+    # TODO: Need to stub FOLIO record/holdings.
+    # Then test Equipment and Video/Film|Blu-ray
+
+    context 'when record is an Image' do
+      context 'when leader[6] = k and 008[33] matches [aciklnopst 0-9|]' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000k00000000000000000'
+            r.append(MARC::ControlField.new('008', '000000000000000000000000000000000a0000'))
+          end
+        end
+
+        it 'maps to Image' do
+          expect(result[field]).to eq ['Image']
+        end
+      end
+
+      context 'when leader[6] = g and 008[33] matches [ aciklnopst]' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000g00000000000000000'
+            r.append(MARC::ControlField.new('008', '000000000000000000000000000000000k0000'))
+          end
+        end
+
+        it 'maps to Image' do
+          expect(result[field]).to eq ['Image']
+        end
+      end
+
+      context 'when record is an Image based on 245h terms' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000a00000000000000000'
+            r.append(MARC::DataField.new('245', '1', ' ',
+                                         MARC::Subfield.new('a', 'Example title'),
+                                         MARC::Subfield.new('h', 'This is a technical drawing')))
+          end
+        end
+
+        it 'maps to Image' do
+          expect(result[field]).to eq ['Image']
+        end
+      end
+
+      context 'when the 245h term contains a partial string match' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000a00000000000000000'
+            r.append(MARC::DataField.new('245', '1', ' ',
+                                         MARC::Subfield.new('a', 'Example title'),
+                                         MARC::Subfield.new('h', 'technical')))
+          end
+        end
+
+        it 'does not map to Image' do
+          expect(result[field]).not_to eq ['Image']
+        end
+      end
+
+      context 'when record is an Image based on 007 and 245h = kit' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000a00000000000000000'
+            r.append(MARC::ControlField.new('007', 'k0000000000'))
+            r.append(MARC::DataField.new('245', '1', ' ',
+                                         MARC::Subfield.new('a', 'Example kit title'),
+                                         MARC::Subfield.new('h', 'kit')))
+          end
+        end
+
+        it 'maps to Image' do
+          expect(result[field]).to eq ['Image']
+        end
+      end
+
+      context 'when record is an Image|Photo' do
+        context 'when 007[0] = k and 007[1] in [g, h, r, v]' do
+          let(:record) do
+            MARC::Record.new.tap do |r|
+              r.leader = '000000a00000000000000000'
+              r.append(MARC::ControlField.new('007', 'kg0000000000'))
+            end
+          end
+
+          it 'maps to Image|Photo' do
+            expect(result[field]).to eq ['Image', 'Image|Photo']
+          end
+        end
+      end
+
+      context 'when record is an Image|Poster' do
+        context 'when 007[0] = k and 007[1] = k' do
+          let(:record) do
+            MARC::Record.new.tap do |r|
+              r.leader = '000000a00000000000000000'
+              r.append(MARC::ControlField.new('007', 'kk0000000000'))
+            end
+          end
+
+          it 'maps to Image|Poster' do
+            expect(result[field]).to eq ['Image', 'Image|Poster']
+          end
+        end
+      end
+
+      context 'when record is an Image|Slide' do
+        context 'when 007[0] = g and 007[1] = s' do
+          let(:record) do
+            MARC::Record.new.tap do |r|
+              r.leader = '000000a00000000000000000'
+              r.append(MARC::ControlField.new('007', 'gs0000000000'))
+            end
+          end
+
+          it 'maps to Image|Slide' do
+            expect(result[field]).to eq ['Image', 'Image|Slide']
+          end
+        end
+      end
+    end
+
+    context 'when the match is based on regex matching in a MARC subfield' do
+      context 'when 338h term contains piano roll terms' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000a00000000000000000'
+            r.append(MARC::DataField.new('338', '1', ' ',
+                                         MARC::Subfield.new('a',
+                                                            'This is a sentence containing the phrase piano roll')))
+          end
+        end
+
+        it 'maps to Sound recording|Piano/Organ roll' do
+          expect(result[field]).to eq ['Sound recording', 'Sound recording|Piano/Organ roll']
+        end
+      end
+
+      context 'when 245n contains video terms' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000000000000000000000'
+            r.append(MARC::DataField.new('245', '1', ' ',
+                                         MARC::Subfield.new('n', 'A set of video recordings')))
+          end
+        end
+
+        it 'maps to Video/Film' do
+          expect(result[field]).to eq ['Video/Film']
+        end
+      end
+
+      context 'when 538a contains blu-ray terms' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000000000000000000000'
+            r.append(MARC::DataField.new('538', '1', ' ',
+                                         MARC::Subfield.new('a', 'A set of blu-ray discs')))
+          end
+        end
+
+        it 'maps to Video/Film' do
+          expect(result[field]).to eq ['Video/Film', 'Video/Film|Blu-ray']
+        end
+      end
+    end
+
+    context 'when record is Software/Multimedia' do
+      context 'when leader[6] = m and 008 is missing' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000m00000000000000000'
+          end
+        end
+
+        it 'maps to Software/Multimedia' do
+          expect(result[field]).to eq ['Software/Multimedia']
+        end
+      end
+
+      context 'when leader[6] = m and 008[26] is not a/g/j' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000m00000000000000000'
+            # 26th position (index 25) = 'z', which is not in excluded_values
+            r.append(MARC::ControlField.new('008', '00000000000000000000000000z00000000000'))
+          end
+        end
+
+        it 'maps to Software/Multimedia' do
+          expect(result[field]).to eq ['Software/Multimedia']
+        end
+      end
+
+      # If 008[26] is a, g, or j, it should not map to Software/Multimedia
+      context 'when leader[6] = m and 008[26] is j' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000m00000000000000000'
+            r.append(MARC::ControlField.new('008', '00000000000000000000000000j00000000000'))
+          end
+        end
+
+        # In this case it is covered by another rule
+        it 'does not map to Software/Multimedia' do
+          expect(result[field]).to eq ['Database']
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔
So that Argo's format facet will have parity with Searchworks


## How was this change tested? 🤨
ci

