### PR TITLE
Use lane-id for releaseWF created by PublishJob.

### DIFF
--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -141,7 +141,9 @@ class ObjectsController < ApplicationController # rubocop:disable Metrics/ClassL
     EventFactory.create(druid: params[:id], event_type: 'publish_request_received',
                         data: { background_job_result_id: result.id })
     # This will also start a releaseWF.
-    PublishJob.set(queue: publish_queue).perform_later(druid: params[:id], background_job_result: result, release: true)
+    PublishJob.set(queue: publish_queue)
+              .perform_later(druid: params[:id], background_job_result: result, release: true,
+                             lane_id: params['lane-id'])
     head :created, location: result
   end
 

--- a/app/jobs/publish_job.rb
+++ b/app/jobs/publish_job.rb
@@ -10,7 +10,8 @@ class PublishJob < ApplicationJob
   #  be published.
   # @param [BackgroundJobResult] background_job_result identifier of a background job result to store status info
   # @param [Boolean] release whether to release after publishing
-  def perform(druid:, background_job_result:, user_version: nil, release: false)
+  # @param [String,nil] lane_id the identifier of the lane to be used for releaseWF, if release is true
+  def perform(druid:, background_job_result:, user_version: nil, release: false, lane_id: nil)
     background_job_result.processing!
     cocina_object = CocinaObjectStore.find(druid)
 
@@ -28,8 +29,7 @@ class PublishJob < ApplicationJob
                         data: { background_job_result_id: background_job_result.id })
 
     if release
-      Workflow::Service.create(druid:, workflow_name: 'releaseWF',
-                               version: cocina_object.version)
+      Workflow::Service.create(druid:, workflow_name: 'releaseWF', version: cocina_object.version, lane_id: lane_id)
     end
 
     background_job_result.complete!

--- a/spec/jobs/publish_job_spec.rb
+++ b/spec/jobs/publish_job_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe PublishJob do
   subject(:perform) do
-    described_class.perform_now(druid:, background_job_result: result, release:)
+    described_class.perform_now(druid:, background_job_result: result, release:, lane_id: 'low')
   end
 
   let(:druid) { 'druid:mk420bs7601' }
@@ -52,7 +52,7 @@ RSpec.describe PublishJob do
 
     it 'starts a releaseWF' do
       expect(Workflow::Service).to have_received(:create).with(druid:, workflow_name: 'releaseWF',
-                                                               version: 2)
+                                                               version: 2, lane_id: 'low')
     end
   end
 

--- a/spec/requests/publish_object_spec.rb
+++ b/spec/requests/publish_object_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe 'Publish object' do
 
   # This happens when Argo invokes the API
   it 'calls Publish::MetadataTransferService and returns 201' do
-    post "/v1/objects/#{druid}/publish", headers: { 'Authorization' => "Bearer #{jwt}" }
+    post "/v1/objects/#{druid}/publish?lane-id=low", headers: { 'Authorization' => "Bearer #{jwt}" }
 
     expect(job).to have_received(:perform_later)
-      .with(druid:, background_job_result: BackgroundJobResult, release: true)
+      .with(druid:, background_job_result: BackgroundJobResult, release: true, lane_id: 'low')
     expect(response).to have_http_status(:created)
   end
 end


### PR DESCRIPTION
refs #5959

## Why was this change made? 🤔
So that all aspects of republishing use the intended queue. Otherwise, low republishing may interfere with higher priority accessioning.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



