### PR TITLE
Adds lane id param to release tags create endpoint.

### DIFF
--- a/app/controllers/release_tags_controller.rb
+++ b/app/controllers/release_tags_controller.rb
@@ -26,7 +26,7 @@ class ReleaseTagsController < ApplicationController
   end
 
   def create
-    ReleaseTagService.create(cocina_object: @cocina_object, tag: new_tag)
+    ReleaseTagService.create(cocina_object: @cocina_object, tag: new_tag, lane_id: params[:'lane-id'])
     head :created
   end
 

--- a/app/services/release_tag_service.rb
+++ b/app/services/release_tag_service.rb
@@ -11,7 +11,8 @@ class ReleaseTagService
   # @param [Dor::ReleaseTag] tag
   # @param [Cocina::Models::DROWithMetadata|CollectionWithMetadata|AdminPolicyWithMetadata] cocina_object
   # @param [Boolean] create_only or reindex and releaseWF workflow after creating the tag, defaults to false
-  def self.create(tag:, cocina_object:, create_only: false)
+  # @param [String] lane_id for releaseWF
+  def self.create(tag:, cocina_object:, create_only: false, lane_id: nil)
     ReleaseTag.from_cocina(druid: cocina_object.externalIdentifier, tag:).save!
     return if create_only
 
@@ -19,7 +20,7 @@ class ReleaseTagService
     return unless Publish::Item.new(druid: cocina_object.externalIdentifier).published?
 
     Workflow::Service.create(workflow_name: 'releaseWF', druid: cocina_object.externalIdentifier,
-                             version: cocina_object.version)
+                             version: cocina_object.version, lane_id:)
   end
 
   # Retrieve the latest release tags for each release target for an item

--- a/openapi.yml
+++ b/openapi.yml
@@ -585,6 +585,10 @@ paths:
           required: true
           schema:
             $ref: "https://raw.githubusercontent.com/sul-dlss/cocina-models/refs/tags/v0.113.0/schema.json#/$defs/Druid"
+        - name: lane-id
+          in: query
+          schema:
+            $ref: "#/components/schemas/LaneId"
       requestBody:
         description: release tag to add to the system
         content:

--- a/spec/requests/release_tags_spec.rb
+++ b/spec/requests/release_tags_spec.rb
@@ -74,12 +74,12 @@ RSpec.describe 'Operations on release tags' do
     before { allow(ReleaseTagService).to receive(:create) }
 
     it 'creates a tag' do
-      post "/v1/objects/#{druid}/release_tags",
+      post "/v1/objects/#{druid}/release_tags?lane-id=low",
            headers: auth_headers.merge('Content-Type' => 'application/json'),
            params: data
       expect(response).to have_http_status :created
       expect(ReleaseTagService).to have_received(:create).with(cocina_object: cocina_object_with_metadata,
-                                                               tag: an_instance_of(Dor::ReleaseTag))
+                                                               tag: an_instance_of(Dor::ReleaseTag), lane_id: 'low')
     end
   end
 end

--- a/spec/services/release_tag_service_spec.rb
+++ b/spec/services/release_tag_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ReleaseTagService do
   let(:druid) { 'druid:bb004bn8654' }
 
   describe '.create' do
-    subject(:create_tag) { described_class.create(cocina_object:, tag:) }
+    subject(:create_tag) { described_class.create(cocina_object:, tag:, lane_id: 'low') }
 
     let(:tag) { Dor::ReleaseTag.new(to: 'Earthworks', what: 'self', who: 'cathy', date: 2.days.ago.iso8601) }
     let(:cocina_object) { instance_double(Cocina::Models::DROWithMetadata, externalIdentifier: druid, version: 2) }
@@ -21,8 +21,8 @@ RSpec.describe ReleaseTagService do
     it 'adds another release tag' do
       expect { create_tag }.to change { ReleaseTag.where(druid:).count }.by(1)
       expect(Indexer).to have_received(:reindex).with(cocina_object:)
-      expect(Workflow::Service).to have_received(:create).with(workflow_name: 'releaseWF',
-                                                               druid:, version: 2)
+      expect(Workflow::Service).to have_received(:create)
+        .with(workflow_name: 'releaseWF', druid:, version: 2, lane_id: 'low')
     end
 
     context 'when create_only is true' do


### PR DESCRIPTION
refs #5959

## Why was this change made? 🤔
So that Argo bulk action can create tags on the low queue.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



