### PR TITLE
Handle MARC 260 mapping when only invalid subfields are present.

### DIFF
--- a/app/services/cocina/from_marc/event.rb
+++ b/app/services/cocina/from_marc/event.rb
@@ -58,7 +58,7 @@ module Cocina
 
       def publication_events
         build_linked_events(marc['260']) do |field|
-          EventDataFieldBuilder.build(
+          event = EventDataFieldBuilder.build(
             field:,
             type: 'publication',
             role: 'publisher',
@@ -66,6 +66,8 @@ module Cocina
             contributor_codes: ['b'],
             date_code: 'c'
           )
+
+          event if event.except(:type).present?
         end
       end
 

--- a/spec/services/cocina/from_marc/event_spec.rb
+++ b/spec/services/cocina/from_marc/event_spec.rb
@@ -102,6 +102,28 @@ RSpec.describe Cocina::FromMarc::Event do
         end
       end
 
+      context 'with a single script that has only a 260$d' do
+        let(:marc_hash) do
+          {
+            'fields' => [
+              { '260' => {
+                'ind1' => ' ',
+                'ind2' => ' ',
+                'subfields' => [
+                  {
+                    'd' => '1831.'
+                  }
+                ]
+              } }
+            ]
+          }
+        end
+
+        it 'returns nothing' do
+          expect(build).to eq []
+        end
+      end
+
       context 'with multiple $b subfields' do
         # See a10422378
         let(:marc_hash) do


### PR DESCRIPTION
closes #6230

## Why was this change made? 🤔
Valid cocina.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



