### PR TITLE
Skip Folio releaseWF steps when no Folio catalog link.

### DIFF
--- a/app/jobs/robots/dor_repo/release/start.rb
+++ b/app/jobs/robots/dor_repo/release/start.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Robots
+  module DorRepo
+    module Release
+      # Start the release workflow for an object
+      class Start < Robots::Robot
+        def initialize
+          super('releaseWF', 'start')
+        end
+
+        def perform_work
+          # If the cocina_object is not associated with an HRID or a previous HRID
+          # then mark the Folio steps as skipped.
+          return if cocina_object.identification.catalogLinks.any?(Cocina::Models::FolioCatalogLink)
+
+          Workflow::ProcessService.update(druid:, workflow_name:, process: 'update-marc', status: 'skipped')
+          Workflow::ProcessService.update(druid:, workflow_name:, process: 'update-holdings', status: 'skipped')
+        end
+      end
+    end
+  end
+end

--- a/app/services/queue_service.rb
+++ b/app/services/queue_service.rb
@@ -33,6 +33,7 @@ class QueueService
     'Robots::DorRepo::Accession::UpdateDoi',
     'Robots::DorRepo::Accession::UpdateOrcidWork',
     'Robots::DorRepo::Goobi::GoobiNotify',
+    'Robots::DorRepo::Release::Start',
     'Robots::DorRepo::Release::ReleaseMembers',
     'Robots::DorRepo::Release::ReleasePublish',
     'Robots::DorRepo::Release::UpdateHoldings'

--- a/config/workflows/releaseWF.xml
+++ b/config/workflows/releaseWF.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <workflow-def id="releaseWF">
-  <process name="start" skip-queue="true" status="completed">
+  <process name="start">
     <label>Initiate item release of the object</label>
   </process>
   <process name="release-members">

--- a/spec/jobs/robots/dor_repo/release/start_spec.rb
+++ b/spec/jobs/robots/dor_repo/release/start_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Robots::DorRepo::Release::Start, type: :robot do
+  subject(:perform) { test_perform(robot, druid) }
+
+  let(:druid) { 'druid:zz000zz0001' }
+  let(:robot) { described_class.new }
+
+  before do
+    allow(CocinaObjectStore).to receive(:find).with(druid).and_return(object)
+    allow(Workflow::ProcessService).to receive(:update)
+  end
+
+  context 'when the object has a Folio catalog link' do
+    let(:object) do
+      build(:dro, id: druid).new(identification: {
+                                   sourceId: 'sul:123',
+                                   catalogLinks: [{ catalog: 'folio', catalogRecordId: 'in00000000001' }]
+                                 })
+    end
+
+    it 'returns early without skipping any workflow steps' do
+      perform
+      expect(Workflow::ProcessService).not_to have_received(:update)
+    end
+  end
+
+  context 'when the object has no Folio catalog link' do
+    let(:object) { build(:dro, id: druid) }
+
+    it 'skips update-marc and update-holdings workflow steps' do
+      perform
+      expect(Workflow::ProcessService).to have_received(:update).with(druid:, workflow_name: 'releaseWF',
+                                                                      process: 'update-marc', status: 'skipped')
+      expect(Workflow::ProcessService).to have_received(:update).with(druid:, workflow_name: 'releaseWF',
+                                                                      process: 'update-holdings', status: 'skipped')
+    end
+  end
+end


### PR DESCRIPTION
closes #5974

## Why was this change made? 🤔
To avoid unnecessary bottlenecks around Folio robot steps.


## How was this change tested? 🤨
Unit, Andrew

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



