### PR TITLE
Update the definition for assembling_druids

### DIFF
--- a/app/services/workflow/state_batch_service.rb
+++ b/app/services/workflow/state_batch_service.rb
@@ -47,7 +47,7 @@ module Workflow
         .where.not(workflow: 'assemblyWF', process: 'accessioning-initiate')
         .where.not(workflow: 'wasCrawlPreassemblyWF', process: 'end-was-crawl-preassembly')
         .where.not(workflow: 'wasSeedPreassemblyWF', process: 'end-was-seed-preassembly')
-        .where.not(workflow: 'gisAssemblyWF', process: 'start-accession-workflow')
+        .where.not(workflow: 'gisAssemblyWF', process: 'start-derivative-workflow')
         .where.not(workflow: 'ocrWF', process: 'end-ocr')
         .where.not(workflow: 'speechToTextWF', process: 'end-stt')
         .select(:druid).distinct.pluck(:druid)


### PR DESCRIPTION
PR #5695 added the new gisDerivativeWF, but didn't update the
definition of assembling_druids to take it into account.
