### PR TITLE
Write migrate-cocina results to temp files

### DIFF
--- a/app/services/migrators/migration_runner.rb
+++ b/app/services/migrators/migration_runner.rb
@@ -8,12 +8,10 @@ module Migrators
     DEFAULT_MODE = :dryrun
 
     # Returns a count of the druids to migrate, for the progress bar.
-    # We need to get it before we start migrating, using the same logic as #druids_for to determine
-    # the list of druids to migrate, without sending all the druids to each process.
     def self.druids_count_for(migrator_class:, sample:)
       specific_druids = migrator_class.druids.presence
       if specific_druids
-        sample ? [sample, specific_druids.size].min : specific_druids.size
+        specific_druids.size
       elsif sample
         [sample, RepositoryObject.count].min
       else
@@ -21,17 +19,37 @@ module Migrators
       end
     end
 
-    # Returns the druids to migrate. When no specific druid list is provided by the migrator class,
-    # returns a lazy enumerator that pages through the DB to avoid loading all druids into memory at once.
-    def self.druids_for(migrator_class:, sample:)
+    BATCH_SIZE = 100
+
+    # Returns the druids for a single batch. Each parallel worker calls this after forking so that
+    # only a small slice is loaded into each worker's memory.
+    # @param migrator_class [Migrators::Base] the migrator class to be run
+    # @param sample [Integer, nil] limits the number of druids returned from the entire set of druids
+    # @param batch_index [Integer] index of the batch to fetch
+    # @return [Array<String>] list of druids for the batch
+    # rubocop:disable Metrics/AbcSize
+    def self.druids_for_batch(migrator_class:, sample:, batch_index:)
+      Rails.logger.info("Fetching batch #{batch_index} of druids to migrate...")
       specific_druids = migrator_class.druids.presence
       if specific_druids
-        sample ? specific_druids.take(sample) : specific_druids
+        specific_druids.each_slice(BATCH_SIZE).to_a[batch_index] || []
       elsif sample
-        RepositoryObject.limit(sample).pluck(:external_identifier)
+        sample_druids = druids_for_sample(sample:)
+        Rails.logger.info("Sample druids for batch #{batch_index}: #{sample_druids}")
+        sample_druids.each_slice(BATCH_SIZE).to_a[batch_index] || []
       else
-        RepositoryObject.select(:id, :external_identifier).find_each.lazy.map(&:external_identifier)
+        RepositoryObject.order(:id)
+                        .offset(batch_index * BATCH_SIZE)
+                        .limit(BATCH_SIZE)
+                        .pluck(:external_identifier)
       end
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    # Sample from the full set of druids
+    def self.druids_for_sample(sample:)
+      druids = RepositoryObject.pluck(:external_identifier)
+      @druids_for_sample ||= druids.take(sample)
     end
 
     def self.migrate_druid_list(migrator_class:, mode:, druids_slice:)

--- a/bin/migrate-cocina
+++ b/bin/migrate-cocina
@@ -88,37 +88,21 @@ def migrate_slice(migrator_class:, mode:, druids_slice:, temp_dir:, index:)
   write_results_to_temp_file(results, temp_dir, index)
 end
 
-BATCH_SIZE = 100
-
 # @return [Array<String>] paths to temporary CSV files
 def migrate(migrator_class:, sample:, processes:, mode:, temp_dir:)
   count = Migrators::MigrationRunner.druids_count_for(migrator_class:, sample:)
-
+  total_batches = (count.to_f / Migrators::MigrationRunner::BATCH_SIZE).ceil
   progress_bar = tty_progress_bar(count, mode)
   progress_bar.start
 
-  if (specific_druids = migrator_class.druids.presence)
-    # Migrator provides a specific druid list
-    specific_druids = specific_druids.take(sample) if sample
-    Parallel.map(specific_druids.each_slice(BATCH_SIZE).with_index,
-                 in_processes: processes,
-                 finish: ->(_, _, result) { on_finish(result[1], progress_bar) }) do |druids_slice, index|
-      [migrate_slice(migrator_class:, mode:, druids_slice:, temp_dir:, index:), druids_slice.size]
-    end.compact.map(&:first)
-  else
-    # No custom druid list: pass only batch indices to Parallel so each worker fetches its own
-    # slice from the DB after forking, avoiding loading all druids into the parent process.
-    total_batches = (count.to_f / BATCH_SIZE).ceil
-    Parallel.map(0...total_batches,
-                 in_processes: processes,
-                 finish: ->(_, _, result) { on_finish(result[1], progress_bar) }) do |batch_index|
-      druids_slice = RepositoryObject.order(:id)
-                                     .offset(batch_index * BATCH_SIZE)
-                                     .limit(BATCH_SIZE)
-                                     .pluck(:external_identifier)
-      [migrate_slice(migrator_class:, mode:, druids_slice:, temp_dir:, index: batch_index), druids_slice.size]
-    end.compact.map(&:first)
-  end
+  # Pass only batch indices to Parallel so each worker fetches its own slice from the DB
+  # after forking, avoiding loading all druids into the parent process.
+  Parallel.map(0...total_batches,
+               in_processes: processes,
+               finish: ->(_, _, result) { on_finish(result[1], progress_bar) }) do |batch_index|
+    druids_slice = Migrators::MigrationRunner.druids_for_batch(migrator_class:, sample:, batch_index:)
+    [migrate_slice(migrator_class:, mode:, druids_slice:, temp_dir:, index: batch_index), druids_slice.size]
+  end.compact.map(&:first)
 end
 
 # Consolidate all temp files into the final CSV

--- a/spec/bin/migrate_cocina_spec.rb
+++ b/spec/bin/migrate_cocina_spec.rb
@@ -45,8 +45,10 @@ RSpec.describe 'bin/migrate-cocina' do # rubocop:disable RSpec/DescribeClass
     expect(objects_to_ignore.second.head_version.label).not_to include('migrated')
 
     puts "#{cmd_str} -- #{cmd_result}"
+
     expect(cmd_result[:status].exitstatus).to eq 0
 
+    expect(RepositoryObject.find_by(external_identifier: migrated_druids[0]).head_version.label).to include('migrated')
     expect(RepositoryObject.find_by(external_identifier: migrated_druids[0]).head_version.label).to include('migrated')
     expect(RepositoryObject.find_by(external_identifier: migrated_druids[1]).head_version.label).to include('migrated')
     expect(

--- a/spec/services/migrators/migration_runner_spec.rb
+++ b/spec/services/migrators/migration_runner_spec.rb
@@ -59,11 +59,17 @@ RSpec.describe Migrators::MigrationRunner do
     end
   end
 
-  describe '.druids_for' do
+  describe '.druids_for_batch' do
     let(:sample) { nil }
 
-    it 'returns the druids it cares about' do
-      expect(described_class.druids_for(migrator_class:, sample:)).to eq(migrated_druids)
+    context 'when the migrator class specifies druids' do
+      it 'returns the correct batch of druids' do
+        expect(described_class.druids_for_batch(migrator_class:, sample:, batch_index: 0)).to eq(migrated_druids)
+      end
+
+      it 'returns an empty array for an out-of-range batch index' do
+        expect(described_class.druids_for_batch(migrator_class:, sample:, batch_index: 999)).to eq([])
+      end
     end
 
     context 'when the migrator class does not specify druids' do
@@ -73,16 +79,19 @@ RSpec.describe Migrators::MigrationRunner do
         end
       end
 
-      it 'returns a lazy enumerator over all repository objects' do
+      it 'returns druids from the DB for the given batch index' do
         all_druids = (migrated_druids + ignored_druids + ['druid:hy787xj5878']).sort
-        expect(described_class.druids_for(migrator_class:, sample:).to_a.sort).to eq(all_druids)
+        batch = described_class.druids_for_batch(migrator_class:, sample:, batch_index: 0)
+        expect(batch).not_to be_empty
+        expect(batch).to all(be_in(all_druids))
       end
 
       context 'with a sample size' do
         let(:sample) { 2 }
 
-        it 'limits to the sample size' do
-          expect(described_class.druids_for(migrator_class:, sample:).size).to eq(2)
+        it 'limits total results to the sample size' do
+          batch = described_class.druids_for_batch(migrator_class:, sample:, batch_index: 0)
+          expect(batch.size).to eq(2)
         end
       end
     end
@@ -90,7 +99,7 @@ RSpec.describe Migrators::MigrationRunner do
 
   describe '.migrate_druid_list' do
     let(:mode) { :commit }
-    let(:druids_slice) { described_class.druids_for(migrator_class:, sample: nil) }
+    let(:druids_slice) { described_class.druids_for_batch(migrator_class:, sample: nil, batch_index: 0) }
 
     it 'migrates exactly the objects it should' do
       expect(objects_to_migrate.first.head_version.label).not_to include('migrated')


### PR DESCRIPTION
## Why was this change made? 🤔
Avoid keeping results in memory. Write to temp files as bin/validate-cocina now does and also query using offset instead of keeping all of the druids in memory in each process. This was an experiment with Copilot to see what approaches it might suggest to reduce memory usage. 

## How was this change tested? 🤨
With just the temp files writing when running this on prod, it was using up to 2.0g a process, so that was not great.  Running on prod, it used < 500MB a process and the results looked good. 



