### PR TITLE
Bump cocina-models to 0.129.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
       capistrano-bundler (>= 1.1, < 3)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.128.0)
+    cocina-models (0.129.0)
       activesupport
       cocina_display
       deprecation
@@ -174,9 +174,9 @@ GEM
       capistrano-shared_configs
       ed25519
     domain_name (0.6.20240107)
-    dor-services-client (15.63.0)
+    dor-services-client (15.64.0)
       activesupport (>= 7.0.0)
-      cocina-models (~> 0.128.0)
+      cocina-models (~> 0.129.0)
       deprecation
       faraday (~> 2.0)
       faraday-retry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
       capistrano-shared_configs
       ed25519
     domain_name (0.6.20240107)
-    dor-services-client (15.64.0)
+    dor-services-client (15.64.1)
       activesupport (>= 7.0.0)
       cocina-models (~> 0.129.0)
       deprecation

--- a/app/services/refresh_description_from_catalog.rb
+++ b/app/services/refresh_description_from_catalog.rb
@@ -27,7 +27,7 @@ class RefreshDescriptionFromCatalog
   # @return [Dry::Monads::Results] Returns Failure if description unchanged (e.g., no refreshable identifiers),
   #   otherwise Success (Result with description_props)
   # @raise [Catalog::MarcService::Error]
-  def run
+  def run # rubocop:disable Metrics/AbcSize
     # Admin policies don't have identification.
     return Failure() if cocina_object.admin_policy?
     return Failure() unless refreshable?
@@ -40,6 +40,7 @@ class RefreshDescriptionFromCatalog
     description_props = Cocina::FromMarc::Description.props(marc:, druid:)
 
     return Failure() if description_props.nil?
+    return Failure() if description_props[:title].blank?
 
     Success(Result.new(description_props))
   end

--- a/app/services/registration_csv_converter.rb
+++ b/app/services/registration_csv_converter.rb
@@ -36,7 +36,7 @@ class RegistrationCsvConverter
   #   3: initial_workflow (required)
   #   4: content_type (required)
   #   5: source_id (required)
-  #   6: catkey or folio_id (optional)
+  #   6: folio_id (optional)
   #   7: barcode (optional)
   #   8: rights_view (required)
   #   9: rights_download (required)
@@ -45,6 +45,7 @@ class RegistrationCsvConverter
   #   is "none")
   #  12: project_name (optional)
   #  13: tags (optional, may repeat)
+  #  14: title (required if no folio_id)
 
   def convert
     CSV.parse(csv_string, headers: true).map { |row| { druid: row['druid'], cocina_request_object: convert_row(row) } }
@@ -59,7 +60,7 @@ class RegistrationCsvConverter
     Failure(e)
   end
 
-  def model_params(row)
+  def model_params(row) # rubocop:disable Metrics/AbcSize
     model_params = {
       type: dro_type(row.fetch('content_type')),
       version: 1,
@@ -71,11 +72,18 @@ class RegistrationCsvConverter
         barcode: row['barcode']
       }.compact
     }
-
     model_params[:structural] = structural(row)
     model_params[:access] = access(row)
+    title = row['title']
+    model_params[:description] = description(row) if title.present?
     project_name = row['project_name']
     model_params[:administrative][:partOfProject] = project_name if project_name.present?
+    folio_id = row['folio_id']
+    if folio_id.present?
+      model_params[:identification] = model_params[:identification].merge(
+        catalogLinks: [{ catalog: 'folio', catalogRecordId: folio_id, refresh: true }]
+      )
+    end
     model_params
   end
 
@@ -133,5 +141,11 @@ class RegistrationCsvConverter
       cdl = row['rights_controlledDigitalLending']
       access[:controlledDigitalLending] = ActiveModel::Type::Boolean.new.cast(cdl) if cdl.present?
     end.compact
+  end
+
+  def description(row)
+    {}.tap do |description|
+      description[:title] = [{ value: row['title'] }]
+    end
   end
 end

--- a/spec/requests/metadata_refresh_spec.rb
+++ b/spec/requests/metadata_refresh_spec.rb
@@ -167,9 +167,9 @@ RSpec.describe 'Refresh metadata' do
     context 'when Cocina validation error' do
       let(:result) { Success(RefreshDescriptionFromCatalog::Result.new(description_props)) }
       let(:description_props) do
-        # Missing title
+        # Invalid title type
         {
-          purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
+          title: [{ value: 'Paying for College', type: 'not a type' }]
         }
       end
 
@@ -181,7 +181,7 @@ RSpec.describe 'Refresh metadata' do
         post '/v1/objects/druid:mk420bs7601/refresh_metadata',
              headers: { 'Authorization' => "Bearer #{jwt}" }
         expect(response).to have_http_status(:unprocessable_content)
-        expect(response.body).to match('\\\"title\\\" is a required property')
+        expect(response.body).to include('Unrecognized types in description: title1 (not a type)')
       end
     end
   end

--- a/spec/services/create_object_service_spec.rb
+++ b/spec/services/create_object_service_spec.rb
@@ -179,17 +179,6 @@ RSpec.describe CreateObjectService do
       end
     end
 
-    context 'when there is no description' do
-      let(:requested_cocina_object) do
-        props = build(:request_dro).new(label: 'Roadside Geology of Utah').to_h.except(:description)
-        Cocina::Models::RequestDRO.new(props)
-      end
-
-      it 'creates a description from label' do
-        expect(store.create(requested_cocina_object).description.title.first.value).to eq 'Roadside Geology of Utah'
-      end
-    end
-
     context 'when there is structural' do
       let(:requested_cocina_object) do
         build(:request_dro).new(

--- a/spec/services/refresh_description_from_catalog_spec.rb
+++ b/spec/services/refresh_description_from_catalog_spec.rb
@@ -210,5 +210,32 @@ RSpec.describe RefreshDescriptionFromCatalog do
         expect(refresh.failure?).to be(true)
       end
     end
+
+    context 'when no fields mapped from MARC' do
+      let(:marc) do
+        { fields: [] }.with_indifferent_access
+      end
+
+      it 'returns failure' do
+        expect(refresh.failure?).to be(true)
+      end
+    end
+
+    context 'when marc has fields but none of them map to a title' do
+      let(:marc) do
+        { fields: [
+          { '100': {
+            ind1: '1',
+            subfields: [
+              { a: 'Sayers, Dorothy L.' }
+            ]
+          } }
+        ] }.with_indifferent_access
+      end
+
+      it 'returns failure' do
+        expect(refresh.failure?).to be(true)
+      end
+    end
   end
 end

--- a/spec/services/registration_csv_converter_spec.rb
+++ b/spec/services/registration_csv_converter_spec.rb
@@ -14,6 +14,22 @@ RSpec.describe RegistrationCsvConverter do
         access: { view: 'world', download: 'world', controlledDigitalLending: false },
         administrative: { hasAdminPolicy: 'druid:bc123df4567' },
         identification: { sourceId: 'foo:123' },
+        structural: { isMemberOf: ['druid:bk024qs1808'] },
+        description: { title: [{ value: 'A title' }] }
+      }
+    )
+  end
+
+  let(:expected_cocina_folio) do
+    Cocina::Models.build_request(
+      {
+        cocinaVersion: Cocina::Models::VERSION,
+        type: Cocina::Models::ObjectType.book,
+        version: 1,
+        access: { view: 'world', download: 'world', controlledDigitalLending: false },
+        administrative: { hasAdminPolicy: 'druid:bc123df4567' },
+        identification: { sourceId: 'foo:123',
+                          catalogLinks: [{ catalog: 'folio', catalogRecordId: 'a12345', refresh: true }] },
         structural: { isMemberOf: ['druid:bk024qs1808'] }
       }
     )
@@ -22,19 +38,22 @@ RSpec.describe RegistrationCsvConverter do
   context 'when all values provided in CSV' do
     let(:csv_string) do
       <<~CSV
-        administrative_policy_object,collection,initial_workflow,content_type,source_id,rights_view,rights_download,tags,tags
-        druid:bc123df4567,druid:bk024qs1808,accessionWF,book,foo:123,world,world,csv : test,Project : two
-        xdruid:dj123qx4567,druid:bk024qs1808,accessionWF,book,foo:123,world,world
+        administrative_policy_object,collection,initial_workflow,content_type,source_id,folio_id,rights_view,rights_download,tags,tags,title
+        druid:bc123df4567,druid:bk024qs1808,accessionWF,book,foo:123,,world,world,csv : test,Project : two,A title
+        druid:dj123qx4567,druid:bk024qs1808,accessionWF,book,foo:123,,world,world,,,
+        druid:bc123df4567,druid:bk024qs1808,accessionWF,book,foo:123,a12345,world,world,,,
       CSV
     end
 
     it 'returns result with model, workflow, and tags' do
-      expect(results.size).to be 2
+      expect(results.size).to be 3
       expect(results.first[:cocina_request_object].success?).to be true
       expect(results.first[:cocina_request_object].value![:workflow]).to eq('accessionWF')
       expect(results.first[:cocina_request_object].value![:tags]).to eq(['csv : test', 'Project : two'])
       expect(results.first[:cocina_request_object].value![:model]).to eq(expected_cocina)
       expect(results.second[:cocina_request_object].success?).to be false
+      expect(results.third[:cocina_request_object].success?).to be true
+      expect(results.third[:cocina_request_object].value![:model]).to eq(expected_cocina_folio)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Keep cocina-models in sync and also handle new validation that a catalog link or title must be present. 


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



