### PR TITLE
Remove label from published cocina.

### DIFF
--- a/app/services/publish/public_cocina_service.rb
+++ b/app/services/publish/public_cocina_service.rb
@@ -11,16 +11,14 @@ module Publish
       @cocina = cocina
     end
 
-    # update the label to match what is in the description.title (used by sul-embed and searchworks_traject_indexer)
     # remove any file that is not published
     # remove any file_set that doesn't have at least one published file
     # remove partOfProject (similar to how we remove tags from identityMetadata)
-    def build # rubocop:disable Metrics/AbcSize
-      label = Cocina::Models::Builders::TitleBuilder.build(cocina.description.title)
+    def build
       if cocina.dro?
-        cocina.new(label:, structural: build_structural, administrative: build_administrative)
+        cocina.new(structural: build_structural, administrative: build_administrative)
       elsif cocina.collection?
-        cocina.new(label:, administrative: build_administrative)
+        cocina.new(administrative: build_administrative)
       else
         raise "unexpected call to PublicCocinaService.build for #{cocina.externalIdentifier}"
       end

--- a/spec/services/publish/public_cocina_service_spec.rb
+++ b/spec/services/publish/public_cocina_service_spec.rb
@@ -130,10 +130,6 @@ RSpec.describe Publish::PublicCocinaService do
       )
     end
 
-    it 'updates the label' do
-      expect(create.label).to eq 'Constituent label &amp; A Special character'
-    end
-
     context 'when there are no published files' do
       it 'discards the non-published filesets and files' do
         expect(create.structural.contains.size).to eq 0


### PR DESCRIPTION
closes #6207

## Why was this change made? 🤔
Label is deprecated.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



