### PR TITLE
Handle invalid characters when reading MARC.

### DIFF
--- a/app/services/catalog/marc_dump.rb
+++ b/app/services/catalog/marc_dump.rb
@@ -26,11 +26,11 @@ module Catalog
         filename = File.basename(filepath)
         Rails.logger.info("Processing file: #{filename}")
         Zlib::GzipReader.open(filepath, encoding: 'binary') do |gz|
-          reader = MARC::ForgivingReader.new(gz)
+          reader = MARC::ForgivingReader.new(gz, invalid: :replace, replace: '', external_encoding: 'UTF-8')
           new_db.transaction do # Transaction speeds up inserts.
             reader.each_with_index do |record, index|
               new_db.execute 'insert into records values ( ?, ?, ? )',
-                             [record['001'].value.encode('UTF-8'), filename, index]
+                             [record['001'].value, filename, index]
             end
           end
         end
@@ -47,7 +47,7 @@ module Catalog
       filename, position = row
       filepath = File.join(dump_filepath, filename)
       Zlib::GzipReader.open(filepath, encoding: 'binary') do |gz|
-        reader = MARC::ForgivingReader.new(gz)
+        reader = MARC::ForgivingReader.new(gz, invalid: :replace, replace: '', external_encoding: 'UTF-8')
         reader.each_with_index do |record, index|
           return record if index == position
         end


### PR DESCRIPTION
refs https://github.com/sul-dlss/dor-services-app/issues/6061

## Why was this change made? 🤔
Invalid UTF-8 was causing mapping to Cocina to fail.


## How was this change tested? 🤨
Production

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



