### PR TITLE
Adds head to openapi for object show endpoint.

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1493,6 +1493,43 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/Druid"
+    head:
+      tags:
+        - objects
+      summary: Retrieve the head for object COCINA metadata
+      operationId: "objects#head"
+      responses:
+        "200":
+          description: OK
+          headers:
+            ETag:
+              schema:
+                type: string
+            Last-Modified:
+              schema:
+                type: string
+            X-Created-At:
+              schema:
+                type: string
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: "#/components/schemas/Druid"
     delete:
       tags:
         - objects


### PR DESCRIPTION
refs https://github.com/sul-dlss/hungry-hungry-hippo/issues/1954

## Why was this change made? 🤔
So that H3 can get the ETag without retrieving the entire cocina.


## How was this change tested? 🤨
QA

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



