### PR TITLE
Fix to RemoveParallelContributor migrator

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,7 @@ Layout/LineLength:
   Exclude:
     - "spec/services/cocina/mapping/descriptive/h2_datacite/subject_h2_datacite_spec.rb"
     - "spec/services/cocina/from_marc/**/*"
+    - "spec/services/migrators/remove_parallel_contributor_spec.rb"
     - "app/reports/**/*"
 
 Lint/UnusedMethodArgument:

--- a/app/services/migrators/remove_parallel_contributor.rb
+++ b/app/services/migrators/remove_parallel_contributor.rb
@@ -15,12 +15,12 @@ module Migrators
       end
     end
 
-    def migrate_version(version) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def migrate_version(version) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
       # Nothing to do if there is no description
       return unless version.description
 
       # Remove parallelContributor from all contributors
-      # including those in event, event['parallelEvent'], relatedResource, and adminMetadata
+      # including any in event, parallelEvent, relatedResource, and adminMetadata
       remove_parallel_contributor(version.description)
       version.description['event']&.each do |event|
         remove_parallel_contributor(event)
@@ -31,8 +31,12 @@ module Migrators
       version.description['relatedResource']&.each do |related_resource|
         remove_parallel_contributor(related_resource)
       end
-      version.description['adminMetadata']&.each do |admin_metadata|
-        remove_parallel_contributor(admin_metadata)
+      remove_parallel_contributor(version.description&.dig('adminMetadata'))
+      version.description.dig('adminMetadata', 'event')&.each do |event|
+        remove_parallel_contributor(event)
+        event['parallelEvent']&.each do |parallel_event|
+          remove_parallel_contributor(parallel_event)
+        end
       end
     end
 

--- a/spec/services/migrators/remove_parallel_contributor_spec.rb
+++ b/spec/services/migrators/remove_parallel_contributor_spec.rb
@@ -15,30 +15,60 @@ RSpec.describe Migrators::RemoveParallelContributor do
 
   describe 'migrate' do
     let(:description) do
-      { 'title' => 'Test Title', 'contributor' => contributor, 'relatedResource' => related_resource, 'event' => event,
+      { 'title' => 'Test Title',
+        'contributor' => contributor,
+        'relatedResource' => related_resource,
+        'event' => event,
+        'adminMetadata' => admin_metadata,
         'purl' => 'https://purl.stanford.edu' }
     end
     let(:contributor) { [{ 'name' => 'Test Contributor', 'parallelContributor' => [] }] }
     let(:related_resource) do
       [{ 'title' => 'Test Title', 'contributor' => contributor }]
     end
-    let(:event) { [{ 'name' => 'Test Event', 'contributor' => contributor }] }
+    let(:event) do
+      [{ 'name' => 'Test Event', 'contributor' => contributor, 'parallelEvent' => [{ 'contributor' => contributor }] }]
+    end
+    let(:admin_metadata) do
+      { 'name' => 'Test Event', 'contributor' => contributor,
+        'event' => [{ 'name' => 'Test Admin Event', 'contributor' => contributor, 'parallelEvent' => [{ 'contributor' => contributor }] }] }
+    end
     let(:repository_object_version) do
       build(:repository_object_version, label: 'Test DRO', description:)
     end
     let(:repository_object) { create(:repository_object, :with_repository_object_version, repository_object_version:) }
 
-    it 'removes parallelContributor from contributors, events, and relatedResources' do
+    it 'removes parallelContributor from contributors in events, relatedResources, adminMetadata' do
       migrator.migrate
       expect(repository_object.versions.last.description['contributor']).to eq([{ 'name' => 'Test Contributor' }])
       expect(repository_object.versions.last.description['event']).to eq([{ 'name' => 'Test Event',
                                                                             'contributor' => [{
                                                                               'name' => 'Test Contributor'
-                                                                            }] }])
+                                                                            }],
+                                                                            'parallelEvent' => [{ 'contributor' => [{
+                                                                              'name' => 'Test Contributor'
+                                                                            }] }] }])
       expect(repository_object.versions.last.description['relatedResource']).to eq([{ 'title' => 'Test Title',
                                                                                       'contributor' => [{
                                                                                         'name' => 'Test Contributor'
                                                                                       }] }])
+      expect(repository_object.versions.last.description['adminMetadata']).to eq({ 'name' => 'Test Event',
+                                                                                   'contributor' => [{
+                                                                                     'name' => 'Test Contributor'
+                                                                                   }],
+                                                                                   'event' => [{ 'name' => 'Test Admin Event',
+                                                                                                 'contributor' => [{
+                                                                                                   'name' => 'Test Contributor'
+                                                                                                 }],
+                                                                                                 'parallelEvent' => [
+                                                                                                   {
+                                                                                                     'contributor' => [
+                                                                                                       {
+                                                                                                         'name' => 'Test Contributor'
+                                                                                                       }
+                                                                                                     ]
+                                                                                                   }
+                                                                                                 ] }] })
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔
Missed some parallelContributors previously.


## How was this change tested? 🤨
Ran on QA in dryrun



