### PR TITLE
Cleanup if publish/shelve fails.

### DIFF
--- a/app/services/publish/metadata_transfer_service.rb
+++ b/app/services/publish/metadata_transfer_service.rb
@@ -58,14 +58,28 @@ module Publish
       # It's fine. The object is already deleted.
     end
 
-    def publish_shelve
+    def publish_shelve # rubocop:disable Metrics/AbcSize
       if filepaths_to_shelve.present?
         ShelvableFilesStager.stage(cocina_object:, filepaths: filepaths_to_shelve, workspace_content_pathname:)
         TransferStager.copy(druid:, filepath_map: filepath_uuid_map, workspace_content_pathname:)
       end
+
       PurlFetcher::Client::Publish.publish(cocina: public_cocina, file_uploads: filepath_uuid_map,
                                            version: public_version,
                                            must_version: must_version?, version_date:)
+    rescue StandardError
+      delete_staged_files
+      raise
+    end
+
+    def delete_staged_files
+      transfer_stage = Pathname(Settings.stacks.transfer_stage_root)
+      filepath_uuid_map.each_value do |uuid|
+        stage_file = transfer_stage.join(uuid)
+        stage_file.delete if stage_file.exist?
+      rescue StandardError => e
+        Rails.logger.warn("Failed to delete stage file #{uuid}: #{e.message}")
+      end
     end
 
     def check_stacks

--- a/spec/services/publish/metadata_transfer_service_spec.rb
+++ b/spec/services/publish/metadata_transfer_service_spec.rb
@@ -257,6 +257,73 @@ RSpec.describe Publish::MetadataTransferService do
       end
     end
 
+    context 'when a discoverable DRO and publish raises an error' do
+      let(:public_cocina) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, dro?: true) }
+      let(:transfer_stage_root) { 'tmp/transfer_staging' }
+
+      let(:structural) do
+        { contains: [
+          {
+            type: Cocina::Models::FileSetType.file,
+            externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/123-456-789', label: 'Page 1', version: 1,
+            structural: {
+              contains: [
+                {
+                  type: Cocina::Models::ObjectType.file,
+                  externalIdentifier: 'https://cocina.sul.stanford.edu/file/123-456-789',
+                  label: '00001.html',
+                  filename: '00001.html',
+                  size: 0,
+                  version: 1,
+                  hasMimeType: 'text/html',
+                  use: 'transcription',
+                  hasMessageDigests: [
+                    { type: 'sha1', digest: 'cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7' },
+                    { type: 'md5', digest: 'e6d52da47a5ade91ae31227b978fb023' }
+                  ],
+                  access: { view: 'world', download: 'world' },
+                  administrative: { publish: true, sdrPreserve: true, shelve: true }
+                }
+              ]
+            }
+          }
+        ] }
+      end
+
+      before do
+        repository_object_version = create(:repository_object_version, :with_repository_object,
+                                           external_identifier: druid, closed_at:, structural:)
+        repository_object_version.repository_object
+                                 .open_version!(description: 'draft')
+        allow(DigitalStacksDiffer).to receive(:call).and_return(['00001.html'])
+        allow(ShelvableFilesStager).to receive(:stage)
+        allow(Publish::TransferStager).to receive(:copy)
+        allow(SecureRandom).to receive(:uuid).and_return(uuid)
+        allow(Settings.stacks).to receive_messages(transfer_stage_root:)
+        FileUtils.mkdir_p(transfer_stage_root)
+        allow(PurlFetcher::Client::Publish).to receive(:publish).and_raise(RuntimeError, 'publish failed')
+      end
+
+      after { FileUtils.rm_rf(transfer_stage_root) }
+
+      it 'deletes the staged file and re-raises the error' do
+        File.write("#{transfer_stage_root}/#{uuid}", 'staged content')
+        expect { described_class.publish(druid:) }.to raise_error(RuntimeError, 'publish failed')
+        expect(File.exist?("#{transfer_stage_root}/#{uuid}")).to be false
+      end
+
+      it 're-raises the error when the staged file is already absent' do
+        expect { described_class.publish(druid:) }.to raise_error(RuntimeError, 'publish failed')
+      end
+
+      it 'logs a warning and re-raises when deletion fails' do
+        FileUtils.mkdir_p("#{transfer_stage_root}/#{uuid}/nested")
+        allow(Rails.logger).to receive(:warn)
+        expect { described_class.publish(druid:) }.to raise_error(RuntimeError, 'publish failed')
+        expect(Rails.logger).to have_received(:warn).with(a_string_including(uuid))
+      end
+    end
+
     context 'when a file missing from shelves' do
       let(:public_cocina) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, dro?: true) }
 


### PR DESCRIPTION
refs https://github.com/sul-dlss/dor-services-app/issues/6156

## Why was this change made? 🤔
Avoid filling up the staging area.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



