### PR TITLE
Add HRID-keyed locking for UpdateHoldings robot.

### DIFF
--- a/app/jobs/reindex_job.rb
+++ b/app/jobs/reindex_job.rb
@@ -4,12 +4,10 @@
 #
 # NOTE: INFO-level logging is filtered out when this job runs due to ApplicationJob::IgnoreReindexingLogSubscriber
 class ReindexJob < ApplicationJob
-  class DeadLockError < StandardError; end
-
   queue_as :low
 
   # Retry at ~3 seconds, ~18 seconds, ~83 seconds. If all attempts fail, the error is swallowed not bubbled up.
-  retry_on DeadLockError, attempts: 3, wait: :polynomially_longer, queue: :low do |_job, _error|
+  retry_on RedisLock::DeadLockError, attempts: 3, wait: :polynomially_longer, queue: :low do |_job, _error|
     nil # do nothing
   end
   # ActiveJob retries are used instead of Sidekiq retries. Bump up log level to filter out start/end job logging
@@ -23,7 +21,7 @@ class ReindexJob < ApplicationJob
     return if skip?(druid:, current_as_of:, trace_id:)
 
     # Reindexing should be fast, so timeout is only 30 seconds.
-    raise DeadLockError unless RedisLock.with_lock(key: "reindex-#{druid}", lock_timeout: 30) do
+    raise RedisLock::DeadLockError unless RedisLock.with_lock(key: "reindex-#{druid}", lock_timeout: 30) do
       cocina_object = CocinaObjectStore.find(druid, validate: false)
       Rails.logger.error("Starting reindexing #{druid} - trace_id #{trace_id}")
       Indexer.reindex(cocina_object:, trace_id:, current_as_of: current_as_of)

--- a/app/jobs/robots/dor_repo/release/update_holdings.rb
+++ b/app/jobs/robots/dor_repo/release/update_holdings.rb
@@ -6,11 +6,23 @@ module Robots
       # Update/create FOLIO holdings record for an object
       class UpdateHoldings < Robots::Robot
         def initialize
-          super('releaseWF', 'update-holdings')
+          super('releaseWF', 'update-holdings', retriable_exceptions: [RedisLock::DeadLockError])
         end
 
         def perform_work
-          Catalog::UpdateHoldingsService.update(cocina_object)
+          return if cocina_object.admin_policy?
+          return if folio_hrid.nil?
+
+          raise RedisLock::DeadLockError unless RedisLock.with_lock(key: "update-holdings-#{folio_hrid}",
+                                                                    lock_timeout: 180) do
+            Catalog::UpdateHoldingsService.update(cocina_object)
+          end
+        end
+
+        def folio_hrid
+          @folio_hrid ||= cocina_object.identification.catalogLinks.find do |link|
+            link.catalog == 'folio'
+          end&.catalogRecordId
         end
       end
     end

--- a/app/services/redis_lock.rb
+++ b/app/services/redis_lock.rb
@@ -4,6 +4,8 @@
 # This is useful for ensuring that only one worker is processing a given job at a time.
 # Based on https://github.com/sul-dlss/preservation_catalog/blob/main/app/jobs/concerns/unique_job.rb
 class RedisLock
+  class DeadLockError < StandardError; end
+
   # @param [String] key the key to lock
   # @param [Integer] lock_timeout the number of seconds before the lock expires
   # @return [Boolean] true if the lock can be acquired

--- a/spec/jobs/reindex_job_spec.rb
+++ b/spec/jobs/reindex_job_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ReindexJob do
     it 'raises' do
       expect do
         described_class.new.perform(druid: dro.externalIdentifier, trace_id:, current_as_of:)
-      end.to raise_error(ReindexJob::DeadLockError)
+      end.to raise_error(RedisLock::DeadLockError)
     end
   end
 

--- a/spec/jobs/robots/dor_repo/release/update_holdings_spec.rb
+++ b/spec/jobs/robots/dor_repo/release/update_holdings_spec.rb
@@ -8,15 +8,65 @@ RSpec.describe Robots::DorRepo::Release::UpdateHoldings, type: :robot do
   let(:druid) { 'druid:zz000zz0001' }
   let(:robot) { described_class.new }
 
-  let(:object) { build(:dro, id: druid) }
+  let(:object) do
+    build(:dro, id: druid).new(identification: {
+                                 sourceId: 'sul:8832162',
+                                 catalogLinks: [
+                                   {
+                                     catalog: 'folio',
+                                     catalogRecordId: 'a123'
+                                   }
+                                 ]
+                               })
+  end
 
   before do
     allow(CocinaObjectStore).to receive(:find).with(druid).and_return(object)
     allow(Catalog::UpdateHoldingsService).to receive(:update)
+    allow(RedisLock).to receive(:with_lock) do |*_args, &block|
+      block.call
+      true
+    end
   end
 
   it 'updates the FOLIO holdings for the object' do
     expect { perform }.not_to raise_error
+    expect(RedisLock).to have_received(:with_lock).with(key: 'update-holdings-a123', lock_timeout: 180)
     expect(Catalog::UpdateHoldingsService).to have_received(:update).with(object)
+  end
+
+  context 'when the object is an admin policy' do
+    let(:object) { build(:admin_policy, id: druid) }
+
+    it 'skips the object' do
+      expect { perform }.not_to raise_error
+      expect(RedisLock).not_to have_received(:with_lock)
+      expect(Catalog::UpdateHoldingsService).not_to have_received(:update)
+    end
+  end
+
+  context 'when the object has no FOLIO catalog link' do
+    let(:object) do
+      build(:dro, id: druid).new(identification: {
+                                   sourceId: 'sul:8832162',
+                                   catalogLinks: []
+                                 })
+    end
+
+    it 'skips the object' do
+      expect { perform }.not_to raise_error
+      expect(RedisLock).not_to have_received(:with_lock)
+      expect(Catalog::UpdateHoldingsService).not_to have_received(:update)
+    end
+  end
+
+  context 'when getting a lock fails' do
+    before do
+      allow(RedisLock).to receive(:with_lock).and_return(false)
+    end
+
+    it 'raises' do
+      expect { perform }.to raise_error(RedisLock::DeadLockError)
+    end
   end
 end


### PR DESCRIPTION
closes #6244

## Why was this change made? 🤔
Avoid creating dupe holdings records.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



