### PR TITLE
Handles non-empty directory when pruning.

### DIFF
--- a/app/services/prune_service.rb
+++ b/app/services/prune_service.rb
@@ -17,11 +17,14 @@ class PruneService
   # @param [Pathname] outermost_branch The branch at which pruning begins
   # @return [void] Ascend the druid tree and prune empty branches
   def prune_ancestors(outermost_branch)
-    while outermost_branch.exist? && outermost_branch.children.empty?
+    while outermost_branch.exist?
       begin
         outermost_branch.rmdir
       rescue Errno::ENOENT
         # This handles a race condition with other pruning.
+      rescue Errno::ENOTEMPTY
+        # The directory is not empty, so we stop pruning.
+        break
       end
       outermost_branch = outermost_branch.parent
       break if outermost_branch == druid.base_pathname

--- a/spec/services/prune_service_spec.rb
+++ b/spec/services/prune_service_spec.rb
@@ -79,6 +79,17 @@ RSpec.describe PruneService do
       end
     end
 
+    context 'when rmdir raises Errno::ENOTEMPTY due to a race condition' do
+      it 'does not raise and stops ascending' do
+        dr1.mkdir
+        allow_any_instance_of(Pathname).to receive(:rmdir).and_raise(Errno::ENOTEMPTY) # rubocop:disable RSpec/AnyInstance
+        expect { described_class.new(druid: dr1).prune! }.not_to raise_error
+        # The leaf directory is removed via rmtree, but ancestor rmdir calls
+        # all raise ENOTEMPTY, so no ancestor directories get removed.
+        expect(File).to exist(dr1.pruning_base.parent)
+      end
+    end
+
     it 'removes all directories up to the base path when there are no common ancestors' do
       # Nil the create records for this test
       dr1.mkdir


### PR DESCRIPTION
closes #6191

## Why was this change made? 🤔
Non-empty directories were raising. They should just be skipped.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



