### PR TITLE
Temporarily pin lyber-core to < 9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,9 @@ gem 'druid-tools'
 gem 'folio_client'
 gem 'graphql'
 gem 'json_schemer-rails'
-gem 'lyber-core' # For robots
+# Temporarily pinned lyber-core on 7/10/2026 since >v9.0 lybercore has version-aware breaking changes requiring updates
+# to all consumers simultaneously. See https://github.com/sul-dlss/dor-services-app/pull/6196
+gem 'lyber-core', '~> 8.0' # For robots
 gem 'mais_orcid_client'
 gem 'marc'
 gem 'moab-versioning', require: 'moab/stanford'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,13 +287,13 @@ GEM
       json_schemer (~> 2.5)
       railties (~> 8.0)
       zeitwerk
-    jsonschema_rs (0.46.10-aarch64-linux)
+    jsonschema_rs (0.47.0-aarch64-linux)
       bigdecimal (>= 3.1, < 5)
-    jsonschema_rs (0.46.10-arm64-darwin)
+    jsonschema_rs (0.47.0-arm64-darwin)
       bigdecimal (>= 3.1, < 5)
-    jsonschema_rs (0.46.10-x86_64-darwin)
+    jsonschema_rs (0.47.0-x86_64-darwin)
       bigdecimal (>= 3.1, < 5)
-    jsonschema_rs (0.46.10-x86_64-linux)
+    jsonschema_rs (0.47.0-x86_64-linux)
       bigdecimal (>= 3.1, < 5)
     jwt (3.2.0)
       base64
@@ -308,7 +308,7 @@ GEM
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    lyber-core (8.1.0)
+    lyber-core (8.2.0)
       activesupport
       config
       dor-services-client
@@ -671,7 +671,7 @@ DEPENDENCIES
   json_schemer-rails
   jwt
   lograge
-  lyber-core
+  lyber-core (~> 8.0)
   mais_orcid_client
   marc
   moab-versioning


### PR DESCRIPTION
## Why was this change made? 🤔

To prevent breaking change in lyber-core being deployed until ready.
