### PR TITLE
Maps format_ssimdv.

### DIFF
--- a/app/services/indexing/builders/format_builder.rb
+++ b/app/services/indexing/builders/format_builder.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Indexing
+  module Builders
+    # Helper methods for working with formats
+    class FormatBuilder
+      # @param [Array<Cocina::Models::DescriptiveValue>] forms
+      # @return [Array<String>] the list of forms to index into solr
+      def self.build(forms)
+        new(forms).build
+      end
+
+      def initialize(forms)
+        @forms = Array(forms)
+      end
+
+      def build # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
+        formats = []
+        formats << 'Archived website' if genre_includes?('Archived website')
+        formats << 'Archive/Manuscript' if archive_manuscript?
+        formats << 'Dataset' if lc_resource_type_includes?('Dataset') || genre_includes?(['dataset', 'data set'])
+        formats << 'Image' if lc_resource_type_includes?('Still image') || mods_resource_type_includes?('still image')
+        formats << 'Journal/Periodical' if genre_includes?('Periodicals')
+        formats << 'Map' if lc_resource_type_includes?('Cartographic') || mods_resource_type_includes?('cartographic')
+        formats << 'Music score' if notated_music?
+        formats << 'Newspaper' if genre_includes?('Newspapers')
+        formats << 'Object' if object?
+        formats << 'Software/Multimedia' if software_multimedia?
+        formats << 'Sound recording' if sound_recording?
+        formats << 'Video/Film' if video_film?
+        formats << 'Book' if book?
+
+        formats << 'No format specified' if formats.empty?
+
+        formats
+      end
+
+      private
+
+      attr_reader :forms
+
+      def archive_manuscript?
+        lc_resource_type_includes?(['Collection', 'Manuscript', 'Mixed material']) ||
+          mods_resource_type_includes?(['collection', 'manuscript', 'mixed material'])
+      end
+
+      def notated_music?
+        lc_resource_type_includes?('Notated music') || mods_resource_type_includes?('Notated music')
+      end
+
+      def object?
+        lc_resource_type_includes?('Artifact') || mods_resource_type_includes?('three dimensional object')
+      end
+
+      def software_multimedia?
+        lc_resource_type_includes?(['Digital', 'Multimedia']) || mods_resource_type_includes?('software, multimedia')
+      end
+
+      def sound_recording?
+        lc_resource_type_includes?('Audio') ||
+          mods_resource_type_includes?(['sound recording', 'sound recording-musical', 'sound recording-nonmusical'])
+      end
+
+      def video_film?
+        lc_resource_type_includes?('Moving image') || mods_resource_type_includes?('moving image')
+      end
+
+      def book?
+        (lc_resource_type_includes?('Text') || mods_resource_type_includes?('text')) &&
+          !genre_includes?(['Archived website', 'dataset', 'data set', 'Periodicals', 'Newspaper'])
+      end
+
+      def genres
+        @genres ||= forms.filter_map { |form| form.value if form.type == 'genre' }.map(&:downcase)
+      end
+
+      def genre_includes?(genre_candidates)
+        Array(genre_candidates).any? { |genre_candidate| genres.include?(genre_candidate.downcase) }
+      end
+
+      def lc_resource_types
+        @lc_resource_types ||= forms.filter_map do |form|
+          form.value&.downcase if resource_type?(form: form, source: 'LC Resource Types Scheme')
+        end
+      end
+
+      def lc_resource_type_includes?(resource_type_candidates)
+        Array(resource_type_candidates).any? do |resource_type_candidate|
+          lc_resource_types.include?(resource_type_candidate.downcase)
+        end
+      end
+
+      def mods_resource_types
+        @mods_resource_types ||= forms.filter_map do |form|
+          form.value&.downcase if resource_type?(form: form, source: 'MODS resource types')
+        end
+      end
+
+      def mods_resource_type_includes?(resource_type_candidates)
+        Array(resource_type_candidates).any? do |resource_type_candidate|
+          mods_resource_types.include?(resource_type_candidate.downcase)
+        end
+      end
+
+      def resource_type?(form:, source:)
+        form.type == 'resource type' && form.source&.value == source
+      end
+    end
+  end
+end

--- a/app/services/indexing/indexers/descriptive_metadata_indexer.rb
+++ b/app/services/indexing/indexers/descriptive_metadata_indexer.rb
@@ -35,6 +35,7 @@ module Indexing
         'publication_year_ssidv' => :pub_year_int,
 
         # SW facets plus a friend facet
+        'format_ssimdv' => :format,
         'sw_format_ssimdv' => :sw_format,
         'mods_typeOfResource_ssimdv' => :resource_type, # MODS Resource Type facet
         'genre_ssimdv' => :genres,
@@ -102,6 +103,10 @@ module Indexing
       def display_title
         Cocina::Models::Builders::TitleBuilder.build(cocina.description.title,
                                                      catalog_links: catalog_links)
+      end
+
+      def format
+        Indexing::Builders::FormatBuilder.build(cocina.description.form)
       end
 
       def forms

--- a/spec/services/indexing/builders/format_builder_spec.rb
+++ b/spec/services/indexing/builders/format_builder_spec.rb
@@ -1,0 +1,557 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Indexing::Builders::FormatBuilder do
+  describe '.build' do
+    subject(:build) { described_class.build(forms) }
+
+    describe 'Archived website' do
+      context 'with a genre of Archived website' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Archived website', type: 'genre')
+          ]
+        end
+
+        it 'includes Archived website' do
+          expect(build).to eq(['Archived website'])
+        end
+      end
+
+      context 'with a genre of archived website in a different case' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'archived website', type: 'genre')
+          ]
+        end
+
+        it 'includes Archived website' do
+          expect(build).to eq(['Archived website'])
+        end
+      end
+    end
+
+    describe 'No format specified' do
+      context 'with an unrelated genre' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'photographs', type: 'genre')
+          ]
+        end
+
+        it 'returns No format specified' do
+          expect(build).to eq(['No format specified'])
+        end
+      end
+
+      context 'with a non-genre form of the same value' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Archived website', type: 'resource type')
+          ]
+        end
+
+        it 'returns No format specified' do
+          expect(build).to eq(['No format specified'])
+        end
+      end
+
+      context 'with no forms' do
+        let(:forms) { [] }
+
+        it 'returns No format specified' do
+          expect(build).to eq(['No format specified'])
+        end
+      end
+
+      context 'with nil forms' do
+        let(:forms) { nil }
+
+        it 'returns No format specified' do
+          expect(build).to eq(['No format specified'])
+        end
+      end
+    end
+
+    describe 'Archive/Manuscript' do
+      context 'with a resource type of Collection sourced from LC Resource Types Scheme' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Collection', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' })
+          ]
+        end
+
+        it 'includes Archive/Manuscript' do
+          expect(build).to eq(['Archive/Manuscript'])
+        end
+      end
+
+      context 'with a resource type of collection sourced from MODS resource types' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'collection', type: 'resource type',
+                                                 source: { value: 'MODS resource types' })
+          ]
+        end
+
+        it 'includes Archive/Manuscript' do
+          expect(build).to eq(['Archive/Manuscript'])
+        end
+      end
+
+      context 'with a resource type of Manuscript sourced from LC Resource Types Scheme' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Manuscript', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' })
+          ]
+        end
+
+        it 'includes Archive/Manuscript' do
+          expect(build).to eq(['Archive/Manuscript'])
+        end
+      end
+
+      context 'with a resource type of manuscript sourced from MODS resource types' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'manuscript', type: 'resource type',
+                                                 source: { value: 'MODS resource types' })
+          ]
+        end
+
+        it 'includes Archive/Manuscript' do
+          expect(build).to eq(['Archive/Manuscript'])
+        end
+      end
+
+      context 'with a resource type of Mixed material sourced from LC Resource Types Scheme' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Mixed material', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' })
+          ]
+        end
+
+        it 'includes Archive/Manuscript' do
+          expect(build).to eq(['Archive/Manuscript'])
+        end
+      end
+
+      context 'with a resource type of mixed material sourced from MODS resource types' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'mixed material', type: 'resource type',
+                                                 source: { value: 'MODS resource types' })
+          ]
+        end
+
+        it 'includes Archive/Manuscript' do
+          expect(build).to eq(['Archive/Manuscript'])
+        end
+      end
+    end
+
+    describe 'Dataset' do
+      context 'with a resource type of Dataset sourced from LC Resource Types Scheme' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Dataset', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' })
+          ]
+        end
+
+        it 'includes Dataset' do
+          expect(build).to eq(['Dataset'])
+        end
+      end
+
+      context 'with a genre of dataset' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'dataset', type: 'genre')
+          ]
+        end
+
+        it 'includes Dataset' do
+          expect(build).to eq(['Dataset'])
+        end
+      end
+
+      context 'with a genre of Data set' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Data set', type: 'genre')
+          ]
+        end
+
+        it 'includes Dataset' do
+          expect(build).to eq(['Dataset'])
+        end
+      end
+    end
+
+    describe 'Image' do
+      context 'with a resource type of Still image sourced from LC Resource Types Scheme' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Still image', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' })
+          ]
+        end
+
+        it 'includes Image' do
+          expect(build).to eq(['Image'])
+        end
+      end
+
+      context 'with a resource type of still image sourced from MODS resource types' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'still image', type: 'resource type',
+                                                 source: { value: 'MODS resource types' })
+          ]
+        end
+
+        it 'includes Image' do
+          expect(build).to eq(['Image'])
+        end
+      end
+    end
+
+    describe 'Journal/Periodical' do
+      context 'with a genre of Periodicals' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Periodicals', type: 'genre')
+          ]
+        end
+
+        it 'includes Journal/Periodical' do
+          expect(build).to eq(['Journal/Periodical'])
+        end
+      end
+    end
+
+    describe 'Map' do
+      context 'with a resource type of Cartographic sourced from LC Resource Types Scheme' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Cartographic', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' })
+          ]
+        end
+
+        it 'includes Map' do
+          expect(build).to eq(['Map'])
+        end
+      end
+
+      context 'with a resource type of cartographic sourced from MODS resource types' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'cartographic', type: 'resource type',
+                                                 source: { value: 'MODS resource types' })
+          ]
+        end
+
+        it 'includes Map' do
+          expect(build).to eq(['Map'])
+        end
+      end
+    end
+
+    describe 'Music score' do
+      context 'with a resource type of Notated music sourced from LC Resource Types Scheme' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Notated music', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' })
+          ]
+        end
+
+        it 'includes Music score' do
+          expect(build).to eq(['Music score'])
+        end
+      end
+
+      context 'with a resource type of Notated music sourced from MODS resource types' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Notated music', type: 'resource type',
+                                                 source: { value: 'MODS resource types' })
+          ]
+        end
+
+        it 'includes Music score' do
+          expect(build).to eq(['Music score'])
+        end
+      end
+    end
+
+    describe 'Newspaper' do
+      context 'with a genre of Newspapers' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Newspapers', type: 'genre')
+          ]
+        end
+
+        it 'includes Newspaper' do
+          expect(build).to eq(['Newspaper'])
+        end
+      end
+    end
+
+    describe 'Object' do
+      context 'with a resource type of Artifact sourced from LC Resource Types Scheme' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Artifact', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' })
+          ]
+        end
+
+        it 'includes Object' do
+          expect(build).to eq(['Object'])
+        end
+      end
+
+      context 'with a resource type of three dimensional object sourced from MODS resource types' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'three dimensional object', type: 'resource type',
+                                                 source: { value: 'MODS resource types' })
+          ]
+        end
+
+        it 'includes Object' do
+          expect(build).to eq(['Object'])
+        end
+      end
+    end
+
+    describe 'Software/Multimedia' do
+      context 'with a resource type of Digital sourced from LC Resource Types Scheme' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Digital', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' })
+          ]
+        end
+
+        it 'includes Software/Multimedia' do
+          expect(build).to eq(['Software/Multimedia'])
+        end
+      end
+
+      context 'with a resource type of Multimedia sourced from LC Resource Types Scheme' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Multimedia', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' })
+          ]
+        end
+
+        it 'includes Software/Multimedia' do
+          expect(build).to eq(['Software/Multimedia'])
+        end
+      end
+
+      context 'with a resource type of software, multimedia sourced from MODS resource types' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'software, multimedia', type: 'resource type',
+                                                 source: { value: 'MODS resource types' })
+          ]
+        end
+
+        it 'includes Software/Multimedia' do
+          expect(build).to eq(['Software/Multimedia'])
+        end
+      end
+    end
+
+    describe 'Sound recording' do
+      context 'with a resource type of Audio sourced from LC Resource Types Scheme' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Audio', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' })
+          ]
+        end
+
+        it 'includes Sound recording' do
+          expect(build).to eq(['Sound recording'])
+        end
+      end
+
+      context 'with a resource type of sound recording sourced from MODS resource types' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'sound recording', type: 'resource type',
+                                                 source: { value: 'MODS resource types' })
+          ]
+        end
+
+        it 'includes Sound recording' do
+          expect(build).to eq(['Sound recording'])
+        end
+      end
+
+      context 'with a resource type of sound recording-musical sourced from MODS resource types' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'sound recording-musical', type: 'resource type',
+                                                 source: { value: 'MODS resource types' })
+          ]
+        end
+
+        it 'includes Sound recording' do
+          expect(build).to eq(['Sound recording'])
+        end
+      end
+
+      context 'with a resource type of sound recording-nonmusical sourced from MODS resource types' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'sound recording-nonmusical', type: 'resource type',
+                                                 source: { value: 'MODS resource types' })
+          ]
+        end
+
+        it 'includes Sound recording' do
+          expect(build).to eq(['Sound recording'])
+        end
+      end
+    end
+
+    describe 'Video/Film' do
+      context 'with a resource type of Moving image sourced from LC Resource Types Scheme' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Moving image', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' })
+          ]
+        end
+
+        it 'includes Video/Film' do
+          expect(build).to eq(['Video/Film'])
+        end
+      end
+
+      context 'with a resource type of moving image sourced from MODS resource types' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'moving image', type: 'resource type',
+                                                 source: { value: 'MODS resource types' })
+          ]
+        end
+
+        it 'includes Video/Film' do
+          expect(build).to eq(['Video/Film'])
+        end
+      end
+    end
+
+    describe 'Book' do
+      context 'with a resource type of Text sourced from LC Resource Types Scheme' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Text', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' })
+          ]
+        end
+
+        it 'includes Book' do
+          expect(build).to eq(['Book'])
+        end
+      end
+
+      context 'with a resource type of text sourced from MODS resource types' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'text', type: 'resource type',
+                                                 source: { value: 'MODS resource types' })
+          ]
+        end
+
+        it 'includes Book' do
+          expect(build).to eq(['Book'])
+        end
+      end
+
+      context 'with a resource type of Text and a genre of Archived website' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Text', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' }),
+            Cocina::Models::DescriptiveValue.new(value: 'Archived website', type: 'genre')
+          ]
+        end
+
+        it 'does not include Book' do
+          expect(build).to eq(['Archived website'])
+        end
+      end
+
+      context 'with a resource type of Text and a genre of dataset' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Text', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' }),
+            Cocina::Models::DescriptiveValue.new(value: 'dataset', type: 'genre')
+          ]
+        end
+
+        it 'does not include Book' do
+          expect(build).to eq(['Dataset'])
+        end
+      end
+
+      context 'with a resource type of Text and a genre of Data set' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Text', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' }),
+            Cocina::Models::DescriptiveValue.new(value: 'Data set', type: 'genre')
+          ]
+        end
+
+        it 'does not include Book' do
+          expect(build).to eq(['Dataset'])
+        end
+      end
+
+      context 'with a resource type of Text and a genre of Periodicals' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Text', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' }),
+            Cocina::Models::DescriptiveValue.new(value: 'Periodicals', type: 'genre')
+          ]
+        end
+
+        it 'does not include Book' do
+          expect(build).to eq(['Journal/Periodical'])
+        end
+      end
+
+      context 'with a resource type of Text and a genre of Newspaper' do
+        let(:forms) do
+          [
+            Cocina::Models::DescriptiveValue.new(value: 'Text', type: 'resource type',
+                                                 source: { value: 'LC Resource Types Scheme' }),
+            Cocina::Models::DescriptiveValue.new(value: 'Newspaper', type: 'genre')
+          ]
+        end
+
+        it 'does not include Book' do
+          expect(build).to eq(['No format specified'])
+        end
+      end
+    end
+  end
+end

--- a/spec/services/indexing/indexers/composite_indexer_spec.rb
+++ b/spec/services/indexing/indexers/composite_indexer_spec.rb
@@ -49,6 +49,9 @@ RSpec.describe Indexing::Indexers::CompositeIndexer do
         'subject_topic_tesim' => ['word'],
         'sw_format_ssimdv' => [
           'Software/Multimedia'
+        ],
+        'format_ssimdv' => [
+          'No format specified'
         ]
       )
       # rubocop:enable Style/StringHashKeys

--- a/spec/services/indexing/indexers/descriptive_metadata_indexer_spec.rb
+++ b/spec/services/indexing/indexers/descriptive_metadata_indexer_spec.rb
@@ -405,6 +405,7 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
         'descriptive_teiv' => all_search_text,
         'descriptive_text_nostem_i' => all_search_text,
         'sw_language_names_ssimdv' => ['English'],
+        'format_ssimdv' => ['Book'],
         'sw_format_ssimdv' => ['Book'],
         'mods_typeOfResource_ssimdv' => ['text'],
         'subject_place_ssimdv' => ['Europe'],
@@ -494,6 +495,9 @@ RSpec.describe Indexing::Indexers::DescriptiveMetadataIndexer do
           'additional_titles_tenim' => ['History of the Jews in the Islamic countries'],
           'display_title_ss' =>
             'Toldot ha-Yehudim be-artsot ha-Islam : ha-ʻet ha-ḥadashah-ʻad emtsaʻ ha-meʼah ha-19, Part 1',
+          'format_ssimdv' => [
+            'No format specified'
+          ],
           'sw_format_ssimdv' => [
             'Software/Multimedia'
           ]


### PR DESCRIPTION
closes #6223

## Why was this change made? 🤔
To replace sw_format_ssimdv with a non-SW format facet.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



