### PR TITLE
when processing identifier indicators, ignore value if not specified in list

### DIFF
--- a/app/services/cocina/from_marc/identifier.rb
+++ b/app/services/cocina/from_marc/identifier.rb
@@ -81,7 +81,10 @@ module Cocina
       def publisher_number(field)
         parts = values_for(field, %w[a b q])
 
-        { value: parts.join(' '), type: PUBLISHER_NUMBER_TYPES.fetch(field.indicator1) }.compact_blank if parts.any?
+        return unless parts.any? && PUBLISHER_NUMBER_TYPES.key?(field.indicator1)
+
+        { value: parts.join(' '),
+          type: PUBLISHER_NUMBER_TYPES.fetch(field.indicator1) }.compact_blank
       end
 
       def values_for(field, subfields)

--- a/spec/services/cocina/from_marc/identifier_spec.rb
+++ b/spec/services/cocina/from_marc/identifier_spec.rb
@@ -414,5 +414,44 @@ RSpec.describe Cocina::FromMarc::Identifier do
         expect(build).to eq [{ value: '440 073 032-9 Deutsche Grammophon (set and guide)', type: 'videorecording identifier' }]
       end
     end
+
+    context 'with unknown publisher number type (028 ind1=5)' do
+      let(:marc_hash) do
+        {
+          'fields' => [
+            { '028' => {
+              'ind1' => '5', 'ind2' => '0',
+              'subfields' => [
+                { 'a' => 'ABC 123' },
+                { 'b' => 'Some Publisher' }
+              ]
+            } }
+          ]
+        }
+      end
+
+      it 'excludes the identifier' do
+        expect(build).to eq []
+      end
+    end
+
+    context 'with unknown other identifier type (024 ind1=6)' do
+      let(:marc_hash) do
+        {
+          'fields' => [
+            { '024' => {
+              'ind1' => '6', 'ind2' => ' ',
+              'subfields' => [
+                { 'a' => '1234567890' }
+              ]
+            } }
+          ]
+        }
+      end
+
+      it 'excludes the identifier' do
+        expect(build).to eq []
+      end
+    end
   end
 end


### PR DESCRIPTION
closes #6145

## Why was this change made? 🤔
They cause metadata refresh to fail.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



