### PR TITLE
Set lane_id when initiating releaseWF.

### DIFF
--- a/app/jobs/robots/dor_repo/accession/release_initiate.rb
+++ b/app/jobs/robots/dor_repo/accession/release_initiate.rb
@@ -21,7 +21,7 @@ module Robots
           end
 
           Workflow::Service.create(druid:, workflow_name: 'releaseWF',
-                                   version: cocina_object.version)
+                                   version: cocina_object.version, lane_id:)
         end
 
         def skipped?

--- a/spec/jobs/robots/dor_repo/accession/release_initiate_spec.rb
+++ b/spec/jobs/robots/dor_repo/accession/release_initiate_spec.rb
@@ -8,12 +8,13 @@ RSpec.describe Robots::DorRepo::Accession::ReleaseInitiate, type: :robot do
   let(:druid) { 'druid:zz000zz0001' }
   let(:robot) { described_class.new }
   let(:workflow_context) { {} }
+  let(:lane_id) { 'default' }
 
   before do
     allow(CocinaObjectStore).to receive(:find).with(druid).and_return(object)
     allow(Workflow::Service).to receive(:create)
     allow(robot).to receive(:workflow).and_return(instance_double(Robots::Robot::RobotWorkflow,
-                                                                  context: workflow_context))
+                                                                  context: workflow_context, lane_id:))
   end
 
   context 'when the object is an admin policy' do
@@ -54,14 +55,16 @@ RSpec.describe Robots::DorRepo::Accession::ReleaseInitiate, type: :robot do
 
       it 'creates the workflow' do
         expect(perform).to be_nil # no return state defaults to completed.
-        expect(Workflow::Service).to have_received(:create).with(druid: druid, workflow_name: 'releaseWF', version: 1)
+        expect(Workflow::Service).to have_received(:create).with(druid: druid, workflow_name: 'releaseWF', version: 1,
+                                                                 lane_id: 'default')
       end
     end
 
     context 'when workflow context does not indicate release should be skipped' do
       it 'creates the workflow' do
         expect(perform).to be_nil # no return state defaults to completed.
-        expect(Workflow::Service).to have_received(:create).with(druid: druid, workflow_name: 'releaseWF', version: 1)
+        expect(Workflow::Service).to have_received(:create).with(druid: druid, workflow_name: 'releaseWF', version: 1,
+                                                                 lane_id: 'default')
       end
     end
   end


### PR DESCRIPTION
closes #6194

## Why was this change made? 🤔
Robots that create workflows should maintain the lane_id.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



