### PR TITLE
publish messages to the rabbit queue when an error occurs

### DIFF
--- a/app/services/workflow/next_step_service.rb
+++ b/app/services/workflow/next_step_service.rb
@@ -18,17 +18,15 @@ module Workflow
     # @return [ActiveRecord::Relation] a list of WorkflowSteps that have been enqueued
     def enqueue_next_steps(step:)
       next_steps = find_next(step:)
-      if last_accession_step?(step)
-        # https://github.com/sul-dlss/argo/issues/3817
-        # Theory is that many commits to solr are not being executed in the correct order, resulting in
-        # older data being indexed last.  This is an attempt to force a delay when indexing the very
-        # last step of the accessionWF.
-        sleep 1
 
-        # In theory, notifications should be sent for every step.
-        # However, currently consumers only care about the end-accession step.
-        Notifications::WorkflowStepUpdated.publish(step:)
-      end
+      # https://github.com/sul-dlss/argo/issues/3817
+      # Theory is that many commits to solr are not being executed in the correct order, resulting in
+      # older data being indexed last.  This is an attempt to force a delay when indexing the very
+      # last step of the accessionWF.
+      sleep 1 if last_accession_step?(step)
+
+      # send message to RabbitMQ for accessioning complete/error steps, pre-assembly/H3 consume one or both to update UI
+      Notifications::WorkflowStepUpdated.publish(step:) if step.status == 'error' || last_accession_step?(step)
 
       Indexer.reindex_later(druid: step.druid)
       next_steps

--- a/spec/services/workflow/next_step_service_spec.rb
+++ b/spec/services/workflow/next_step_service_spec.rb
@@ -58,13 +58,7 @@ RSpec.describe Workflow::NextStepService do
                active_version: true)
       end
 
-      before do
-        allow(QueueService).to receive(:enqueue)
-        allow(Notifications::WorkflowStepUpdated).to receive(:publish)
-        allow(Indexer).to receive(:reindex_later)
-      end
-
-      it 'returns a list of unblocked statuses' do
+      it 'returns a list of unblocked statuses and publishes a message' do
         expect(next_steps).to eq []
         expect(QueueService).not_to have_received(:enqueue)
         expect(Notifications::WorkflowStepUpdated).to have_received(:publish).with(step:)
@@ -106,9 +100,24 @@ RSpec.describe Workflow::NextStepService do
                active_version: true)
       end
 
-      it 'does not enqueue any steps' do
+      it 'does not enqueue any steps but publishes a message' do
         expect { next_steps }.not_to(change { step.reload.status })
+        expect(Notifications::WorkflowStepUpdated).to have_received(:publish).with(step:)
         expect(next_steps).to eq []
+      end
+    end
+
+    context 'when a step in the middle of a workflow is completed' do
+      let(:step) do
+        create(:workflow_step,
+               process: 'publish',
+               version: 1,
+               status: 'completed',
+               active_version: true)
+      end
+
+      it 'does not publish a message' do
+        expect(Notifications::WorkflowStepUpdated).not_to have_received(:publish)
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

See sul-dlss/pre-assembly#1648

As per Mike's analysis, this may only be happening when an error occurs during accessioning, since we do not appear to be publishing messages to RabbitMQ when an error in a workflow step occurs.  Since pre-assembly counts on these messages, it will never know.

We already have a rabbitmq exchage setup so that "error" messages to the `preassembly.accession_complete` queue, so everything else should be setup to process these messages.  See https://sul-rabbit-stage.stanford.edu/#/exchanges/workflow/sdr.workflow

## How was this change tested? 🤨

~~Not yet. Hold for testing.  Plan:~~

1.  Deploy to stage, run an integration test with pre-assembly that succeeds.  Verify status is still updated in pre-assembly (it works now, it should continue to work).
2. Run an integration test with pre-assembly that fails during accessioning.  Verify status is now updated in pre-assembly to error (it likely does not work now, and now it should)

Test was successful, see https://github.com/sul-dlss/pre-assembly/issues/1648#issuecomment-3999594747