### PR TITLE
Refactor MigrationRunner for clarity and performance.

### DIFF
--- a/app/services/migrators/migration_runner.rb
+++ b/app/services/migrators/migration_runner.rb
@@ -2,7 +2,7 @@
 
 module Migrators
   # Performs migration on a RepositoryObject given a migrator class.
-  class MigrationRunner # rubocop:disable Metrics/ClassLength
+  class MigrationRunner
     # see README for explanation of modes
     MODES = %i[dryrun migrate].freeze
     DEFAULT_MODE = :dryrun
@@ -35,84 +35,174 @@ module Migrators
             "migrator #{migrator_class} is dryrun-only and cannot be run in mode #{mode}"
     end
 
-    # @return [Array<Result>] results for the migration attempt
-    def call # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-      original_model_hash_map = build_original_model_hash_map.tap do |original_model_hash_map|
-        # Modify as if the version was open if the version is going to be opened.
-        # This allows for migration errors to occur before actually opening the version.
-        if migrator_class.version? && repository_object.closed?
-          new_version = repository_object.last_closed_version.version + 1
-          model_hash = to_model_hash(repository_object.last_closed_version, version: new_version)
-          original_model_hash_map[new_version] = model_hash.freeze
-          @last_closed_version = head_version
-          @opened_version = new_version
-          @head_version = new_version
-        end
-      end
-
-      # Do the migration on the model hashes.
-      migrated_model_hashes = original_model_hash_map.values.filter_map do |model_hash|
-        migrated_model_hash = migrate_model_hash(model_hash:)
-        next if migrated_model_hash == model_hash # Don't add if nothing changed
-
-        migrated_model_hash
-      rescue StandardError => e
-        Rails.logger.info("#{druid} (version #{model_hash['version']}) failed to migrate#{' (dry run)' if dryrun?}: #{e.message} -- #{e.backtrace}") # rubocop:disable Layout/LineLength
-        return [Result.new(status: 'ERROR', version: model_hash['version'], exception: e.message, **result_id_attrs)]
-      end
-
-      return [Result.new(status: 'UNCHANGED', **result_id_attrs)] if migrated_model_hashes.empty?
-
-      invalid_results = validate_migrated_model_hashes(migrated_model_hashes:, original_model_hash_map:)
-      return invalid_results if invalid_results.present?
-
-      opened = open_version! if migrator_class.version? # Note that open_version! is dryrun-aware.
-
-      unless dryrun?
-        if migrator_class.cocina_update?
-          cocina_update!(migrated_model_hashes:)
-        else
-          commit!(migrated_model_hashes:)
-        end
-
-        Publish::MetadataTransferService.publish(druid:) if migrator_class.publish?
-        close_version! if migrator_class.version? && opened # Not closing objects that were already open.
-      end
-
-      Rails.logger.info("#{druid} successfully migrated#{' (dry run)' if dryrun?}")
-
-      migrated_model_hashes.map do |migrated_model_hash|
-        Result.new(status: "MIGRATED#{' (dry run)' if dryrun?}", version: migrated_model_hash['version'],
-                   **result_id_attrs)
-      end
-    rescue StandardError => e
-      Rails.logger.info("#{druid} failed to migrate#{' (dry run)' if dryrun?}: #{e.message} -- #{e.backtrace}")
-      [Result.new(status: 'ERROR', exception: e.message, **result_id_attrs)]
+    def call
+      runner_class = migrator_class.cocina_update? ? CocinaUpdateRunner : CommitRunner
+      runner_class.new(migrator_class:, repository_object:, mode:).call
     end
 
     private
 
     attr_reader :migrator_class, :repository_object, :mode
 
-    # @return [Integer, nil] the opened version number if the object is open, nil otherwise
-    def opened_version
-      @opened_version ||= repository_object.opened_version&.version
+    # Base class for migration runners.
+    class BaseRunner
+      def initialize(migrator_class:, repository_object:, mode:)
+        @migrator_class = migrator_class
+        @repository_object = repository_object
+        @mode = mode
+        @open_before_migration = version_service.open?
+      end
+
+      private
+
+      attr_reader :migrator_class, :repository_object, :mode
+
+      # @return [Integer, nil] the opened version number if the object is open, nil otherwise
+      def opened_version
+        @opened_version ||= repository_object.opened_version&.version
+      end
+
+      # @return [Integer, nil] the last closed version number if the object has been closed, nil otherwise
+      def last_closed_version
+        @last_closed_version ||= repository_object.last_closed_version&.version
+      end
+
+      # @return [Integer] the head version number
+      def head_version
+        @head_version ||= repository_object.head_version.version
+      end
+
+      def version_service
+        @version_service ||= VersionService.new(druid:, version: repository_object.head_version.version,
+                                                repository_object:)
+      end
+
+      def open_before_migration?
+        @open_before_migration
+      end
+
+      def open_version!
+        # This allows us to know if the object can be opened for versioning without actually opening it during a dry run
+        if dryrun?
+          # Raise an error if the migration is trying to version an object that is not openable
+          version_service.ensure_openable!(assume_accessioned: false)
+        else
+          version_service.open(cocina_object: repository_object.head_version.to_cocina,
+                               description: migrator_class.version_description,
+                               assume_accessioned: false)
+        end
+      end
+
+      def result_id_attrs
+        { id: repository_object.id, external_identifier: repository_object.external_identifier }
+      end
+
+      def druid
+        repository_object.external_identifier
+      end
+
+      def dryrun?
+        mode == :dryrun
+      end
+
+      def to_model_hash(repository_object_version, version: nil)
+        model_hash = repository_object_version.to_h.stringify_keys
+        model_hash['version'] = version if version
+        model_hash.freeze
+      end
+
+      def migrate_model_hash(model_hash:, valid:)
+        migrator_class.new(model_hash: model_hash.deep_dup,
+                           opened_version: model_hash['version'] == opened_version,
+                           last_closed_version: model_hash['version'] == last_closed_version,
+                           head_version: model_hash['version'] == head_version,
+                           valid:).migrate
+      end
+
+      def close_version!
+        VersionService.close(druid:,
+                             version: repository_object.head_version.version,
+                             accession_args: { lane_id: 'low', context: }, # Always send to low queue.
+                             description: nil) # Use the existing version description
+      end
+
+      def context
+        migrator_class.workflow_context || {}
+      end
+
+      # @return [Hash] the model hash for the last closed version with an incremented version number
+      def build_incremented_last_closed_version_model_hash
+        new_version = repository_object.last_closed_version.version + 1
+        to_model_hash(repository_object.last_closed_version, version: new_version).freeze
+      end
+
+      def adjust_versions(new_version)
+        @last_closed_version = head_version
+        @opened_version = new_version
+        @head_version = new_version
+      end
     end
 
-    # @return [Integer, nil] the last closed version number if the object has been closed, nil otherwise
-    def last_closed_version
-      @last_closed_version ||= repository_object.last_closed_version&.version
-    end
+    # Runner that migrates a RepositoryObject by committing the migrated model hashes to the database.
+    # Note that this migrates all versions (though it is up to the migrator to decide which actually to change.)
+    class CommitRunner < BaseRunner
+      # @return [Array<Result>] results for the migration attempt
+      def call # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        original_model_hash_map = build_original_model_hash_map.tap do |original_model_hash_map|
+          # Modify as if the version was open if the version is going to be opened.
+          # This allows for migration errors to occur before actually opening the version.
+          if migrator_class.version? && repository_object.closed?
+            model_hash = build_incremented_last_closed_version_model_hash
+            original_model_hash_map[model_hash['version']] = model_hash
+            adjust_versions(model_hash['version'])
+          end
+        end
+        # Keep track of which model hashes are valid.
+        original_model_hash_valid_map = build_original_model_hash_valid_map(original_model_hash_map:)
 
-    # @return [Integer] the head version number
-    def head_version
-      @head_version ||= repository_object.head_version.version
-    end
+        # Do the migration on the model hashes.
+        migrated_model_hashes = original_model_hash_map.values.filter_map do |model_hash|
+          migrated_model_hash = migrate_model_hash(model_hash:,
+                                                   valid: original_model_hash_valid_map[model_hash['version']])
+          next if migrated_model_hash == model_hash # Don't add if nothing changed
 
-    def build_original_model_hash_map
-      if migrator_class.cocina_update?
-        repository_object.open? ? { opened_version => to_model_hash(repository_object.opened_version) } : {}
-      else
+          migrated_model_hash
+        rescue StandardError => e
+          Rails.logger.info("#{druid} (version #{model_hash['version']}) failed to migrate#{' (dry run)' if dryrun?}: #{e.message} -- #{e.backtrace}") # rubocop:disable Layout/LineLength
+          return [Result.new(status: 'ERROR', version: model_hash['version'], exception: e.message,
+                             **result_id_attrs)]
+        end
+
+        return [Result.new(status: 'UNCHANGED', **result_id_attrs)] if migrated_model_hashes.empty?
+
+        invalid_results = validate_migrated_model_hashes(migrated_model_hashes:, original_model_hash_valid_map:)
+        return invalid_results if invalid_results.present?
+
+        # Note that open_version! is dryrun-aware.
+        open_version! if migrator_class.version? && !open_before_migration?
+
+        unless dryrun?
+          commit!(migrated_model_hashes:)
+
+          Publish::MetadataTransferService.publish(druid:) if migrator_class.publish?
+          # Not closing objects that were already open.
+          close_version! if migrator_class.version? && !open_before_migration?
+        end
+
+        Rails.logger.info("#{druid} successfully migrated#{' (dry run)' if dryrun?}")
+
+        migrated_model_hashes.map do |migrated_model_hash|
+          Result.new(status: "MIGRATED#{' (dry run)' if dryrun?}", version: migrated_model_hash['version'],
+                     **result_id_attrs)
+        end
+      rescue StandardError => e
+        Rails.logger.info("#{druid} failed to migrate#{' (dry run)' if dryrun?}: #{e.message} -- #{e.backtrace}")
+        [Result.new(status: 'ERROR', exception: e.message, **result_id_attrs)]
+      end
+
+      private
+
+      def build_original_model_hash_map
         repository_object.versions
                          .select(&:has_cocina?)
                          .to_h do |repository_object_version|
@@ -120,113 +210,116 @@ module Migrators
                             to_model_hash(repository_object_version)]
                          end
       end
-    end
 
-    # @return [Boolean] true if the version was opened by this method call, false otherwise
-    def open_version! # rubocop:disable Naming/PredicateMethod
-      cocina_object = repository_object.head_version.to_cocina
-      version_service = VersionService.new(druid: cocina_object.externalIdentifier, version: cocina_object.version,
-                                           repository_object:)
-      return false if version_service.open?
-
-      # This allows us to know if the object can be opened for versioning without actually opening it during a dry run
-      if dryrun?
-        # Raise an error if the migration is trying to version an object that is not openable
-        version_service.ensure_openable!(assume_accessioned: false)
-        return false
-      end
-
-      version_service.open(cocina_object:, description: migrator_class.version_description, assume_accessioned: false)
-      true
-    end
-
-    def result_id_attrs
-      { id: repository_object.id, external_identifier: repository_object.external_identifier }
-    end
-
-    def valid_model_hash?(model_hash)
-      Cocina::Models.build(model_hash)
-      true
-    rescue Cocina::Models::ValidationError, Dry::Struct::Error
-      false
-    end
-
-    def druid
-      repository_object.external_identifier
-    end
-
-    def dryrun?
-      mode == :dryrun
-    end
-
-    def to_model_hash(repository_object_version, version: nil)
-      model_hash = repository_object_version.to_h.stringify_keys
-      model_hash['version'] = version if version
-      model_hash.freeze
-    end
-
-    def migrate_model_hash(model_hash:)
-      migrator_class.new(model_hash: model_hash.deep_dup,
-                         opened_version: model_hash['version'] == opened_version,
-                         last_closed_version: model_hash['version'] == last_closed_version,
-                         head_version: model_hash['version'] == head_version,
-                         valid: valid_model_hash?(model_hash)).migrate
-    end
-
-    # @return [Array<Result>] results for the migration attempts of the migrated model hashes.
-    def validate_migrated_model_hashes(migrated_model_hashes:, original_model_hash_map:)
-      migrated_model_hashes.filter_map do |migrated_model_hash|
-        if migrator_class.allow_invalid?
-          next unless [opened_version, last_closed_version].include?(migrated_model_hash['version'])
-        else
-          next unless valid_model_hash?(original_model_hash_map[migrated_model_hash['version']])
+      # @return [Hash{Integer => Boolean}] a map of version number to whether the model hash is valid
+      def build_original_model_hash_valid_map(original_model_hash_map:)
+        original_model_hash_map.transform_values do |model_hash|
+          valid_model_hash?(model_hash)
         end
-
-        Cocina::Models.build(migrated_model_hash)
-        nil
-      rescue Cocina::Models::ValidationError, Dry::Struct::Error => e
-        Result.new(status: 'INVALID', exception: e.message, version: migrated_model_hash['version'], **result_id_attrs)
       end
-    end
 
-    def cocina_update!(migrated_model_hashes:)
-      migrated_cocina_object = Cocina::Models.build(migrated_model_hashes.first)
-      migrated_cocina_object_with_metadata = Cocina::Models.with_metadata(migrated_cocina_object,
-                                                                          repository_object.external_lock)
-      UpdateObjectService.update(cocina_object: migrated_cocina_object_with_metadata,
-                                 skip_open_check: true)
-    end
+      def valid_model_hash?(model_hash)
+        Cocina::Models.build(model_hash)
+        true
+      rescue Cocina::Models::ValidationError, Dry::Struct::Error
+        false
+      end
 
-    def commit!(migrated_model_hashes:)
-      repository_object.transaction do
-        repository_object.reload # ensure we have the latest versions before updating
-        migrated_model_hashes.each do |migrated_model_hash|
-          repository_object_version = repository_object.versions.find do |repository_object_version|
-            repository_object_version.version == migrated_model_hash['version']
+      # @return [Array(Array<Result>] invalid results
+      def validate_migrated_model_hashes(migrated_model_hashes:, original_model_hash_valid_map:)
+        migrated_model_hashes.filter_map do |migrated_model_hash|
+          if migrator_class.allow_invalid?
+            next unless [opened_version, last_closed_version].include?(migrated_model_hash['version'])
+          else
+            next unless original_model_hash_valid_map[migrated_model_hash['version']]
           end
-          repository_object_version.update!(migrated_model_hash_for_update(migrated_model_hash))
+
+          Cocina::Models.build(migrated_model_hash)
+
+          nil
+        rescue Cocina::Models::ValidationError, Dry::Struct::Error => e
+          Result.new(status: 'INVALID', exception: e.message, version: migrated_model_hash['version'],
+                     **result_id_attrs)
         end
+      end
+
+      def commit!(migrated_model_hashes:)
+        repository_object.transaction do
+          repository_object.reload # ensure we have the latest versions before updating
+          migrated_model_hashes.each do |migrated_model_hash|
+            repository_object_version = repository_object.versions.find do |repository_object_version|
+              repository_object_version.version == migrated_model_hash['version']
+            end
+            repository_object_version.update!(migrated_model_hash_for_update(migrated_model_hash))
+          end
+        end
+      end
+
+      def migrated_model_hash_for_update(migrated_model_hash)
+        migrated_model_hash
+          .except('externalIdentifier', 'version', 'cocinaVersion')
+          .tap do |object_hash|
+            object_hash['cocina_version'] = Cocina::Models::VERSION # When saving, set to latest cocina version.
+            object_hash['content_type'] = object_hash.delete('type')
+          end
       end
     end
 
-    def migrated_model_hash_for_update(migrated_model_hash)
-      migrated_model_hash
-        .except('externalIdentifier', 'version', 'cocinaVersion')
-        .tap do |object_hash|
-          object_hash['cocina_version'] = Cocina::Models::VERSION # When saving, set to latest cocina version.
-          object_hash['content_type'] = object_hash.delete('type')
+    # A runner that migrates a RepositoryObject by using UpdateObjectService to persist the migrated model hashes.
+    # Note that this only migrates the head version, not all versions.
+    class CocinaUpdateRunner < BaseRunner
+      def call # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        if repository_object.open?
+          original_cocina_model_hash = to_model_hash(repository_object.opened_version)
+        else
+          # Modify as if the version was open if the version is going to be opened.
+          # This allows for migration errors to occur before actually opening the version.
+
+          original_cocina_model_hash = build_incremented_last_closed_version_model_hash
+          adjust_versions(original_cocina_model_hash['version'])
         end
-    end
 
-    def close_version!
-      VersionService.close(druid:,
-                           version: repository_object.head_version.version,
-                           accession_args: { lane_id: 'low', context: }, # Always send to low queue.
-                           description: nil) # Use the existing version description
-    end
+        begin
+          migrated_model_hash = migrate_model_hash(model_hash: original_cocina_model_hash, valid: true)
+        rescue StandardError => e
+          Rails.logger.info("#{druid} (version #{original_cocina_model_hash['version']}) failed to migrate#{' (dry run)' if dryrun?}: #{e.message} -- #{e.backtrace}") # rubocop:disable Layout/LineLength
+          return [Result.new(status: 'ERROR', version: original_cocina_model_hash['version'], exception: e.message,
+                             **result_id_attrs)]
+        end
 
-    def context
-      migrator_class.workflow_context || {}
+        return [Result.new(status: 'UNCHANGED', **result_id_attrs)] if migrated_model_hash == original_cocina_model_hash
+
+        begin
+          migrated_cocina_object = Cocina::Models.build(migrated_model_hash)
+        rescue Cocina::Models::ValidationError, Dry::Struct::Error => e
+          return [Result.new(status: 'INVALID', exception: e.message, version: migrated_model_hash['version'],
+                             **result_id_attrs)]
+        end
+
+        open_version! unless open_before_migration?
+
+        unless dryrun?
+          cocina_update!(migrated_cocina_object:)
+          close_version! unless open_before_migration? # Not closing objects that were already open.
+        end
+
+        Rails.logger.info("#{druid} successfully migrated#{' (dry run)' if dryrun?}")
+
+        [Result.new(status: "MIGRATED#{' (dry run)' if dryrun?}", version: migrated_model_hash['version'],
+                    **result_id_attrs)]
+      rescue StandardError => e
+        Rails.logger.info("#{druid} failed to migrate#{' (dry run)' if dryrun?}: #{e.message} -- #{e.backtrace}")
+        [Result.new(status: 'ERROR', exception: e.message, **result_id_attrs)]
+      end
+
+      private
+
+      def cocina_update!(migrated_cocina_object:)
+        migrated_cocina_object_with_metadata = Cocina::Models.with_metadata(migrated_cocina_object,
+                                                                            repository_object.external_lock)
+        UpdateObjectService.update(cocina_object: migrated_cocina_object_with_metadata,
+                                   skip_open_check: true)
+      end
     end
   end
 end

--- a/spec/services/migrators/migration_runner_spec.rb
+++ b/spec/services/migrators/migration_runner_spec.rb
@@ -765,6 +765,136 @@ RSpec.describe Migrators::MigrationRunner do
           expect(Publish::MetadataTransferService).not_to have_received(:publish)
         end
       end
+
+      context 'when migration strategy is commit' do
+        let(:migrator_class) do
+          stub_const(
+            'Migrators::TestMigrator',
+            Class.new(Migrators::Base) do
+              def migrate
+                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash
+              end
+            end
+          )
+        end
+
+        it 'does not commit the changes' do
+          expect(results.map(&:to_h)).to contain_exactly(
+            hash_including(external_identifier: druid, version: 1, status: 'MIGRATED (dry run)'),
+            hash_including(external_identifier: druid, version: 2, status: 'MIGRATED (dry run)'),
+            hash_including(external_identifier: druid, version: 3, status: 'MIGRATED (dry run)')
+          )
+
+          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1'
+          expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2'
+          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3'
+        end
+      end
+
+      context 'when migration strategy is cocina_update and object is open' do
+        let(:migrator_class) do
+          stub_const(
+            'Migrators::TestMigrator',
+            Class.new(Migrators::Base) do
+              def migrate
+                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash
+              end
+
+              def self.migration_strategy
+                :cocina_update
+              end
+            end
+          )
+        end
+
+        it 'does not call UpdateObjectService or open/close the version' do
+          expect(results.map(&:to_h)).to contain_exactly(
+            hash_including(external_identifier: druid, version: 3, status: 'MIGRATED (dry run)')
+          )
+
+          expect(repository_object.reload.versions.count).to eq 3
+          expect(version_service).not_to have_received(:open)
+          expect(UpdateObjectService).not_to have_received(:update)
+          expect(version_service).not_to have_received(:close)
+        end
+      end
+
+      context 'when migration strategy is commit_with_version and object is closed' do
+        let(:migrator_class) do
+          stub_const(
+            'Migrators::TestMigrator',
+            Class.new(Migrators::Base) do
+              def migrate
+                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash
+              end
+
+              def self.migration_strategy
+                :commit_with_version
+              end
+
+              def self.version_description
+                'test migration'
+              end
+            end
+          )
+        end
+
+        before do
+          repository_object.close_version!
+          allow(version_service).to receive(:open?).and_return(false)
+        end
+
+        it 'calls ensure_openable! but does not commit or open a new version' do
+          expect(results.map(&:to_h)).to contain_exactly(
+            hash_including(external_identifier: druid, version: 1, status: 'MIGRATED (dry run)'),
+            hash_including(external_identifier: druid, version: 2, status: 'MIGRATED (dry run)'),
+            hash_including(external_identifier: druid, version: 3, status: 'MIGRATED (dry run)'),
+            hash_including(external_identifier: druid, version: 4, status: 'MIGRATED (dry run)')
+          )
+
+          expect(repository_object.reload.versions.count).to eq 3
+          expect(version_service).to have_received(:ensure_openable!)
+          expect(version_service).not_to have_received(:open)
+          expect(version_service).not_to have_received(:close)
+        end
+      end
+
+      context 'when ensure_openable! raises' do
+        let(:migrator_class) do
+          stub_const(
+            'Migrators::TestMigrator',
+            Class.new(Migrators::Base) do
+              def migrate
+                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash
+              end
+
+              def self.migration_strategy
+                :commit_with_version
+              end
+
+              def self.version_description
+                'test migration'
+              end
+            end
+          )
+        end
+
+        before do
+          repository_object.close_version!
+          allow(version_service).to receive(:open?).and_return(false)
+          allow(version_service).to receive(:ensure_openable!).and_raise('Object cannot be opened')
+        end
+
+        it 'returns a result with status ERROR' do
+          expect(results.map(&:to_h)).to contain_exactly(
+            hash_including(external_identifier: druid, status: 'ERROR', exception: 'Object cannot be opened')
+          )
+        end
+      end
     end
 
     context 'when there is an error in the migrator' do
@@ -814,6 +944,34 @@ RSpec.describe Migrators::MigrationRunner do
         expect(results.map(&:to_h)).to contain_exactly(
           hash_including(external_identifier: druid, version: nil, status: 'ERROR',
                          exception: 'Something went wrong in the runner')
+        )
+      end
+    end
+
+    context 'when there is an error in the CommitRunner after migration (e.g., publish fails)' do
+      let(:migrator_class) do
+        stub_const(
+          'Migrators::TestMigrator',
+          Class.new(Migrators::Base) do
+            def migrate
+              model_hash['label'] = "#{model_hash['label']} migrated"
+              model_hash
+            end
+
+            def self.migration_strategy
+              :commit_with_publish
+            end
+          end
+        )
+      end
+
+      before do
+        allow(Publish::MetadataTransferService).to receive(:publish).and_raise('Publish failed')
+      end
+
+      it 'returns a result with status ERROR and the exception message' do
+        expect(results.map(&:to_h)).to contain_exactly(
+          hash_including(external_identifier: druid, status: 'ERROR', exception: 'Publish failed')
         )
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔
I went to make some performance improvements in the migrator (reducing repetitive validations and building of cocina objects), but found the code handling both cocina updates and commits confusing. This separates them so that logic is clearer.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



