### PR TITLE
Revert #6249. Published cocina no longer needs label.

### DIFF
--- a/app/services/publish/public_cocina_service.rb
+++ b/app/services/publish/public_cocina_service.rb
@@ -14,12 +14,11 @@ module Publish
     # remove any file that is not published
     # remove any file_set that doesn't have at least one published file
     # remove partOfProject (similar to how we remove tags from identityMetadata)
-    def build # rubocop:disable Metrics/AbcSize
-      label = Cocina::Models::Builders::TitleBuilder.build(cocina.description.title)
+    def build
       if cocina.dro?
-        cocina.new(label:, structural: build_structural, administrative: build_administrative)
+        cocina.new(structural: build_structural, administrative: build_administrative)
       elsif cocina.collection?
-        cocina.new(label:, administrative: build_administrative)
+        cocina.new(administrative: build_administrative)
       else
         raise "unexpected call to PublicCocinaService.build for #{cocina.externalIdentifier}"
       end

--- a/spec/services/publish/public_cocina_service_spec.rb
+++ b/spec/services/publish/public_cocina_service_spec.rb
@@ -130,10 +130,6 @@ RSpec.describe Publish::PublicCocinaService do
       )
     end
 
-    it 'updates the label' do
-      expect(create.label).to eq 'Constituent label &amp; A Special character'
-    end
-
     context 'when there are no published files' do
       it 'discards the non-published filesets and files' do
         expect(create.structural.contains.size).to eq 0


### PR DESCRIPTION
## Why was this change made? 🤔

Now that purl-fetcher will make a label from the title, we don't need to populate it when publishing. 

## How was this change tested? 🤨
Integration test to confirm a label is available in public cocina. 



