### PR TITLE
Fixes GisAssemblyWF start-accession prereq

### DIFF
--- a/config/workflows/gisAssemblyWF.xml
+++ b/config/workflows/gisAssemblyWF.xml
@@ -44,7 +44,7 @@
     <label>Finalize assembly workflow to prepare for assembly/delivery/discovery</label>
   </process>
   <process name="start-accession-workflow">
-    <prereq>metadata-cleanup</prereq>
+    <prereq>finish-gis-assembly-workflow</prereq>
     <label>Initiate accession workflow for the object</label>
   </process>
 </workflow-def>


### PR DESCRIPTION
## Why was this change made? 🤔
To allow WF to finish.


## How was this change tested? 🤨
Unit. Tested on stage with GIS vector integration test and realized that the files are not in place with just the change. So there may be other fixes to GISAssemblyWF needed here or in gis-robot-suite
