### PR TITLE
Adds migrator to remove nested identifiers.

### DIFF
--- a/app/services/migrators/remove_nested_identifier.rb
+++ b/app/services/migrators/remove_nested_identifier.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Migrators
+  # Removes a nested identifier property from description in all objects and versions.
+  # For example:
+  # "identifier" =>
+  # [{"note" => [],
+  #   "type" => "local",
+  #   "value" => "sul-chs:PC010_09_1009",
+  #   "appliesTo" => [],
+  #   "identifier" => [], <-- nested identifier to be removed
+  #   "displayLabel" => "Source ID",
+  #   "groupedValue" => [],
+  #   "parallelValue" => [],
+  #   "structuredValue" => []}]
+  # See parent class and Migrators::MigrationRunner for more information.
+  class RemoveNestedIdentifier < Base
+    def migrate
+      remove_from_hash(hash: model_hash['description'], nested: false)
+
+      model_hash
+    end
+
+    private
+
+    def remove_from_hash(hash:, nested: false)
+      hash.delete('identifier') if nested
+
+      hash.each do |key, value|
+        next unless value.is_a?(Array)
+
+        value.each do |item|
+          remove_from_hash(hash: item, nested: key == 'identifier') if item.is_a?(Hash)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/migrators/remove_nested_identifier_spec.rb
+++ b/spec/services/migrators/remove_nested_identifier_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Migrators::RemoveNestedIdentifier do
+  subject(:migrator) do
+    described_class.new(model_hash: model_hash, valid: true, opened_version: false, last_closed_version: false,
+                        head_version: false)
+  end
+
+  describe 'migrate' do
+    subject(:migrated_model_hash) { migrator.migrate }
+
+    let(:model_hash) do
+      # Only providing description instead of complete model hash.
+      { 'description' => description }
+    end
+
+    let(:description) do
+      { 'title' => 'Test Title',
+        'contributor' => contributor,
+        'relatedResource' => related_resource,
+        # 'event' => event,
+        # 'adminMetadata' => admin_metadata,
+        'identifier' => identifier,
+        'purl' => 'https://purl.stanford.edu' }
+    end
+
+    let(:identifier) do
+      [{ 'type' => 'local',
+         'value' => 'sul-chs:PC010_09_1009',
+         'identifier' => [],
+         'displayLabel' => 'Source ID' }]
+    end
+    let(:contributor) { [{ 'name' => 'Test Contributor', 'identifier' => identifier }] }
+    let(:related_resource) do
+      [{ 'title' => 'Test Related Resource Title', 'identifier' => identifier }]
+    end
+
+    it 'removes nested identifier from description' do
+      migrated_description = migrated_model_hash['description'].with_indifferent_access
+      expect(migrated_description)
+        .to match(
+          {
+            title: 'Test Title',
+            contributor: [{ name: 'Test Contributor',
+                            identifier: [{ type: 'local', value: 'sul-chs:PC010_09_1009',
+                                           displayLabel: 'Source ID' }] }],
+            relatedResource: [
+              {
+                title: 'Test Related Resource Title',
+                identifier: [{ type: 'local', value: 'sul-chs:PC010_09_1009', displayLabel: 'Source ID' }]
+              }
+            ],
+            identifier: [{ type: 'local', value: 'sul-chs:PC010_09_1009', displayLabel: 'Source ID' }],
+            purl: 'https://purl.stanford.edu'
+          }
+        )
+    end
+  end
+
+  describe '#migration_strategy' do
+    it 'returns commit since using base default' do
+      expect(described_class.migration_strategy).to eq :commit
+    end
+  end
+end


### PR DESCRIPTION
closes #6074

## Why was this change made? 🤔
Nested identifiers are deprecated.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



