### PR TITLE
Allow version to be taken into account when running robots/updating workflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,7 @@ gem 'druid-tools'
 gem 'folio_client'
 gem 'graphql'
 gem 'json_schemer-rails'
-# Temporarily pinned lyber-core on 7/10/2026 since >v9.0 lybercore has version-aware breaking changes requiring updates
-# to all consumers simultaneously. See https://github.com/sul-dlss/dor-services-app/pull/6196
-gem 'lyber-core', '~> 8.0' # For robots
+gem 'lyber-core' # For robots
 gem 'mais_orcid_client'
 gem 'marc'
 gem 'moab-versioning', require: 'moab/stanford'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,7 +308,7 @@ GEM
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    lyber-core (8.2.0)
+    lyber-core (9.0.0)
       activesupport
       config
       dor-services-client
@@ -671,7 +671,7 @@ DEPENDENCIES
   json_schemer-rails
   jwt
   lograge
-  lyber-core (~> 8.0)
+  lyber-core
   mais_orcid_client
   marc
   moab-versioning

--- a/app/controllers/workflow_processes_controller.rb
+++ b/app/controllers/workflow_processes_controller.rb
@@ -5,11 +5,12 @@ class WorkflowProcessesController < WorkflowApplicationController
   def update # rubocop:disable Metrics/AbcSize
     if status == 'error'
       Workflow::ProcessService.update_error(druid:, workflow_name:, process: workflow_process,
-                                            error_msg: params[:error_msg], error_text: params[:error_text])
+                                            error_msg: params[:error_msg], error_text: params[:error_text],
+                                            version:)
     else
       Workflow::ProcessService.update(druid:, workflow_name:, process: workflow_process, status:,
                                       elapsed: params[:elapsed] || 0, lifecycle: params[:lifecycle],
-                                      note: params[:note], current_status: params[:current_status])
+                                      note: params[:note], current_status: params[:current_status], version:)
     end
 
     head :no_content
@@ -31,5 +32,9 @@ class WorkflowProcessesController < WorkflowApplicationController
 
   def status
     params[:status]
+  end
+
+  def version
+    params[:version]
   end
 end

--- a/app/jobs/robots/robot.rb
+++ b/app/jobs/robots/robot.rb
@@ -14,17 +14,18 @@ module Robots
     private
 
     def workflow
-      @workflow ||= RobotWorkflow.new(workflow_name: workflow_name, process: process, druid:)
+      @workflow ||= RobotWorkflow.new(workflow_name: workflow_name, process: process, druid:, version:)
     end
 
     # This encapsulates the workflow operations that lyber-core does.
     # This implementation uses local services instead of the dor-services-client.
     # It should have the same interface as LyberCore::Workflow.
     class RobotWorkflow
-      def initialize(workflow_name:, process:, druid:)
+      def initialize(workflow_name:, process:, druid:, version:)
         @workflow_name = workflow_name
         @process = process
         @druid = druid
+        @version = version
       end
 
       def object_workflow
@@ -46,24 +47,31 @@ module Robots
       end
 
       def start!(note)
-        Workflow::ProcessService.update(druid:, workflow_name:, process:, status: 'started', note:, elapsed: 1.0)
+        Workflow::ProcessService.update(druid:, workflow_name:, process:, status: 'started', note:, elapsed: 1.0,
+                                        version:)
       end
 
       def complete!(status, elapsed, note)
-        Workflow::ProcessService.update(druid:, workflow_name:, process:, status:, note:, elapsed:)
+        Workflow::ProcessService.update(druid:, workflow_name:, process:, status:, note:, elapsed:, version:)
       end
 
       def retrying!
-        Workflow::ProcessService.update(druid:, workflow_name:, process:, status: 'retrying', note: nil, elapsed: 1.0)
+        Workflow::ProcessService.update(druid:, workflow_name:, process:, status: 'retrying', note: nil,
+                                        elapsed: 1.0, version:)
       end
 
       def error!(error_msg, error_text)
-        Workflow::ProcessService.update_error(druid:, workflow_name:, process:, error_msg:, error_text:)
+        Workflow::ProcessService.update_error(druid:, workflow_name:, process:, error_msg:, error_text:, version:)
+      end
+
+      def skip!(note)
+        Workflow::ProcessService.update(druid:, workflow_name:, process:, status: 'skipped', note:, elapsed: 0,
+                                        version:)
       end
 
       delegate :context, :status, :lane_id, :active_version?, to: :process_response
 
-      attr_reader :workflow_name, :process, :druid
+      attr_reader :workflow_name, :process, :druid, :version
     end
   end
 end

--- a/app/services/queue_service.rb
+++ b/app/services/queue_service.rb
@@ -17,8 +17,9 @@ class QueueService
   end
 
   # Enqueue the provided step
-  def enqueue
-    job_id = ROBOT_SIDEKIQ_CLIENT.push('queue' => queue_name, 'class' => class_name, 'args' => [step.druid])
+  def enqueue # rubocop:disable Metrics/AbcSize
+    job_id = ROBOT_SIDEKIQ_CLIENT.push('queue' => queue_name, 'class' => class_name,
+                                       'args' => [step.druid, step.version])
     raise "Enqueueing #{class_name} for #{step.druid} to #{queue_name} failed." unless job_id
 
     Rails.logger.info "Enqueued #{class_name} for #{step.druid} to #{queue_name}: #{job_id}"

--- a/app/services/workflow/process_service.rb
+++ b/app/services/workflow/process_service.rb
@@ -4,22 +4,24 @@ module Workflow
   # Service for interacting with workflows processes (steps).
   class ProcessService
     def self.update(druid:, workflow_name:, process:, status:, elapsed: 0, lifecycle: nil, note: nil, # rubocop:disable Metrics/ParameterLists
-                    current_status: nil, enqueue_next_steps: true)
-      new(druid:, workflow_name:, process:).update(status:, elapsed:, lifecycle:, note:, current_status:,
-                                                   enqueue_next_steps:)
+                    version: nil, current_status: nil, enqueue_next_steps: true)
+      new(druid:, workflow_name:, process:, version:).update(status:, elapsed:, lifecycle:, note:, current_status:,
+                                                             enqueue_next_steps:)
     end
 
-    def self.update_error(druid:, workflow_name:, process:, error_msg:, error_text: nil)
-      new(druid:, workflow_name:, process:).update_error(error_msg:, error_text:)
+    def self.update_error(druid:, workflow_name:, process:, error_msg:, error_text: nil, version: nil) # rubocop:disable Metrics/ParameterLists
+      new(druid:, workflow_name:, process:, version:).update_error(error_msg:, error_text:)
     end
 
     # @param [String] druid
     # @param [String] workflow_name The name of the workflow
     # @param [String] process The name of the workflow step
-    def initialize(druid:, workflow_name:, process:)
+    # @param [String] version The object version of the workflow step (nil if workflow step for latest version)
+    def initialize(druid:, workflow_name:, process:, version: nil)
       @druid = druid
       @workflow_name = workflow_name
       @process = process
+      @version = version
     end
 
     # Updates the status of one step in a workflow.
@@ -45,7 +47,7 @@ module Workflow
 
     private
 
-    attr_reader :druid, :workflow_name, :process
+    attr_reader :druid, :workflow_name, :process, :version
 
     def workflow_client
       @workflow_client ||= WorkflowClientFactory.build
@@ -71,11 +73,18 @@ module Workflow
       Workflow::NextStepService.enqueue_next_steps(step:) if enqueue_next_steps
     end
 
-    def find_step_for_process
+    def find_step_for_process # rubocop:disable Metrics/AbcSize
       query = WorkflowStep.where(druid:,
                                  workflow: workflow_name,
                                  process: process)
-                          .order(version: :desc)
+      query = if version.present?
+                query.for_version(version)
+              else
+                query.active
+              end
+      # ordering should not be necessary since we target a specific version
+      # but just in case there are multiple rows for the same version, we want the latest one
+      query = query.order(version: :desc)
       # Validate uniqueness until https://github.com/sul-dlss/workflow-server-rails/pull/40 is in place
       if query.size != query.pluck(:version).uniq.size
         raise "Duplicate workflow step for #{druid} #{workflow_name} #{process}"

--- a/openapi.yml
+++ b/openapi.yml
@@ -1935,6 +1935,9 @@ paths:
                   type: string
                 error_message:
                   type: string
+                version:
+                  # description: The version of the object this workflow step belongs to (defaults to the active version)
+                  type: integer
               required:
                 - status
 components:

--- a/spec/jobs/robots/robot_spec.rb
+++ b/spec/jobs/robots/robot_spec.rb
@@ -21,25 +21,44 @@ RSpec.describe Robots::Robot do
   end
 
   describe '#perform' do
-    let(:robot_workflow) { instance_double(Robots::Robot::RobotWorkflow, status: 'queued', start!: true, complete!: true) }
+    let(:robot_workflow) do
+      instance_double(Robots::Robot::RobotWorkflow, status: 'queued', start!: true, complete!: true,
+                                                    active_version?: true)
+    end
+    let(:cocina_object) { instance_double(Cocina::Models::DRO, version: 2) }
 
     before do
       allow(Robots::Robot::RobotWorkflow).to receive(:new).and_return(robot_workflow)
+      allow(CocinaObjectStore).to receive(:find).and_return(cocina_object)
     end
 
     it 'invokes a RobotWorkflow' do
-      robot.perform('druid:gv054hp4128')
+      robot.perform('druid:gv054hp4128', 2)
       expect(robot.send(:workflow)).to be robot_workflow
       expect(Robots::Robot::RobotWorkflow).to have_received(:new).with(workflow_name: 'testWF', process: 'test-step',
-                                                                       druid: 'druid:gv054hp4128')
+                                                                       druid: 'druid:gv054hp4128', version: 2)
       expect(robot_workflow).to have_received(:start!).with(Socket.gethostname)
       expect(robot_workflow).to have_received(:complete!).with('completed', Float, Socket.gethostname)
+    end
+
+    context 'when the given version is not active' do
+      before do
+        allow(robot_workflow).to receive_messages(active_version?: false, skip!: true)
+      end
+
+      it 'skips the job without performing the work' do
+        robot.perform('druid:gv054hp4128', 1)
+        expect(robot_workflow).to have_received(:skip!)
+          .with(/queued for version 1 of test-step \(testWF\), but that is not the active version/)
+        expect(robot_workflow).not_to have_received(:start!)
+        expect(robot_workflow).not_to have_received(:complete!)
+      end
     end
   end
 
   describe Robots::Robot::RobotWorkflow do
     subject(:workflow) do
-      described_class.new(workflow_name: 'testWF', process: 'test-step', druid: 'druid:gv054hp4128')
+      described_class.new(workflow_name: 'testWF', process: 'test-step', druid: 'druid:gv054hp4128', version: 3)
     end
 
     let(:workflow_response) { instance_double(Workflow::WorkflowResponse, process_for_recent_version: process_response) }
@@ -85,7 +104,7 @@ RSpec.describe Robots::Robot do
         workflow.start!('Starting workflow')
         expect(Workflow::ProcessService).to have_received(:update)
           .with(druid: 'druid:gv054hp4128', workflow_name: 'testWF',
-                process: 'test-step', status: 'started', note: 'Starting workflow', elapsed: 1.0)
+                process: 'test-step', status: 'started', note: 'Starting workflow', elapsed: 1.0, version: 3)
       end
     end
 
@@ -94,7 +113,8 @@ RSpec.describe Robots::Robot do
         workflow.complete!('completed', 1.0, 'Workflow completed successfully')
         expect(Workflow::ProcessService).to have_received(:update)
           .with(druid: 'druid:gv054hp4128', workflow_name: 'testWF',
-                process: 'test-step', status: 'completed', note: 'Workflow completed successfully', elapsed: 1.0)
+                process: 'test-step', status: 'completed', note: 'Workflow completed successfully', elapsed: 1.0,
+                version: 3)
       end
     end
 
@@ -103,7 +123,7 @@ RSpec.describe Robots::Robot do
         workflow.retrying!
         expect(Workflow::ProcessService).to have_received(:update)
           .with(druid: 'druid:gv054hp4128', workflow_name: 'testWF',
-                process: 'test-step', status: 'retrying', note: nil, elapsed: 1.0)
+                process: 'test-step', status: 'retrying', note: nil, elapsed: 1.0, version: 3)
       end
     end
 
@@ -112,7 +132,18 @@ RSpec.describe Robots::Robot do
         workflow.error!('An error occurred', 'Detailed error information')
         expect(Workflow::ProcessService).to have_received(:update_error)
           .with(druid: 'druid:gv054hp4128', workflow_name: 'testWF',
-                process: 'test-step', error_msg: 'An error occurred', error_text: 'Detailed error information')
+                process: 'test-step', error_msg: 'An error occurred', error_text: 'Detailed error information',
+                version: 3)
+      end
+    end
+
+    describe '.skip!' do
+      it 'updates the workflow process to skipped' do
+        workflow.skip!('Superseded by a newer version')
+        expect(Workflow::ProcessService).to have_received(:update)
+          .with(druid: 'druid:gv054hp4128', workflow_name: 'testWF',
+                process: 'test-step', status: 'skipped', note: 'Superseded by a newer version', elapsed: 0,
+                version: 3)
       end
     end
 
@@ -137,6 +168,12 @@ RSpec.describe Robots::Robot do
     describe '.active_version?' do
       it 'returns the active_version? of the process response' do
         expect(workflow.active_version?).to be true
+      end
+    end
+
+    describe '.version' do
+      it 'returns the version passed to the constructor, not the process response version' do
+        expect(workflow.version).to eq(3)
       end
     end
   end

--- a/spec/requests/update_workflow_process_spec.rb
+++ b/spec/requests/update_workflow_process_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe 'Update a workflow process' do
     it 'updates the status' do
       put '/v1/objects/druid:mx123qw2323/workflows/accessionWF/processes/shelve',
           headers: { 'Authorization' => "Bearer #{jwt}" },
-          params: { status: 'completed' },
+          params: { status: 'completed', version: 2 },
           as: :json
       expect(response).to have_http_status(:no_content)
       expect(Workflow::ProcessService).to have_received(:update)
         .with(druid:, workflow_name: 'accessionWF', process: 'shelve', status: 'completed', elapsed:  0,
-              lifecycle: nil, note: nil, current_status: nil)
+              lifecycle: nil, note: nil, current_status: nil, version: 2)
     end
   end
 
@@ -28,12 +28,12 @@ RSpec.describe 'Update a workflow process' do
       put '/v1/objects/druid:mx123qw2323/workflows/accessionWF/processes/shelve',
           headers: { 'Authorization' => "Bearer #{jwt}" },
           params: { status: 'completed', elapsed: 5.1, lifecycle: 'accession', note: 'Test note',
-                    current_status: 'started' },
+                    current_status: 'started', version: 2 },
           as: :json
       expect(response).to have_http_status(:no_content)
       expect(Workflow::ProcessService).to have_received(:update)
         .with(druid:, workflow_name: 'accessionWF', process: 'shelve', status: 'completed', elapsed:  5.1,
-              lifecycle: 'accession', note: 'Test note', current_status: 'started')
+              lifecycle: 'accession', note: 'Test note', current_status: 'started', version: 2)
     end
   end
 
@@ -41,12 +41,13 @@ RSpec.describe 'Update a workflow process' do
     it 'updates the status' do
       put '/v1/objects/druid:mx123qw2323/workflows/accessionWF/processes/shelve',
           headers: { 'Authorization' => "Bearer #{jwt}" },
-          params: { status: 'error', error_msg: 'Something went wrong', error_text: 'Detailed error message' },
+          params: { status: 'error', error_msg: 'Something went wrong', error_text: 'Detailed error message',
+                    version: 2 },
           as: :json
       expect(response).to have_http_status(:no_content)
       expect(Workflow::ProcessService).to have_received(:update_error)
         .with(druid:, workflow_name: 'accessionWF', process: 'shelve', error_msg: 'Something went wrong',
-              error_text: 'Detailed error message')
+              error_text: 'Detailed error message', version: 2)
     end
   end
 

--- a/spec/services/queue_service_spec.rb
+++ b/spec/services/queue_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe QueueService do
   let(:service) { described_class.new step }
 
-  let(:step) { create(:workflow_step, workflow: 'assemblyWF', process: 'jp2-create') }
+  let(:step) { create(:workflow_step, workflow: 'assemblyWF', process: 'jp2-create', version: 2) }
 
   describe '#enqueue' do
     before do
@@ -19,7 +19,7 @@ RSpec.describe QueueService do
         service.enqueue
         expect(ROBOT_SIDEKIQ_CLIENT).to have_received(:push).with('queue' => 'assemblyWF_jp2',
                                                                   'class' => 'Robots::DorRepo::Assembly::Jp2Create',
-                                                                  'args' => [step.druid])
+                                                                  'args' => [step.druid, step.version])
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe QueueService do
         service.enqueue
         expect(ROBOT_SIDEKIQ_CLIENT).to have_received(:push).with('queue' => 'accessionWF_default_dsa',
                                                                   'class' => 'Robots::DorRepo::Accession::Publish',
-                                                                  'args' => [step.druid])
+                                                                  'args' => [step.druid, step.version])
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe QueueService do
         service.enqueue
         expect(ROBOT_SIDEKIQ_CLIENT).to have_received(:push).with('queue' => 'accessionWF_default',
                                                                   'class' => 'Robots::DorRepo::Accession::TechnicalMetadata',
-                                                                  'args' => [step.druid])
+                                                                  'args' => [step.druid, step.version])
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe QueueService do
         service.enqueue
         expect(ROBOT_SIDEKIQ_CLIENT).to have_received(:push).with('queue' => 'preservationIngestWF_default',
                                                                   'class' => 'Robots::SdrRepo::PreservationIngest::TransferObject',
-                                                                  'args' => [step.druid])
+                                                                  'args' => [step.druid, step.version])
       end
     end
 

--- a/spec/services/workflow/process_service_spec.rb
+++ b/spec/services/workflow/process_service_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Workflow::ProcessService do
                status: 'error',
                error_msg: 'Bang!',
                error_txt: 'This is error',
-               lifecycle: 'submitted')
+               lifecycle: 'submitted',
+               active_version: true)
       end
 
       it 'clears the old error message, but preserves the lifecycle' do
@@ -38,7 +39,7 @@ RSpec.describe Workflow::ProcessService do
 
     context 'when a non-default lane_id' do
       let(:step) do
-        create(:workflow_step, lane_id: 'low')
+        create(:workflow_step, lane_id: 'low', active_version: true)
       end
 
       it 'does not change the lane_id' do
@@ -61,7 +62,7 @@ RSpec.describe Workflow::ProcessService do
     end
 
     context 'when current status does not match' do
-      let(:step) { create(:workflow_step) }
+      let(:step) { create(:workflow_step, active_version: true) }
 
       it 'raises ConflictException' do
         expect do
@@ -73,7 +74,7 @@ RSpec.describe Workflow::ProcessService do
     end
 
     context 'when current status matches' do
-      let(:step) { create(:workflow_step) }
+      let(:step) { create(:workflow_step, active_version: true) }
 
       it 'does not raise' do
         expect do
@@ -84,8 +85,10 @@ RSpec.describe Workflow::ProcessService do
     end
 
     context 'when there are multiple versions' do
-      let(:version1_step) { create(:workflow_step, status: 'error', version: 1) }
-      let(:version2_step) { create(:workflow_step, status: 'error', version: 2, druid: version1_step.druid) }
+      let(:version1_step) { create(:workflow_step, status: 'error', version: 1, active_version: false) }
+      let(:version2_step) do
+        create(:workflow_step, status: 'error', version: 2, druid: version1_step.druid, active_version: true)
+      end
 
       it 'updates the newest version' do
         expect do
@@ -98,8 +101,25 @@ RSpec.describe Workflow::ProcessService do
       end
     end
 
+    context 'when a version is given' do
+      let(:version1_step) { create(:workflow_step, status: 'queued', version: 1, active_version: false) }
+      let(:version2_step) do
+        create(:workflow_step, status: 'queued', version: 2, druid: version1_step.druid, active_version: true)
+      end
+
+      it 'updates the given version, even when it is not the active version' do
+        expect do
+          described_class.update(druid: version1_step.druid, workflow_name: version1_step.workflow,
+                                 process: version1_step.process, status: 'completed', version: 1)
+        end.to change { version1_step.reload.status }.from('queued').to('completed')
+                                                     .and not_change { version2_step.reload.status }.from('queued')
+
+        expect(Workflow::NextStepService).to have_received(:enqueue_next_steps).with(step: version1_step)
+      end
+    end
+
     context 'when enqueue_next_steps is false' do
-      let(:step) { create(:workflow_step) }
+      let(:step) { create(:workflow_step, active_version: true) }
 
       it 'does not enqueue next steps' do
         described_class.update(druid: step.druid, workflow_name: step.workflow, process: step.process,
@@ -115,7 +135,7 @@ RSpec.describe Workflow::ProcessService do
       allow(Workflow::NextStepService).to receive(:enqueue_next_steps)
     end
 
-    let(:step) { create(:workflow_step) }
+    let(:step) { create(:workflow_step, active_version: true) }
 
     it 'updates the step with error message/text' do
       expect do


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes https://github.com/sul-dlss/dor-services-app/issues/6172

Alternative to #6188 

Coordinate with [lyber-core PR](https://github.com/sul-dlss/lyber-core/pull/297) and [dor-services-client PR](https://github.com/sul-dlss/dor-services-client/pull/630), see release plan below for timing.  This should be last.

Note: we allow version: nil as the default so that old long running jobs will not break during rollout.

## Release plan: ##


- [x] Merge [lyber-core PR](https://github.com/sul-dlss/lyber-core/pull/300) and release new full point version of lyber-core gem.
- [x] Go to PRs above and bump to new release of lyber-core
- [x] Pause stage accessioning queues (pause button):
- https://robot-console-stage.stanford.edu/queues 
- [x] Quiet stage workers and wait until all running jobs at bottom of page are done (quiet all workers button):
- https://robot-console-stage.stanford.edu/busy
- [x] Deploy all apps above to stage which should restart quieted workers.
- [x] Unpause all queues in stage
- https://robot-console-stage.stanford.edu/queues 
- [x]  Run accessioning integration tests in stage
- [x]  Unhold, rebase and merge all PRs below and then quiet/pause workers in qa, stage and prod.  Note that you will likely need to fix merge conflicts with Gemfiles since lyber-core was pinned in DSA, gis-robot-suite, and preservation-robots.  Common-accessioning and was-robot-suite were previously already pinning lyber-core, so should not need to do anything with those to resolve conflicts. 
- Consumer apps:
  - #6196 (this PR)
  - https://github.com/sul-dlss/common-accessioning/pull/1639
  - https://github.com/sul-dlss/gis-robot-suite/pull/1148
  - https://github.com/sul-dlss/preservation_robots/pull/692
  - https://github.com/sul-dlss/was_robot_suite/pull/880
- https://robot-console-stage.stanford.edu/queues (pause button for all queues) 
- https://robot-console-qa.stanford.edu/queues (pause button for each queue)
- https://robot-console-prod.stanford.edu/queues (pause button for each queue)
- https://robot-console-stage.stanford.edu/busy (quiet all workers button)
- https://robot-console-qa.stanford.edu/busy (quiet all workers button)
- https://robot-console-prod.stanford.edu/busy (quiet all workers button)
- [x]  Deploy all apps that had PRs above to stage, qa and prod, which should unquiet all workers.
- [x]  Unpause all queues in prod and qa 
- https://robot-console-stage.stanford.edu/queues (unpause button for all queues) 
- https://robot-console-qa.stanford.edu/queues (unpause button for all queues) 
- https://robot-console-prod.stanford.edu/queues (unpause button for all queues)
 
**Failure/Rollback:**
-  [x] Revert PRs above
-  [x] Make new PRs that pin lyber-core to previous full point release ( < 9) in all those apps, merge those PRs, re-deploy them all

## How was this change tested? 🤨

- [x] Specs
- [x] Integration tests