### PR TITLE
Avoid redundant reindexing.

### DIFF
--- a/app/jobs/reindex_job.rb
+++ b/app/jobs/reindex_job.rb
@@ -17,14 +17,39 @@ class ReindexJob < ApplicationJob
 
   # @param [String] druid
   # @param [String] trace_id the trace id
-  def perform(druid:, trace_id:)
+  def perform(druid:, trace_id:, current_as_of: nil)
+    # Skip reindexing if the current_as_of timestamp in Solr is more recent than the current_as_of timestamp passed in.
+    # This avoids redundant reindexing.
+    return if skip?(druid:, current_as_of:, trace_id:)
+
     # Reindexing should be fast, so timeout is only 30 seconds.
     raise DeadLockError unless RedisLock.with_lock(key: "reindex-#{druid}", lock_timeout: 30) do
       cocina_object = CocinaObjectStore.find(druid, validate: false)
-      Indexer.reindex(cocina_object:, trace_id:)
+      Rails.logger.error("Starting reindexing #{druid} - trace_id #{trace_id}")
+      Indexer.reindex(cocina_object:, trace_id:, current_as_of: current_as_of)
     rescue CocinaObjectStore::CocinaObjectStoreError => e
       Rails.logger.error("Error reindexing #{druid} - trace_id #{trace_id}: #{e.message}")
       Honeybadger.notify(e, context: { druid:, trace_id: })
+    end
+  end
+
+  def skip?(druid:, current_as_of:, trace_id:)
+    return false unless current_as_of
+
+    results = SolrService.query("id:\"#{druid}\"", fl: 'current_as_of_dttsi', rows: 1)
+    return false if results.empty?
+
+    solr_timestamp = results.first['current_as_of_dttsi'].then { |ts| Time.zone.parse(ts) if ts }
+    return false unless solr_timestamp
+
+    (solr_timestamp > current_as_of).tap do |skip|
+      if skip
+        Rails.logger.info(
+          "Skipping reindexing #{druid} - #{trace_id}: " \
+          "current_as_of_dttsi (#{solr_timestamp.iso8601(6)}) > " \
+          "current_as_of (#{current_as_of.iso8601(6)})."
+        )
+      end
     end
   end
 end

--- a/app/services/indexer.rb
+++ b/app/services/indexer.rb
@@ -3,13 +3,14 @@
 # Indexes a Cocina object into Solr for use by Argo.
 class Indexer
   # @param [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata]
-  def self.reindex(cocina_object:, trace_id: nil)
+  def self.reindex(cocina_object:, trace_id: nil, current_as_of: nil)
     return unless Settings.solr.enabled
 
     trace_id ||= trace_id_for(druid: cocina_object.externalIdentifier)
     solr_doc = Indexing::Builders::DocumentBuilder.for(
       model: cocina_object,
-      trace_id:
+      trace_id:,
+      current_as_of:
     ).to_solr
     solr.add(solr_doc)
     # This logging is to assist with https://github.com/sul-dlss/dor-services-app/issues/5231
@@ -40,7 +41,8 @@ class Indexer
     Sidekiq::Client.via(REDIS) do
       ReindexJob.perform_later(
         druid:,
-        trace_id: trace_id || trace_id_for(druid:)
+        trace_id: trace_id || trace_id_for(druid:),
+        current_as_of: Time.zone.now
       )
     end
   end

--- a/app/services/indexer.rb
+++ b/app/services/indexer.rb
@@ -21,6 +21,11 @@ class Indexer
     solr.commit
   end
 
+  def self.reindex_by_druid(druid:, trace_id: nil, current_as_of: nil)
+    cocina_object = CocinaObjectStore.find(druid, validate: false)
+    reindex(cocina_object:, trace_id:, current_as_of:)
+  end
+
   def self.validate_descriptive(cocina_object:)
     return unless Settings.solr.enabled
 

--- a/app/services/indexing/builders/document_builder.rb
+++ b/app/services/indexing/builders/document_builder.rb
@@ -53,7 +53,7 @@ module Indexing
       # Optional parameters allow passing in pre-fetched data to avoid redundant lookups.
       # If an optional parameter is not provided, it will be fetched as needed.
       def initialize(model:, workflows: nil, parent_collections: nil, parent_collections_release_tags: nil, # rubocop:disable Metrics/ParameterLists
-                     milestones: nil, release_tags: nil, trace_id: SecureRandom.uuid)
+                     milestones: nil, release_tags: nil, trace_id: SecureRandom.uuid, current_as_of: nil)
         @model = model
         @workflows = workflows
         @parent_collections = parent_collections
@@ -61,6 +61,7 @@ module Indexing
         @release_tags = release_tags
         @milestones = milestones
         @trace_id = trace_id
+        @current_as_of ||= Time.zone.now
       end
 
       # @param [Cocina::Models::DROWithMetadata,Cocina::Models::CollectionWithMetadata,Cocina::Model::AdminPolicyWithMetadata] model # rubocop:disable Layout/LineLength
@@ -74,6 +75,7 @@ module Indexing
                                          administrative_tags:,
                                          release_tags:,
                                          milestones:,
+                                         current_as_of:,
                                          trace_id:)
       rescue StandardError => e
         Honeybadger.notify('[DATA ERROR] Unexpected indexing exception',
@@ -86,7 +88,7 @@ module Indexing
 
       private
 
-      attr_reader :model, :trace_id
+      attr_reader :model, :trace_id, :current_as_of
 
       def druid
         model.externalIdentifier

--- a/app/services/indexing/indexers/basic_indexer.rb
+++ b/app/services/indexing/indexers/basic_indexer.rb
@@ -4,20 +4,22 @@ module Indexing
   module Indexers
     # Basic indexing for any object
     class BasicIndexer
-      attr_reader :cocina, :workflow_client, :trace_id, :milestones
+      attr_reader :cocina, :workflow_client, :trace_id, :milestones, :current_as_of
 
-      def initialize(cocina:, trace_id:, milestones: nil, **)
+      def initialize(cocina:, trace_id:, current_as_of:, milestones: nil, **)
         @cocina = cocina
         @milestones = milestones
         @trace_id = trace_id
         @workflow_client = workflow_client
+        @current_as_of = current_as_of
       end
 
       # @return [Hash] the partial solr document for basic data
-      def to_solr # rubocop:disable Metrics/AbcSize
+      def to_solr # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         {}.tap do |solr_doc|
           solr_doc[:id] = cocina.externalIdentifier
           solr_doc['trace_id_ss'] = trace_id
+          solr_doc['current_as_of_dttsi'] = current_as_of.utc.iso8601(6)
           solr_doc['current_version_ipsidv'] = cocina.version # Argo Facet field "Version"
           solr_doc['obj_label_tesim'] = cocina.label
           solr_doc['purl_ss'] = Purl.for(druid: cocina.externalIdentifier) if purl?

--- a/app/services/workflow/next_step_service.rb
+++ b/app/services/workflow/next_step_service.rb
@@ -28,7 +28,9 @@ module Workflow
       # send message to RabbitMQ for accessioning complete/error steps, pre-assembly/H3 consume one or both to update UI
       Notifications::WorkflowStepUpdated.publish(step:) if step.status == 'error' || last_accession_step?(step)
 
-      Indexer.reindex_later(druid: step.druid)
+      # Performing a synchronous reindex to avoid a large number of reindexing jobs being enqueued right after another.
+      # This slows down the processing of workflow steps for the sake of less thrashing of reindexing jobs.
+      reindex!(step: step)
       next_steps
     end
 
@@ -74,6 +76,15 @@ module Workflow
 
     def last_accession_step?(step)
       step.workflow == 'accessionWF' && step.process == 'end-accession' && step.status == 'completed'
+    end
+
+    def reindex!(step:)
+      # Performing a synchronous reindex to avoid a large number of reindexing jobs being enqueued right after another.
+      # This slows down the processing of workflow steps for the sake of less thrashing of reindexing jobs.
+      Indexer.reindex_by_druid(druid: step.druid)
+    rescue StandardError => e
+      # Don't raise the error to avoid blocking the workflow.
+      Honeybadger.notify(e, context: { druid: step.druid, workflow: step.workflow, process: step.process })
     end
   end
 end

--- a/spec/jobs/reindex_job_spec.rb
+++ b/spec/jobs/reindex_job_spec.rb
@@ -4,29 +4,30 @@ require 'rails_helper'
 
 RSpec.describe ReindexJob do
   subject(:perform) do
-    described_class.perform_now(druid: dro.externalIdentifier, trace_id:)
+    described_class.perform_now(druid: dro.externalIdentifier, trace_id:, current_as_of:)
   end
 
   let(:dro) { build(:dro) }
   let(:trace_id) { 'abc123' }
+  let(:current_as_of) { nil }
 
   before do
     allow(CocinaObjectStore).to receive(:find).and_return(dro)
+    allow(SolrService).to receive(:query).and_return([])
   end
 
   context 'when no errors' do
     before do
       allow(Indexer).to receive(:reindex)
-      allow(RedisLock).to receive(:lock).and_return(true)
-      allow(RedisLock).to receive(:clear_lock)
+      allow(RedisLock).to receive(:with_lock) { |*_args, &block| block.call }
     end
 
     it 'invokes the Indexer' do
       perform
-      expect(Indexer).to have_received(:reindex).with(cocina_object: dro, trace_id:)
+      expect(Indexer).to have_received(:reindex).with(cocina_object: dro, trace_id:, current_as_of:)
       expect(CocinaObjectStore).to have_received(:find).with(dro.externalIdentifier, validate: false)
-      expect(RedisLock).to have_received(:lock).with(key: "reindex-#{dro.externalIdentifier}", lock_timeout: Integer)
-      expect(RedisLock).to have_received(:clear_lock)
+      expect(SolrService).not_to have_received(:query)
+      expect(RedisLock).to have_received(:with_lock).with(key: "reindex-#{dro.externalIdentifier}", lock_timeout: 30)
     end
   end
 
@@ -34,28 +35,68 @@ RSpec.describe ReindexJob do
     before do
       allow(Indexer).to receive(:reindex).and_raise(CocinaObjectStore::CocinaObjectStoreError)
       allow(Honeybadger).to receive(:notify)
-      allow(RedisLock).to receive(:lock).and_return(true)
-      allow(RedisLock).to receive(:clear_lock)
+      allow(RedisLock).to receive(:with_lock) { |*_args, &block| block.call }
     end
 
     it 'Honeybadger alerts' do
       perform
-      expect(Indexer).to have_received(:reindex).with(cocina_object: dro, trace_id:)
-      expect(Honeybadger).to have_received(:notify)
-      expect(RedisLock).to have_received(:lock)
-      expect(RedisLock).to have_received(:clear_lock)
+      expect(Indexer).to have_received(:reindex).with(cocina_object: dro, trace_id:, current_as_of:)
+      expect(Honeybadger).to have_received(:notify).with(instance_of(CocinaObjectStore::CocinaObjectStoreError),
+                                                         context: { druid: dro.externalIdentifier, trace_id: })
+      expect(RedisLock).to have_received(:with_lock)
     end
   end
 
   context 'when getting a lock fails' do
     before do
-      allow(RedisLock).to receive(:lock).and_return(false)
+      allow(RedisLock).to receive(:with_lock).and_return(false)
     end
 
     it 'raises' do
       expect do
-        described_class.new.perform(druid: dro.externalIdentifier, trace_id:)
+        described_class.new.perform(druid: dro.externalIdentifier, trace_id:, current_as_of:)
       end.to raise_error(ReindexJob::DeadLockError)
+    end
+  end
+
+  context 'when current_as_of is provided' do
+    let(:current_as_of) { Time.zone.parse('2026-04-10T12:00:00Z') }
+
+    before do
+      allow(Indexer).to receive(:reindex)
+      allow(RedisLock).to receive(:with_lock) { |*_args, &block| block.call }
+    end
+
+    context 'when Solr has a newer current_as_of timestamp' do
+      before do
+        allow(SolrService).to receive(:query).and_return([{ 'current_as_of_dttsi' => '2026-04-10T12:00:01.012345Z' }])
+      end
+
+      it 'skips reindexing' do
+        perform
+
+        expect(SolrService).to have_received(:query).with("id:\"#{dro.externalIdentifier}\"",
+                                                          fl: 'current_as_of_dttsi', rows: 1)
+        expect(RedisLock).not_to have_received(:with_lock)
+        expect(CocinaObjectStore).not_to have_received(:find)
+        expect(Indexer).not_to have_received(:reindex)
+      end
+    end
+
+    context 'when Solr has an older current_as_of timestamp' do
+      before do
+        allow(SolrService).to receive(:query).and_return([{ 'current_as_of_dttsi' => '2026-04-10T11:59:59.987654Z' }])
+      end
+
+      it 'reindexes the object' do
+        perform
+
+        expect(SolrService).to have_received(:query).with("id:\"#{dro.externalIdentifier}\"",
+                                                          fl: 'current_as_of_dttsi', rows: 1)
+        expect(RedisLock).to have_received(:with_lock).with(key: "reindex-#{dro.externalIdentifier}", lock_timeout: 30)
+        expect(CocinaObjectStore).to have_received(:find).with(dro.externalIdentifier, validate: false)
+        expect(Indexer).to have_received(:reindex).with(cocina_object: dro, trace_id:, current_as_of:)
+      end
     end
   end
 end

--- a/spec/services/indexer_spec.rb
+++ b/spec/services/indexer_spec.rb
@@ -11,10 +11,12 @@ RSpec.describe Indexer do
   let(:solr) { instance_double(RSolr::Client, add: nil, commit: nil, delete_by_id: nil) }
   let(:trace_id) { 'abc123' }
   let(:generated_trace_id) { 'def456' }
+  let(:current_as_of) { Time.zone.parse('2026-04-10T12:00:00Z') }
 
   before do
     allow(RSolr).to receive(:connect).and_return(solr)
     allow(SecureRandom).to receive(:uuid).and_return(generated_trace_id)
+    allow(Time.zone).to receive(:now).and_return(current_as_of)
   end
 
   describe '#reindex' do
@@ -26,7 +28,8 @@ RSpec.describe Indexer do
       described_class.reindex(cocina_object:, trace_id:)
       expect(Indexing::Builders::DocumentBuilder).to have_received(:for).with(
         model: cocina_object,
-        trace_id:
+        trace_id:,
+        current_as_of: nil
       )
       expect(solr).to have_received(:add).with(solr_doc)
       expect(solr).to have_received(:commit)
@@ -50,7 +53,8 @@ RSpec.describe Indexer do
         described_class.reindex(cocina_object:)
         expect(Indexing::Builders::DocumentBuilder).to have_received(:for).with(
           model: cocina_object,
-          trace_id: generated_trace_id
+          trace_id: generated_trace_id,
+          current_as_of: nil
         )
       end
     end
@@ -85,7 +89,8 @@ RSpec.describe Indexer do
       described_class.reindex_later(druid:, trace_id:)
       expect(ReindexJob).to have_received(:perform_later).with(
         druid:,
-        trace_id:
+        trace_id:,
+        current_as_of:
       )
     end
 
@@ -94,7 +99,8 @@ RSpec.describe Indexer do
         described_class.reindex_later(druid:)
         expect(ReindexJob).to have_received(:perform_later).with(
           druid:,
-          trace_id: generated_trace_id
+          trace_id: generated_trace_id,
+          current_as_of:
         )
       end
     end

--- a/spec/services/indexer_spec.rb
+++ b/spec/services/indexer_spec.rb
@@ -60,6 +60,26 @@ RSpec.describe Indexer do
     end
   end
 
+  describe '#reindex_by_druid' do
+    before do
+      allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
+      allow(described_class).to receive(:reindex)
+    end
+
+    it 'finds by druid and reindexes the object' do
+      described_class.reindex_by_druid(druid:, trace_id:)
+
+      expect(CocinaObjectStore).to have_received(:find).with(druid, validate: false)
+      expect(described_class).to have_received(:reindex).with(cocina_object:, trace_id:, current_as_of: nil)
+    end
+
+    it 'passes current_as_of to reindex' do
+      described_class.reindex_by_druid(druid:, trace_id:, current_as_of:)
+
+      expect(described_class).to have_received(:reindex).with(cocina_object:, trace_id:, current_as_of:)
+    end
+  end
+
   describe '#delete' do
     it 'reindexes the object' do
       described_class.delete(druid:)

--- a/spec/services/indexing/builders/document_builder_spec.rb
+++ b/spec/services/indexing/builders/document_builder_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe Indexing::Builders::DocumentBuilder do
   let(:druid) { 'druid:xx999xx9999' }
   let(:collection_druid) { 'druid:bc999df2323' }
   let(:trace_id) { 'abc123' }
+  let(:current_as_of) { Time.zone.parse('2026-04-10T12:00:00Z') }
+
+  before do
+    allow(Time.zone).to receive(:now).and_return(current_as_of)
+  end
 
   context 'when the model is an item' do
     it { is_expected.to be_instance_of Indexing::Indexers::CompositeIndexer::Instance }
@@ -122,6 +127,7 @@ RSpec.describe Indexing::Builders::DocumentBuilder do
               parent_collections_release_tags: { 'druid:bc999df2323' => parent_collection_release_tags },
               release_tags:,
               workflows:,
+              current_as_of:,
               trace_id:
             }
           )
@@ -151,6 +157,7 @@ RSpec.describe Indexing::Builders::DocumentBuilder do
               parent_collections_release_tags:,
               release_tags:,
               workflows:,
+              current_as_of:,
               trace_id:
             }
           )

--- a/spec/services/indexing/indexers/basic_indexer_spec.rb
+++ b/spec/services/indexing/indexers/basic_indexer_spec.rb
@@ -32,10 +32,12 @@ RSpec.describe Indexing::Indexers::BasicIndexer do
     let(:indexer) do
       Indexing::Indexers::CompositeIndexer.new(
         described_class
-      ).new(id: 'druid:ab123cd4567', cocina:, workflow_client: instance_double(Dor::Services::Client), trace_id:)
+      ).new(id: 'druid:ab123cd4567', cocina:, workflow_client: instance_double(Dor::Services::Client), trace_id:,
+            current_as_of:)
     end
     let(:doc) { indexer.to_solr }
     let(:trace_id) { 'abc123' }
+    let(:current_as_of) { Time.zone.parse('2026-04-10T12:00:00Z') }
 
     context 'with collections' do
       let(:structural) do
@@ -46,6 +48,7 @@ RSpec.describe Indexing::Indexers::BasicIndexer do
         expect(doc).to eq(
           'obj_label_tesim' => 'item label',
           'current_version_ipsidv' => 4,
+          'current_as_of_dttsi' => '2026-04-10T12:00:00.000000Z',
           'milestones_ssim' => %w[foo bar],
           'has_constituents_ssimdv' => nil,
           'governed_by_ssim' => 'druid:vv888vv8888',
@@ -64,6 +67,7 @@ RSpec.describe Indexing::Indexers::BasicIndexer do
         expect(doc).to eq(
           'obj_label_tesim' => 'item label',
           'current_version_ipsidv' => 4,
+          'current_as_of_dttsi' => '2026-04-10T12:00:00.000000Z',
           'milestones_ssim' => %w[foo bar],
           'governed_by_ssim' => 'druid:vv888vv8888',
           'bare_governed_by_ss' => 'vv888vv8888',
@@ -86,6 +90,7 @@ RSpec.describe Indexing::Indexers::BasicIndexer do
         expect(doc).to eq(
           'obj_label_tesim' => 'item label',
           'current_version_ipsidv' => 4,
+          'current_as_of_dttsi' => '2026-04-10T12:00:00.000000Z',
           'milestones_ssim' => %w[foo bar],
           'has_constituents_ssimdv' => ['druid:bb777bb7777', 'druid:dd666dd6666'],
           'constituents_count_ips' => 2,

--- a/spec/services/version_batch_status_service_spec.rb
+++ b/spec/services/version_batch_status_service_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe VersionBatchStatusService do
       accessioning_repository_object_version.repository_object.close_version!(description: 'Best version ever')
       # This object has an assembly workflow that is sufficiently completed.
       allow(QueueService).to receive(:enqueue)
+      allow(Indexer).to receive(:reindex_by_druid)
       Workflow::Service.create(druid: accessioning_druid, workflow_name: 'assemblyWF', version: 2)
       steps = WorkflowStep.where(druid: accessioning_druid, active_version: true,
                                  workflow: 'assemblyWF').order(:id).to_a

--- a/spec/services/workflow/creator_spec.rb
+++ b/spec/services/workflow/creator_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Workflow::Creator do
 
   before do
     allow(QueueService).to receive(:enqueue)
+    allow(Indexer).to receive(:reindex_by_druid)
   end
 
   describe '#create_workflow_steps' do

--- a/spec/services/workflow/next_step_service_spec.rb
+++ b/spec/services/workflow/next_step_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Workflow::NextStepService do
     before do
       allow(QueueService).to receive(:enqueue)
       allow(Notifications::WorkflowStepUpdated).to receive(:publish)
-      allow(Indexer).to receive(:reindex_later)
+      allow(Indexer).to receive(:reindex_by_druid)
       allow_any_instance_of(described_class).to receive(:sleep) # rubocop:disable RSpec/AnyInstance
     end
 
@@ -45,7 +45,7 @@ RSpec.describe Workflow::NextStepService do
         expect(next_steps).to eq [ready]
         expect(QueueService).to have_received(:enqueue).with(ready)
         expect(Notifications::WorkflowStepUpdated).not_to have_received(:publish)
-        expect(Indexer).to have_received(:reindex_later).with(druid: step.druid)
+        expect(Indexer).to have_received(:reindex_by_druid).with(druid: step.druid)
       end
     end
 
@@ -62,7 +62,7 @@ RSpec.describe Workflow::NextStepService do
         expect(next_steps).to eq []
         expect(QueueService).not_to have_received(:enqueue)
         expect(Notifications::WorkflowStepUpdated).to have_received(:publish).with(step:)
-        expect(Indexer).to have_received(:reindex_later).with(druid: step.druid)
+        expect(Indexer).to have_received(:reindex_by_druid).with(druid: step.druid)
       end
     end
 
@@ -104,6 +104,29 @@ RSpec.describe Workflow::NextStepService do
         expect { next_steps }.not_to(change { step.reload.status })
         expect(Notifications::WorkflowStepUpdated).to have_received(:publish).with(step:)
         expect(next_steps).to eq []
+      end
+    end
+
+    context 'when Indexer.reindex_by_druid raises an error' do
+      let(:step) do
+        create(:workflow_step,
+               process: 'start-accession',
+               version: 1,
+               status: 'completed',
+               active_version: true)
+      end
+
+      before do
+        allow(Indexer).to receive(:reindex_by_druid).and_raise(StandardError, 'solr is down')
+        allow(Honeybadger).to receive(:notify)
+      end
+
+      it 'does not raise and notifies Honeybadger' do
+        expect { next_steps }.not_to raise_error
+        expect(Honeybadger).to have_received(:notify).with(
+          an_instance_of(StandardError),
+          context: { druid: step.druid, workflow: step.workflow, process: step.process }
+        )
       end
     end
 

--- a/spec/services/workflow/state_batch_service_spec.rb
+++ b/spec/services/workflow/state_batch_service_spec.rb
@@ -6,6 +6,7 @@ require 'rails_helper'
 RSpec.describe Workflow::StateBatchService do
   before do
     allow(QueueService).to receive(:enqueue)
+    allow(Indexer).to receive(:reindex_by_druid)
   end
 
   describe '.accessioning_druids' do


### PR DESCRIPTION
## Why was this change made? 🤔
The current approach to avoiding concurrent indexing results in many reindexing retries. Most of those retries are redundant since no additional changes have been made since the last reindexing. This approach skips reindexing if the object has been reindexed after the reindexing request was made.

In addition, it changes the NextStepService to do synchronous indexing to help avoid indexing thrashing.

## How was this change tested? 🤨
Unit, stage

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



