### PR TITLE
Allows update workflow steps without enqueueing next.

### DIFF
--- a/app/jobs/robots/dor_repo/release/start.rb
+++ b/app/jobs/robots/dor_repo/release/start.rb
@@ -14,8 +14,10 @@ module Robots
           # then mark the Folio steps as skipped.
           return if cocina_object.identification.catalogLinks.any?(Cocina::Models::FolioCatalogLink)
 
-          Workflow::ProcessService.update(druid:, workflow_name:, process: 'update-marc', status: 'skipped')
-          Workflow::ProcessService.update(druid:, workflow_name:, process: 'update-holdings', status: 'skipped')
+          Workflow::ProcessService.update(druid:, workflow_name:, process: 'update-marc', status: 'skipped',
+                                          enqueue_next_steps: false)
+          Workflow::ProcessService.update(druid:, workflow_name:, process: 'update-holdings', status: 'skipped',
+                                          enqueue_next_steps: false)
         end
       end
     end

--- a/app/services/workflow/process_service.rb
+++ b/app/services/workflow/process_service.rb
@@ -4,8 +4,9 @@ module Workflow
   # Service for interacting with workflows processes (steps).
   class ProcessService
     def self.update(druid:, workflow_name:, process:, status:, elapsed: 0, lifecycle: nil, note: nil, # rubocop:disable Metrics/ParameterLists
-                    current_status: nil)
-      new(druid:, workflow_name:, process:).update(status:, elapsed:, lifecycle:, note:, current_status:)
+                    current_status: nil, enqueue_next_steps: true)
+      new(druid:, workflow_name:, process:).update(status:, elapsed:, lifecycle:, note:, current_status:,
+                                                   enqueue_next_steps:)
     end
 
     def self.update_error(druid:, workflow_name:, process:, error_msg:, error_text: nil)
@@ -27,11 +28,12 @@ module Workflow
     # @param [String] lifecycle Bookeeping label for this particular workflow step.  Examples: 'registered', 'shelved'
     # @param [String] note Any kind of string annotation that you want to attach to the workflow
     # @param [String] current_status Compare the current status to this value and raise if mismatch.
+    # @param [Boolean] enqueue_next_steps Whether to enqueue the next steps in the workflow.
     # @raise [Workflow::Service::ConflictException] if the current status does not match the passed in current_status.
     # @raise [Workflow::Service::NotFoundException] if the workflow step is not found.
-    def update(status:, elapsed: 0, lifecycle: nil, note: nil,
-               current_status: nil)
-      update_status(status:, elapsed:, lifecycle:, note:, current_status:)
+    def update(status:, elapsed: 0, lifecycle: nil, note: nil, # rubocop:disable Metrics/ParameterLists
+               current_status: nil, enqueue_next_steps: true)
+      update_status(status:, elapsed:, lifecycle:, note:, current_status:, enqueue_next_steps:)
     end
 
     # Updates the status of one step in a workflow to error.
@@ -50,7 +52,7 @@ module Workflow
     end
 
     def update_status(status:, elapsed: 0, lifecycle: nil, note: nil, # rubocop:disable Metrics/ParameterLists
-                      current_status: nil, error_msg: nil, error_text: nil)
+                      current_status: nil, error_msg: nil, error_text: nil, enqueue_next_steps: true)
       parser = ProcessParser.new(status:, elapsed:, lifecycle:, note:,
                                  error_msg:, error_txt: error_text, use_default_lane_id: false)
 
@@ -66,7 +68,7 @@ module Workflow
       end
 
       # Enqueue next steps
-      Workflow::NextStepService.enqueue_next_steps(step:)
+      Workflow::NextStepService.enqueue_next_steps(step:) if enqueue_next_steps
     end
 
     def find_step_for_process

--- a/spec/jobs/robots/dor_repo/release/start_spec.rb
+++ b/spec/jobs/robots/dor_repo/release/start_spec.rb
@@ -32,10 +32,12 @@ RSpec.describe Robots::DorRepo::Release::Start, type: :robot do
 
     it 'skips update-marc and update-holdings workflow steps' do
       perform
-      expect(Workflow::ProcessService).to have_received(:update).with(druid:, workflow_name: 'releaseWF',
-                                                                      process: 'update-marc', status: 'skipped')
-      expect(Workflow::ProcessService).to have_received(:update).with(druid:, workflow_name: 'releaseWF',
-                                                                      process: 'update-holdings', status: 'skipped')
+      expect(Workflow::ProcessService)
+        .to have_received(:update).with(druid:, workflow_name: 'releaseWF',
+                                        process: 'update-marc', status: 'skipped', enqueue_next_steps: false)
+      expect(Workflow::ProcessService)
+        .to have_received(:update).with(druid:, workflow_name: 'releaseWF',
+                                        process: 'update-holdings', status: 'skipped', enqueue_next_steps: false)
     end
   end
 end

--- a/spec/services/workflow/process_service_spec.rb
+++ b/spec/services/workflow/process_service_spec.rb
@@ -97,6 +97,17 @@ RSpec.describe Workflow::ProcessService do
         expect(Workflow::NextStepService).to have_received(:enqueue_next_steps).with(step: version2_step)
       end
     end
+
+    context 'when enqueue_next_steps is false' do
+      let(:step) { create(:workflow_step) }
+
+      it 'does not enqueue next steps' do
+        described_class.update(druid: step.druid, workflow_name: step.workflow, process: step.process,
+                               status: 'completed', enqueue_next_steps: false)
+
+        expect(Workflow::NextStepService).not_to have_received(:enqueue_next_steps)
+      end
+    end
   end
 
   describe '.update_error' do


### PR DESCRIPTION
refs #5974

## Why was this change made? 🤔
In the releaseWF stop robot, marking `update-marc` as skipped was causing `update-holdings` to be enqueued before it could be skipped.


## How was this change tested? 🤨
Unit, stage

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



