### PR TITLE
Adds migrator to remove parallel events.

### DIFF
--- a/app/services/migrators/remove_parallel_event.rb
+++ b/app/services/migrators/remove_parallel_event.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Migrators
+  # Removes the unused parallelEvent property from description in all objects and versions.
+  # See parent class and Migrators::MigrationRunner for more information.
+  class RemoveParallelEvent < Base
+    def migrate
+      remove_parallel_event_from_resource(model_hash['description'])
+
+      model_hash
+    end
+
+    private
+
+    def remove_parallel_event_from_resource(resource_hash)
+      return if resource_hash.nil?
+
+      remove_parallel_event(resource_hash)
+
+      Array(resource_hash['relatedResource']).each do |related_resource_hash|
+        remove_parallel_event_from_resource(related_resource_hash)
+      end
+
+      remove_parallel_event(resource_hash['adminMetadata'])
+    end
+
+    def remove_parallel_event(hash)
+      return if hash.nil?
+
+      Array(hash['event']).each do |event_hash|
+        event_hash.delete('parallelEvent')
+      end
+
+      Array(hash['event']).delete_if do |event_hash|
+        %w[date contributor location identifier note structuredValue].none? do |field|
+          event_hash[field].present?
+        end
+      end
+    end
+  end
+end

--- a/spec/services/migrators/remove_parallel_event_spec.rb
+++ b/spec/services/migrators/remove_parallel_event_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Migrators::RemoveParallelEvent do
+  subject(:migrator) do
+    described_class.new(model_hash: model_hash, valid: true, opened_version: false, last_closed_version: false,
+                        head_version: false)
+  end
+
+  describe 'migrate' do
+    subject(:migrated_model_hash) { migrator.migrate }
+
+    let(:model_hash) do
+      # Only providing description instead of complete model hash.
+      { 'description' => description }
+    end
+
+    let(:description) do
+      { 'title' => 'Test Title',
+        'relatedResource' => related_resource,
+        'event' => event,
+        'adminMetadata' => admin_metadata,
+        'purl' => 'https://purl.stanford.edu' }
+    end
+    let(:related_resource) do
+      [{ 'title' => 'Test Related Resource Title', 'event' => event, 'adminMetadata' => admin_metadata }]
+    end
+    let(:event) do
+      [
+        { 'location' => location, 'parallelEvent' => [{ 'name' => 'Test Parallel Event' }] },
+        { 'displayLabel' => 'Event with parallel event', 'parallelEvent' => [{ 'name' => 'Test Parallel Event' }] }
+      ]
+    end
+    let(:location) { [{ 'value' => 'Test Location' }] }
+    let(:admin_metadata) do
+      { 'name' => 'Test Admin Metadata',
+        'event' => [{ 'location' => location, 'parallelEvent' => [{ 'name' => 'Test Admin Parallel Event' }] }] }
+    end
+
+    it 'removes parallelEvent from events in events, relatedResources, adminMetadata' do
+      migrated_description = migrated_model_hash['description'].with_indifferent_access
+      expect(migrated_description)
+        .to match(
+          {
+            title: 'Test Title',
+            relatedResource: [
+              {
+                title: 'Test Related Resource Title',
+                event: [{ location: [{ value: 'Test Location' }] }],
+                adminMetadata: {
+                  name: 'Test Admin Metadata',
+                  event: [{ location: [{ value: 'Test Location' }] }]
+                }
+              }
+            ],
+            event: [{ location: [{ value: 'Test Location' }] }],
+            adminMetadata: {
+              name: 'Test Admin Metadata',
+              event: [{ location: [{ value: 'Test Location' }] }]
+            },
+            purl: 'https://purl.stanford.edu'
+          }
+        )
+    end
+  end
+
+  describe '#migration_strategy' do
+    it 'returns commit since using base default' do
+      expect(described_class.migration_strategy).to eq :commit
+    end
+  end
+end


### PR DESCRIPTION
refs #6033

## Why was this change made? 🤔
parallel events are deprecated.


## How was this change tested? 🤨
Unit, migrated QA and ran `validate-data`

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



