### PR TITLE
Enhance bin/export-cocina-head-versions and add to schedule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,19 +220,21 @@ Custom reports are stored in dor-services-app in the `app/reports` directory.  E
 
 ### Export Cocina JSON data
 
-You may want to export a full dataset of Cocina JSON to do validation on your local machine to run Cocina validation or [jq](https://jqlang.org/) queries.
+You may want to export a full dataset of Cocina JSON perform actions like the following on your local machine:
+* Run validation. See `bin/validata-data` (in cocina-models). 
+* Create reports using [jq](https://jqlang.org/) queries. See the `/cocina-jq-query` skill (also in cocina-models).
 
-To export data, in a screen session:
+To export data, in a screen session on `sdr-deploy`:
 
 1. `ksu deploy`
 2. Export the database variables as above.
-3. `cd /sdrmd/cocina`
-4. Delete any existing `*.jsonl.xz` that are no longer necessary.
-5. Export in parallel: `RAILS_ENV=production ~/dor-services-app/bin/export-cocina-head-versions -p12`
-6. Compress: `cat *.jsonl | xz -T 8 > cocina-head-versions-$(date +%Y-%m-%d).jsonl.xz`
-7. Remove the temporary files: `rm *.jsonl`
+3. `cd ~/dor-services-app`
+4. Export in parallel: `RAILS_ENV=production bin/export-cocina-head-versions -p12 -r --output-dir /sdrmd/cocina`
 
-Once this is done, you may download the file to your local computer and run `bin/validate-data` (from cocina-models). See also the `/cocina-jq-query` skill (also in cocina-models).
+Once this is done, you may download the file to your local computer from `/sdrmd/cocina`.
+
+#### Scheduled Cocina JSON data exports
+Periodic data exports are available from `/dor/cocina_dump` in all environments. (See `schedule.rb`.)
 
 ### Generate a list of druids from Solr query
 

--- a/bin/export-cocina-head-versions
+++ b/bin/export-cocina-head-versions
@@ -11,11 +11,16 @@ require 'tty-progressbar'
 APPROX_DOC_COUNT = 5_483_724
 BATCH_SIZE = 1000
 
-options = { processes: 4 }
+options = { processes: 4, output_dir: '.' }
 parser = OptionParser.new do |option_parser|
   option_parser.banner = 'Usage: bin/export-cocina-head-versions [options]'
   option_parser.on('-pPROCESSES', '--processes PROCESSES', Integer,
                    "Number of processes. Default is #{options[:processes]}.")
+  option_parser.on('-oOUTPUT_DIR', '--output-dir OUTPUT_DIR', String,
+                   'Directory to write output files. Default is current directory.') do |dir|
+    options[:output_dir] = dir
+  end
+  option_parser.on('-r', '--rotate', 'Delete all but the 2 most recent .jsonl.xz files in the output directory.')
   option_parser.on('-h', '--help', 'Displays help.') do
     puts option_parser
     exit
@@ -41,15 +46,35 @@ def tty_progress_bar(count)
   )
 end
 
-def export(processes)
+def compress(output_dir, env)
+  compressed_filename = "cocina-head-versions-#{env}-#{Time.zone.today.iso8601}.jsonl.xz"
+  compressed_path = File.join(output_dir, compressed_filename)
+  puts "\nCompressing to #{compressed_path} ..."
+  system("cat #{File.join(output_dir, '*.jsonl')} | xz -T 8 > #{compressed_path}") || abort('Compression failed')
+  puts "Compressed to #{compressed_path}"
+  compressed_path
+end
+
+def rotate(output_dir)
+  old_files = Dir[File.join(output_dir, 'cocina-head-versions-*.jsonl.xz')]
+              .sort_by { |f| File.mtime(f) }
+              .reverse
+              .drop(2)
+  old_files.each do |path|
+    FileUtils.rm_f(path)
+    puts "Rotated #{path}"
+  end
+end
+
+def export(processes, output_dir, env)
   obj_ids = RepositoryObject.ids
   progress_bar = tty_progress_bar(APPROX_DOC_COUNT)
 
   Parallel.map(obj_ids.each_slice(1000).with_index,
                in_processes: processes,
                finish: ->(_, _, _results) { progress_bar.advance(1000) }) do |slice_obj_ids, index|
-                 @file ||= File.open("cocina-head-versions-#{Time.zone.today.iso8601}-#{format('%02d', index)}.jsonl",
-                                     'w')
+                 filename = "cocina-head-versions-#{env}-#{format('%02d', index)}.jsonl"
+                 @file ||= File.open(File.join(output_dir, filename), 'w')
                  RepositoryObject.includes(:head_version).where(id: slice_obj_ids).find_each do |repository_object|
                    repository_object.head_version.repository_object = repository_object # avoid N+1 query
                    @file.write("#{repository_object.head_version.to_cocina(validate: false).to_json}\n")
@@ -58,8 +83,22 @@ def export(processes)
                end
 end
 
-paths = export(options[:processes])
-puts 'Exported to:'
-paths.each do |path|
-  puts path
+jsonl_paths = []
+env = Honeybadger.config[:env]
+
+begin
+  jsonl_paths = export(options[:processes], options[:output_dir], env)
+  puts 'Exported to:'
+  jsonl_paths.each do |path|
+    puts path
+  end
+
+  output_dir = options[:output_dir]
+  compress(output_dir, env)
+
+  rotate(output_dir) if options[:rotate]
+ensure
+  jsonl_paths.each do |path|
+    FileUtils.rm_f(path)
+  end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -36,6 +36,9 @@ job_type :rake_hb,
 job_type :runner_hb,
          "cd :path && bin/rails runner -e :environment ':task' :output && curl --silent https://api.honeybadger.io/v1/check_in/:check_in"
 
+job_type :bin,
+         'cd :path && RAILS_ENV=:environment :task :output'
+
 # Suppress warnings to avoid unnecessary cron emails.
 env 'RUBYOPT', '-W0'
 
@@ -58,4 +61,8 @@ end
 every :friday, at: '8:00pm' do
   set :check_in, Settings.honeybadger_checkins.reindex_jobs
   rake_hb 'indexer:reindex_jobs'
+end
+
+every :day, at: '2:00am' do
+  bin 'bin/export-cocina-head-versions -p6 -r --output-dir /dor/cocina_dump > /dev/null'
 end


### PR DESCRIPTION
closes #6078

## Why was this change made? 🤔
So that data dumps are available to speed up querying / mediating / validating.


## How was this change tested? 🤨
QA

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



