### PR TITLE
Dispatch reindex jobs more efficiently.

### DIFF
--- a/lib/tasks/indexer.rake
+++ b/lib/tasks/indexer.rake
@@ -3,12 +3,9 @@
 namespace :indexer do
   desc 'Reindex all objects in jobs'
   task :reindex_jobs, %i[batch_size] => :environment do |_task, args|
-    druids = RepositoryObject.pluck(:external_identifier)
-
-    batches = druids.each_slice(args.batch_size&.to_i || 100)
-
-    batches.each do |batch|
-      BatchReindexJob.perform_later(batch)
+    RepositoryObject.in_batches(batch_size: args.batch_size&.to_i || 100) do |relation|
+      druids = relation.pluck(:external_identifier)
+      BatchReindexJob.perform_later(druids)
     end
   end
 end


### PR DESCRIPTION
closes #6175

## Why was this change made? 🤔
To avoid loading all druids into a single array.


## How was this change tested? 🤨
QA

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



