### PR TITLE
Update ruby-rails orb to 4.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@4.8.0
+  ruby-rails: sul-dlss/ruby-rails@4.9.0
 workflows:
   build:
     jobs:


### PR DESCRIPTION
## Why was this change made? 🤔
So that docker images are build for amd64 and arm64.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



