### PR TITLE
Match mapping change in datacite-ruby

### DIFF
--- a/app/services/cocina/to_datacite/creator_contributor_funder.rb
+++ b/app/services/cocina/to_datacite/creator_contributor_funder.rb
@@ -145,7 +145,7 @@ module Cocina
           {
             nameIdentifier: identifier.value || identifier.uri,
             nameIdentifierScheme: identifier.type,
-            schemeURI: identifier.source.uri
+            schemeURI: identifier.source&.uri
           }.compact
         end
       end
@@ -194,7 +194,7 @@ module Cocina
       def degree_committee_member?(cocina_contributor)
         cocina_contributor.role.any? { |contrib_role| contrib_role.value == 'degree committee member' } &&
           cocina_contributor.role.any? do |contrib_role|
-            contrib_role.code == 'ths' && contrib_role.source.code == 'marcrelator'
+            contrib_role.code == 'ths' && contrib_role.source&.code == 'marcrelator'
           end
       end
 


### PR DESCRIPTION
Missed this in my last PR, this needs to be updated here to match the change in the gem.


