### PR TITLE
Avoid compacting titles twice

### DIFF
--- a/app/services/cocina/from_marc/title.rb
+++ b/app/services/cocina/from_marc/title.rb
@@ -132,7 +132,7 @@ module Cocina
         if titles.size == 1
           titles
         else
-          [{ structuredValue: [non_sort, sortable, subtitle_node].compact }]
+          [{ structuredValue: titles }]
         end
       end
 


### PR DESCRIPTION
## Why was this change made? 🤔

once is nicer.

## How was this change tested? 🤨
ci



