### PR TITLE
Refactor to use keyset pagination

### DIFF
--- a/app/services/migrators/migration_runner.rb
+++ b/app/services/migrators/migration_runner.rb
@@ -21,35 +21,49 @@ module Migrators
 
     BATCH_SIZE = 100
 
-    # Returns the druids for a single batch. Each parallel worker calls this after forking so that
-    # only a small slice is loaded into each worker's memory.
-    # @param migrator_class [Migrators::Base] the migrator class to be run
-    # @param sample [Integer, nil] limits the number of druids returned from the entire set of druids
-    # @param batch_index [Integer] index of the batch to fetch
-    # @return [Array<String>] list of druids for the batch
+    # Pre-computes batch descriptors in the parent process using a single keyset scan, so that
+    # parallel workers can each fetch their own slice with an efficient indexed range query.
+    # For migrators with specific druids (small lists): returns [batch_index, batch_size] pairs.
+    # For DB-wide migrations: returns [after_id, limit] pairs where after_id is a PK boundary.
+    #
+    # @return [Array<Array(Integer, Integer)>] array of [index_or_after_id, limit] pairs
     # rubocop:disable Metrics/AbcSize
-    def self.druids_for_batch(migrator_class:, sample:, batch_index:)
-      Rails.logger.info("Fetching batch #{batch_index} of druids to migrate...")
+    def self.batch_descriptors(migrator_class:, sample:)
       specific_druids = migrator_class.druids.presence
       if specific_druids
-        specific_druids.each_slice(BATCH_SIZE).to_a[batch_index] || []
-      elsif sample
-        sample_druids = druids_for_sample(sample:)
-        Rails.logger.info("Sample druids for batch #{batch_index}: #{sample_druids}")
-        sample_druids.each_slice(BATCH_SIZE).to_a[batch_index] || []
+        druids = sample ? specific_druids.take(sample) : specific_druids
+        druids.each_slice(BATCH_SIZE).map.with_index { |slice, i| [i, slice.size] }
       else
-        RepositoryObject.order(:id)
-                        .offset(batch_index * BATCH_SIZE)
-                        .limit(BATCH_SIZE)
-                        .pluck(:external_identifier)
+        # Pluck only integer PKs once in parent to compute keyset boundaries (~8 bytes each).
+        # Workers then fetch their slice via indexed WHERE id > after_id LIMIT n queries.
+        scope = RepositoryObject.order(:id)
+        scope = scope.limit(sample) if sample
+        ids = scope.pluck(:id)
+        slices = ids.each_slice(BATCH_SIZE).to_a
+        after_ids = [0] + slices[0..-2].map(&:last)
+        slices.zip(after_ids).map { |slice, after_id| [after_id, slice.size] }
       end
     end
     # rubocop:enable Metrics/AbcSize
 
-    # Sample from the full set of druids
-    def self.druids_for_sample(sample:)
-      druids = RepositoryObject.pluck(:external_identifier)
-      @druids_for_sample ||= druids.take(sample)
+    # Returns the druids for a single batch using an indexed range query (keyset pagination).
+    # Each parallel worker calls this after forking so that only a small slice is loaded
+    # into each worker's memory.
+    # @param batch_descriptor [Array(Integer, Integer)] a [index_or_after_id, limit] pair
+    #   as returned by .batch_descriptors
+    # @return [Array<String>] list of druids for the batch
+    def self.druids_for_batch(migrator_class:, batch_descriptor:)
+      index_or_after_id, limit = batch_descriptor
+      Rails.logger.info("Fetching batch after_id=#{index_or_after_id} of druids to migrate...")
+      specific_druids = migrator_class.druids.presence
+      if specific_druids
+        specific_druids.each_slice(BATCH_SIZE).to_a[index_or_after_id] || []
+      else
+        RepositoryObject.where('id > ?', index_or_after_id)
+                        .order(:id)
+                        .limit(limit)
+                        .pluck(:external_identifier)
+      end
     end
 
     def self.migrate_druid_list(migrator_class:, mode:, druids_slice:)

--- a/bin/migrate-cocina
+++ b/bin/migrate-cocina
@@ -91,17 +91,17 @@ end
 # @return [Array<String>] paths to temporary CSV files
 def migrate(migrator_class:, sample:, processes:, mode:, temp_dir:)
   count = Migrators::MigrationRunner.druids_count_for(migrator_class:, sample:)
-  total_batches = (count.to_f / Migrators::MigrationRunner::BATCH_SIZE).ceil
+  # Pre-compute keyset pagination boundaries in the parent process (a single indexed scan)
+  # so workers can each fetch their slice with an efficient WHERE id > ? LIMIT n query
+  batch_descriptors = Migrators::MigrationRunner.batch_descriptors(migrator_class:, sample:)
   progress_bar = tty_progress_bar(count, mode)
   progress_bar.start
 
-  # Pass only batch indices to Parallel so each worker fetches its own slice from the DB
-  # after forking, avoiding loading all druids into the parent process.
-  Parallel.map(0...total_batches,
+  Parallel.map(batch_descriptors.each_with_index,
                in_processes: processes,
-               finish: ->(_, _, result) { on_finish(result[1], progress_bar) }) do |batch_index|
-    druids_slice = Migrators::MigrationRunner.druids_for_batch(migrator_class:, sample:, batch_index:)
-    [migrate_slice(migrator_class:, mode:, druids_slice:, temp_dir:, index: batch_index), druids_slice.size]
+               finish: ->(_, _, result) { on_finish(result[1], progress_bar) }) do |batch_descriptor, index|
+    druids_slice = Migrators::MigrationRunner.druids_for_batch(migrator_class:, batch_descriptor:)
+    [migrate_slice(migrator_class:, mode:, druids_slice:, temp_dir:, index:), druids_slice.size]
   end.compact.map(&:first)
 end
 

--- a/spec/services/migrators/migration_runner_spec.rb
+++ b/spec/services/migrators/migration_runner_spec.rb
@@ -59,16 +59,18 @@ RSpec.describe Migrators::MigrationRunner do
     end
   end
 
-  describe '.druids_for_batch' do
-    let(:sample) { nil }
-
+  describe '.batch_descriptors' do
     context 'when the migrator class specifies druids' do
-      it 'returns the correct batch of druids' do
-        expect(described_class.druids_for_batch(migrator_class:, sample:, batch_index: 0)).to eq(migrated_druids)
+      it 'returns one descriptor per batch with index and count' do
+        descriptors = described_class.batch_descriptors(migrator_class:, sample: nil)
+        expect(descriptors).to eq([[0, migrated_druids.size]])
       end
 
-      it 'returns an empty array for an out-of-range batch index' do
-        expect(described_class.druids_for_batch(migrator_class:, sample:, batch_index: 999)).to eq([])
+      context 'with a sample size' do
+        it 'limits the descriptors to the sample' do
+          descriptors = described_class.batch_descriptors(migrator_class:, sample: 1)
+          expect(descriptors.sum(&:last)).to eq(1)
+        end
       end
     end
 
@@ -79,18 +81,54 @@ RSpec.describe Migrators::MigrationRunner do
         end
       end
 
-      it 'returns druids from the DB for the given batch index' do
+      it 'returns [0, count] for the first (and only) batch' do
+        descriptors = described_class.batch_descriptors(migrator_class:, sample: nil)
+        expect(descriptors.size).to eq(1)
+        expect(descriptors.first.first).to eq(0) # after_id starts at 0
+        expect(descriptors.first.last).to eq(RepositoryObject.count)
+      end
+
+      context 'with a sample size' do
+        it 'limits total druids to the sample size' do
+          descriptors = described_class.batch_descriptors(migrator_class:, sample: 2)
+          expect(descriptors.sum(&:last)).to eq(2)
+        end
+      end
+    end
+  end
+
+  describe '.druids_for_batch' do
+    context 'when the migrator class specifies druids' do
+      it 'returns the correct batch of druids' do
+        expect(described_class.druids_for_batch(migrator_class:,
+                                                batch_descriptor: [0,
+                                                                   migrated_druids.size])).to eq(migrated_druids)
+      end
+
+      it 'returns an empty array for an out-of-range batch index' do
+        expect(described_class.druids_for_batch(migrator_class:,
+                                                batch_descriptor: [999,
+                                                                   described_class::BATCH_SIZE])).to eq([])
+      end
+    end
+
+    context 'when the migrator class does not specify druids' do
+      let(:migrator_class) do
+        Class.new(Migrators::Base) do
+          def self.druids = nil
+        end
+      end
+
+      it 'returns druids from the DB for the given batch descriptor' do
         all_druids = (migrated_druids + ignored_druids + ['druid:hy787xj5878']).sort
-        batch = described_class.druids_for_batch(migrator_class:, sample:, batch_index: 0)
+        batch = described_class.druids_for_batch(migrator_class:, batch_descriptor: [0, described_class::BATCH_SIZE])
         expect(batch).not_to be_empty
         expect(batch).to all(be_in(all_druids))
       end
 
       context 'with a sample size' do
-        let(:sample) { 2 }
-
         it 'limits total results to the sample size' do
-          batch = described_class.druids_for_batch(migrator_class:, sample:, batch_index: 0)
+          batch = described_class.druids_for_batch(migrator_class:, batch_descriptor: [0, 2])
           expect(batch.size).to eq(2)
         end
       end
@@ -99,7 +137,9 @@ RSpec.describe Migrators::MigrationRunner do
 
   describe '.migrate_druid_list' do
     let(:mode) { :commit }
-    let(:druids_slice) { described_class.druids_for_batch(migrator_class:, sample: nil, batch_index: 0) }
+    let(:druids_slice) do
+      described_class.druids_for_batch(migrator_class:, batch_descriptor: [0, migrated_druids.size])
+    end
 
     it 'migrates exactly the objects it should' do
       expect(objects_to_migrate.first.head_version.label).not_to include('migrated')


### PR DESCRIPTION
## Why was this change made? 🤔
The previous offset-based querying was not sustainable with the 5.5 million objects on prod. This tries to avoid db timeouts / connections getting closed (this is a theory about what was happening) when the queries were in the latter half of the migration and the scans got increasingly long. Refactor got an assist from Copilot/Claude Sonnet 4.6.

## How was this change tested? 🤨
Ran on stage in dryrun and commit mode. 



