### PR TITLE
Add property existence with no hrid report

### DIFF
--- a/app/reports/property_existence_collections_without_hrid.rb
+++ b/app/reports/property_existence_collections_without_hrid.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Report collection objects with occurrences of a property.
+#  it is expected the property is an array, and we are selecting non-empty arrays with '? (@.size() > 0))'
+#  To check for property of type string, or to include empty arrays, remove '? (@.size() > 0))' from JSON_PATH
+
+# Invoke via:
+# bin/rails r -e production "PropertyExistenceCollections.report"
+class PropertyExistenceCollectionsWithoutHrid
+  # NOTE: JSON_PATH may need to be changed, in addition to PROPERTY
+
+  # this can be any JSON PATH desired, not just single property, e.g. 'contributor.type'
+  PROPERTY = 'groupedValue' # could also be, e.g. 'contributor.type'
+
+  # NOTE: checking the size allows checking for only non-empty arrays;  we may have empty arrays, too.
+  # NOTE: Prefer strict JSON querying over lax when using the `.**` operator, per
+  #       https://www.postgresql.org/docs/14/functions-json.html#STRICT-AND-LAX-MODES
+  JSON_PATH = "strict $.**.#{PROPERTY} ? (@.size() > 0)".freeze # when property is array
+
+  SQL = <<~SQL.squish.freeze
+    SELECT ro.external_identifier as collection_druid
+           FROM repository_objects AS ro, repository_object_versions AS rov
+           WHERE ro.head_version_id = rov.id
+           AND ro.object_type = 'collection'
+           AND jsonb_path_exists(rov.description, '#{JSON_PATH}')
+           AND NOT jsonb_path_exists(rov.identification, '$.catalogLinks[*] ? (@.catalog == "folio").catalogRecordId')
+  SQL
+
+  def self.report
+    puts "collection_druid,collection_name,collections with #{PROPERTY}\n"
+    rows(SQL).compact.each { |row| puts row }
+  end
+
+  def self.rows(sql_query)
+    sql_result_rows = ActiveRecord::Base.connection.execute(sql_query).to_a
+
+    sql_result_rows.map do |row|
+      collection_druid = row['collection_druid']
+      collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+
+      [
+        collection_druid,
+        collection_name
+      ].to_csv
+    end
+  end
+end

--- a/app/reports/property_existence_collections_without_hrid.rb
+++ b/app/reports/property_existence_collections_without_hrid.rb
@@ -5,7 +5,7 @@
 #  To check for property of type string, or to include empty arrays, remove '? (@.size() > 0))' from JSON_PATH
 
 # Invoke via:
-# bin/rails r -e production "PropertyExistenceCollections.report"
+# bin/rails r -e production "PropertyExistenceCollectionsWithoutHrid.report"
 class PropertyExistenceCollectionsWithoutHrid
   # NOTE: JSON_PATH may need to be changed, in addition to PROPERTY
 

--- a/app/reports/property_existence_dros_without_hrid.rb
+++ b/app/reports/property_existence_dros_without_hrid.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Report dro objects with occurrences of a property.
+#
+# Invoke via: `bin/rails r -e production PropertyExistenceDrosWithoutHrid.report`
+class PropertyExistenceDrosWithoutHrid
+  # This name is misleading: it can be any valid JSON path desired, not just a
+  # single property, e.g. `contributor[*].type`, `groupedValue`,
+  # `relatedResource.**.relatedResource`
+  PROPERTY = 'groupedValue'
+
+  # JSON_PATH may need to be changed, in addition to PROPERTY, depending on
+  # whether or not you're dealing with an array-like property. If the value of
+  # PROPERTY is array-like, and you don't care about empties, make sure
+  # JSON_PATH ends with `? (@.size() > 0))`
+
+  # NOTE: Prefer strict JSON querying over lax when using the `.**` operator, per
+  #       https://www.postgresql.org/docs/14/functions-json.html#STRICT-AND-LAX-MODES
+  JSON_PATH = "strict $.**.#{PROPERTY} ? (@.size() > 0)".freeze
+
+  SQL_QUERY = <<~SQL.squish.freeze
+    SELECT ro.external_identifier as item_druid,
+           jsonb_path_query(rov.description, '$.title[0].value') ->> 0 as title,
+           jsonb_path_query(rov.identification, '$.catalogLinks[*] ? (@.catalog == "folio").catalogRecordId') ->> 0 as folio_instance_hrid,
+           jsonb_path_query(rov.structural, '$.isMemberOf') ->> 0 as collection_druid
+           FROM repository_objects AS ro, repository_object_versions AS rov
+           WHERE ro.head_version_id = rov.id
+           AND ro.object_type = 'dro'
+           AND jsonb_path_exists(rov.description, '#{JSON_PATH}')
+           AND NOT jsonb_path_exists(rov.identification, '$.catalogLinks[*] ? (@.catalog == "folio").catalogRecordId')
+  SQL
+
+  def self.report
+    puts 'item_druid,item_title,collection_druid,folio_instance_hrid'
+
+    ActiveRecord::Base.connection.execute(SQL_QUERY).to_a.each do |row|
+      next if row.blank?
+
+      collection_name = RepositoryObject.collections.find_by(external_identifier: row['collection_druid'])&.head_version&.label
+
+      puts [
+        row['item_druid'],
+        row['title'],
+        row['collection_druid'],
+        collection_name
+      ].to_csv
+    end
+  end
+end

--- a/app/reports/property_existence_dros_without_hrid.rb
+++ b/app/reports/property_existence_dros_without_hrid.rb
@@ -21,7 +21,6 @@ class PropertyExistenceDrosWithoutHrid
   SQL_QUERY = <<~SQL.squish.freeze
     SELECT ro.external_identifier as item_druid,
            jsonb_path_query(rov.description, '$.title[0].value') ->> 0 as title,
-           jsonb_path_query(rov.identification, '$.catalogLinks[*] ? (@.catalog == "folio").catalogRecordId') ->> 0 as folio_instance_hrid,
            jsonb_path_query(rov.structural, '$.isMemberOf') ->> 0 as collection_druid
            FROM repository_objects AS ro, repository_object_versions AS rov
            WHERE ro.head_version_id = rov.id
@@ -31,7 +30,7 @@ class PropertyExistenceDrosWithoutHrid
   SQL
 
   def self.report
-    puts 'item_druid,item_title,collection_druid,folio_instance_hrid'
+    puts 'item_druid,item_title,collection_druid,collection_name'
 
     ActiveRecord::Base.connection.execute(SQL_QUERY).to_a.each do |row|
       next if row.blank?


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #5968 

Adds a copy of the PropertyExistenceDros report for Dros without HRID.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



