### PR TITLE
Remove label usage from CreateObjectService

### DIFF
--- a/app/services/create_object_service.rb
+++ b/app/services/create_object_service.rb
@@ -38,7 +38,6 @@ class CreateObjectService
     updated_cocina_request_object = merge_access_for(cocina_request_object)
     druid = id_minter.call
     updated_cocina_request_object = sync_from_catalog(updated_cocina_request_object, druid)
-    updated_cocina_request_object = add_description(updated_cocina_request_object)
     cocina_object = cocina_from_request(updated_cocina_request_object, druid, assign_doi)
     cocina_object = assign_doi(cocina_object) if assign_doi
     cocina_object_with_metadata = RepositoryObject.create_from(cocina_object:).to_cocina_with_metadata
@@ -102,14 +101,7 @@ class CreateObjectService
     description_props = result.value!.description_props
     # Remove PURL since this is still a request
     description_props.delete(:purl)
-    label = label_from_title(description_props)
-    cocina_request_object.new(label:, description: description_props)
-  end
-
-  def add_description(cocina_request_object)
-    return cocina_request_object if cocina_request_object.description.present?
-
-    cocina_request_object.new(description: { title: [{ value: cocina_request_object.label }] })
+    cocina_request_object.new(description: description_props)
   end
 
   def assign_doi(cocina_object)
@@ -177,9 +169,5 @@ class CreateObjectService
 
     tags = ["Project : #{cocina_request_object.administrative.partOfProject}"]
     AdministrativeTags.create(identifier: druid, tags:)
-  end
-
-  def label_from_title(description_props)
-    CocinaDisplay::CocinaRecord.new({ 'description' => description_props.with_indifferent_access }).short_title
   end
 end

--- a/spec/requests/create_collection_spec.rb
+++ b/spec/requests/create_collection_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Create object' do
         {
           "cocinaVersion":"#{Cocina::Models::VERSION}",
           "type":"#{Cocina::Models::ObjectType.collection}",
-          "label":"","version":1,"access":{"view":"world"},
+          "version":1,"access":{"view":"world"},
           "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
           "description":{"title":[{"value":"#{expected_title}"}]},
           "identification":#{identification.to_json}}
@@ -33,7 +33,6 @@ RSpec.describe 'Create object' do
 
     let(:expected) do
       build(:collection, id: druid, title: expected_title, admin_policy_id: 'druid:dd999df4567').new(
-        label: expected_title,
         identification:,
         access: {
           view: 'world'
@@ -107,7 +106,7 @@ RSpec.describe 'Create object' do
         {
           "cocinaVersion":"#{Cocina::Models::VERSION}",
           "type":"#{Cocina::Models::ObjectType.collection}",
-          "label":"","version":1,"access":{"view":"world"},
+          "version":1,"access":{"view":"world"},
           "administrative":{"hasAdminPolicy":"druid:dd999df4567","partOfProject":"Hydrus"},
           "identification":{"sourceId":"hydrus:collection-456"},
           "description":{"title":[{"value":"#{expected_title}"}]}
@@ -131,7 +130,6 @@ RSpec.describe 'Create object' do
         {
           "cocinaVersion":"#{Cocina::Models::VERSION}",
           "type":"#{Cocina::Models::ObjectType.collection}",
-          "label":"",
           "version":1,
           "access":{"view":"world"},
           "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
@@ -173,7 +171,6 @@ RSpec.describe 'Create object' do
         {
           "cocinaVersion":"#{Cocina::Models::VERSION}",
           "type":"#{Cocina::Models::ObjectType.collection}",
-          "label":"",
           "version":1,
           "access":{ "view": "world" },
           "administrative":{"hasAdminPolicy":"druid:dd999df4567"},

--- a/spec/services/create_object_service_spec.rb
+++ b/spec/services/create_object_service_spec.rb
@@ -115,7 +115,6 @@ RSpec.describe CreateObjectService do
       it 'with a basic title it adds to description' do
         cocina_object = store.create(requested_cocina_object)
         expect(cocina_object.description.title.first.value).to eq 'Example Item Title'
-        expect(cocina_object.label).to eq 'Example Item Title'
         expect(Catalog::MarcService).to have_received(:new).with(folio_instance_hrid: 'a999123',
                                                                  create_marc_if_missing: true)
         expect(marc_service).to have_received(:marc)
@@ -145,7 +144,6 @@ RSpec.describe CreateObjectService do
         expect(cocina_object.description.title.first&.structuredValue&.find do |t|
           t.type == 'main title'
         end&.value).to eq 'well-grounded Rubyist'
-        expect(cocina_object.label).to eq 'The well-grounded Rubyist'
         expect(Catalog::MarcService).to have_received(:new).with(folio_instance_hrid: 'a999123',
                                                                  create_marc_if_missing: true)
         expect(marc_service).to have_received(:marc)


### PR DESCRIPTION
## Why was this change made? 🤔
Fixes #6183. 


## How was this change tested? 🤨
Integration tests that involve CreateObjectService (e.g. Argo registration ) and H3 object creation. 



