### PR TITLE
Set wf context to skip releaseWF for Folio Refresh migrator.

### DIFF
--- a/app/services/migrators/folio_refresh.rb
+++ b/app/services/migrators/folio_refresh.rb
@@ -30,6 +30,10 @@ module Migrators
       'Refresh description from Folio.'
     end
 
+    def self.workflow_context
+      { 'skipReleaseWF' => true }
+    end
+
     private
 
     def refreshable_hrid

--- a/spec/services/migrators/folio_refresh_spec.rb
+++ b/spec/services/migrators/folio_refresh_spec.rb
@@ -74,4 +74,10 @@ RSpec.describe Migrators::FolioRefresh do
       expect(described_class.migration_tag).to eq('Migration : Folio Refresh')
     end
   end
+
+  describe '.workflow_context' do
+    it 'returns the workflow context' do
+      expect(described_class.workflow_context).to eq({ 'skipReleaseWF' => true })
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Nobody needs the headache of the releaseWF.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



