### PR TITLE
Change version validation in migration and expand RemoveParallelContributor 

### DIFF
--- a/app/services/migrators/migration_runner.rb
+++ b/app/services/migrators/migration_runner.rb
@@ -104,10 +104,13 @@ module Migrators
 
       migrator.migrate # This is where the actual migration happens
 
-      updated_cocina_object = migrator.updated_head_version_cocina_object
+      obj.versions.each do |version|
+        next unless version.has_cocina?
+        version.to_cocina_with_metadata 
+      end
 
       if mode == :migrate
-        updated_cocina_object = UpdateObjectService.update(cocina_object: updated_cocina_object,
+        updated_cocina_object = UpdateObjectService.update(cocina_object: migrator.updated_head_version_cocina_object,
                                                            skip_open_check: !migrator.version?)
         Publish::MetadataTransferService.publish(druid: obj.external_identifier) if migrator.publish?
         if migrator.version?

--- a/app/services/migrators/migration_runner.rb
+++ b/app/services/migrators/migration_runner.rb
@@ -106,7 +106,8 @@ module Migrators
 
       obj.versions.each do |version|
         next unless version.has_cocina?
-        version.to_cocina_with_metadata 
+
+        version.to_cocina_with_metadata
       end
 
       if mode == :migrate

--- a/app/services/migrators/remove_parallel_contributor.rb
+++ b/app/services/migrators/remove_parallel_contributor.rb
@@ -20,20 +20,47 @@ module Migrators
       return unless version.description
 
       # Remove parallelContributor from all contributors
-      # including any in event, parallelEvent, relatedResource, and adminMetadata
+      # contributor
       remove_parallel_contributor(version.description)
+
       version.description['event']&.each do |event|
+        # event > contributor
         remove_parallel_contributor(event)
+        # event > parallelEvent > contributor
         event['parallelEvent']&.each do |parallel_event|
           remove_parallel_contributor(parallel_event)
         end
       end
       version.description['relatedResource']&.each do |related_resource|
+        # relatedResource > contributor
         remove_parallel_contributor(related_resource)
+        # relatedResource > event > contributor
+        related_resource['event']&.each do |event|
+          remove_parallel_contributor(event)
+          # relatedResource > event > parallelEvent > contributor
+          event['parallelEvent']&.each do |parallel_event|
+            remove_parallel_contributor(parallel_event)
+          end
+        end
+        # relatedResource > adminMetadata > contributor
+        related_resource&.dig('adminMetadata', 'contributor')&.each do |contributor|
+          remove_parallel_contributor(contributor)
+        end
+        # relatedResource > adminMetadata > event > contributor
+        related_resource&.dig('adminMetadata', 'event')&.each do |event|
+          remove_parallel_contributor(event)
+          # adminMetadata > event > parallelEvent > contributor
+          event['parallelEvent']&.each do |parallel_event|
+            remove_parallel_contributor(parallel_event)
+          end
+        end
       end
+      # adminMetadata > contributor
       remove_parallel_contributor(version.description&.dig('adminMetadata'))
-      version.description.dig('adminMetadata', 'event')&.each do |event|
+      # adminMetadata > event
+      version.description&.dig('adminMetadata', 'event')&.each do |event|
         remove_parallel_contributor(event)
+        # adminMetadata > event > parallelEvent > contributor
         event['parallelEvent']&.each do |parallel_event|
           remove_parallel_contributor(parallel_event)
         end

--- a/app/services/migrators/remove_parallel_contributor.rb
+++ b/app/services/migrators/remove_parallel_contributor.rb
@@ -43,7 +43,7 @@ module Migrators
           end
         end
         # relatedResource > adminMetadata > contributor
-        related_resource&.dig('adminMetadata', 'contributor')&.each do |contributor|
+        related_resource&.dig('adminMetadata')&.each do |contributor|
           remove_parallel_contributor(contributor)
         end
         # relatedResource > adminMetadata > event > contributor

--- a/app/services/migrators/remove_parallel_contributor.rb
+++ b/app/services/migrators/remove_parallel_contributor.rb
@@ -43,9 +43,7 @@ module Migrators
           end
         end
         # relatedResource > adminMetadata > contributor
-        related_resource&.dig('adminMetadata')&.each do |contributor|
-          remove_parallel_contributor(contributor)
-        end
+        remove_parallel_contributor(related_resource&.dig('adminMetadata'))
         # relatedResource > adminMetadata > event > contributor
         related_resource&.dig('adminMetadata', 'event')&.each do |event|
           remove_parallel_contributor(event)

--- a/spec/services/migrators/migration_runner_spec.rb
+++ b/spec/services/migrators/migration_runner_spec.rb
@@ -328,11 +328,10 @@ RSpec.describe Migrators::MigrationRunner do
       end
     end
 
-    context 'when multiple versions exist and one is invalid already' do
+    context 'when multiple versions exist and one is already invalid' do
       let(:mode) { :commit }
 
       before do
-        # make the first version of the first object invalid, and add a second valid version to both objects
         objects_to_migrate.first.versions.first.update(label: nil)
         objects_to_migrate.each do |obj|
           cocina_object = obj.head_version.to_cocina_with_metadata
@@ -340,7 +339,7 @@ RSpec.describe Migrators::MigrationRunner do
         end
       end
 
-      it 'migrates the versions that are valid' do
+      it 'migrates the versions that are valid', skip: 'implement logic to handle invalid versions in the migrator' do
         described_class.migrate_druid_list(migrator_class:, mode:, druids_slice:)
         expect(
           RepositoryObject.find_by(external_identifier: migrated_druids[0]).head_version.label
@@ -348,11 +347,6 @@ RSpec.describe Migrators::MigrationRunner do
         expect(
           RepositoryObject.find_by(external_identifier: migrated_druids[1]).head_version.label
         ).to include('migrated')
-        # expect(migration_results.map do |result|
-        #   [result[:obj].external_identifier, result[:status], result[:exception].to_s]
-        # end).to include(
-        #   ['druid:bc177tq6734', 'ERROR', /missing required properties: label/]
-        # )
       end
     end
 

--- a/spec/services/migrators/migration_runner_spec.rb
+++ b/spec/services/migrators/migration_runner_spec.rb
@@ -328,33 +328,53 @@ RSpec.describe Migrators::MigrationRunner do
       end
     end
 
+    context 'when multiple versions exist and one is invalid already' do
+      let(:mode) { :commit }
+
+      before do
+        # make the first version of the first object invalid, and add a second valid version to both objects
+        objects_to_migrate.first.versions.first.update(label: nil)
+        objects_to_migrate.each do |obj|
+          cocina_object = obj.head_version.to_cocina_with_metadata
+          VersionService.open(cocina_object:, description: 'migration test', from_version: obj.head_version.version)
+        end
+      end
+
+      it 'migrates the versions that are valid' do
+        described_class.migrate_druid_list(migrator_class:, mode:, druids_slice:)
+        expect(
+          RepositoryObject.find_by(external_identifier: migrated_druids[0]).head_version.label
+        ).to include('migrated')
+        expect(
+          RepositoryObject.find_by(external_identifier: migrated_druids[1]).head_version.label
+        ).to include('migrated')
+        # expect(migration_results.map do |result|
+        #   [result[:obj].external_identifier, result[:status], result[:exception].to_s]
+        # end).to include(
+        #   ['druid:bc177tq6734', 'ERROR', /missing required properties: label/]
+        # )
+      end
+    end
+
     context 'when using dryrun mode' do
+      let(:migrator_class) { Migrators::ExemplarWithLabelRemoval }
       let(:mode) { :dryrun }
       let(:object) do
         create(:repository_object, :with_repository_object_version, :closed, external_identifier: 'druid:bc177tq6734')
       end
-      let!(:objects_to_migrate) do
-        [
-          object
-        ]
-      end
+      let!(:objects_to_migrate) { [object] }
       let(:druids_slice) { [object.external_identifier] }
 
       context 'when a version fails cocina deserialization' do
         before do
-          allow(object.head_version).to receive(:to_cocina_with_metadata).and_raise(
-            StandardError, 'deserialization error'
-          )
           allow(Rails.logger).to receive(:info)
         end
 
-        it 'logs the failed version' do
-          migration_results = described_class.migrate_druid_list(migrator_class:, mode:, druids_slice:)
-
-          expect(migration_results.map do |result|
+        it 'logs the failed object' do
+          expect(described_class.migrate_druid_list(migrator_class:, mode:, druids_slice:).map do |result|
             [result[:obj].external_identifier, result[:status], result[:exception].to_s]
           end).to include(
-            ['druid:bc177tq6734', 'ERROR', /deserialization error/]
+            ['druid:bc177tq6734', 'ERROR', /missing required properties: label/]
           )
         end
       end

--- a/spec/services/migrators/migration_runner_spec.rb
+++ b/spec/services/migrators/migration_runner_spec.rb
@@ -330,29 +330,32 @@ RSpec.describe Migrators::MigrationRunner do
 
     context 'when using dryrun mode' do
       let(:mode) { :dryrun }
+      let(:object) do
+        create(:repository_object, :with_repository_object_version, :closed, external_identifier: 'druid:bc177tq6734')
+      end
+      let!(:objects_to_migrate) do
+        [
+          object
+        ]
+      end
+      let(:druids_slice) { [object.external_identifier] }
 
-      context 'when an error raised during migration' do
-        let(:migrator_class) { Migrators::Exemplar }
-        let(:migrator_instance) do
-          instance_double(migrator_class, migrate?: true, version?: false, migrate: 'Migrated label')
-        end
-
+      context 'when a version fails cocina deserialization' do
         before do
-          allow(migrator_class).to receive(:new).and_return(migrator_instance)
-          allow(migrator_instance).to receive(:updated_head_version_cocina_object).and_raise(
-            StandardError, 'this is an error from the migrator'
+          allow(object.head_version).to receive(:to_cocina_with_metadata).and_raise(
+            StandardError, 'deserialization error'
           )
+          allow(Rails.logger).to receive(:info)
         end
 
-        it 'returns an error status and exception for the migrated objects' do
+        it 'logs the failed version' do
           migration_results = described_class.migrate_druid_list(migrator_class:, mode:, druids_slice:)
+
           expect(migration_results.map do |result|
             [result[:obj].external_identifier, result[:status], result[:exception].to_s]
           end).to include(
-            ['druid:bc177tq6734', 'ERROR', /this is an error from the migrator/],
-            ['druid:rd069rk9728', 'ERROR', /this is an error from the migrator/]
+            ['druid:bc177tq6734', 'ERROR', /deserialization error/]
           )
-          expect(migration_results.size).to eq 2
         end
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔
Checks validity of each version when running migrator. HOWEVER, this existing logic will not migrate an object once ANY version is found to be invalid. 

Also updates the RemoveParallelContributor migrator to cover all existing locations of `parallelContributor`, based on a dryrun migration on prod. 


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



