### PR TITLE
Fix raising ArgumentError in migration runner.

### DIFF
--- a/app/services/migrators/migration_runner.rb
+++ b/app/services/migrators/migration_runner.rb
@@ -28,7 +28,7 @@ module Migrators
       @repository_object = repository_object
       @mode = mode
 
-      raise ArgumentError("invalid mode #{mode}") unless MODES.include?(mode)
+      raise ArgumentError, "invalid mode #{mode}" unless MODES.include?(mode)
     end
 
     # @return [Array<Result>] results for the migration attempt

--- a/bin/migrate-cocina
+++ b/bin/migrate-cocina
@@ -98,10 +98,11 @@ job_result_ids = if File.exist?(LAST_MIGRATION_FILENAME)
                    JSON.parse(File.read(LAST_MIGRATION_FILENAME))
                  elsif options[:file]
                    start_migrate_from_file(migrator_class:, sample: options[:sample], processes: options[:processes],
-                                           mode: options[:mode], batch_size: options[:batch], file: options[:file])
+                                           mode: options[:mode].to_sym, batch_size: options[:batch],
+                                           file: options[:file])
                  else
                    start_migrate(migrator_class:, sample: options[:sample], processes: options[:processes],
-                                 mode: options[:mode], batch_size: options[:batch])
+                                 mode: options[:mode].to_sym, batch_size: options[:batch])
                  end
 File.write(LAST_MIGRATION_FILENAME, job_result_ids.to_json)
 


### PR DESCRIPTION
## Why was this change made? 🤔
```
NoMethodError: undefined method 'ArgumentError' for an instance of Migrators::MigrationRunner

      raise ArgumentError("invalid mode #{mode}") unless MODES.include?(mode)
```


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



