### PR TITLE
Handle pruning when directories no longer exist.

### DIFF
--- a/app/services/prune_service.rb
+++ b/app/services/prune_service.rb
@@ -16,10 +16,13 @@ class PruneService
 
   # @param [Pathname] outermost_branch The branch at which pruning begins
   # @return [void] Ascend the druid tree and prune empty branches
-  # @raise [Errno::ENOENT] if the directory does not exist
   def prune_ancestors(outermost_branch)
     while outermost_branch.exist? && outermost_branch.children.empty?
-      outermost_branch.rmdir
+      begin
+        outermost_branch.rmdir
+      rescue Errno::ENOENT
+        # This handles a race condition with other pruning.
+      end
       outermost_branch = outermost_branch.parent
       break if outermost_branch == druid.base_pathname
     end

--- a/spec/services/prune_service_spec.rb
+++ b/spec/services/prune_service_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe PruneService do
       end
     end
 
+    context 'when rmdir raises Errno::ENOENT due to a race condition' do
+      it 'does not raise' do
+        dr1.mkdir
+        allow_any_instance_of(Pathname).to receive(:rmdir).and_raise(Errno::ENOENT) # rubocop:disable RSpec/AnyInstance
+        expect { described_class.new(druid: dr1).prune! }.not_to raise_error
+      end
+    end
+
     it 'removes all directories up to the base path when there are no common ancestors' do
       # Nil the create records for this test
       dr1.mkdir


### PR DESCRIPTION
closes #6167

## Why was this change made? 🤔
Reset workspace robots were failing.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



