### PR TITLE
Remove duplicate validation

### DIFF
--- a/app/services/migrators/migration_runner.rb
+++ b/app/services/migrators/migration_runner.rb
@@ -51,7 +51,6 @@ module Migrators
       migrator.migrate # This is where the actual migration happens
 
       updated_cocina_object = migrator.updated_head_version_cocina_object
-      Cocina::ObjectValidator.validate(updated_cocina_object)
 
       if mode == :migrate
         updated_cocina_object = UpdateObjectService.update(cocina_object: updated_cocina_object,


### PR DESCRIPTION

## Why was this change made? 🤔
The validation is done in UpdateObjectService.update. And when in `:commit` mode, we aren't supposed to validate, according to the comments.



## How was this change tested? 🤨
ci
