### PR TITLE
Fix batch reindexing.

### DIFF
--- a/lib/tasks/indexer.rake
+++ b/lib/tasks/indexer.rake
@@ -3,7 +3,7 @@
 namespace :indexer do
   desc 'Reindex all objects in jobs'
   task :reindex_jobs, %i[batch_size] => :environment do |_task, args|
-    RepositoryObject.in_batches(batch_size: args.batch_size&.to_i || 100) do |relation|
+    RepositoryObject.in_batches(of: args.batch_size&.to_i || 100) do |relation|
       druids = relation.pluck(:external_identifier)
       BatchReindexJob.perform_later(druids)
     end


### PR DESCRIPTION
## Why was this change made? 🤔
```
ArgumentError: unknown keyword: :batch_size
/opt/app/dor_services/dor_services/shared/bundle/ruby/3.4.0/gems/activerecord-8.0.5/lib/active_record/relation/batches.rb:259:in 'in_batches'
/opt/app/dor_services/dor_services/shared/bundle/ruby/3.4.0/gems/activerecord-8.0.5/lib/active_record/querying.rb:24:in 'ActiveRecord::Querying#in_batches'
/opt/app/dor_services/dor_services/releases/20260702182358/lib/tasks/indexer.rake:6:in 'block (2 levels) in <compiled>'
```

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



