### PR TITLE
Do not delete populated parallelEvents when migrating.

### DIFF
--- a/app/services/migrators/remove_parallel_event.rb
+++ b/app/services/migrators/remove_parallel_event.rb
@@ -28,14 +28,20 @@ module Migrators
       return if hash.nil?
 
       Array(hash['event']).each do |event_hash|
-        event_hash.delete('parallelEvent')
+        event_hash.delete('parallelEvent') if delete?(event_hash)
       end
 
       Array(hash['event']).delete_if do |event_hash|
-        %w[date contributor location identifier note structuredValue].none? do |field|
+        %w[date contributor location identifier note structuredValue parallelEvent].none? do |field|
           event_hash[field].present?
         end
       end
+    end
+
+    def delete?(event_hash)
+      return false unless event_hash.key?('parallelEvent')
+
+      event_hash['parallelEvent'].empty? || opened_version? || last_closed_version?
     end
   end
 end

--- a/spec/services/migrators/remove_parallel_event_spec.rb
+++ b/spec/services/migrators/remove_parallel_event_spec.rb
@@ -4,9 +4,12 @@ require 'rails_helper'
 
 RSpec.describe Migrators::RemoveParallelEvent do
   subject(:migrator) do
-    described_class.new(model_hash: model_hash, valid: true, opened_version: false, last_closed_version: false,
+    described_class.new(model_hash: model_hash, valid: true, opened_version:, last_closed_version:,
                         head_version: false)
   end
+
+  let(:opened_version) { false }
+  let(:last_closed_version) { false }
 
   describe 'migrate' do
     subject(:migrated_model_hash) { migrator.migrate }
@@ -26,42 +29,105 @@ RSpec.describe Migrators::RemoveParallelEvent do
     let(:related_resource) do
       [{ 'title' => 'Test Related Resource Title', 'event' => event, 'adminMetadata' => admin_metadata }]
     end
-    let(:event) do
-      [
-        { 'location' => location, 'parallelEvent' => [{ 'name' => 'Test Parallel Event' }] },
-        { 'displayLabel' => 'Event with parallel event', 'parallelEvent' => [{ 'name' => 'Test Parallel Event' }] }
-      ]
-    end
     let(:location) { [{ 'value' => 'Test Location' }] }
-    let(:admin_metadata) do
-      { 'name' => 'Test Admin Metadata',
-        'event' => [{ 'location' => location, 'parallelEvent' => [{ 'name' => 'Test Admin Parallel Event' }] }] }
-    end
 
-    it 'removes parallelEvent from events in events, relatedResources, adminMetadata' do
-      migrated_description = migrated_model_hash['description'].with_indifferent_access
-      expect(migrated_description)
-        .to match(
+    let(:description_hash_without_parallel_event) do
+      {
+        title: 'Test Title',
+        relatedResource: [
           {
-            title: 'Test Title',
-            relatedResource: [
-              {
-                title: 'Test Related Resource Title',
-                event: [{ location: [{ value: 'Test Location' }] }],
-                adminMetadata: {
-                  name: 'Test Admin Metadata',
-                  event: [{ location: [{ value: 'Test Location' }] }]
-                }
-              }
-            ],
+            title: 'Test Related Resource Title',
             event: [{ location: [{ value: 'Test Location' }] }],
             adminMetadata: {
               name: 'Test Admin Metadata',
               event: [{ location: [{ value: 'Test Location' }] }]
-            },
-            purl: 'https://purl.stanford.edu'
+            }
           }
-        )
+        ],
+        event: [{ location: [{ value: 'Test Location' }] }],
+        adminMetadata: {
+          name: 'Test Admin Metadata',
+          event: [{ location: [{ value: 'Test Location' }] }]
+        },
+        purl: 'https://purl.stanford.edu'
+      }
+    end
+
+    context 'when parallelEvent is empty' do
+      let(:event) do
+        [
+          { 'location' => location, 'parallelEvent' => [] },
+          { 'displayLabel' => 'Event with parallel event', 'parallelEvent' => [] }
+        ]
+      end
+
+      let(:admin_metadata) do
+        { 'name' => 'Test Admin Metadata',
+          'event' => [{ 'location' => location, 'parallelEvent' => [] }] }
+      end
+
+      it 'removes parallelEvent from events in events, relatedResources, adminMetadata' do
+        migrated_description = migrated_model_hash['description'].with_indifferent_access
+        expect(migrated_description).to match(description_hash_without_parallel_event)
+      end
+    end
+
+    context 'when parallelEvent is missing' do
+      let(:event) do
+        [
+          { 'location' => location },
+          { 'displayLabel' => 'Event with parallel event' }
+        ]
+      end
+
+      let(:admin_metadata) do
+        { 'name' => 'Test Admin Metadata',
+          'event' => [{ 'location' => location }] }
+      end
+
+      it 'leaves unchanged' do
+        migrated_description = migrated_model_hash['description'].with_indifferent_access
+        expect(migrated_description)
+          .to match(description)
+      end
+    end
+
+    context 'when parallelEvent is populated' do
+      let(:event) do
+        [
+          { 'location' => location, 'parallelEvent' => [{ 'name' => 'Test Parallel Event' }] },
+          { 'displayLabel' => 'Event with parallel event', 'parallelEvent' => [{ 'name' => 'Test Parallel Event' }] }
+        ]
+      end
+      let(:location) { [{ 'value' => 'Test Location' }] }
+      let(:admin_metadata) do
+        { 'name' => 'Test Admin Metadata',
+          'event' => [{ 'location' => location, 'parallelEvent' => [{ 'name' => 'Test Admin Parallel Event' }] }] }
+      end
+
+      context 'when opened version' do
+        let(:opened_version) { true }
+
+        it 'removes parallelEvent from events in events, relatedResources, adminMetadata' do
+          migrated_description = migrated_model_hash['description'].with_indifferent_access
+          expect(migrated_description).to match(description_hash_without_parallel_event)
+        end
+      end
+
+      context 'when last closed version' do
+        let(:last_closed_version) { true }
+
+        it 'removes parallelEvent from events in events, relatedResources, adminMetadata' do
+          migrated_description = migrated_model_hash['description'].with_indifferent_access
+          expect(migrated_description).to match(description_hash_without_parallel_event)
+        end
+      end
+
+      it 'leaves unchanged' do
+        migrated_description = migrated_model_hash['description'].with_indifferent_access
+        expect(migrated_description)
+          .to match(description)
+      end
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔
To avoid removing data from old version when populated.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡



