### PR TITLE
any previously published version is ok when running releaseWF

### DIFF
--- a/app/jobs/robots/dor_repo/release/release_publish.rb
+++ b/app/jobs/robots/dor_repo/release/release_publish.rb
@@ -40,10 +40,23 @@ module Robots
         end
 
         def published_version_available?
-          last_closed_version = RepositoryObject.find_by!(external_identifier: druid).last_closed_version_version
-          return false unless last_closed_version
+          workflow_version = version.to_i
 
-          Workflow::LifecycleService.milestone?(druid:, milestone_name: 'published', version: last_closed_version)
+          # The release workflow version itself has been published.
+          return true if version_published?(version: workflow_version)
+
+          # The release workflow may have started for a newer open version while an earlier version
+          # was already published. See https://github.com/sul-dlss/dor-services-app/issues/6278.
+          latest_version = latest_published_version
+          latest_version.present? && latest_version < workflow_version
+        end
+
+        def version_published?(version:)
+          Workflow::LifecycleService.milestone?(druid:, milestone_name: 'published', version:)
+        end
+
+        def latest_published_version
+          Workflow::LifecycleService.latest_milestone_version(druid:, milestone_name: 'published')
         end
       end
     end

--- a/app/services/workflow/lifecycle_service.rb
+++ b/app/services/workflow/lifecycle_service.rb
@@ -11,6 +11,10 @@ module Workflow
       new(druid: druid, version: version).milestone?(milestone_name: milestone_name)
     end
 
+    def self.latest_milestone_version(druid:, milestone_name:)
+      new(druid:).latest_milestone_version(milestone_name:)
+    end
+
     def self.milestones(...)
       new(...).milestones
     end
@@ -45,6 +49,12 @@ module Workflow
     # @return [Boolean] true if the object has the milestone
     def milestone?(milestone_name:)
       workflow_steps.exists?(lifecycle: milestone_name)
+    end
+
+    # @param [String] milestone_name the name of the milestone
+    # @return [Integer, nil] the most recent version with the completed milestone
+    def latest_milestone_version(milestone_name:)
+      workflow_steps.where(lifecycle: milestone_name).maximum(:version)
     end
 
     # @return [Array<Hash>]

--- a/spec/jobs/robots/dor_repo/release/release_publish_spec.rb
+++ b/spec/jobs/robots/dor_repo/release/release_publish_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Robots::DorRepo::Release::ReleasePublish, type: :robot do
   subject(:perform) { test_perform(robot, druid, version: 4) }
 
   let(:druid) { 'bb222cc3333' }
-  let!(:repository_object) { create(:repository_object, :closed, external_identifier: druid) }
   let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: true, access: dro_access, admin_policy?: false) }
   let(:dro_access) { instance_double(Cocina::Models::DROAccess, view: 'world') }
   let(:robot) { described_class.new }
@@ -43,6 +42,8 @@ RSpec.describe Robots::DorRepo::Release::ReleasePublish, type: :robot do
     allow(CocinaObjectStore).to receive(:find).with(druid).and_return(cocina_object)
     allow(PurlFetcher::Client::ReleaseTags).to receive(:release)
     allow(Workflow::LifecycleService).to receive(:milestone?).and_return(true)
+    allow(Workflow::LifecycleService).to receive(:latest_milestone_version)
+    allow(UserVersionService).to receive(:latest_user_version).with(druid:).and_return(nil)
   end
 
   context 'when the last closed version is published' do
@@ -50,29 +51,44 @@ RSpec.describe Robots::DorRepo::Release::ReleasePublish, type: :robot do
       perform
 
       expect(Workflow::LifecycleService).to have_received(:milestone?)
-        .with(druid:, milestone_name: 'published', version: repository_object.last_closed_version_version)
+        .with(druid:, milestone_name: 'published', version: 4)
+      expect(Workflow::LifecycleService).not_to have_received(:latest_milestone_version)
       expect(PurlFetcher::Client::ReleaseTags).to have_received(:release)
         .with(druid:, index: ['Searchworks', 'Purl sitemap'], delete: ['Earthworks'])
+    end
+
+    context 'when the workflow version is not published but an earlier version is published' do
+      before do
+        allow(Workflow::LifecycleService).to receive_messages(milestone?: false, latest_milestone_version: 3)
+      end
+
+      it 'calls purl fetcher with the release tags' do
+        perform
+
+        expect(Workflow::LifecycleService).to have_received(:latest_milestone_version)
+          .with(druid:, milestone_name: 'published')
+        expect(PurlFetcher::Client::ReleaseTags).to have_received(:release)
+      end
+    end
+
+    context 'when only a later version is published' do
+      before do
+        allow(Workflow::LifecycleService).to receive_messages(milestone?: false, latest_milestone_version: 5)
+      end
+
+      it 'raises' do
+        expect { perform }.to raise_error(Robots::DorRepo::Release::ReleasePublish::PublishNotCompleteError)
+      end
     end
   end
 
   context 'when an unpublished item' do
     before do
-      allow(Workflow::LifecycleService).to receive(:milestone?).and_return(false)
+      allow(Workflow::LifecycleService).to receive_messages(milestone?: false, latest_milestone_version: nil)
     end
 
     it 'raises when the last closed version is not published' do
       expect { perform }.to raise_error(Robots::DorRepo::Release::ReleasePublish::PublishNotCompleteError)
-    end
-  end
-
-  context 'when the object does not have a closed version' do
-    let!(:repository_object) { create(:repository_object, external_identifier: druid) }
-
-    it 'raises without checking for a published milestone' do
-      expect { perform }.to raise_error(Robots::DorRepo::Release::ReleasePublish::PublishNotCompleteError)
-
-      expect(Workflow::LifecycleService).not_to have_received(:milestone?)
     end
   end
 

--- a/spec/services/workflow/lifecycle_service_spec.rb
+++ b/spec/services/workflow/lifecycle_service_spec.rb
@@ -88,6 +88,45 @@ RSpec.describe Workflow::LifecycleService do
     end
   end
 
+  describe '.latest_milestone_version' do
+    subject(:latest_milestone_version) do
+      described_class.latest_milestone_version(druid:, milestone_name: 'published')
+    end
+
+    before do
+      create(:workflow_step,
+             druid:,
+             version: 2,
+             process: 'publish',
+             status: 'completed',
+             lifecycle: 'published')
+      create(:workflow_step,
+             druid:,
+             version: 4,
+             process: 'publish',
+             status: 'completed',
+             lifecycle: 'published')
+      create(:workflow_step,
+             druid:,
+             version: 5,
+             process: 'publish',
+             status: 'waiting',
+             lifecycle: 'published')
+    end
+
+    it 'returns the most recent version with the completed milestone' do
+      expect(latest_milestone_version).to eq 4
+    end
+
+    context 'when the milestone has not been completed' do
+      subject(:latest_milestone_version) do
+        described_class.latest_milestone_version(druid:, milestone_name: 'accessioned')
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe '#milestones' do
     subject(:milestones) { service.milestones }
 


### PR DESCRIPTION
## Why was this change made? 🤔

Note: Alternative to #6289 in case we need it later (to deal with #6278)

A previous fix for https://github.com/sul-dlss/dor-services-app/issues/6246 causes an issue when you open a new version of an object, and then run releaseWF on it.  The fix in #6289 checks if the last closed version has a publish lifecycle.  There may edge cases where there was a previously published version other than in the last closed version.  This alternative implementation would allow release to continue in those situations.

This code adds a new Lifecycle service helper method to find the latest version of a particular lifecycle.  It then uses this in the release step.

Question: should we constraint this further so that the previous version must be n-1 the workflow version?  This might be too tight a constraint.

Note: Codex helped identify the underlying cause and suggested some fixes, which I iterated on and narrowed down in scope.  I wrote most of the code using some of it's suggestions.  It wrote most of the specs.

## How was this change tested? 🤨

Specs, but could be worth deploying to stage, and seeing if the current stage object succeeds on retries: https://argo-stage.stanford.edu/view/druid:bb975xt8207