### PR TITLE
Update date selection for "today" in create_object_spec to align with cocina

### DIFF
--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -170,10 +170,9 @@ RSpec.describe 'Create object' do
               }
             )
         end
-        let(:today) { Time.zone.now.strftime('%Y-%m-%d') }
+        let(:today) { Time.zone.today.iso8601 }
 
         let(:expected_description) do
-          debugger
           expected.description.new(adminMetadata: { note: [{
                                      value: "Converted from MARC to Cocina #{today}", type: 'record origin'
                                    }] },


### PR DESCRIPTION
## Why was this change made? 🤔

This is a small change to match the `Time.zone.today.iso8601` call that is used in cocina-models (https://github.com/sul-dlss/cocina-models/pull/964, or will be, currently it's `Date.today.iso8601` without the zone, which is problematic)

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



