### PR TITLE
Fix RemoveNestedIdentifier migrator.

### DIFF
--- a/app/services/migrators/remove_nested_identifier.rb
+++ b/app/services/migrators/remove_nested_identifier.rb
@@ -27,6 +27,7 @@ module Migrators
       hash.delete('identifier') if nested
 
       hash.each do |key, value|
+        next remove_from_hash(hash: value) if value.is_a?(Hash)
         next unless value.is_a?(Array)
 
         value.each do |item|

--- a/spec/services/migrators/remove_nested_identifier_spec.rb
+++ b/spec/services/migrators/remove_nested_identifier_spec.rb
@@ -13,15 +13,14 @@ RSpec.describe Migrators::RemoveNestedIdentifier do
 
     let(:model_hash) do
       # Only providing description instead of complete model hash.
-      { 'description' => description }
+      { 'description' => description.deep_dup }
     end
 
     let(:description) do
       { 'title' => 'Test Title',
         'contributor' => contributor,
         'relatedResource' => related_resource,
-        # 'event' => event,
-        # 'adminMetadata' => admin_metadata,
+        'adminMetadata' => admin_metadata,
         'identifier' => identifier,
         'purl' => 'https://purl.stanford.edu' }
     end
@@ -35,6 +34,11 @@ RSpec.describe Migrators::RemoveNestedIdentifier do
     let(:contributor) { [{ 'name' => 'Test Contributor', 'identifier' => identifier }] }
     let(:related_resource) do
       [{ 'title' => 'Test Related Resource Title', 'identifier' => identifier }]
+    end
+    let(:admin_metadata) do
+      {
+        'identifier' => identifier
+      }
     end
 
     it 'removes nested identifier from description' do
@@ -53,6 +57,9 @@ RSpec.describe Migrators::RemoveNestedIdentifier do
               }
             ],
             identifier: [{ type: 'local', value: 'sul-chs:PC010_09_1009', displayLabel: 'Source ID' }],
+            adminMetadata: {
+              identifier: [{ type: 'local', value: 'sul-chs:PC010_09_1009', displayLabel: 'Source ID' }]
+            },
             purl: 'https://purl.stanford.edu'
           }
         )


### PR DESCRIPTION
## Why was this change made? 🤔
It wasn't accounting for `adminMetadata`, which is a hash, not an array like other props.


## How was this change tested? 🤨
Unit, stage

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



