### PR TITLE
Add a general report for getting details about a druid list

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,13 @@ xzcat cocina-head-versions-2026-03-12.jsonl.xz|jq 'select(.description.contribut
 xzcat cocina-head-versions-2026-03-12.jsonl.xz |jq -r '.externalIdentifier as $id | .description.contributor[]?.role[]? | select(has("code")) | [$id, .code] | @csv' > role_codes.csv
 ```
 
+#### Getting more information
+
+If you want hrid/title/collection/etc for the problems logged above. You can scp your `role_codes.csv` file to the sdr-infra server and run:
+```
+./bin/find-item-details.rb -f ~jcoyne85/role_codes.csv  > full_role_codes.csv
+```
+
 
 ### Generate a list of druids from Solr query
 

--- a/bin/find-item-details.rb
+++ b/bin/find-item-details.rb
@@ -35,8 +35,10 @@ def result(batch)
 end
 
 def create_report(csv)
-  puts %w[druid title collection_druid collection_title apo apo_name project_tag HRID object_type].join(',')
+  puts %w[druid title second_column collection_druid collection_title apo apo_name project_tag HRID
+          object_type].join(',')
   csv.each_slice(BATCH_SIZE) do |batch|
+    second_column = batch.to_h
     result(batch).each do |row|
       druid = row['druid']
       collection_druid = row['collection_id']
@@ -48,6 +50,7 @@ def create_report(csv)
       puts [
         druid,
         (row['structured_title'] || row['title'])&.delete("\n"),
+        second_column[druid],
         collection_druid,
         collection_name,
         apo_druid,


### PR DESCRIPTION
```
./bin/find-item-details.rb -f bad_druids.csv > info_about_bad_druids.csv
```

## Why was this change made? 🤔

So we can get details about a list of druids. Many times it is faster to do calculations on an extracted set of data.  Once the set is winnowed down, we need to know details about the members of the set.  This script gets those details.

## How was this change tested? 🤨
run on sdr-infra

