### PR TITLE
Remove usage of label from RepositoryObjectVersion.to_h and migrators

### DIFF
--- a/app/models/repository_object_version.rb
+++ b/app/models/repository_object_version.rb
@@ -76,7 +76,6 @@ class RepositoryObjectVersion < ApplicationRecord
       cocinaVersion: cocina_version,
       type: content_type,
       externalIdentifier: repository_object.external_identifier,
-      label:,
       version:,
       access:,
       administrative:,

--- a/spec/requests/create_object_spec.rb
+++ b/spec/requests/create_object_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Create object' do
         {#{' '}
           "cocinaVersion":"#{Cocina::Models::VERSION}",
           "type":"#{Cocina::Models::ObjectType.image}",
-          "label":"","version":1,
+          "version":1,
           "access":{
             "view":"#{view}",
             "download":"none",
@@ -111,8 +111,6 @@ RSpec.describe 'Create object' do
     end
 
     context 'when folio instance hrid is provided' do
-      let(:expected_label) { title } # label derived from catalog data
-
       let(:identification) do
         {
           sourceId: 'googlebooks:999999',
@@ -126,8 +124,6 @@ RSpec.describe 'Create object' do
         let(:marc_service) do
           instance_double(Catalog::MarcService, marc: nil)
         end
-
-        let(:expected_label) { label }
 
         it 'registers the object with the registration service' do
           expect do
@@ -151,7 +147,6 @@ RSpec.describe 'Create object' do
           build(:dro, id: druid, title: expected_title, type: Cocina::Models::ObjectType.image,
                       admin_policy_id:)
             .new(
-              label: expected_title,
               identification: expected_identification,
               structural: expected_structural,
               access: {
@@ -171,7 +166,6 @@ RSpec.describe 'Create object' do
                                    note: [{ value: 'by Some Author.',
                                             type: 'statement of responsibility' }])
         end
-        let(:label) { 'Here is my title' }
         let(:title) { 'Here is my title' }
         let(:marc) do
           { fields: [
@@ -197,7 +191,7 @@ RSpec.describe 'Create object' do
             {
               "cocinaVersion":"#{Cocina::Models::VERSION}",
               "type":"#{Cocina::Models::ObjectType.image}",
-              "label":"#{label}","version":1,
+              "version":1,
               "access":{
                 "view":"#{view}",
                 "download":"none",
@@ -709,7 +703,7 @@ RSpec.describe 'Create object' do
           {#{' '}
             "cocinaVersion":"#{Cocina::Models::VERSION}",
             "type":"#{Cocina::Models::ObjectType.image}",
-            "label":"","version":1,
+            "version":1,
             "administrative":{"hasAdminPolicy":"#{admin_policy_id}","partOfProject":"Google Books"},
             "description":{"title":[{"value":"#{title}"}]},
             "identification":#{identification.to_json},
@@ -757,7 +751,8 @@ RSpec.describe 'Create object' do
         {#{' '}
           "cocinaVersion":"#{Cocina::Models::VERSION}",
           "type":"#{Cocina::Models::ObjectType.book}",
-          "label":"","version":1,"access":{"view":"world","download":"world"},
+          "version":1,
+          "access":{"view":"world","download":"world"},
           "administrative":{"hasAdminPolicy":"#{admin_policy_id}"},
           "description":{"title":[{"value":"#{expected_title}"}]},
           "identification":{"sourceId":"googlebooks:999999"},
@@ -784,7 +779,6 @@ RSpec.describe 'Create object' do
   context 'when an APO is provided' do
     let(:expected) do
       Cocina::Models::AdminPolicy.new(type: Cocina::Models::ObjectType.admin_policy,
-                                      label: 'This is my label',
                                       version: 1,
                                       description: {
                                         title: [{ value: 'This is my title' }],
@@ -824,7 +818,7 @@ RSpec.describe 'Create object' do
         {
           "cocinaVersion":"#{Cocina::Models::VERSION}",
           "type":"#{Cocina::Models::ObjectType.admin_policy}",
-          "label":"This is my label","version":1,
+          "version":1,
           "administrative":{
             "accessTemplate":{
               "view":"location-based",
@@ -880,7 +874,6 @@ RSpec.describe 'Create object' do
   context 'when an embargo is provided' do
     let(:expected) do
       Cocina::Models::DRO.new(type: Cocina::Models::ObjectType.book,
-                              label: 'This is my label',
                               version: 1,
                               description: {
                                 title: [{ value: 'This is my title' }],
@@ -909,7 +902,7 @@ RSpec.describe 'Create object' do
         {#{' '}
           "cocinaVersion":"#{Cocina::Models::VERSION}",
           "type":"#{Cocina::Models::ObjectType.book}",
-          "label":"This is my label","version":1,"access":{"view":"stanford","download":"none","controlledDigitalLending":false,
+          "version":1,"access":{"view":"stanford","download":"none","controlledDigitalLending":false,
           "embargo":{"view":"world","download":"world","releaseDate":"2020-02-29T07:00:00.000+00:00"}},
           "administrative":{"hasAdminPolicy":"#{admin_policy_id}"},
           "description":{"title":[{"value":"This is my title"}]},
@@ -938,7 +931,6 @@ RSpec.describe 'Create object' do
   context 'when location access is specified' do
     let(:expected) do
       Cocina::Models::DRO.new(type: Cocina::Models::ObjectType.book,
-                              label: 'This is my label',
                               version: 1,
                               description: {
                                 title: [{ value: 'This is my title' }],
@@ -966,7 +958,7 @@ RSpec.describe 'Create object' do
           "cocinaVersion":"#{Cocina::Models::VERSION}",
           "cocinaVersion":"#{Cocina::Models::VERSION}",
           "type":"#{Cocina::Models::ObjectType.book}",
-          "label":"This is my label","version":1,
+          "version":1,
           "access":{"view":"location-based","download":"location-based","location":"m&m"},
           "administrative":{"hasAdminPolicy":"#{admin_policy_id}"},
           "description":{"title":[{"value":"This is my title"}]},
@@ -1013,7 +1005,7 @@ RSpec.describe 'Create object' do
         {#{' '}
           "cocinaVersion":"#{Cocina::Models::VERSION}",
           "type":"#{Cocina::Models::ObjectType.book}",
-          "label":"","version":1,
+          "version":1,
           "access":{"view":"world","download":"none"},
           "administrative":{"hasAdminPolicy":"#{admin_policy_id}"},
           "description":{"title":[{"value":"This is my title"}]},
@@ -1052,7 +1044,7 @@ RSpec.describe 'Create object' do
           {#{' '}
             "cocinaVersion":"#{Cocina::Models::VERSION}",
             "type":"#{Cocina::Models::ObjectType.object}",
-            "label":"","version":1,"access":{},
+            "version":1,"access":{},
             "administrative":{"hasAdminPolicy":"#{admin_policy_id}"},
             "identification":{"sourceId":"googlebooks:999999"},
             "description":{"title":[{"value":"This is my title"}]},
@@ -1088,7 +1080,7 @@ RSpec.describe 'Create object' do
           {#{' '}
             "cocinaVersion":"#{Cocina::Models::VERSION}",
             "type":"#{Cocina::Models::ObjectType.object}",
-            "label":"","version":1,"access":{},
+            "version":1,"access":{},
             "administrative":{"hasAdminPolicy":"#{admin_policy_id}"},
             "identification":{"sourceId":"googlebooks:999999"},
             "description":{"title":[{"value":"This is my title"}]},
@@ -1126,7 +1118,7 @@ RSpec.describe 'Create object' do
           {#{' '}
             "cocinaVersion":"#{Cocina::Models::VERSION}",
             "type":"#{Cocina::Models::ObjectType.object}",
-            "label":"","version":1,
+            "version":1,
             "administrative":{"hasAdminPolicy":"#{admin_policy_id}"},
             "access":{},
             "identification":{"sourceId":"googlebooks:999999"},

--- a/spec/requests/show_object_spec.rb
+++ b/spec/requests/show_object_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe 'Get the object' do
           {
             externalIdentifier: druid,
             type: Cocina::Models::ObjectType.object,
-            label: 'foo',
             version: 1,
             access: {
               view: 'world',
@@ -53,7 +52,6 @@ RSpec.describe 'Get the object' do
       before do
         object.head_version.update(
           content_type: Cocina::Models::ObjectType.object,
-          label: 'foo',
           version: 1,
           access: {
             view: 'world',
@@ -209,7 +207,6 @@ RSpec.describe 'Get the object' do
         json = response.parsed_body
 
         expect(json['type']).to eq Cocina::Models::ObjectType.admin_policy
-        expect(json['label']).to eq 'Test Admin Policy'
         expect(json['version']).to eq 1
         expect(json['administrative']['registrationWorkflow']).to eq %w[registrationWF goobiWF]
         expect(json['administrative']['disseminationWorkflow']).to eq 'wasCrawlPreassemblyWF'

--- a/spec/services/migrators/migration_runner_spec.rb
+++ b/spec/services/migrators/migration_runner_spec.rb
@@ -79,21 +79,21 @@ RSpec.describe Migrators::MigrationRunner do
     subject(:results) { described_class.new(migrator_class:, repository_object:, mode:).call }
 
     let(:repository_object) do
-      # This repository object will have 3 versions, each with a unique label:
+      # This repository object will have 3 versions, each with a unique title:
       # version 1
       # version 2 (last closed)
       # version 3 (opened and head)
       create(:repository_object, :with_repository_object_version).tap do |repository_object|
-        repository_object.head_version.update!(label: 'version 1')
+        update_title!(repository_object.head_version, 'version 1 title')
         # First version is open. Close it.
         repository_object.close_version!(description: 'first version')
         # Open a second version.
         repository_object.open_version!(description: 'second version')
-        repository_object.head_version.update!(label: 'version 2')
+        update_title!(repository_object.head_version, 'version 2 title')
         # Close it and open a third version.
         repository_object.close_version!
         repository_object.open_version!(description: 'third version')
-        repository_object.head_version.update!(label: 'version 3')
+        update_title!(repository_object.head_version, 'version 3 title')
       end
     end
     let(:druid) { repository_object.external_identifier }
@@ -106,6 +106,11 @@ RSpec.describe Migrators::MigrationRunner do
       allow(UpdateObjectService).to receive(:update)
     end
 
+    def update_title!(repository_object_version, title)
+      new_description = repository_object_version.description.merge('title' => [{ 'value' => title }])
+      repository_object_version.update!(description: new_description)
+    end
+
     context 'when migration strategy is commit' do
       context 'when some versions are changed' do
         let(:migrator_class) do
@@ -113,7 +118,10 @@ RSpec.describe Migrators::MigrationRunner do
             'Migrators::TestMigrator',
             Class.new(Migrators::Base) do
               def migrate
-                model_hash['label'] = "#{model_hash['label']} migrated" unless model_hash['version'] == 2
+                unless model_hash['version'] == 2
+                  model_hash['description']['title'].first['value'] =
+                    "#{model_hash['description']['title'].first['value']} migrated"
+                end
                 model_hash
               end
             end
@@ -125,9 +133,13 @@ RSpec.describe Migrators::MigrationRunner do
             hash_including(external_identifier: druid, version: 1, status: 'MIGRATED'),
             hash_including(external_identifier: druid, version: 3, status: 'MIGRATED')
           )
-          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1 migrated'
-          expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2'
-          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3 migrated'
+
+          expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+            .to eq 'version 1 title migrated'
+          expect(repository_object.versions.find_by(version: 2).description['title'].first['value'])
+            .to eq 'version 2 title'
+          expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+            .to eq 'version 3 title migrated'
 
           expect(version_service).not_to have_received(:open)
           expect(version_service).not_to have_received(:close)
@@ -165,7 +177,8 @@ RSpec.describe Migrators::MigrationRunner do
           'Migrators::TestMigrator',
           Class.new(Migrators::Base) do
             def migrate
-              model_hash['label'] = "#{model_hash['label']} migrated"
+              model_hash['description']['title'].first['value'] =
+                "#{model_hash['description']['title'].first['value']} migrated"
               model_hash
             end
 
@@ -187,14 +200,17 @@ RSpec.describe Migrators::MigrationRunner do
           )
 
           # Changes aren't persisted.
-          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1'
-          expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2'
-          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3'
+          expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+            .to eq 'version 1 title'
+          expect(repository_object.versions.find_by(version: 2).description['title'].first['value'])
+            .to eq 'version 2 title'
+          expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+            .to eq 'version 3 title'
 
           expect(version_service).not_to have_received(:open)
           expect(UpdateObjectService).to have_received(:update) do |args|
             expect(args[:cocina_object]).to be_an_instance_of(Cocina::Models::DROWithMetadata)
-            expect(args[:cocina_object].label).to eq 'version 3 migrated'
+            expect(args[:cocina_object].description.title.first.value).to eq 'version 3 title migrated'
             expect(args[:skip_open_check]).to be true
           end
           expect(version_service).not_to have_received(:close)
@@ -214,9 +230,12 @@ RSpec.describe Migrators::MigrationRunner do
           )
 
           # Changes aren't persisted.
-          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1'
-          expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2'
-          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3'
+          expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+            .to eq 'version 1 title'
+          expect(repository_object.versions.find_by(version: 2).description['title'].first['value'])
+            .to eq 'version 2 title'
+          expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+            .to eq 'version 3 title'
 
           expect(VersionService).to have_received(:new)
             .with(druid:, version: 3, repository_object: repository_object).at_least(:once)
@@ -230,7 +249,7 @@ RSpec.describe Migrators::MigrationRunner do
           expect(UpdateObjectService).to have_received(:update) do |args|
             expect(args[:cocina_object]).to be_an_instance_of(Cocina::Models::DROWithMetadata)
             expect(args[:cocina_object].version).to eq 4
-            expect(args[:cocina_object].label).to eq 'version 3 migrated'
+            expect(args[:cocina_object].description.title.first.value).to eq 'version 3 title migrated'
             expect(args[:skip_open_check]).to be true
           end
 
@@ -248,7 +267,8 @@ RSpec.describe Migrators::MigrationRunner do
             'Migrators::TestMigrator',
             Class.new(Migrators::Base) do
               def migrate
-                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash['description']['title'].first['value'] =
+                  "#{model_hash['description']['title'].first['value']} migrated"
                 model_hash
               end
 
@@ -317,7 +337,10 @@ RSpec.describe Migrators::MigrationRunner do
           'Migrators::TestMigrator',
           Class.new(Migrators::Base) do
             def migrate
-              model_hash['label'] = "#{model_hash['label']} migrated" unless model_hash['version'] == 2
+              unless model_hash['version'] == 2
+                model_hash['description']['title'].first['value'] =
+                  "#{model_hash['description']['title'].first['value']} migrated"
+              end
               model_hash
             end
 
@@ -338,9 +361,12 @@ RSpec.describe Migrators::MigrationRunner do
             hash_including(external_identifier: druid, version: 1, status: 'MIGRATED'),
             hash_including(external_identifier: druid, version: 3, status: 'MIGRATED')
           )
-          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1 migrated'
-          expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2'
-          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3 migrated'
+          expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+            .to eq 'version 1 title migrated'
+          expect(repository_object.versions.find_by(version: 2).description['title'].first['value'])
+            .to eq 'version 2 title'
+          expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+            .to eq 'version 3 title migrated'
 
           expect(version_service).not_to have_received(:open)
           expect(version_service).not_to have_received(:close)
@@ -366,10 +392,14 @@ RSpec.describe Migrators::MigrationRunner do
             hash_including(external_identifier: druid, version: 3, status: 'MIGRATED'),
             hash_including(external_identifier: druid, version: 4, status: 'MIGRATED')
           )
-          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1 migrated'
-          expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2'
-          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3 migrated'
-          expect(repository_object.versions.find_by(version: 4).label).to eq 'version 3 migrated'
+          expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+            .to eq 'version 1 title migrated'
+          expect(repository_object.versions.find_by(version: 2).description['title'].first['value'])
+            .to eq 'version 2 title'
+          expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+            .to eq 'version 3 title migrated'
+          expect(repository_object.versions.find_by(version: 4).description['title'].first['value'])
+            .to eq 'version 3 title migrated'
 
           expect(version_service).to have_received(:open).with(
             cocina_object: cocina_object_for_opening,
@@ -415,7 +445,10 @@ RSpec.describe Migrators::MigrationRunner do
           'Migrators::TestMigrator',
           Class.new(Migrators::Base) do
             def migrate
-              model_hash['label'] = "#{model_hash['label']} migrated" unless model_hash['version'] == 2
+              unless model_hash['version'] == 2
+                model_hash['description']['title'].first['value'] =
+                  "#{model_hash['description']['title'].first['value']} migrated"
+              end
               model_hash
             end
 
@@ -436,9 +469,12 @@ RSpec.describe Migrators::MigrationRunner do
             hash_including(external_identifier: druid, version: 1, status: 'MIGRATED'),
             hash_including(external_identifier: druid, version: 3, status: 'MIGRATED')
           )
-          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1 migrated'
-          expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2'
-          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3 migrated'
+          expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+            .to eq 'version 1 title migrated'
+          expect(repository_object.versions.find_by(version: 2).description['title'].first['value'])
+            .to eq 'version 2 title'
+          expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+            .to eq 'version 3 title migrated'
 
           expect(version_service).not_to have_received(:open)
           expect(version_service).not_to have_received(:close)
@@ -482,7 +518,8 @@ RSpec.describe Migrators::MigrationRunner do
             Class.new(Migrators::Base) do
               def migrate
                 model_hash['identification'].delete('sourceId') if model_hash['version'] == 1
-                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash['description']['title'].first['value'] =
+                  "#{model_hash['description']['title'].first['value']} migrated"
                 model_hash
               end
 
@@ -500,9 +537,12 @@ RSpec.describe Migrators::MigrationRunner do
             hash_including(external_identifier: druid, version: 3, status: 'MIGRATED')
           )
 
-          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1 migrated'
-          expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2 migrated'
-          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3 migrated'
+          expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+            .to eq 'version 1 title migrated'
+          expect(repository_object.versions.find_by(version: 2).description['title'].first['value'])
+            .to eq 'version 2 title migrated'
+          expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+            .to eq 'version 3 title migrated'
 
           expect { repository_object.reload.versions.find_by(version: 1).to_cocina }.to raise_error(Cocina::Models::ValidationError)
         end
@@ -514,7 +554,8 @@ RSpec.describe Migrators::MigrationRunner do
             'Migrators::TestMigrator',
             Class.new(Migrators::Base) do
               def migrate
-                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash['description']['title'].first['value'] =
+                  "#{model_hash['description']['title'].first['value']} migrated"
                 model_hash['identification'].delete('sourceId') if model_hash['version'] == 3
                 model_hash
               end
@@ -531,9 +572,12 @@ RSpec.describe Migrators::MigrationRunner do
             hash_including(external_identifier: druid, version: 3, status: 'INVALID', exception: /When validating DRO/)
           )
 
-          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1'
-          expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2'
-          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3'
+          expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+            .to eq 'version 1 title'
+          expect(repository_object.versions.find_by(version: 2).description['title'].first['value'])
+            .to eq 'version 2 title'
+          expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+            .to eq 'version 3 title'
         end
       end
 
@@ -543,7 +587,8 @@ RSpec.describe Migrators::MigrationRunner do
             'Migrators::TestMigrator',
             Class.new(Migrators::Base) do
               def migrate
-                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash['description']['title'].first['value'] =
+                  "#{model_hash['description']['title'].first['value']} migrated"
                 model_hash['identification'].delete('sourceId') if model_hash['version'] == 2
                 model_hash
               end
@@ -560,9 +605,12 @@ RSpec.describe Migrators::MigrationRunner do
             hash_including(external_identifier: druid, version: 2, status: 'INVALID', exception: /When validating DRO/)
           )
 
-          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1'
-          expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2'
-          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3'
+          expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+            .to eq 'version 1 title'
+          expect(repository_object.versions.find_by(version: 2).description['title'].first['value'])
+            .to eq 'version 2 title'
+          expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+            .to eq 'version 3 title'
         end
       end
     end
@@ -575,7 +623,8 @@ RSpec.describe Migrators::MigrationRunner do
             Class.new(Migrators::Base) do
               def migrate
                 model_hash['identification'].delete('sourceId') if model_hash['version'] == 1
-                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash['description']['title'].first['value'] =
+                  "#{model_hash['description']['title'].first['value']} migrated"
                 model_hash
               end
             end
@@ -588,9 +637,12 @@ RSpec.describe Migrators::MigrationRunner do
                            exception: /When validating DRO/)
           )
 
-          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1'
-          expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2'
-          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3'
+          expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+            .to eq 'version 1 title'
+          expect(repository_object.versions.find_by(version: 2).description['title'].first['value'])
+            .to eq 'version 2 title'
+          expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+            .to eq 'version 3 title'
         end
       end
 
@@ -600,7 +652,8 @@ RSpec.describe Migrators::MigrationRunner do
             'Migrators::TestMigrator',
             Class.new(Migrators::Base) do
               def migrate
-                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash['description']['title'].first['value'] =
+                  "#{model_hash['description']['title'].first['value']} migrated"
                 model_hash
               end
             end
@@ -622,9 +675,12 @@ RSpec.describe Migrators::MigrationRunner do
             hash_including(external_identifier: druid, version: 3, status: 'MIGRATED')
           )
 
-          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1 migrated'
-          expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2 migrated'
-          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3 migrated'
+          expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+            .to eq 'version 1 title migrated'
+          expect(repository_object.versions.find_by(version: 2).description['title'].first['value'])
+            .to eq 'version 2 title migrated'
+          expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+            .to eq 'version 3 title migrated'
         end
       end
     end
@@ -635,7 +691,8 @@ RSpec.describe Migrators::MigrationRunner do
           'Migrators::TestMigrator',
           Class.new(Migrators::Base) do
             def migrate
-              model_hash['label'] = "#{model_hash['label']} migrated"
+              model_hash['description']['title'].first['value'] =
+                "#{model_hash['description']['title'].first['value']} migrated"
               model_hash
             end
           end
@@ -651,9 +708,12 @@ RSpec.describe Migrators::MigrationRunner do
           hash_including(external_identifier: druid, version: 1, status: 'MIGRATED'),
           hash_including(external_identifier: druid, version: 3, status: 'MIGRATED')
         )
-        expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1 migrated'
-        expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2'
-        expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3 migrated'
+        expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+          .to eq 'version 1 title migrated'
+        expect(repository_object.versions.find_by(version: 2).description['title'].first['value'])
+          .to eq 'version 2 title'
+        expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+          .to eq 'version 3 title migrated'
       end
     end
 
@@ -666,7 +726,8 @@ RSpec.describe Migrators::MigrationRunner do
             'Migrators::TestMigrator',
             Class.new(Migrators::Base) do
               def migrate
-                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash['description']['title'].first['value'] =
+                  "#{model_hash['description']['title'].first['value']} migrated"
                 model_hash
               end
 
@@ -703,7 +764,8 @@ RSpec.describe Migrators::MigrationRunner do
             'Migrators::TestMigrator',
             Class.new(Migrators::Base) do
               def migrate
-                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash['description']['title'].first['value'] =
+                  "#{model_hash['description']['title'].first['value']} migrated"
                 model_hash
               end
 
@@ -725,9 +787,12 @@ RSpec.describe Migrators::MigrationRunner do
             hash_including(external_identifier: druid, version: 3, status: 'MIGRATED (dry run)')
           )
 
-          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1'
-          expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2'
-          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3'
+          expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+            .to eq 'version 1 title'
+          expect(repository_object.versions.find_by(version: 2).description['title'].first['value'])
+            .to eq 'version 2 title'
+          expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+            .to eq 'version 3 title'
 
           expect(version_service).not_to have_received(:open)
           expect(version_service).not_to have_received(:close)
@@ -740,7 +805,8 @@ RSpec.describe Migrators::MigrationRunner do
             'Migrators::TestMigrator',
             Class.new(Migrators::Base) do
               def migrate
-                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash['description']['title'].first['value'] =
+                  "#{model_hash['description']['title'].first['value']} migrated"
                 model_hash
               end
 
@@ -758,9 +824,12 @@ RSpec.describe Migrators::MigrationRunner do
             hash_including(external_identifier: druid, version: 3, status: 'MIGRATED (dry run)')
           )
 
-          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1'
-          expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2'
-          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3'
+          expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+            .to eq 'version 1 title'
+          expect(repository_object.versions.find_by(version: 2).description['title'].first['value'])
+            .to eq 'version 2 title'
+          expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+            .to eq 'version 3 title'
 
           expect(Publish::MetadataTransferService).not_to have_received(:publish)
         end
@@ -772,7 +841,8 @@ RSpec.describe Migrators::MigrationRunner do
             'Migrators::TestMigrator',
             Class.new(Migrators::Base) do
               def migrate
-                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash['description']['title'].first['value'] =
+                  "#{model_hash['description']['title'].first['value']} migrated"
                 model_hash
               end
             end
@@ -786,9 +856,12 @@ RSpec.describe Migrators::MigrationRunner do
             hash_including(external_identifier: druid, version: 3, status: 'MIGRATED (dry run)')
           )
 
-          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1'
-          expect(repository_object.versions.find_by(version: 2).label).to eq 'version 2'
-          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3'
+          expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+            .to eq 'version 1 title'
+          expect(repository_object.versions.find_by(version: 2).description['title'].first['value'])
+            .to eq 'version 2 title'
+          expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+            .to eq 'version 3 title'
         end
       end
 
@@ -798,7 +871,8 @@ RSpec.describe Migrators::MigrationRunner do
             'Migrators::TestMigrator',
             Class.new(Migrators::Base) do
               def migrate
-                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash['description']['title'].first['value'] =
+                  "#{model_hash['description']['title'].first['value']} migrated"
                 model_hash
               end
 
@@ -827,7 +901,8 @@ RSpec.describe Migrators::MigrationRunner do
             'Migrators::TestMigrator',
             Class.new(Migrators::Base) do
               def migrate
-                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash['description']['title'].first['value'] =
+                  "#{model_hash['description']['title'].first['value']} migrated"
                 model_hash
               end
 
@@ -868,7 +943,8 @@ RSpec.describe Migrators::MigrationRunner do
             'Migrators::TestMigrator',
             Class.new(Migrators::Base) do
               def migrate
-                model_hash['label'] = "#{model_hash['label']} migrated"
+                model_hash['description']['title'].first['value'] =
+                  "#{model_hash['description']['title'].first['value']} migrated"
                 model_hash
               end
 
@@ -925,7 +1001,8 @@ RSpec.describe Migrators::MigrationRunner do
           'Migrators::TestMigrator',
           Class.new(Migrators::Base) do
             def migrate
-              model_hash['label'] = "#{model_hash['label']} migrated"
+              model_hash['description']['title'].first['value'] =
+                "#{model_hash['description']['title'].first['value']} migrated"
               model_hash
             end
 
@@ -945,8 +1022,10 @@ RSpec.describe Migrators::MigrationRunner do
           expect(results.map(&:to_h)).to contain_exactly(
             hash_including(external_identifier: druid, status: 'SKIPPED')
           )
-          expect(repository_object.reload.versions.find_by(version: 1).label).to eq 'version 1'
-          expect(repository_object.versions.find_by(version: 3).label).to eq 'version 3'
+          expect(repository_object.reload.versions.find_by(version: 1).description['title'].first['value'])
+            .to eq 'version 1 title'
+          expect(repository_object.versions.find_by(version: 3).description['title'].first['value'])
+            .to eq 'version 3 title'
         end
 
         context 'when dryrun' do
@@ -993,7 +1072,8 @@ RSpec.describe Migrators::MigrationRunner do
           'Migrators::TestMigrator',
           Class.new(Migrators::Base) do
             def migrate
-              model_hash['label'] = "#{model_hash['label']} migrated"
+              model_hash['description']['title'].first['value'] =
+                "#{model_hash['description']['title'].first['value']} migrated"
               model_hash
             end
 
@@ -1022,7 +1102,8 @@ RSpec.describe Migrators::MigrationRunner do
           'Migrators::TestMigrator',
           Class.new(Migrators::Base) do
             def migrate
-              model_hash['label'] = "#{model_hash['label']} migrated"
+              model_hash['description']['title'].first['value'] =
+                "#{model_hash['description']['title'].first['value']} migrated"
               model_hash
             end
 


### PR DESCRIPTION
## Why was this change made? 🤔
Fixes #6210.

## How was this change tested? 🤨
Integration tests and CI
