### PR TITLE
Harden MARC event parsing and mapping

### DIFF
--- a/app/services/cocina/from_marc/event.rb
+++ b/app/services/cocina/from_marc/event.rb
@@ -3,7 +3,19 @@
 module Cocina
   module FromMarc
     # Maps event information from MARC records to Cocina models.
-    class Event # rubocop:disable Metrics/ClassLength
+    class Event
+      MARC_264_INDICATOR2 = {
+        '0' => { type: 'production', role: 'creator' },
+        '1' => { type: 'publication', role: 'publisher' },
+        '2' => { type: 'distribution', role: 'distributor' },
+        '3' => { type: 'manufacture', role: 'manufacturer' },
+        '4' => { type: 'copyright notice', role: '' },
+        ' ' => { type: nil, role: nil }
+      }.freeze
+
+      FREQUENCY_TAGS = %w[310 321].freeze
+      CREATION_RECORD_TYPES = %w[d f p t].freeze
+
       # @see #initialize
       # @see #build
       def self.build(...)
@@ -16,189 +28,129 @@ module Cocina
       end
 
       # @return [Array<Hash>] an array of event hashes
-      def build # rubocop:disable Metrics/AbcSize
+      def build
         [
-          publication_from008,
-          publication(marc['260']),
-          manufacture(marc['260']),
-          marc.fields.filter_map { production(it) if it.tag == '264' },
-          edition_statement(marc['250']),
-          frequency_statement,
-          mode_of_issuance(marc['334'])
+          event_from_008,
+          publication_events,
+          manufacture_event,
+          marc_264_events,
+          edition_events,
+          frequency_event,
+          issuance_event
         ].flatten.compact
       end
 
-      MARC_264_INDICATOR2 = {
-        '0' => { type: 'production', role: 'creator' },
-        '1' => { type: 'publication', role: 'publisher' },
-        '2' => { type: 'distribution', role: 'distributor' },
-        '3' => { type: 'manufacture', role: 'manufacturer' },
-        '4' => { type: 'copyright notice', role: '' },
-        ' ' => { type: nil, role: nil }
-      }.freeze
-
       private
 
-      def publication_from008
+      attr_reader :marc
+
+      def event_from_008 # rubocop:disable Naming/VariableNumber
         field = marc['008']
         return unless field
 
-        type = %w[d f p t].include?(marc.leader[6]) ? 'creation' : 'publication'
+        type = CREATION_RECORD_TYPES.include?(marc.leader[6]) ? 'creation' : 'publication'
+        date = EventDate.build(record_type: type, field:)
 
-        date = dates_from008(type, field)
-        { type:, date: } if date
+        return if date.blank?
+
+        { type:, date: }
       end
 
-      def dates_from008(type, field)
-        case field.value[6]
-        when 'm'
-          [{ value: field.value[7..10], type:, encoding: { code: 'marc' } },
-           { value: field.value[11..14], type:, encoding: { code: 'marc' } }]
-        when 'c', 'd', 'i', 'k', 'u'
-          build_range(type, field)
-        when 'q'
-          build_range(type, field, qualifier: 'questionable')
-        when 'n'
-          nil
-        else
-          [{ value: field.value[7..10], type:, encoding: { code: 'marc' } }]
+      def publication_events
+        build_linked_events(marc['260']) do |field|
+          EventDataFieldBuilder.build(
+            field:,
+            type: 'publication',
+            role: 'publisher',
+            location_codes: ['a'],
+            contributor_codes: ['b'],
+            date_code: 'c'
+          )
         end
       end
 
-      def build_range(type, field, qualifier: nil)
-        start_value = field.value[7..10]
-        end_value = field.value[11..14]
-        return if start_value.blank? || end_value.blank? # Invalid MARC
-
-        [{
-          structuredValue: [{ value: start_value, type: 'start' },
-                            { value: end_value, type: 'end' }],
-          type:, qualifier:, encoding: { code: 'marc' }
-        }.compact]
-      end
-
-      def production(field)
+      def manufacture_event
+        field = marc['260']
         return unless field
 
-        fields = [build_production(field)]
-        alt_script_field = Util.linked_field(marc, field)
-        fields << build_production(alt_script_field) if alt_script_field
-        fields
+        event = EventDataFieldBuilder.build(
+          field:,
+          type: 'manufacture',
+          role: 'manufacturer',
+          location_codes: ['e'],
+          contributor_codes: ['f'],
+          date_code: 'g',
+          strip_date_punctuation: false
+        )
+
+        event if event.except(:type).present?
       end
 
-      def build_production(field) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
-        indicator = MARC_264_INDICATOR2.fetch(field.indicator2)
-        return copyright(field) if indicator[:type] == 'copyright notice'
-
-        locations = field.subfields.filter_map { Util.strip_punctuation(it.value) if it.code == 'a' }
-        contributors = field.subfields.select { it.code == 'b' }.map(&:value)
-        date = field.subfields.find { it.code == 'c' }
-
-        event = { type: indicator[:type] }.compact_blank
-        event[:location] = locations.map { { value: it } } if locations.present?
-        contributor_template = indicator[:role] ? { role: [{ value: indicator[:role] }] } : {}
-        if contributors.present?
-          event[:contributor] = contributors.map do |contributor|
-            contributor_template.merge({ name: [{ value: Util.strip_punctuation(contributor) }] })
-          end
+      def marc_264_events
+        marc.fields.filter_map do |field|
+          build_linked_events(field) { |script_field| build_marc_264_event(script_field) } if field.tag == '264'
         end
-
-        event[:date] = [{ value: date.value.delete_suffix('.'), type: indicator[:type] }.compact_blank] if date
-
-        event
       end
 
-      def copyright(field)
-        date = field.subfields.find { it.code == 'c' }.value.delete_suffix('.')
+      def build_marc_264_event(field)
+        indicator = MARC_264_INDICATOR2.fetch(field.indicator2)
+        return copyright_event(field) if indicator[:type] == 'copyright notice'
+
+        EventDataFieldBuilder.build(
+          field:,
+          type: indicator[:type],
+          role: indicator[:role],
+          location_codes: ['a'],
+          contributor_codes: ['b'],
+          date_code: 'c'
+        )
+      end
+
+      def copyright_event(field)
+        date = field.subfields.find { it.code == 'c' }&.value&.delete_suffix('.')
+        return unless date
 
         { type: 'copyright notice', note: [{ value: date, type: 'copyright statement' }] }
       end
 
-      def edition_statement(field)
-        return unless field
-
-        fields = [build_edition_statement(field)]
-        alt_script_field = Util.linked_field(marc, field)
-        fields << build_edition_statement(alt_script_field) if alt_script_field
-        fields
+      def edition_events
+        build_linked_events(marc['250']) do |field|
+          statement = joined_subfield_values(field, 'a', 'b')
+          { type: 'publication', note: [{ value: statement, type: 'edition' }] }
+        end
       end
 
-      def build_edition_statement(field)
-        statement = field.subfields.select { %w[a b].include? it.code }.map(&:value).join(' ')
-        { type: 'publication', note: [{ value: statement, type: 'edition' }] }
-      end
-
-      def frequency_statement
+      def frequency_event
         notes = marc.fields.filter_map do |field|
-          if %w[310 321].include?(field.tag)
-            fields = [build_frequency_note(field)]
-            alt_script_field = Util.linked_field(marc, field)
-            fields << build_frequency_note(alt_script_field) if alt_script_field
-            fields
+          next unless FREQUENCY_TAGS.include?(field.tag)
+
+          build_linked_events(field) do |script_field|
+            { value: joined_subfield_values(script_field, 'a', 'b'), type: 'frequency' }
           end
         end.flatten
+
         { type: 'publication', note: notes } if notes.present?
       end
 
-      def build_frequency_note(field)
-        statement = field.subfields.select { %w[a b].include? it.code }.map(&:value).join(' ')
-        { value: statement, type: 'frequency' }
-      end
-
-      def mode_of_issuance(field)
+      def issuance_event
+        field = marc['334']
         return unless field
 
-        statement = field.subfields.find { %w[a].include? it.code }.value
+        statement = field.subfields.find { it.code == 'a' }&.value
+        return unless statement
+
         { note: [{ value: statement, type: 'issuance' }] }
       end
 
-      def publication(field)
+      def build_linked_events(field, &)
         return unless field
 
-        fields = [build_publication(field)]
-        alt_script_field = Util.linked_field(marc, field)
-        fields << build_publication(alt_script_field) if alt_script_field
-        fields
+        [field, Util.linked_field(marc, field)].compact.map(&)
       end
 
-      def build_publication(field) # rubocop:disable Metrics/AbcSize
-        publication_locations = field.subfields.filter_map { Util.strip_punctuation(it.value) if it.code == 'a' }
-        publisher_names = field.subfields.select { it.code == 'b' }.map(&:value)
-        contributor = publisher_names.map do |publisher_name|
-          { name: [{ value: Util.strip_punctuation(publisher_name) }],
-            role: [{ value: 'publisher' }] }
-        end
-        publication_date = field.subfields.find { it.code == 'c' }&.value&.delete_suffix('.')
-
-        date = [{ value: publication_date, type: 'publication' }] if publication_date
-        {
-          type: 'publication',
-          location: publication_locations.map { { value: it } },
-          contributor:,
-          date:
-        }.compact_blank
+      def joined_subfield_values(field, *codes)
+        field.subfields.select { |subfield| codes.include?(subfield.code) }.map(&:value).join(' ')
       end
-
-      def manufacture(field) # rubocop:disable Metrics/PerceivedComplexity,Metrics/AbcSize,Metrics/CyclomaticComplexity
-        return unless field
-
-        manufacture_location = field.subfields.find { |subfield| subfield.code == 'e' }&.value
-        manufacturer = field.subfields.find { |subfield| subfield.code == 'f' }&.value
-        manufacture_date = field.subfields.find { |subfield| subfield.code == 'g' }&.value
-        return nil unless manufacture_location || manufacturer || manufacture_date
-
-        event = { type: 'manufacture' }
-        event[:location] = [{ value: Util.strip_punctuation(manufacture_location) }] if manufacture_location.present?
-        if manufacturer.present?
-          event[:contributor] =
-            [{ name: [{ value: Util.strip_punctuation(manufacturer) }],
-               role: [{ value: 'manufacturer' }] }]
-        end
-        event[:date] = [{ value: manufacture_date, type: 'manufacture' }] if manufacture_date.present?
-        event
-      end
-
-      attr_reader :marc
     end
   end
 end

--- a/app/services/cocina/from_marc/event_data_field_builder.rb
+++ b/app/services/cocina/from_marc/event_data_field_builder.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Cocina
+  module FromMarc
+    # Builds a Cocina event hash from a MARC data field using configured
+    # subfield mappings for locations, contributors, and dates.
+    class EventDataFieldBuilder
+      # @see #initialize
+      # @see #build
+      def self.build(...)
+        new(...).build
+      end
+
+      def initialize(field:, type:, role:, location_codes:, contributor_codes:, date_code:, # rubocop:disable Metrics/ParameterLists
+                     strip_date_punctuation: true)
+        @field = field
+        @type = type
+        @role = role
+        @location_codes = location_codes
+        @contributor_codes = contributor_codes
+        @date_code = date_code
+        @strip_date_punctuation = strip_date_punctuation
+      end
+
+      def build
+        {
+          type:,
+          location: locations,
+          contributor: contributors,
+          date:
+        }.compact_blank
+      end
+
+      private
+
+      attr_reader :field, :type, :role, :location_codes, :contributor_codes, :date_code, :strip_date_punctuation
+
+      def locations
+        values_for(*location_codes).map { |value| { value: Util.strip_punctuation(value) } }.presence
+      end
+
+      def contributors
+        values = values_for(*contributor_codes)
+        return if values.blank?
+
+        values.map do |value|
+          {
+            name: [{ value: Util.strip_punctuation(value) }],
+            role: role_value
+          }.compact_blank
+        end
+      end
+
+      def role_value
+        [{ value: role }] if role.present?
+      end
+
+      def date
+        value = field.subfields.find { it.code == date_code }&.value
+        return if value.blank?
+
+        value = value.delete_suffix('.') if strip_date_punctuation
+        [{ value:, type: }.compact_blank]
+      end
+
+      def values_for(*codes)
+        field.subfields.filter_map { |subfield| subfield.value if codes.include?(subfield.code) }
+      end
+    end
+  end
+end

--- a/app/services/cocina/from_marc/event_date.rb
+++ b/app/services/cocina/from_marc/event_date.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+module Cocina
+  module FromMarc
+    # Maps event date information from MARC 008 field to Cocina
+    #
+    # 008/06 values are as follows:
+    #
+    #  * Indicating multiple dates: c, d, i, k, m, p, q, r, t, u
+    #  * Indicating single date: s (assumed single if space character or filler character, |)
+    #  * Indicating no date: n
+    #
+    # When the terminal date is open-ended (9999) or unknown (uuuu), map to a
+    # single-value structured date with only a `start` value.
+    class EventDate
+      OPEN_ENDED_DATE = '9999'
+      UNKNOWN_DATE = 'uuuu'
+      BLANK_DATE = '||||'
+      SIMPLE_RANGE_TYPES = %w[m].freeze
+      STRUCTURED_RANGE_TYPES = %w[c d i k q u].freeze
+
+      # @see #initialize
+      # @see #build
+      def self.build(...)
+        new(...).build
+      end
+
+      # @param record_type [String] the type of event being mapped, e.g. "publication", "creation"
+      # @param field [MARC::ControlField] the MARC control field containing event date information (008)
+      def initialize(record_type:, field:)
+        @type = record_type
+        @date_code = field.value[6]
+        @start_date = normalize_date(field.value[7..10])
+        @end_date = normalize_date(field.value[11..14])
+      end
+
+      # @return [Array<Hash>] an array of event date hashes
+      def build
+        return if no_date?
+        return structured_open_range if open_range?
+        return simple_range if simple_range?
+        return structured_range if structured_range?
+        return single_date if start_date
+
+        nil
+      end
+
+      private
+
+      attr_reader :type, :date_code, :start_date, :end_date
+
+      def no_date?
+        date_code == 'n'
+      end
+
+      def open_range?
+        start_date && [OPEN_ENDED_DATE, UNKNOWN_DATE].include?(end_date)
+      end
+
+      def simple_range?
+        SIMPLE_RANGE_TYPES.include?(date_code)
+      end
+
+      def structured_range?
+        STRUCTURED_RANGE_TYPES.include?(date_code)
+      end
+
+      def qualifier
+        return 'questionable' if date_code == 'q'
+
+        nil
+      end
+
+      def single_date
+        [date_hash(start_date)]
+      end
+
+      def simple_range
+        return single_date unless end_date
+
+        [date_hash(start_date), date_hash(end_date)]
+      end
+
+      def structured_open_range
+        [
+          {
+            structuredValue: [
+              { value: start_date, type: 'start' }
+            ],
+            type:,
+            encoding: { code: 'marc' }
+          }
+        ]
+      end
+
+      def structured_range
+        return unless start_date && end_date
+
+        [
+          {
+            structuredValue: [
+              { value: start_date, type: 'start' },
+              { value: end_date, type: 'end' }
+            ],
+            type:,
+            qualifier:,
+            encoding: { code: 'marc' }
+          }.compact
+        ]
+      end
+
+      def date_hash(value)
+        { value:, type:, encoding: { code: 'marc' } }
+      end
+
+      def normalize_date(date)
+        return if date.blank? || date == BLANK_DATE
+
+        date
+      end
+    end
+  end
+end

--- a/spec/services/cocina/from_marc/event_data_field_builder_spec.rb
+++ b/spec/services/cocina/from_marc/event_data_field_builder_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::FromMarc::EventDataFieldBuilder do
+  describe '.build' do
+    subject(:build) do
+      described_class.build(
+        field:,
+        type:,
+        role:,
+        location_codes:,
+        contributor_codes:,
+        date_code:,
+        strip_date_punctuation:
+      )
+    end
+
+    let(:type) { 'publication' }
+    let(:role) { 'publisher' }
+    let(:location_codes) { ['a'] }
+    let(:contributor_codes) { ['b'] }
+    let(:date_code) { 'c' }
+    let(:strip_date_punctuation) { true }
+    let(:field) do
+      MARC::DataField.new(
+        '264',
+        ' ',
+        '1',
+        ['a', 'Stanford, Calif. :'],
+        ['b', 'Stanford University Press,'],
+        ['c', '2019.']
+      )
+    end
+
+    it 'builds a normalized event hash' do
+      expect(build).to eq(
+        type: 'publication',
+        location: [{ value: 'Stanford, Calif.' }],
+        contributor: [{ name: [{ value: 'Stanford University Press' }], role: [{ value: 'publisher' }] }],
+        date: [{ value: '2019', type: 'publication' }]
+      )
+    end
+
+    context 'when multiple mapped subfields are present' do
+      let(:field) do
+        MARC::DataField.new(
+          '264',
+          ' ',
+          '1',
+          ['a', 'Paris :'],
+          ['a', 'London :'],
+          ['b', 'Publisher one :'],
+          ['b', 'Publisher two,'],
+          ['c', '[after 1803]']
+        )
+      end
+
+      it 'builds arrays for each mapped value' do
+        expect(build).to eq(
+          type: 'publication',
+          location: [{ value: 'Paris' }, { value: 'London' }],
+          contributor: [
+            { name: [{ value: 'Publisher one' }], role: [{ value: 'publisher' }] },
+            { name: [{ value: 'Publisher two' }], role: [{ value: 'publisher' }] }
+          ],
+          date: [{ value: '[after 1803]', type: 'publication' }]
+        )
+      end
+    end
+
+    context 'when no role is provided' do
+      let(:role) { nil }
+
+      it 'omits contributor roles' do
+        expect(build).to eq(
+          type: 'publication',
+          location: [{ value: 'Stanford, Calif.' }],
+          contributor: [{ name: [{ value: 'Stanford University Press' }] }],
+          date: [{ value: '2019', type: 'publication' }]
+        )
+      end
+    end
+
+    context 'when date punctuation should be preserved' do
+      let(:type) { 'manufacture' }
+      let(:role) { 'manufacturer' }
+      let(:location_codes) { ['e'] }
+      let(:contributor_codes) { ['f'] }
+      let(:date_code) { 'g' }
+      let(:strip_date_punctuation) { false }
+      let(:field) do
+        MARC::DataField.new(
+          '260',
+          ' ',
+          ' ',
+          ['e', '(Twickenham :'],
+          ['f', 'CTD Printers,'],
+          ['g', '1974)']
+        )
+      end
+
+      it 'keeps the original date value' do
+        expect(build).to eq(
+          type: 'manufacture',
+          location: [{ value: '(Twickenham' }],
+          contributor: [{ name: [{ value: 'CTD Printers' }], role: [{ value: 'manufacturer' }] }],
+          date: [{ value: '1974)', type: 'manufacture' }]
+        )
+      end
+    end
+
+    context 'when only the type is present' do
+      let(:field) { MARC::DataField.new('264', ' ', '1') }
+
+      it 'returns only the type' do
+        expect(build).to eq(type: 'publication')
+      end
+    end
+  end
+end

--- a/spec/services/cocina/from_marc/event_date_spec.rb
+++ b/spec/services/cocina/from_marc/event_date_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cocina::FromMarc::EventDate do
+  describe '.build' do
+    subject(:build) do
+      described_class.build(record_type:, field: MARC::ControlField.new('008', field_value))
+    end
+
+    let(:record_type) { 'publication' }
+    let(:date_code) { 's' }
+    let(:initial_date) { '2019' }
+    let(:terminal_date) { '    ' }
+    let(:field_value) { "000000#{date_code}#{initial_date}#{terminal_date}" }
+
+    context 'when 008/06 indicates multiple dates but terminal date is blank' do
+      let(:date_code) { 'm' }
+      let(:initial_date) { '1844' }
+
+      it 'returns a single encoded date' do
+        expect(build).to eq([
+                              { value: '1844', type: 'publication', encoding: { code: 'marc' } }
+                            ])
+      end
+    end
+
+    context 'when 008/06 indicates multiple dates and both dates are present' do
+      let(:date_code) { 'm' }
+      let(:initial_date) { '2017' }
+      let(:terminal_date) { '2018' }
+
+      it 'returns both encoded dates' do
+        expect(build).to eq([
+                              { value: '2017', type: 'publication', encoding: { code: 'marc' } },
+                              { value: '2018', type: 'publication', encoding: { code: 'marc' } }
+                            ])
+      end
+    end
+
+    context 'when the date range is open ended' do
+      let(:date_code) { 'c' }
+      let(:initial_date) { '2017' }
+      let(:terminal_date) { '9999' }
+
+      it 'returns a structured date with only a start value' do
+        expect(build).to eq([
+                              {
+                                structuredValue: [
+                                  { value: '2017', type: 'start' }
+                                ],
+                                type: 'publication',
+                                encoding: { code: 'marc' }
+                              }
+                            ])
+      end
+    end
+
+    context 'when the date range has an unknown end' do
+      let(:date_code) { 'c' }
+      let(:initial_date) { '2017' }
+      let(:terminal_date) { 'uuuu' }
+
+      it 'returns a structured date with only a start value' do
+        expect(build).to eq([
+                              {
+                                structuredValue: [
+                                  { value: '2017', type: 'start' }
+                                ],
+                                type: 'publication',
+                                encoding: { code: 'marc' }
+                              }
+                            ])
+      end
+    end
+
+    context 'when the date code is uncoded and the initial date is present' do
+      let(:date_code) { ' ' }
+      let(:initial_date) { '2024' }
+
+      it 'treats the value as a single encoded date' do
+        expect(build).to eq([
+                              { value: '2024', type: 'publication', encoding: { code: 'marc' } }
+                            ])
+      end
+    end
+
+    context 'when a structured range is missing its initial date' do
+      let(:date_code) { 'q' }
+      let(:initial_date) { '||||' }
+      let(:terminal_date) { '1965' }
+
+      it 'returns nothing' do
+        expect(build).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/cocina/from_marc/event_spec.rb
+++ b/spec/services/cocina/from_marc/event_spec.rb
@@ -1083,6 +1083,41 @@ RSpec.describe Cocina::FromMarc::Event do
       end
     end
 
+    context 'when 008/06 indicates multiple dates but terminal date is blank' do
+      # see a2119728
+      let(:marc_hash) do
+        {
+          'leader' => '01321cam a2200337 4500',
+          'fields' => [
+            { '008' => '730514m1844    fr b          000 0 fre  ' }
+          ]
+        }
+      end
+
+      it 'returns creation event with encoded date' do
+        expect(build).to eq [{
+          type: 'publication',
+          date: [{ value: '1844', type: 'publication', encoding: { code: 'marc' } }]
+        }]
+      end
+    end
+
+    context 'when 008/06 is uncoded and initial date is blank' do
+      # see a12113669
+      let(:marc_hash) do
+        {
+          'leader' => '02419nem a2200457uu 4500',
+          'fields' => [
+            { '008' => '240711      |||||| |  || |  || | |      ' }
+          ]
+        }
+      end
+
+      it 'returns nothing' do
+        expect(build).to eq []
+      end
+    end
+
     context 'with encoded publication date range (008)' do
       let(:marc_hash) do
         {


### PR DESCRIPTION
# Why was this change made?

Fixes #5920

This commit adds handling for a couple event date cases and extracts the date
parsing and field-building logic into dedicated helper classes.

The two newly handled cases:

* The 008/06 event date is marked as multiple but dates, use the two 008 date
  values to build a range
* The 008/06 value is blank (whitespace) or marked with a filler character (`|`)

The extracted helpers make this logic easier to test and keep the main event
mapper focused on assembling Cocina events.

# How was this change tested?

- [x] CI
- [x] stage
