### PR TITLE
Add gisDeliveryWF to list of deprecated workflows

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -170,6 +170,7 @@ skip_workflows: -accession2WF
   -googleScannedBookWF
   -eemsAccessionWF
   -gisDiscoveryWF
+  -gisDeliveryWF
   -etdSubmitWF
   -hydrusAssemblyWF
   -disseminationWF

--- a/spec/services/workflow/template_service_spec.rb
+++ b/spec/services/workflow/template_service_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe Workflow::TemplateService do
           captionWF
           digitizationWF
           gisAssemblyWF
-          gisDeliveryWF
           gisDerivativeWF
           goobiWF
           ocrWF


### PR DESCRIPTION
## Why was this change made? 🤔

Not sure exactly what this list does, but gisDeliveryWF isn't used anymore.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



