### PR TITLE
Add migrator to check that objects are openable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,13 @@ RAILS_ENV=production bin/rake seed:register[input_file]
 RAILS_ENV=production bin/rake workflow:step[druid,workflow,process,status]
 ```
 
+### Check that objects can be updated
+The `Migrators::CheckCocinaUpdate` migrator can be used to check that all objects that are not open are in an openable state. 
+
+```shell
+RAILS_ENV=production bin/migrate-cocina Migrators::CheckCocinaUpdate
+```
+
 ## Data migrations / bulk remediations
 
 `bin/migrate-cocina` provides a framework for data migrations and bulk remediations. It supports optional versioning and publishing of objects after migration. It also can persist by directly committing RepositoryObjectVersions (for any version for a RepositoryObject) using the UpdateObjectService (only for the head version).

--- a/app/services/migrators/base.rb
+++ b/app/services/migrators/base.rb
@@ -53,6 +53,11 @@ module Migrators
       raise NotImplementedError
     end
 
+    # @return [Boolean] true if this migrator should only be run in dryrun mode, false otherwise
+    def self.dryrun_only?
+      false
+    end
+
     # @return [Boolean] true if changed migrated objects should be published, false otherwise
     def self.publish?
       migration_strategy == :commit_with_publish

--- a/app/services/migrators/check_cocina_update.rb
+++ b/app/services/migrators/check_cocina_update.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Migrators
+  # Fake migrator that can be used to check that objects can be updated.
+  class CheckCocinaUpdate < Base
+    def migrate
+      # This changes every object.
+      model_hash['label'] = 'Test'
+      model_hash
+    end
+
+    def self.migration_strategy
+      :cocina_update
+    end
+
+    def self.version_description
+      'Testing migration'
+    end
+
+    # Guarantee that this migrator will not be run in non-dryrun mode since it changes every object.
+    def self.dryrun_only?
+      true
+    end
+  end
+end

--- a/app/services/migrators/migration_runner.rb
+++ b/app/services/migrators/migration_runner.rb
@@ -29,6 +29,10 @@ module Migrators
       @mode = mode
 
       raise ArgumentError, "invalid mode #{mode}" unless MODES.include?(mode)
+      return unless migrator_class.dryrun_only? && mode != :dryrun
+
+      raise ArgumentError,
+            "migrator #{migrator_class} is dryrun-only and cannot be run in mode #{mode}"
     end
 
     # @return [Array<Result>] results for the migration attempt

--- a/spec/services/migrators/check_cocina_update_spec.rb
+++ b/spec/services/migrators/check_cocina_update_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Migrators::CheckCocinaUpdate do
+  subject(:migrator) do
+    described_class.new(model_hash: model_hash, valid: true, opened_version: false, last_closed_version: false,
+                        head_version: false)
+  end
+
+  let(:model_hash) { { 'label' => 'Original label' } }
+
+  describe '.migration_strategy' do
+    it 'returns cocina_update' do
+      expect(described_class.migration_strategy).to eq :cocina_update
+    end
+  end
+
+  describe '.version_description' do
+    it 'returns the version description' do
+      expect(described_class.version_description).to eq 'Testing migration'
+    end
+  end
+
+  describe '.dryrun_only?' do
+    it 'returns true' do
+      expect(described_class.dryrun_only?).to be true
+    end
+  end
+
+  describe '#migrate' do
+    it 'returns the mutated model hash with label set to Test' do
+      result = migrator.migrate
+      expect(result).to eq model_hash
+      expect(result['label']).to eq 'Test'
+    end
+  end
+end

--- a/spec/services/migrators/migration_runner_spec.rb
+++ b/spec/services/migrators/migration_runner_spec.rb
@@ -33,6 +33,48 @@ RSpec.describe Migrators::MigrationRunner do
     end
   end
 
+  describe '.new' do
+    let(:repository_object) { create(:repository_object, :with_repository_object_version) }
+
+    context 'when the migrator is dryrun_only and mode is migrate' do
+      let(:migrator_class) do
+        stub_const(
+          'Migrators::TestMigrator',
+          Class.new(Migrators::Base) do
+            def migrate = model_hash
+
+            def self.dryrun_only? = true
+          end
+        )
+      end
+
+      it 'raises ArgumentError' do
+        expect do
+          described_class.new(migrator_class:, repository_object:, mode: :migrate)
+        end.to raise_error(ArgumentError, /is dryrun-only and cannot be run in mode migrate/)
+      end
+    end
+
+    context 'when the migrator is dryrun_only and mode is dryrun' do
+      let(:migrator_class) do
+        stub_const(
+          'Migrators::TestMigrator',
+          Class.new(Migrators::Base) do
+            def migrate = model_hash
+
+            def self.dryrun_only? = true
+          end
+        )
+      end
+
+      it 'does not raise' do
+        expect do
+          described_class.new(migrator_class:, repository_object:, mode: :dryrun)
+        end.not_to raise_error
+      end
+    end
+  end
+
   describe '#call' do
     subject(:results) { described_class.new(migrator_class:, repository_object:, mode:).call }
 


### PR DESCRIPTION
closes #6137

## Why was this change made? 🤔
Per @andrewjbtw to allow proactive troubleshooting.


## How was this change tested? 🤨
QA

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



