### PR TITLE
Adds ability to load a cocina object without validation. Skip validation when indexing.

### DIFF
--- a/app/jobs/reindex_job.rb
+++ b/app/jobs/reindex_job.rb
@@ -20,7 +20,7 @@ class ReindexJob < ApplicationJob
   def perform(druid:, trace_id:)
     # Reindexing should be fast, so timeout is only 30 seconds.
     raise DeadLockError unless RedisLock.with_lock(key: "reindex-#{druid}", lock_timeout: 30) do
-      cocina_object = CocinaObjectStore.find(druid)
+      cocina_object = CocinaObjectStore.find(druid, validate: false)
       Indexer.reindex(cocina_object:, trace_id:)
     rescue CocinaObjectStore::CocinaObjectStoreError => e
       Rails.logger.error("Error reindexing #{druid} - trace_id #{trace_id}: #{e.message}")

--- a/app/services/cocina_object_store.rb
+++ b/app/services/cocina_object_store.rb
@@ -24,12 +24,8 @@ class CocinaObjectStore
   COLLECTION = 'Collection'
   ADMIN_POLICY = 'AdminPolicy'
 
-  # Retrieves a Cocina object from the datastore.
-  # @param [String] druid
-  # @return [Cocina::Models::DROWithMetadata, Cocina::Models::CollectionWithMetadata, Cocina::Models::AdminPolicyWithMetadata] cocina_object #rubocop:disable Layout/LineLength
-  # @raise [CocinaObjectNotFoundError] raised when the requested Cocina object is not found.
-  def self.find(druid)
-    new.find(druid)
+  def self.find(...)
+    new.find(...)
   end
 
   # Retrieves a list of Cocina objects from the datastore.
@@ -86,10 +82,12 @@ class CocinaObjectStore
     new.version(druid)
   end
 
+  # Retrieves a Cocina object from the datastore.
   # @param [String] druid to find
+  # @param [Boolean] validate whether to validate the cocina object before returning
   # @return [Cocina::Models::DROWithMetadata,Cocina::Models::CollectionWithMetadata,Cocina::Models::AdminPolicyWithMetadata] for the requested version #rubocop:disable Layout/LineLength
-  def find(druid, version: :head)
-    RepositoryObject.find_by!(external_identifier: druid).head_version.to_cocina_with_metadata
+  def find(druid, validate: true)
+    RepositoryObject.find_by!(external_identifier: druid).head_version.to_cocina_with_metadata(validate:)
   rescue ActiveRecord::RecordNotFound
     return bootstrap_ur_admin_policy if bootstrap_ur_admin_policy?(druid)
 

--- a/spec/jobs/reindex_job_spec.rb
+++ b/spec/jobs/reindex_job_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe ReindexJob do
     it 'invokes the Indexer' do
       perform
       expect(Indexer).to have_received(:reindex).with(cocina_object: dro, trace_id:)
+      expect(CocinaObjectStore).to have_received(:find).with(dro.externalIdentifier, validate: false)
       expect(RedisLock).to have_received(:lock).with(key: "reindex-#{dro.externalIdentifier}", lock_timeout: Integer)
       expect(RedisLock).to have_received(:clear_lock)
     end

--- a/spec/services/cocina_object_store_spec.rb
+++ b/spec/services/cocina_object_store_spec.rb
@@ -51,6 +51,19 @@ RSpec.describe CocinaObjectStore do
           .to be_instance_of(Cocina::Models::CollectionWithMetadata)
       end
     end
+
+    context 'when skipping validation' do
+      let(:repository_object) { create(:repository_object, :with_repository_object_version) }
+
+      before do
+        allow(Cocina::Models).to receive(:build).and_call_original
+      end
+
+      it 'returns Cocina::Models::DROWithMetadata' do
+        expect(store.find(repository_object.external_identifier, validate: false)).to be_instance_of(Cocina::Models::DROWithMetadata)
+        expect(Cocina::Models).to have_received(:build).with(Hash, validate: false)
+      end
+    end
   end
 
   describe '#find_all' do


### PR DESCRIPTION
## Why was this change made? 🤔
Validation is very slow, especially for some objects. In some read-only contexts, validation can be skipped for increased performance.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



