### PR TITLE
Adds endpoint for getting solr doc for head version.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,8 +76,15 @@ class ApplicationController < ActionController::API
   end
 
   # @raise [CocinaObjectStore::CocinaObjectNotFoundError] raised when the requested Cocina object is not found.
-  def load_cocina_object
-    @cocina_object = CocinaObjectStore.find(params[:object_id] || params[:id])
+  def load_cocina_object(**cocina_build_params)
+    @cocina_object = CocinaObjectStore.find(params[:object_id] || params[:id], **cocina_build_params)
+  end
+
+  def cocina_build_params
+    boolean_param(
+      params.permit(:validate).to_h.symbolize_keys,
+      :validate
+    )
   end
 
   # @raise [CocinaObjectStore::CocinaObjectNotFoundError] raised when the requested Cocina object is not found.

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Controller for repository objects.
-class ObjectsController < ApplicationController
+class ObjectsController < ApplicationController # rubocop:disable Metrics/ClassLength
   before_action :load_cocina_object, only: %i[accession destroy show reindex]
   before_action :check_cocina_object_exists, only: :publish
   before_action :validate_from_openapi
@@ -169,6 +169,11 @@ class ObjectsController < ApplicationController
     render json: Indexer.validate_descriptive(cocina_object:)
   rescue StandardError => e
     json_api_error(status: :unprocessable_content, message: e.message)
+  end
+
+  def solr
+    cocina_object = load_cocina_object(**cocina_build_params)
+    render json: Indexing::Builders::DocumentBuilder.for(model: cocina_object).to_solr
   end
 
   private

--- a/app/controllers/user_versions_controller.rb
+++ b/app/controllers/user_versions_controller.rb
@@ -69,11 +69,4 @@ class UserVersionsController < ApplicationController
   def find_user_version
     @user_version = @repository_object.user_versions.find_by!(version: user_version_param)
   end
-
-  def cocina_build_params
-    boolean_param(
-      params.permit(:validate).to_h.symbolize_keys,
-      :validate
-    )
-  end
 end

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -98,13 +98,6 @@ class VersionsController < ApplicationController
     }
   end
 
-  def cocina_build_params
-    boolean_param(
-      params.permit(:validate).to_h.symbolize_keys,
-      :validate
-    )
-  end
-
   def create_params
     params.require(:description)
     new_params = params.permit(

--- a/app/services/indexing/builders/document_builder.rb
+++ b/app/services/indexing/builders/document_builder.rb
@@ -64,6 +64,7 @@ module Indexing
       end
 
       # @param [Cocina::Models::DROWithMetadata,Cocina::Models::CollectionWithMetadata,Cocina::Model::AdminPolicyWithMetadata] model # rubocop:disable Layout/LineLength
+      # @return [Indexing::Indexers::CompositeIndexer] the indexer for the given model
       def for # rubocop:disable Metrics/AbcSize
         indexer_for_type(model.type).new(id: druid,
                                          cocina: model,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
         post 'apply_admin_policy_defaults', to: 'admin_policy_defaults#apply'
         post 'reindex'
         post 'indexable'
+        get 'solr'
       end
 
       collection do

--- a/openapi.yml
+++ b/openapi.yml
@@ -639,6 +639,39 @@ paths:
           required: true
           schema:
             $ref: "https://raw.githubusercontent.com/sul-dlss/cocina-models/refs/tags/v0.113.0/schema.json#/$defs/Druid"
+  "/v1/objects/{id}/solr":
+    get:
+      tags:
+        - objects
+      summary: Show solr document for head version
+      operationId: "objects#solr"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      parameters:
+        - name: id
+          in: path
+          description: ID of object
+          required: true
+          schema:
+            $ref: "https://raw.githubusercontent.com/sul-dlss/cocina-models/refs/tags/v0.113.0/schema.json#/$defs/Druid"
+        - name: validate
+          in: query
+          description: Enable or disable validation ofCocina
+          required: false
+          schema:
+            type: boolean
+            default: true    
   "/v1/objects/{object_id}/workspace":
     post:
       tags:

--- a/spec/requests/show_object_solr_spec.rb
+++ b/spec/requests/show_object_solr_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Show solr for an object' do
+  let(:object) { create(:repository_object, :with_repository_object_version, :closed) }
+
+  let(:solr_doc) { { 'id' => object.external_identifier, 'rights_descriptions_ssimdv' => ['world', 'dark (file)'] } }
+  let(:indexer) { instance_double(Indexing::Indexers::CompositeIndexer::Instance, to_solr: solr_doc) }
+
+  before do
+    allow(Indexing::Builders::DocumentBuilder).to receive(:for).and_return(indexer)
+    allow(CocinaObjectStore).to receive(:find).and_call_original
+  end
+
+  it 'returns a 200' do
+    get "/v1/objects/#{object.external_identifier}/solr?validate=false",
+        headers: { 'Authorization' => "Bearer #{jwt}" }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body).to eq(solr_doc)
+    expect(CocinaObjectStore).to have_received(:find).with(object.external_identifier, validate: false)
+    expect(Indexing::Builders::DocumentBuilder).to have_received(:for).with(model: an_instance_of(Cocina::Models::DROWithMetadata))
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔
So that Argo-B3 can use it for the show page in order to always have latest.


## How was this change tested? 🤨
Unit
⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



