### PR TITLE
Handle blank contributor for MARC mapping.

### DIFF
--- a/app/services/cocina/from_marc/contributor.rb
+++ b/app/services/cocina/from_marc/contributor.rb
@@ -41,19 +41,19 @@ module Cocina
 
       # For 100/700/720
       def build_personal(field, primary: false)
-        name_type = case field.indicator1
-                    when '0', '1'
-                      'person'
-                    when '3'
-                      'family'
-                    end
-        contributor = { type: name_type }.compact
-        contributor[:name] = [build_personal_name(field)].compact
-        contributor[:role] = build_roles(field)
+        contributor = {
+          name: [build_personal_name(field)].compact,
+          role: build_roles(field)
+        }.compact_blank!
+
         id = build_id(field).first
         contributor[:identifier] = [{ uri: id, type: 'ORCID' }.compact_blank] if id&.start_with? 'https://orcid.org/'
+        return if contributor.blank?
+
+        name_type = build_name_type(field)
+        contributor[:type] = name_type if name_type
         contributor[:status] = 'primary' if primary
-        contributor.compact_blank
+        contributor
       end
 
       def build_personal_name(field)
@@ -79,6 +79,15 @@ module Cocina
         end
 
         (primary + expanded).uniq.compact_blank
+      end
+
+      def build_name_type(field)
+        case field.indicator1
+        when '0', '1'
+          'person'
+        when '3'
+          'family'
+        end
       end
 
       def normalize_role_code(value)

--- a/spec/services/cocina/from_marc/contributor_spec.rb
+++ b/spec/services/cocina/from_marc/contributor_spec.rb
@@ -485,6 +485,28 @@ RSpec.describe Cocina::FromMarc::Contributor do
         it 'returns person contributor' do
           expect(build).to eq [{ type: 'person', name: [{ value: 'Street, Stephen (Double bassist).' }] }]
         end
+
+        context 'when blank' do
+          let(:marc_hash) do
+            {
+              'fields' => [
+                { '700' => {
+                  'ind1' => '1',
+                  'ind2' => ' ',
+                  'subfields' => [
+                    {
+                      'a' => ''
+                    }
+                  ]
+                } }
+              ]
+            }
+          end
+
+          it 'returns empty' do
+            expect(build).to eq([])
+          end
+        end
       end
 
       context 'with multiple contributors' do


### PR DESCRIPTION
closes #6232

## Why was this change made? 🤔
Per Arcadia


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



