### PR TITLE
[HOLD] Skip incomplete releaseWF steps when opening a new version

### DIFF
--- a/app/services/version_service.rb
+++ b/app/services/version_service.rb
@@ -73,6 +73,8 @@ class VersionService
 
     ensure_openable!(assume_accessioned:, check_preservation_version: !from_version)
 
+    skip_incomplete_release_steps!
+
     from_repository_object_version = from_version ? repository_object.versions.find_by!(version: from_version) : nil
 
     repository_object.open_version!(description:, from_version: from_repository_object_version)
@@ -251,6 +253,15 @@ class VersionService
 
   def workflow_state_service
     @workflow_state_service ||= Workflow::StateService.new(druid:, version:)
+  end
+
+  # An active releaseWF doesn't block opening a new version, so a releaseWF step from a previous
+  # version can be left incomplete forever once that version is no longer the active one. Skip any
+  # such steps so they stop showing up in stuck workflow monitoring.
+  def skip_incomplete_release_steps!
+    Workflow::Service.skip_incomplete(druid:, workflow_name: 'releaseWF', through_version: version,
+                                      note: 'Automatically skipped because a new object version was opened ' \
+                                            'while this releaseWF step was still incomplete.')
   end
 
   def ensure_closeable!

--- a/app/services/workflow/service.rb
+++ b/app/services/workflow/service.rb
@@ -59,6 +59,10 @@ module Workflow
       new(druid:).skip_all(workflow_name:, note:)
     end
 
+    def self.skip_incomplete(druid:, workflow_name:, through_version:, note: nil)
+      new(druid:).skip_incomplete(workflow_name:, through_version:, note:)
+    end
+
     def initialize(druid:)
       @druid = druid
     end
@@ -147,6 +151,21 @@ module Workflow
     # @param [String] note an optional note to add to the skip action
     def skip_all(workflow_name:, note: nil)
       steps = WorkflowStep.where(druid:, active_version: true, workflow: workflow_name)
+      WorkflowStep.transaction do
+        steps.each do |step|
+          step.update(status: 'skipped', note:)
+        end
+      end
+    end
+
+    # Skips incomplete processes in a workflow for versions up through the given version.
+    # @param [String] workflow_name the name of the workflow to skip
+    # @param [Integer] through_version skip incomplete steps with a version less than or equal to this
+    # @param [String] note an optional note to add to the skip action
+    def skip_incomplete(workflow_name:, through_version:, note: nil)
+      steps = WorkflowStep.incomplete
+                          .where(druid:, workflow: workflow_name)
+                          .where(WorkflowStep.arel_table[:version].lteq(through_version))
       WorkflowStep.transaction do
         steps.each do |step|
           step.update(status: 'skipped', note:)

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -134,6 +134,22 @@ RSpec.describe VersionService do
         expect(repository_object.opened_version.version_description).to eq 'same as it ever was'
       end
     end
+
+    context 'when there are incomplete releaseWF steps from a previous version' do
+      let!(:incomplete_release_step) do
+        create(:workflow_step, druid:, workflow: 'releaseWF', process: 'update-marc', status: 'queued', version:)
+      end
+      let!(:incomplete_accession_step) do
+        create(:workflow_step, druid:, workflow: 'accessionWF', process: 'start-accession', status: 'queued', version:)
+      end
+
+      it 'skips the incomplete releaseWF step but leaves other workflows alone' do
+        expect { open }
+          .to change { incomplete_release_step.reload.status }
+          .from('queued').to('skipped')
+          .and(not_change { incomplete_accession_step.reload.status })
+      end
+    end
   end
 
   describe '.open?' do

--- a/spec/services/workflow/service_spec.rb
+++ b/spec/services/workflow/service_spec.rb
@@ -178,4 +178,39 @@ RSpec.describe Workflow::Service do
         .and(not_change { step_with_different_workflow.reload.status })
     end
   end
+
+  describe '#skip_incomplete' do
+    let!(:queued_step) do
+      create(:workflow_step, druid:, workflow: 'releaseWF', process: 'update-marc', status: 'queued', version: 2)
+    end
+    let!(:earlier_incomplete_step) do
+      create(:workflow_step, druid:, workflow: 'releaseWF', process: 'update-marc', status: 'started', version: 1)
+    end
+    let!(:completed_step) do
+      create(:workflow_step, :completed, druid:, workflow: 'releaseWF', process: 'release-publish', version: 2)
+    end
+    let!(:later_version_step) do
+      create(:workflow_step, druid:, workflow: 'releaseWF', process: 'update-marc', status: 'queued', version: 3)
+    end
+    let!(:step_with_different_workflow) do
+      create(:workflow_step, druid:, workflow: 'accessionWF', process: 'start-accession', status: 'queued',
+                             version: 2)
+    end
+
+    it 'skips incomplete steps in a workflow up through the given version' do
+      expect do
+        described_class.skip_incomplete(druid:, workflow_name: 'releaseWF', through_version: 2,
+                                        note: 'Skipping incomplete steps')
+      end
+        .to change { queued_step.reload.status }
+        .from('queued').to('skipped')
+        .and change(queued_step, :note)
+        .to('Skipping incomplete steps')
+        .and change { earlier_incomplete_step.reload.status }
+        .from('started').to('skipped')
+        .and(not_change { completed_step.reload.status })
+        .and(not_change { later_version_step.reload.status })
+        .and(not_change { step_with_different_workflow.reload.status })
+    end
+  end
 end


### PR DESCRIPTION
alternate approach in progress


## Summary
- Fixes #6172 (option 3 from the discussion): a releaseWF step for a previous version can be left incomplete forever once a new version is opened, since an active releaseWF doesn't block versioning — this trips the 24-hour stuck workflow Honeybadger notice indefinitely.
- `VersionService#open` now skips any incomplete `releaseWF` steps for the version being opened-from (and any earlier stragglers) right after `ensure_openable!` passes and before the new version is created.
- Adds `Workflow::Service#skip_incomplete`, scoped to incomplete steps up through a given version.

## Test plan

Specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)