### PR TITLE
Make sneakers its own role.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -10,7 +10,7 @@ ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }
 set :deploy_to, "/opt/app/dor_services/#{fetch(:application)}"
 
 # Manage sneakers via systemd (from dlss-capistrano gem)
-set :sneakers_systemd_role, :worker
+set :sneakers_systemd_role, :sneakers
 set :sneakers_systemd_use_hooks, true
 
 namespace :rabbitmq do

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -2,8 +2,8 @@
 
 server 'dor-services-app-prod-a.stanford.edu', user: 'dor_services', roles: %w[web app]
 server 'dor-services-app-prod-b.stanford.edu', user: 'dor_services', roles: %w[web app]
-server 'dor-services-worker-prod-a.stanford.edu', user: 'dor_services', roles: %w[app worker scheduler]
-server 'dor-services-worker-prod-b.stanford.edu', user: 'dor_services', roles: %w[app worker]
+server 'dor-services-worker-prod-a.stanford.edu', user: 'dor_services', roles: %w[app worker scheduler sneakers]
+server 'dor-services-worker-prod-b.stanford.edu', user: 'dor_services', roles: %w[app worker sneakers]
 server 'dor-services-worker-prod-c.stanford.edu', user: 'dor_services', roles: %w[app worker]
 server 'dor-services-worker-prod-d.stanford.edu', user: 'dor_services', roles: %w[app worker]
 server 'dor-services-worker-prod-e.stanford.edu', user: 'dor_services', roles: %w[app worker]

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -2,4 +2,4 @@
 
 server 'dor-services-app-qa-a.stanford.edu', user: 'dor_services', roles: %w[web app]
 server 'dor-services-app-qa-b.stanford.edu', user: 'dor_services', roles: %w[web app]
-server 'dor-services-worker-qa-a.stanford.edu', user: 'dor_services', roles: %w[app worker scheduler]
+server 'dor-services-worker-qa-a.stanford.edu', user: 'dor_services', roles: %w[app worker scheduler sneakers]

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,4 +2,4 @@
 
 server 'dor-services-app-stage-a.stanford.edu', user: 'dor_services', roles: %w[web app]
 server 'dor-services-app-stage-b.stanford.edu', user: 'dor_services', roles: %w[web app]
-server 'dor-services-worker-stage-a.stanford.edu', user: 'dor_services', roles: %w[app worker scheduler]
+server 'dor-services-worker-stage-a.stanford.edu', user: 'dor_services', roles: %w[app worker scheduler sneakers]


### PR DESCRIPTION
## Why was this change made? 🤔
Sneakers is only running on -a and -b to conserve DB connections.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



