### PR TITLE
Add latest-versions-only option

### DIFF
--- a/bin/validate-cocina
+++ b/bin/validate-cocina
@@ -53,9 +53,9 @@ def tty_progress_bar(count)
   )
 end
 
-def versions_to_validate(repository_object)
+def versions_to_validate(repository_object, latest_versions_only)
   versions = repository_object.versions.where.not(cocina_version: nil)
-  return versions unless options[:latest_versions_only]
+  return versions unless latest_versions_only
 
   # Only include head_version and last_closed_version (if object is open)
   latest_versions = []
@@ -67,7 +67,7 @@ def versions_to_validate(repository_object)
   latest_versions
 end
 
-def validate(sample_size, processes)
+def validate(sample_size, processes, latest_versions_only)
   obj_ids = if sample_size
               RepositoryObject.limit(sample_size).ids
             else
@@ -81,7 +81,7 @@ def validate(sample_size, processes)
                in_processes: processes,
                finish: ->(_, _, results) { on_finish(results, progress_bar) }) do |slice_obj_ids|
     RepositoryObject.find(slice_obj_ids).map do |repository_object|
-      versions_to_validate(repository_object).map do |repository_object_version|
+      versions_to_validate(repository_object, latest_versions_only).map do |repository_object_version|
         repository_object_version.to_cocina
         [repository_object.external_identifier, repository_object_version.version, nil]
       rescue StandardError => e
@@ -97,7 +97,7 @@ def validate(sample_size, processes)
   end.flatten(2)
 end
 
-results = validate(options[:sample], options[:processes])
+results = validate(options[:sample], options[:processes], options[:latest_versions_only])
 
 CSV.open('validate-cocina.csv', 'w') do |writer|
   writer << %w[druid version type collection message]


### PR DESCRIPTION
## Why was this change made? 🤔
Restore arg passing. Tested on QA. (see conversation on https://github.com/sul-dlss/dor-services-app/pull/5761)



