### PR TITLE
Remove label from graphql.

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -8,7 +8,7 @@ module Types
     include GraphQL::Types::Relay::HasNodeField
     include GraphQL::Types::Relay::HasNodesField
 
-    BASE_ALLOWED_FIELDS = %i[external_identifier cocina_version label version administrative description].freeze
+    BASE_ALLOWED_FIELDS = %i[external_identifier cocina_version version administrative description].freeze
     DRO_ALLOWED_FIELDS = BASE_ALLOWED_FIELDS + %i[content_type access identification structural geographic]
     COLLECTION_ALLOWED_FIELDS = BASE_ALLOWED_FIELDS + %i[collection_type access identification]
 

--- a/spec/requests/graphql_spec.rb
+++ b/spec/requests/graphql_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe 'GraphQL' do
           externalIdentifier
           type
           cocinaVersion
-          label
           description
           geographic
         }
@@ -33,7 +32,6 @@ RSpec.describe 'GraphQL' do
       {
         content_type: 'https://cocina.sul.stanford.edu/models/book',
         cocina_version: '0.96.0',
-        label: 'Test DRO',
         description: {
           purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}",
           title: [
@@ -63,7 +61,6 @@ RSpec.describe 'GraphQL' do
               externalIdentifier: druid,
               type: 'https://cocina.sul.stanford.edu/models/book',
               cocinaVersion: cocina_version,
-              label: 'Test DRO',
               description: {
                 purl:,
                 title: [{
@@ -94,7 +91,6 @@ RSpec.describe 'GraphQL' do
               externalIdentifier: druid,
               type: 'https://cocina.sul.stanford.edu/models/collection',
               cocinaVersion: cocina_version,
-              label: 'Test Collection',
               description: {
                 purl:,
                 title: [{
@@ -125,7 +121,6 @@ RSpec.describe 'GraphQL' do
               externalIdentifier: druid,
               type: 'https://cocina.sul.stanford.edu/models/admin_policy',
               cocinaVersion: cocina_version,
-              label: 'Test Admin Policy',
               description: {
                 purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}",
                 title: [


### PR DESCRIPTION
closes #6184

## Why was this change made? 🤔
Label is deprecated.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



