### PR TITLE
Adds queue per process for accessionWF.

### DIFF
--- a/app/services/queue_service.rb
+++ b/app/services/queue_service.rb
@@ -17,7 +17,8 @@ class QueueService
   end
 
   # Enqueue the provided step
-  def enqueue # rubocop:disable Metrics/AbcSize
+  def enqueue
+    queue_name = build_queue_name
     job_id = ROBOT_SIDEKIQ_CLIENT.push('queue' => queue_name, 'class' => class_name,
                                        'args' => [step.druid, step.version])
     raise "Enqueueing #{class_name} for #{step.druid} to #{queue_name} failed." unless job_id
@@ -48,6 +49,9 @@ class QueueService
     'Robots::DorRepo::Release::UpdateMarc' => 'releaseWF_update-marc_dsa'
   }.freeze
 
+  # Include the process name in the queue name to allow for greater sidekiq control.
+  QUEUE_PER_PROCESS_WORKFLOWS = %w[accessionWF].freeze
+
   private
 
   # Generate the queue name from step
@@ -55,15 +59,14 @@ class QueueService
   # @example
   #     => 'assemblyWF_default'
   #     => 'assemblyWF_low'
-  def queue_name
-    @queue_name ||= if SPECIAL_ROBOTS.include?(class_name)
-                      SPECIAL_ROBOTS[class_name]
-                    elsif DSA_ROBOTS.include?(class_name)
-                      # DSA only handles certain robots. Those need to be sent to separate queues.
-                      "#{step.workflow}_#{step.lane_id}_dsa"
-                    else
-                      "#{step.workflow}_#{step.lane_id}"
-                    end
+  def build_queue_name
+    return SPECIAL_ROBOTS[class_name] if SPECIAL_ROBOTS.include?(class_name)
+
+    queue_name = step.workflow
+    queue_name += "_#{step.process}" if QUEUE_PER_PROCESS_WORKFLOWS.include?(step.workflow)
+    queue_name += "_#{step.lane_id}"
+    queue_name += '_dsa' if DSA_ROBOTS.include?(class_name)
+    queue_name
   end
 
   # Converts a given step to the Robot class name

--- a/spec/services/queue_service_spec.rb
+++ b/spec/services/queue_service_spec.rb
@@ -28,19 +28,31 @@ RSpec.describe QueueService do
 
       it 'enqueues to Sidekiq' do
         service.enqueue
-        expect(ROBOT_SIDEKIQ_CLIENT).to have_received(:push).with('queue' => 'accessionWF_default_dsa',
-                                                                  'class' => 'Robots::DorRepo::Accession::Publish',
-                                                                  'args' => [step.druid, step.version])
+        expect(ROBOT_SIDEKIQ_CLIENT).to have_received(:push)
+          .with('queue' => 'accessionWF_publish_default_dsa',
+                'class' => 'Robots::DorRepo::Accession::Publish',
+                'args' => [step.druid, step.version])
       end
     end
 
-    context 'when DorRepo classes' do
+    context 'when queue per process workflow' do
       let(:step) { create(:workflow_step, workflow: 'accessionWF', process: 'technical-metadata') }
 
       it 'enqueues to Sidekiq' do
         service.enqueue
-        expect(ROBOT_SIDEKIQ_CLIENT).to have_received(:push).with('queue' => 'accessionWF_default',
+        expect(ROBOT_SIDEKIQ_CLIENT).to have_received(:push).with('queue' => 'accessionWF_technical-metadata_default',
                                                                   'class' => 'Robots::DorRepo::Accession::TechnicalMetadata',
+                                                                  'args' => [step.druid, step.version])
+      end
+    end
+
+    context 'when non-queue per process workflow' do
+      let(:step) { create(:workflow_step, workflow: 'assemblyWF', process: 'checksum-compute') }
+
+      it 'enqueues to Sidekiq' do
+        service.enqueue
+        expect(ROBOT_SIDEKIQ_CLIENT).to have_received(:push).with('queue' => 'assemblyWF_default',
+                                                                  'class' => 'Robots::DorRepo::Assembly::ChecksumCompute',
                                                                   'args' => [step.druid, step.version])
       end
     end


### PR DESCRIPTION
closes #6251

## Why was this change made? 🤔
To allow for greater sidekiq control of accession robots.


## How was this change tested? 🤨
Unit, stage

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



