### PR TITLE
Bring back the gisDeliveryWF definition file

### DIFF
--- a/config/workflows/gisDeliveryWF.xml
+++ b/config/workflows/gisDeliveryWF.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<workflow-def id="gisDeliveryWF">
+  <process name="start-gis-delivery-workflow" status="completed">
+    <label>Initiate delivery workflow for the object</label>
+  </process>
+  <process name="load-vector">
+    <prereq>start-gis-delivery-workflow</prereq>
+    <label>Load vector data into PostGIS database</label>
+  </process>
+  <process name="load-raster">
+    <prereq>load-vector</prereq>
+    <label>Load raster into GeoTIFF data store</label>
+  </process>
+  <process name="load-geoserver">
+    <prereq>load-raster</prereq>
+    <label>Load layers into GeoServer</label>
+  </process>
+  <process name="reset-geowebcache">
+    <prereq>load-geoserver</prereq>
+    <label>Reset GeoWebCache for the layer</label>
+  </process>
+  <process name="finish-gis-delivery-workflow">
+    <prereq>reset-geowebcache</prereq>
+    <label>Finalize delivery workflow for the object</label>
+  </process>
+  <process name="metadata-cleanup">
+    <prereq>finish-gis-delivery-workflow</prereq>
+    <label>Clean up staged object metadata</label>
+  </process>
+  <process name="start-accession-workflow">
+    <prereq>metadata-cleanup</prereq>
+    <label>Initiate accession workflow for the object</label>
+  </process>
+</workflow-def>

--- a/spec/services/workflow/template_service_spec.rb
+++ b/spec/services/workflow/template_service_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Workflow::TemplateService do
           captionWF
           digitizationWF
           gisAssemblyWF
+          gisDeliveryWF
           goobiWF
           ocrWF
           preservationAuditWF


### PR DESCRIPTION
This is needed so Argo can render the workflow grid, even though
the workflow won't be invoked any longer.

Fixes https://github.com/sul-dlss/argo/issues/5118.
