### PR TITLE
add active attribute to response

### DIFF
--- a/app/jobs/robots/robot.rb
+++ b/app/jobs/robots/robot.rb
@@ -61,7 +61,7 @@ module Robots
         Workflow::ProcessService.update_error(druid:, workflow_name:, process:, error_msg:, error_text:)
       end
 
-      delegate :context, :status, :lane_id, to: :process_response
+      delegate :context, :status, :lane_id, :active_version?, to: :process_response
 
       attr_reader :workflow_name, :process, :druid
     end

--- a/app/models/workflow_step.rb
+++ b/app/models/workflow_step.rb
@@ -87,7 +87,8 @@ class WorkflowStep < WorkflowApplicationRecord
       # context (which is deserialized as a hash by activerecord) as json so it can be deserialized by client
       context: context&.to_json,
       status:,
-      name: process
+      name: process,
+      activeVersion: active_version
     }.tap do |attr|
       attr[:errorMessage] = error_msg if error_msg
     end

--- a/app/services/workflow/process_response.rb
+++ b/app/services/workflow/process_response.rb
@@ -29,6 +29,10 @@ module Workflow
       step.druid
     end
 
+    def active_version?
+      step.active_version
+    end
+
     private
 
     attr_reader :step

--- a/spec/jobs/robots/robot_spec.rb
+++ b/spec/jobs/robots/robot_spec.rb
@@ -42,8 +42,11 @@ RSpec.describe Robots::Robot do
       described_class.new(workflow_name: 'testWF', process: 'test-step', druid: 'druid:gv054hp4128')
     end
 
-    let(:workflow_response) { instance_double(Dor::Services::Response::Workflow, process_for_recent_version: process_response) }
-    let(:process_response) { instance_double(Dor::Services::Response::Process, name: 'test-step', status: 'waiting', lane_id: 'low', context: { foo: 'bar' }) }
+    let(:workflow_response) { instance_double(Workflow::WorkflowResponse, process_for_recent_version: process_response) }
+    let(:process_response) do
+      instance_double(Workflow::ProcessResponse, name: 'test-step', status: 'waiting', lane_id: 'low',
+                                                 context: { foo: 'bar' }, active_version?: true)
+    end
 
     before do
       allow(Workflow::Service).to receive(:workflow).and_return(workflow_response)
@@ -128,6 +131,12 @@ RSpec.describe Robots::Robot do
     describe '.context' do
       it 'returns the context of the process response' do
         expect(workflow.context).to eq({ foo: 'bar' })
+      end
+    end
+
+    describe '.active_version?' do
+      it 'returns the active_version? of the process response' do
+        expect(workflow.active_version?).to be true
       end
     end
   end

--- a/spec/models/workflow_step_spec.rb
+++ b/spec/models/workflow_step_spec.rb
@@ -192,8 +192,17 @@ RSpec.describe WorkflowStep do
         attempts: 0,
         datetime: String,
         status: 'waiting',
-        name: 'start-accession'
+        name: 'start-accession',
+        activeVersion: false
       )
+    end
+
+    context 'when active_version is true' do
+      before { step.active_version = true }
+
+      it 'includes the active version value' do
+        expect(step.attributes_for_process).to include(activeVersion: true)
+      end
     end
   end
 end

--- a/spec/services/notifications/workflow_step_updated_spec.rb
+++ b/spec/services/notifications/workflow_step_updated_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Notifications::WorkflowStepUpdated do
         context: nil,
         status: 'completed',
         name: 'end-accession',
+        activeVersion: false,
         action: 'workflow updated',
         druid: step.druid
       }.to_json

--- a/spec/services/workflow/service_spec.rb
+++ b/spec/services/workflow/service_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe Workflow::Service do
         <?xml version="1.0"?>
         <workflows objectId="druid:bb033gt0615">
           <workflow id="accessionWF" objectId="druid:bb033gt0615">
-           <process version="2" note="" lifecycle="" laneId="default" elapsed="" attempts="0" datetime="2025-07-22T21:35:36+00:00" context="{&quot;requireOCR&quot;:true,&quot;requireTranscript&quot;:true}" status="waiting" name="start-accession"/>
-           <process version="1" note="" lifecycle="" laneId="default" elapsed="" attempts="0" datetime="2025-07-22T21:35:36+00:00" context="{&quot;requireOCR&quot;:true,&quot;requireTranscript&quot;:true}" status="waiting" name="start-accession"/>
+           <process version="2" note="" lifecycle="" laneId="default" elapsed="" attempts="0" datetime="2025-07-22T21:35:36+00:00" context="{&quot;requireOCR&quot;:true,&quot;requireTranscript&quot;:true}" status="waiting" name="start-accession" activeVersion="false"/>
+           <process version="1" note="" lifecycle="" laneId="default" elapsed="" attempts="0" datetime="2025-07-22T21:35:36+00:00" context="{&quot;requireOCR&quot;:true,&quot;requireTranscript&quot;:true}" status="waiting" name="start-accession" activeVersion="false"/>
          </workflow>
          <workflow id="wasCrawlPreassemblyWF" objectId="druid:bb033gt0615">
-           <process version="1" note="" lifecycle="" laneId="default" elapsed="" attempts="0" datetime="2025-07-22T21:35:36+00:00" context="{&quot;requireOCR&quot;:true,&quot;requireTranscript&quot;:true}" status="waiting" name="start"/>
+           <process version="1" note="" lifecycle="" laneId="default" elapsed="" attempts="0" datetime="2025-07-22T21:35:36+00:00" context="{&quot;requireOCR&quot;:true,&quot;requireTranscript&quot;:true}" status="waiting" name="start" activeVersion="false"/>
          </workflow>
         </workflows>
       XML

--- a/spec/services/workflow/workflow_response_spec.rb
+++ b/spec/services/workflow/workflow_response_spec.rb
@@ -179,6 +179,7 @@ RSpec.describe Workflow::WorkflowResponse do
         expect(process).to be_a Workflow::ProcessResponse
         expect(process.status).to eq 'completed'
         expect(process.name).to eq 'jp2-create'
+        expect(process.active_version?).to be false
       end
     end
 
@@ -187,7 +188,8 @@ RSpec.describe Workflow::WorkflowResponse do
         [
           build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'start-assembly', version: 1),
           build(:workflow_step, :completed, druid:, workflow: workflow_name, process: 'jp2-create', version: 1),
-          build(:workflow_step, :error, druid:, workflow: workflow_name, process: 'jp2-create', version: 2)
+          build(:workflow_step, :error, druid:, workflow: workflow_name, process: 'jp2-create', version: 2,
+                                        active_version: true)
         ]
       end
 
@@ -196,6 +198,7 @@ RSpec.describe Workflow::WorkflowResponse do
         expect(process.status).to eq 'error'
         expect(process.error_message).to eq 'Something went wrong'
         expect(process.name).to eq 'jp2-create'
+        expect(process.active_version?).to be true
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Part of https://github.com/sul-dlss/dor-services-app/issues/6172

We need to expose the active_version attribute in the response.  This is a pre-req to exposing this in the DSA client response.

Once merged, will deploy to stage and then update dsa-client and lyber-core as needed.  And then new PRs and new gems released.

## How was this change tested? 🤨

Specs