### PR TITLE
remove label from reports

### DIFF
--- a/app/reports/data_work_contributor_affiliation.rb
+++ b/app/reports/data_work_contributor_affiliation.rb
@@ -27,7 +27,10 @@ class DataWorkContributorAffiliation
     sql_result_rows.map do |row|
       druid = row['druid']
       collection_druid = row['collection_druid']
-      collection_title = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+      if collection_head_version&.has_cocina?
+        collection_title = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
 
       [
         druid,

--- a/app/reports/data_work_type.rb
+++ b/app/reports/data_work_type.rb
@@ -32,7 +32,10 @@ class DataWorkType
     sql_result_rows.map do |row|
       druid = row['druid']
       collection_druid = row['collection_druid']
-      collection_title = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+      if collection_head_version&.has_cocina?
+        collection_title = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
       work_subtypes = JSON.parse(row['work_subtypes'] || '[]').join(',')
       object = RepositoryObject.find_by(external_identifier: druid)
       content_type = object&.head_version&.content_type

--- a/app/reports/date_encoding_values.rb
+++ b/app/reports/date_encoding_values.rb
@@ -44,7 +44,10 @@ class DateEncodingValues
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/descendant_source_code_no_uri.rb
+++ b/app/reports/descendant_source_code_no_uri.rb
@@ -39,7 +39,10 @@ class DescendantSourceCodeNoUri
 
     sql_result_rows.map do |row|
       collection_druid = row['collection_druid']
-      collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+      if collection_head_version&.has_cocina?
+        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
 
       [
         row['item_druid'],

--- a/app/reports/digital_serials.rb
+++ b/app/reports/digital_serials.rb
@@ -32,7 +32,10 @@ class DigitalSerials
 
     sql_result_rows.map do |row|
       collection_druid = row['collection_id']
-      collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+      if collection_head_version&.has_cocina?
+        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
 
       [
         row['druid'],

--- a/app/reports/digital_serials_based_on_hrid.rb
+++ b/app/reports/digital_serials_based_on_hrid.rb
@@ -33,7 +33,10 @@ class DigitalSerialsBasedOnHrid
       next unless hrid_counts[row['catalog_record_id']] > 1
 
       collection_druid = row['collection_id']
-      collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+      if collection_head_version&.has_cocina?
+        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
 
       [
         row['druid'],

--- a/app/reports/digital_serials_unreleased.rb
+++ b/app/reports/digital_serials_unreleased.rb
@@ -31,7 +31,10 @@ class DigitalSerialsUnreleased
       next if released_to_searchworks?(druid: row['druid'])
 
       collection_druid = row['collection_id']
-      collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+      if collection_head_version&.has_cocina?
+        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
 
       title_part_number_before, title_part_name, title_part_number_after = title_part_label_from(JSON.parse(row['title_part_name_and_number']))
 

--- a/app/reports/druids_refresh_false.rb
+++ b/app/reports/druids_refresh_false.rb
@@ -10,8 +10,7 @@ class DruidsRefreshFalse
       jsonb_path_query(rov.identification, '$.catalogLinks[*] ? (@.catalog == "folio" && @.refresh == false).catalogRecordId') ->> 0 as catalog_record_id,
       jsonb_path_query(rov.description, '$.title[0].structuredValue[*] ? (@.type == "main title").value') ->> 0 as structured_title,
       jsonb_path_query(rov.description, '$.title[0].value') ->> 0 as title,
-      ro.object_type as object_type,
-      rov.label as label
+      ro.object_type as object_type
     FROM repository_objects AS ro, repository_object_versions AS rov
     WHERE
       jsonb_path_exists(rov.identification, '$.catalogLinks[*] ? (@.catalog == "folio" && @.refresh == false)')
@@ -19,7 +18,7 @@ class DruidsRefreshFalse
   SQL
 
   def self.report
-    puts %w[catalogRecordId druid object_type label structured_title title collection_name collection_druid].join(',')
+    puts %w[catalogRecordId druid object_type structured_title title collection_name collection_druid].join(',')
     rows(SQL).compact.each { |row| puts row }
   end
 
@@ -28,13 +27,15 @@ class DruidsRefreshFalse
 
     sql_result_rows.map do |row|
       collection_druid = row['collection_id']
-      collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+      if collection_head_version&.has_cocina?
+        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
 
       [
         row['catalog_record_id'],
         row['druid'],
         row['object_type'],
-        row['label'],
         row['structured_title']&.delete('\n'),
         row['title'],
         collection_name,

--- a/app/reports/events_multiple_date_types.rb
+++ b/app/reports/events_multiple_date_types.rb
@@ -45,7 +45,10 @@ class EventsMultipleDateTypes
         next if event_date_types.blank? || event_date_types.size == 1
 
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
 
         [
           id,

--- a/app/reports/invalid_contributor_name_uris.rb
+++ b/app/reports/invalid_contributor_name_uris.rb
@@ -41,7 +41,10 @@ class InvalidContributorNameUris
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_contributor_source_codes.rb
+++ b/app/reports/invalid_contributor_source_codes.rb
@@ -107,7 +107,10 @@ class InvalidContributorSourceCodes
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_date_encoding_codes.rb
+++ b/app/reports/invalid_date_encoding_codes.rb
@@ -45,7 +45,10 @@ class InvalidDateEncodingCodes
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_doi_uris.rb
+++ b/app/reports/invalid_doi_uris.rb
@@ -40,7 +40,10 @@ class InvalidDoiUris
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_doi_values.rb
+++ b/app/reports/invalid_doi_values.rb
@@ -41,7 +41,10 @@ class InvalidDoiValues
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_edtf_dates.rb
+++ b/app/reports/invalid_edtf_dates.rb
@@ -50,7 +50,10 @@ class InvalidEdtfDates
         next if invalid_values.blank?
 
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
 
         [
           id,

--- a/app/reports/invalid_event_location_codes.rb
+++ b/app/reports/invalid_event_location_codes.rb
@@ -76,7 +76,10 @@ class InvalidEventLocationCodes
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_form_source_codes.rb
+++ b/app/reports/invalid_form_source_codes.rb
@@ -99,7 +99,10 @@ class InvalidFormSourceCodes
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
       collection_druid = rows.first['collection_id']
-      collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+      if collection_head_version&.has_cocina?
+        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
       apo_druid = rows.first['apo']
       apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
       title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_identifier_source_codes.rb
+++ b/app/reports/invalid_identifier_source_codes.rb
@@ -80,7 +80,10 @@ class InvalidIdentifierSourceCodes
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_iso8601_dates.rb
+++ b/app/reports/invalid_iso8601_dates.rb
@@ -47,7 +47,10 @@ class InvalidIso8601Dates
         next if invalid_values.blank?
 
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
 
         [
           id,

--- a/app/reports/invalid_lc_resource_types.rb
+++ b/app/reports/invalid_lc_resource_types.rb
@@ -62,7 +62,10 @@ class InvalidLcResourceTypes
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_role_codes.rb
+++ b/app/reports/invalid_role_codes.rb
@@ -55,7 +55,10 @@ class InvalidRoleCodes
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_role_source_codes.rb
+++ b/app/reports/invalid_role_source_codes.rb
@@ -42,7 +42,10 @@ class InvalidRoleSourceCodes
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
       collection_druid = rows.first['collection_id']
-      collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+      if collection_head_version&.has_cocina?
+        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
       apo_druid = rows.first['apo']
       apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
       title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_script_code.rb
+++ b/app/reports/invalid_script_code.rb
@@ -77,7 +77,10 @@ class InvalidScriptCode
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_script_source_codes.rb
+++ b/app/reports/invalid_script_source_codes.rb
@@ -48,7 +48,10 @@ class InvalidScriptSourceCodes
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_subject_encoding_codes.rb
+++ b/app/reports/invalid_subject_encoding_codes.rb
@@ -43,7 +43,10 @@ class InvalidSubjectEncodingCodes
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_subject_non_source_uris.rb
+++ b/app/reports/invalid_subject_non_source_uris.rb
@@ -40,7 +40,10 @@ class InvalidSubjectNonSourceUris
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
 
         [
           id,

--- a/app/reports/invalid_subject_source_codes.rb
+++ b/app/reports/invalid_subject_source_codes.rb
@@ -123,7 +123,10 @@ class InvalidSubjectSourceCodes
         collection_druid = rows.first['collection_id']
         next if collection_druid == 'druid:yh583fk3400' # ignore the google books collection
 
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_value_language_code.rb
+++ b/app/reports/invalid_value_language_code.rb
@@ -55,7 +55,10 @@ class InvalidValueLanguageCode
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_value_script_code.rb
+++ b/app/reports/invalid_value_script_code.rb
@@ -77,7 +77,10 @@ class InvalidValueScriptCode
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/invalid_w3cdtf_dates.rb
+++ b/app/reports/invalid_w3cdtf_dates.rb
@@ -47,7 +47,10 @@ class InvalidW3cdtfDates
         next if invalid_values.blank?
 
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
 
         [
           id,

--- a/app/reports/invalid_w3cdtf_event_dates.rb
+++ b/app/reports/invalid_w3cdtf_event_dates.rb
@@ -58,7 +58,10 @@ class InvalidW3cdtfEventDates
         next if invalid_values.blank?
 
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
 
         [
           id,

--- a/app/reports/parallel_events.rb
+++ b/app/reports/parallel_events.rb
@@ -12,7 +12,8 @@ class ParallelEvents
 
   SQL = <<~SQL.squish.freeze
     SELECT ro.external_identifier,
-           rov.label as title,
+           jsonb_path_query(rov.description, '$.title[0].structuredValue[*] ? (@.type == "main title").value') ->> 0 as structured_title,
+           jsonb_path_query(rov.description, '$.title[0].value') ->> 0 as title,
            jsonb_path_query(rov.structural, '$.isMemberOf') ->> 0 as collection_id,
            jsonb_path_query(rov.administrative, '$.hasAdminPolicy') ->> 0 as apo
            FROM repository_objects AS ro, repository_object_versions AS rov
@@ -36,13 +37,16 @@ class ParallelEvents
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
 
         [
           id,
-          rows.first['title']&.delete("\n"),
+          (rows.first['structured_title'] || rows.first['title'])&.delete("\n"),
           collection_druid,
           collection_name,
           apo_druid,

--- a/app/reports/property_contains_property_collections.rb
+++ b/app/reports/property_contains_property_collections.rb
@@ -37,7 +37,10 @@ class PropertyContainsPropertyCollections
       .execute(sql_query)
       .to_a
       .map do |row|
-      collection_name = RepositoryObject.collections.find_by(external_identifier: row['collection_druid'])&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: row['collection_druid'])&.head_version
+      if collection_head_version&.has_cocina?
+        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
 
       [
         row['collection_druid'],

--- a/app/reports/property_events_with_display_label.rb
+++ b/app/reports/property_events_with_display_label.rb
@@ -7,7 +7,8 @@
 class PropertyEventsWithDisplayLabel
   SQL = <<~SQL.squish.freeze
     SELECT ro.external_identifier as item_druid,
-           rov.label as title,#{' '}
+           jsonb_path_query(rov.description, '$.title[0].structuredValue[*] ? (@.type == "main title").value') ->> 0 as structured_title,
+           jsonb_path_query(rov.description, '$.title[0].value') ->> 0 as title,
            jsonb_path_query(rov.structural, '$.isMemberOf') ->> 0 as collection_druid,
            jsonb_path_query_array(rov.description, '$.event.displayLabel') as displayLabels,
            jsonb_path_query_first(rov.identification, '$.catalogLinks[*] ? (@.catalog == "folio").catalogRecordId') as catalogRecordId
@@ -27,12 +28,15 @@ class PropertyEventsWithDisplayLabel
     sql_result_rows = ActiveRecord::Base.connection.execute(sql_query).to_a
 
     sql_result_rows.map do |row|
-      collection_name = RepositoryObject.collections.find_by(external_identifier: row['collection_druid'])&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: row['collection_druid'])&.head_version
+      if collection_head_version&.has_cocina?
+        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
       display_labels = JSON.parse(row['displaylabels']).map { |label| "\"#{label}\"" }.join(';')
 
       [
         row['item_druid'],
-        row['title'],
+        (row['structured_title'] || row['title'])&.delete("\n"),
         collection_name,
         row['catalogrecordid'],
         display_labels

--- a/app/reports/property_existence_collections.rb
+++ b/app/reports/property_existence_collections.rb
@@ -36,7 +36,10 @@ class PropertyExistenceCollections
 
     sql_result_rows.map do |row|
       collection_druid = row['collection_druid']
-      collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+      if collection_head_version&.has_cocina?
+        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
 
       [
         collection_druid,

--- a/app/reports/property_existence_collections_without_hrid.rb
+++ b/app/reports/property_existence_collections_without_hrid.rb
@@ -36,7 +36,10 @@ class PropertyExistenceCollectionsWithoutHrid
 
     sql_result_rows.map do |row|
       collection_druid = row['collection_druid']
-      collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+      if collection_head_version&.has_cocina?
+        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
 
       [
         collection_druid,

--- a/app/reports/property_existence_dros.rb
+++ b/app/reports/property_existence_dros.rb
@@ -26,7 +26,10 @@ class PropertyExistenceDros
     ActiveRecord::Base.connection.execute(property_query).to_a.each do |row|
       next if row.blank?
 
-      collection_name = RepositoryObject.collections.find_by(external_identifier: row['collection_druid'])&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: row['collection_druid'])&.head_version
+      if collection_head_version&.has_cocina?
+        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
 
       puts [
         row['item_druid'],

--- a/app/reports/property_existence_dros_without_hrid.rb
+++ b/app/reports/property_existence_dros_without_hrid.rb
@@ -35,7 +35,10 @@ class PropertyExistenceDrosWithoutHrid
     ActiveRecord::Base.connection.execute(SQL_QUERY).to_a.each do |row|
       next if row.blank?
 
-      collection_name = RepositoryObject.collections.find_by(external_identifier: row['collection_druid'])&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: row['collection_druid'])&.head_version
+      if collection_head_version&.has_cocina?
+        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
 
       puts [
         row['item_druid'],

--- a/app/reports/property_multiple_events.rb
+++ b/app/reports/property_multiple_events.rb
@@ -12,7 +12,8 @@ class PropertyMultipleEvents
   SQL = <<~SQL.squish.freeze
     SELECT jsonb_path_query(rov.description, '#{PURL_JSONB_PATH}') ->> 0 as purl,
            ro.external_identifier,
-           rov.label,
+           jsonb_path_query(rov.description, '$.title[0].structuredValue[*] ? (@.type == "main title").value') ->> 0 as structured_title,
+           jsonb_path_query(rov.description, '$.title[0].value') ->> 0 as title,
            jsonb_path_query(rov.structural, '$.isMemberOf') ->> 0 as collection_id,
            jsonb_path_query(rov.administrative, '$.hasAdminPolicy') ->> 0 as apo
            FROM repository_objects AS ro, repository_object_versions AS rov WHERE
@@ -36,11 +37,14 @@ class PropertyMultipleEvents
       .group_by { |row| row['external_identifier'] }
       .map do |_id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
 
         [
           rows.first['purl'],
-          rows.first['label'],
+          (rows.first['structured_title'] || rows.first['title'])&.delete("\n"),
           collection_name,
           rows.first['apo']
         ].to_csv

--- a/app/reports/property_nesting_level_collections.rb
+++ b/app/reports/property_nesting_level_collections.rb
@@ -30,7 +30,10 @@ class PropertyNestingLevelCollections
 
     sql_result_rows.map do |row|
       collection_druid = row['collection_druid']
-      collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+      if collection_head_version&.has_cocina?
+        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
 
       [
         collection_druid,

--- a/app/reports/property_nesting_level_dros.rb
+++ b/app/reports/property_nesting_level_dros.rb
@@ -31,7 +31,10 @@ class PropertyNestingLevelDros
 
     sql_result_rows.map do |row|
       collection_druid = row['collection_id']
-      collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+      collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+      if collection_head_version&.has_cocina?
+        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+      end
 
       [
         row['item_druid'],

--- a/app/reports/subject_encoding_values.rb
+++ b/app/reports/subject_encoding_values.rb
@@ -44,7 +44,10 @@ class SubjectEncodingValues
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")

--- a/app/reports/subjects_without_types.rb
+++ b/app/reports/subjects_without_types.rb
@@ -20,7 +20,8 @@ class SubjectsWithoutTypes
 
   SQL = <<~SQL.squish.freeze
     SELECT ro.external_identifier,
-           rov.label as title,
+           jsonb_path_query(rov.description, '$.title[0].structuredValue[*] ? (@.type == "main title").value') ->> 0 as structured_title,
+           jsonb_path_query(rov.description, '$.title[0].value') ->> 0 as title,
            jsonb_path_query(rov.identification, '$.catalogLinks[*] ? (@.catalog == "folio").catalogRecordId') ->> 0 as hrid,
            jsonb_path_query(rov.structural, '$.isMemberOf') ->> 0 as collection_id,
            jsonb_path_query(rov.administrative, '$.hasAdminPolicy') ->> 0 as apo,
@@ -47,7 +48,10 @@ class SubjectsWithoutTypes
       .group_by { |row| row['external_identifier'] }
       .map do |id, rows|
         collection_druid = rows.first['collection_id']
-        collection_name = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version&.label
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        end
         apo_druid = rows.first['apo']
         apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
 
@@ -58,7 +62,7 @@ class SubjectsWithoutTypes
         [
           id,
           all_values.join(';'),
-          rows.first['title']&.delete("\n"),
+          (rows.first['structured_title'] || rows.first['title'])&.delete("\n"),
           collection_druid,
           collection_name,
           rows.first['hrid'],


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #6280 - we cannot have label referenced in items or collections, since that was removed from cocina.

Claude Code generated code to replace instances of label with title when possible, or just remove it not.
APOs were left alone.
