### PR TITLE
skip releaseWF based on a workflow context value being set

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,9 @@ Additional notes:
 
 * Migrations can be performed against all items or just a list to `bin/migrate-cocina`.
 * The migrator specifies the migration strategy (cocina update, commit, commit with versioning, commit with publish), which determines how the object is persisted, whether it is versioned, and whether it is published.
+* For versioned migrations, a migrator may define `self.workflow_context` to pass optional workflow context when MigrationRunner closes the opened version and starts accessionWF.
+* Workflow context defaults to `{}` if not overridden.
+* See `Migrators::ExemplarWithContext` for a minimal example of context usage.
 * Breaking changes, especially breaking cocina model changes, are going to require additional steps, e.g., stopping SDR processing. The complete process is to be determined.
 
 ## Reset Process (for QA/Stage)

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -108,20 +108,32 @@ class VersionsController < ApplicationController
     boolean_param(new_params, :assume_accessioned)
   end
 
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def close_params
     new_params = params.permit(
       :description,
       :start_accession,
       :user_name,
       :user_versions,
-      :'lane-id'
+      :'lane-id',
+      context: {}
     ).to_h.symbolize_keys
     new_params[:user_version_mode] = new_params.delete(:user_versions).to_sym if new_params.key?(:user_versions)
+
     if new_params.key?(:'lane-id')
       new_params[:accession_args] = { lane_id: LaneSupport.lane_for(new_params.delete(:'lane-id')) }
     end
+
+    if new_params.key?(:context)
+      new_params[:accession_args] ||= {}
+      new_params[:accession_args][:context] = new_params.delete(:context)
+    end
+
     boolean_param(new_params, :start_accession)
   end
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 
   def load_version
     @version = CocinaObjectStore.version(params[:object_id])

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -108,9 +108,7 @@ class VersionsController < ApplicationController
     boolean_param(new_params, :assume_accessioned)
   end
 
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
-  def close_params
+  def close_params # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     new_params = params.permit(
       :description,
       :start_accession,
@@ -132,8 +130,6 @@ class VersionsController < ApplicationController
 
     boolean_param(new_params, :start_accession)
   end
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/AbcSize
 
   def load_version
     @version = CocinaObjectStore.version(params[:object_id])

--- a/app/jobs/robots/dor_repo/accession/release_initiate.rb
+++ b/app/jobs/robots/dor_repo/accession/release_initiate.rb
@@ -15,8 +15,19 @@ module Robots
                                               note: 'Admin policy objects are not released')
           end
 
+          if skipped?
+            return LyberCore::ReturnState.new(status: :skipped,
+                                              note: 'releaseWF was skipped because workflow context indicated this')
+          end
+
           Workflow::Service.create(druid:, workflow_name: 'releaseWF',
                                    version: cocina_object.version)
+        end
+
+        def skipped?
+          # checks if user has indicated that releaseWF should be skipped (sent as workflow_context)
+          # default to false if not present
+          workflow.context['skipReleaseWF'] || false
         end
       end
     end

--- a/app/jobs/robots/dor_repo/accession/release_initiate.rb
+++ b/app/jobs/robots/dor_repo/accession/release_initiate.rb
@@ -27,7 +27,7 @@ module Robots
         def skipped?
           # checks if user has indicated that releaseWF should be skipped (sent as workflow_context)
           # default to false if not present
-          workflow.context['skipReleaseWF'] || false
+          ActiveModel::Type::Boolean.new.cast(workflow.context['skipReleaseWF'])
         end
       end
     end

--- a/app/services/migrators/base.rb
+++ b/app/services/migrators/base.rb
@@ -11,6 +11,7 @@ module Migrators
   # The migrator subclass _may_ override the following methods:
   #   version? - true if the object should be versioned
   #   publish? - true if the object should be published
+  #   workflow_context - optional hash passed as workflow context when MigrationRunner closes a version
   #   initialize(repository_object) - takes the RepositoryObject to be migrated. If possible, consider
   #     overriding this in such a way as to maintain backwards compatibility for existing migrators. E.g.,
   #     if a parameter is added, the default value could maintain the existing behavior. If breaking
@@ -70,6 +71,16 @@ module Migrators
     # @return [Boolean] true if UpdateObjectService should be used to persist changes
     def self.cocina_update?
       migration_strategy == :cocina_update
+    end
+
+    # @return [Hash] optional workflow context passed when MigrationRunner closes a version.
+    # Override in a migrator class when versioning migrations need workflow context.
+    # Example:
+    #   def self.workflow_context
+    #     { 'skipReleaseWF' => true }
+    #   end
+    def self.workflow_context
+      {}
     end
 
     private

--- a/app/services/migrators/exemplar_with_context.rb
+++ b/app/services/migrators/exemplar_with_context.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Migrators
+  # Demonstrates passing workflow context when a versioned migration is closed.
+  class ExemplarWithContext < ExemplarWithCommitWithVersion
+    def self.workflow_context
+      { 'skipReleaseWF' => true }
+    end
+  end
+end

--- a/app/services/migrators/migration_runner.rb
+++ b/app/services/migrators/migration_runner.rb
@@ -217,8 +217,12 @@ module Migrators
     def close_version!
       VersionService.close(druid:,
                            version: repository_object.head_version.version,
-                           accession_args: { lane_id: 'low' }, # Always send to low queue.
+                           accession_args: { lane_id: 'low', context: }, # Always send to low queue.
                            description: nil) # Use the existing version description
+    end
+
+    def context
+      migrator_class.workflow_context || {}
     end
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -904,8 +904,10 @@ paths:
           in: query
           description: Optional workflow context to pass to accessionWF.
           required: false
-          style: deepObject
-          explode: true
+          style: deepObject # Serializes the object using bracket notation rather than as a flat JSON string.
+          explode: true # Expands nested properties into separate query parameter key-value pairs.
+          # Together they mean a client sending: { "skipReleaseWF": true, "ocrLanguages": ["Russian"] }
+          # Should encode it as query string: ?context[skipReleaseWF]=true&context[ocrLanguages][]=Russian
           schema:
             type: object
             additionalProperties: true

--- a/openapi.yml
+++ b/openapi.yml
@@ -900,6 +900,15 @@ paths:
           in: query
           schema:
             $ref: "#/components/schemas/LaneId"
+        - name: context
+          in: query
+          description: Optional workflow context to pass to accessionWF.
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+            additionalProperties: true
   "/v1/objects/{object_id}/versions":
     get:
       tags:

--- a/spec/jobs/robots/dor_repo/accession/release_initiate_spec.rb
+++ b/spec/jobs/robots/dor_repo/accession/release_initiate_spec.rb
@@ -39,6 +39,25 @@ RSpec.describe Robots::DorRepo::Accession::ReleaseInitiate, type: :robot do
       end
     end
 
+    context 'when workflow context indicates release should be skipped using a string value' do
+      let(:workflow_context) { { 'skipReleaseWF' => 'true' } }
+
+      it 'skips release workflow creation' do
+        expect(perform.status).to eq 'skipped'
+        expect(perform.note).to eq 'releaseWF was skipped because workflow context indicated this'
+        expect(Workflow::Service).not_to have_received(:create)
+      end
+    end
+
+    context 'when workflow context has skipReleaseWF string false' do
+      let(:workflow_context) { { 'skipReleaseWF' => 'false' } }
+
+      it 'creates the workflow' do
+        expect(perform).to be_nil # no return state defaults to completed.
+        expect(Workflow::Service).to have_received(:create).with(druid: druid, workflow_name: 'releaseWF', version: 1)
+      end
+    end
+
     context 'when workflow context does not indicate release should be skipped' do
       it 'creates the workflow' do
         expect(perform).to be_nil # no return state defaults to completed.

--- a/spec/jobs/robots/dor_repo/accession/release_initiate_spec.rb
+++ b/spec/jobs/robots/dor_repo/accession/release_initiate_spec.rb
@@ -7,10 +7,13 @@ RSpec.describe Robots::DorRepo::Accession::ReleaseInitiate, type: :robot do
 
   let(:druid) { 'druid:zz000zz0001' }
   let(:robot) { described_class.new }
+  let(:workflow_context) { {} }
 
   before do
     allow(CocinaObjectStore).to receive(:find).with(druid).and_return(object)
     allow(Workflow::Service).to receive(:create)
+    allow(robot).to receive(:workflow).and_return(instance_double(Robots::Robot::RobotWorkflow,
+                                                                  context: workflow_context))
   end
 
   context 'when the object is an admin policy' do
@@ -26,9 +29,21 @@ RSpec.describe Robots::DorRepo::Accession::ReleaseInitiate, type: :robot do
   context 'when the object is not an admin policy' do
     let(:object) { build(:dro, id: druid) }
 
-    it 'creates the workflow' do
-      expect(perform).to be_nil # no return state defaults to completed.
-      expect(Workflow::Service).to have_received(:create).with(druid: druid, workflow_name: 'releaseWF', version: 1)
+    context 'when workflow context indicates release should be skipped' do
+      let(:workflow_context) { { 'skipReleaseWF' => true } }
+
+      it 'skips release workflow creation' do
+        expect(perform.status).to eq 'skipped'
+        expect(perform.note).to eq 'releaseWF was skipped because workflow context indicated this'
+        expect(Workflow::Service).not_to have_received(:create)
+      end
+    end
+
+    context 'when workflow context does not indicate release should be skipped' do
+      it 'creates the workflow' do
+        expect(perform).to be_nil # no return state defaults to completed.
+        expect(Workflow::Service).to have_received(:create).with(druid: druid, workflow_name: 'releaseWF', version: 1)
+      end
     end
   end
 end

--- a/spec/requests/versions_spec.rb
+++ b/spec/requests/versions_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe 'Operations regarding object versions' do
   end
 
   describe 'POST /versions/current/close' do
+    let(:close_path) { "/v1/objects/#{druid}/versions/current/close" }
     let(:close_params) do
       {
         description: 'some text',
@@ -100,7 +101,7 @@ RSpec.describe 'Operations regarding object versions' do
       end
 
       it 'closes the current version when posted to' do
-        post "/v1/objects/druid:mx123qw2323/versions/current/close?#{close_params.to_query}",
+        post "#{close_path}?#{close_params.to_query}",
              headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status :ok
         expect(response.body).to match(/version 1 closed/)
@@ -116,12 +117,30 @@ RSpec.describe 'Operations regarding object versions' do
       end
 
       it 'closes the current version when posted to' do
-        post "/v1/objects/druid:mx123qw2323/versions/current/close?#{close_params.merge('lane-id': 'high').to_query}",
+        post "#{close_path}?#{close_params.merge('lane-id': 'high').to_query}",
              headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status :ok
         expect(response.body).to match(/version 1 closed/)
         expect(VersionService).to have_received(:close)
           .with(druid:, version:, accession_args: { lane_id: :high },
+                **close_params)
+      end
+    end
+
+    context 'when closing a version with workflow context' do
+      let(:workflow_context) { { 'skipReleaseWF' => 'true' } }
+
+      before do
+        allow(VersionService).to receive(:close)
+      end
+
+      it 'passes context as accession_args to close' do
+        post "#{close_path}?#{close_params.merge(context: workflow_context).to_query}",
+             headers: { 'Authorization' => "Bearer #{jwt}" }
+
+        expect(response).to have_http_status :ok
+        expect(VersionService).to have_received(:close)
+          .with(druid:, version:, accession_args: { context: workflow_context },
                 **close_params)
       end
     end
@@ -133,7 +152,7 @@ RSpec.describe 'Operations regarding object versions' do
       end
 
       it 'returns an error' do
-        post "/v1/objects/druid:mx123qw2323/versions/current/close?#{close_params.to_query}",
+        post "#{close_path}?#{close_params.to_query}",
              headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status :unprocessable_content
         expect(response.body).to eq(

--- a/spec/services/migrators/exemplar_with_context_spec.rb
+++ b/spec/services/migrators/exemplar_with_context_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Migrators::ExemplarWithContext do
+  describe '.migration_strategy' do
+    it 'returns commit_with_version' do
+      expect(described_class.migration_strategy).to eq :commit_with_version
+    end
+  end
+
+  describe '.version_description' do
+    it 'returns the inherited version description' do
+      expect(described_class.version_description).to eq 'Testing migration'
+    end
+  end
+
+  describe '.workflow_context' do
+    it 'returns workflow context for accessionWF' do
+      expect(described_class.workflow_context).to eq({ 'skipReleaseWF' => true })
+    end
+  end
+end

--- a/spec/services/migrators/migration_runner_spec.rb
+++ b/spec/services/migrators/migration_runner_spec.rb
@@ -194,8 +194,49 @@ RSpec.describe Migrators::MigrationRunner do
 
           expect(version_service).to have_received(:close)
             .with(description: nil, user_name: nil,
-                  start_accession: true, user_version_mode: :update_if_existing, accession_args: { lane_id: 'low' })
+                  start_accession: true, user_version_mode: :update_if_existing,
+                  accession_args: { lane_id: 'low', context: {} })
           expect(Publish::MetadataTransferService).not_to have_received(:publish)
+        end
+      end
+
+      context 'when the migrator provides workflow context' do
+        let(:migrator_class) do
+          stub_const(
+            'Migrators::TestMigrator',
+            Class.new(Migrators::Base) do
+              def migrate
+                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash
+              end
+
+              def self.migration_strategy
+                :cocina_update
+              end
+
+              def self.version_description
+                'test migration'
+              end
+
+              def self.workflow_context
+                { 'skipReleaseWF' => true }
+              end
+            end
+          )
+        end
+
+        before do
+          repository_object.close_version!
+          allow(version_service).to receive(:open?).and_return(false)
+        end
+
+        it 'passes workflow context when closing the version' do
+          results
+
+          expect(version_service).to have_received(:close)
+            .with(description: nil, user_name: nil,
+                  start_accession: true, user_version_mode: :update_if_existing,
+                  accession_args: { lane_id: 'low', context: { 'skipReleaseWF' => true } })
         end
       end
 

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe VersionService do
                             user_name: 'jcoyne',
                             start_accession:,
                             user_version_mode:,
-                            accession_args: { lane_id: })
+                            accession_args:)
     end
 
     let(:version) { 2 }
@@ -276,6 +276,7 @@ RSpec.describe VersionService do
     let(:user_version_mode) { :none }
     let(:description) { 'closing text' }
     let(:lane_id) { :low }
+    let(:accession_args) { { lane_id: } }
 
     let(:repository_object) { create(:repository_object, :with_repository_object_version, external_identifier: druid) }
 
@@ -291,6 +292,17 @@ RSpec.describe VersionService do
 
       before do
         allow(workflow_state_service).to receive_messages(accessioning?: false, assembling?: false)
+      end
+
+      context 'when workflow context is provided in accession_args' do
+        let(:workflow_context) { { 'skipReleaseWF' => true } }
+        let(:accession_args) { { lane_id:, context: workflow_context } }
+
+        it 'creates accessionWF with lane_id and context' do
+          close
+          expect(Workflow::Service).to have_received(:create).with(druid:, workflow_name: 'accessionWF',
+                                                                   version: '2', lane_id:, context: workflow_context)
+        end
       end
 
       context 'when user_version is none' do


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #6096 

1. initiate release step will do nothing if workflow context is present telling it to be skipped (thus, no releaseWF)
2. migrators can now set workflow context to pass to the accessioning process
3. version closing service now accepts context as a parameter and hands it off to the workflow service to be set

## How was this change tested? 🤨

New specs