### PR TITLE
Bump cocina-models to 0.116

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '~> 8.0.0'
 
 # DLSS/domain-specific dependencies
 gem 'cocina_display'
-gem 'cocina-models', '~> 0.115.0'
+gem 'cocina-models', '~> 0.116.0'
 gem 'datacite', '~> 0.6'
 gem 'dor-services-client' # Used for Dor::Services::Response::* & Dor::Services::Client::InvalidCocina classes
 gem 'druid-tools', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.115.0)
+    cocina-models (0.116.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -169,9 +169,9 @@ GEM
       ed25519
     docile (1.4.1)
     domain_name (0.6.20240107)
-    dor-services-client (15.36.0)
+    dor-services-client (15.37.0)
       activesupport (>= 7.0.0)
-      cocina-models (~> 0.115.0)
+      cocina-models (~> 0.116.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -628,7 +628,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-shared_configs
-  cocina-models (~> 0.115.0)
+  cocina-models (~> 0.116.0)
   cocina_display
   config
   connection_pool


### PR DESCRIPTION
## Why was this change made? 🤔
Updates cocina-models, to add parallelContributor back. 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



