### PR TITLE
Restore label to public cocina

### DIFF
--- a/app/services/publish/public_cocina_service.rb
+++ b/app/services/publish/public_cocina_service.rb
@@ -14,11 +14,12 @@ module Publish
     # remove any file that is not published
     # remove any file_set that doesn't have at least one published file
     # remove partOfProject (similar to how we remove tags from identityMetadata)
-    def build
+    def build # rubocop:disable Metrics/AbcSize
+      label = Cocina::Models::Builders::TitleBuilder.build(cocina.description.title)
       if cocina.dro?
-        cocina.new(structural: build_structural, administrative: build_administrative)
+        cocina.new(label:, structural: build_structural, administrative: build_administrative)
       elsif cocina.collection?
-        cocina.new(administrative: build_administrative)
+        cocina.new(label:, administrative: build_administrative)
       else
         raise "unexpected call to PublicCocinaService.build for #{cocina.externalIdentifier}"
       end

--- a/spec/services/publish/public_cocina_service_spec.rb
+++ b/spec/services/publish/public_cocina_service_spec.rb
@@ -130,6 +130,10 @@ RSpec.describe Publish::PublicCocinaService do
       )
     end
 
+    it 'updates the label' do
+      expect(create.label).to eq 'Constituent label &amp; A Special character'
+    end
+
     context 'when there are no published files' do
       it 'discards the non-published filesets and files' do
         expect(create.structural.contains.size).to eq 0


### PR DESCRIPTION
## Why was this change made? 🤔
Revert change to remove label from publishing cocina, until we determine how to keep a label available there. 


## How was this change tested? 🤨
CI 




