### PR TITLE
allow user to pass in a csv file with druids to validate-cocina script

### DIFF
--- a/bin/validate-cocina
+++ b/bin/validate-cocina
@@ -7,6 +7,7 @@
 # For example, gem 'cocina-models', github: 'sul-dlss/cocina-models', branch: 'test_me'
 
 require_relative '../config/environment'
+require 'csv'
 require 'optparse'
 require 'tty-progressbar'
 require 'tmpdir'
@@ -22,6 +23,8 @@ parser = OptionParser.new do |option_parser|
   option_parser.on('-pPROCESSES', '--processes PROCESSES', Integer,
                    "Number of processes. Default is #{options[:processes]}.")
   option_parser.on('-sSAMPLE', '--sample SAMPLE', Integer, 'Sample size per type, otherwise all objects.')
+  option_parser.on('-fFILE', '--file FILE', String,
+                   'CSV file with druids in the first column (header optional).')
   option_parser.on('-l', '--latest-versions-only',
                    'Only validate the head_version and last_closed_version (when object is open).') do
     options[:latest_versions_only] = true
@@ -33,6 +36,7 @@ parser = OptionParser.new do |option_parser|
 end
 
 parser.parse!(into: options)
+abort("Error: file '#{options[:file]}' not found") if options[:file] && !File.file?(options[:file])
 
 # how many druids to process as a single advance unit of the progress bar
 def num_for_progress_advance(count)
@@ -86,13 +90,23 @@ def write_results_to_temp_file(results, temp_dir, process_index)
   temp_file
 end
 
+def druids_from_csv(csv_file)
+  CSV.foreach(csv_file).filter_map do |row|
+    druid = row.first&.strip&.delete_prefix("\uFEFF")
+    druid unless druid.blank? || druid.casecmp?('druid')
+  end.uniq
+end
+
+def repository_object_ids(sample_size, csv_file)
+  scope = RepositoryObject
+  scope = scope.where(external_identifier: druids_from_csv(csv_file)) if csv_file
+  scope = scope.limit(sample_size) if sample_size
+  scope.ids
+end
+
 # @return [Array<String>] paths to temporary CSV files
-def validate(sample_size, processes, latest_versions_only, temp_dir)
-  obj_ids = if sample_size
-              RepositoryObject.limit(sample_size).ids
-            else
-              RepositoryObject.ids
-            end
+def validate(sample_size, processes, latest_versions_only, temp_dir, csv_file = nil)
+  obj_ids = repository_object_ids(sample_size, csv_file)
 
   progress_bar = tty_progress_bar(obj_ids.size)
   progress_bar.start
@@ -140,7 +154,7 @@ end
 
 temp_dir = Dir.mktmpdir('validate-cocina')
 begin
-  validate(options[:sample], options[:processes], options[:latest_versions_only], temp_dir)
+  validate(options[:sample], options[:processes], options[:latest_versions_only], temp_dir, options[:file])
   temp_files = Dir.glob("#{temp_dir}/*.csv")
 
   consolidate_temp_files(temp_files, 'validate-cocina.csv')

--- a/bin/validate-cocina
+++ b/bin/validate-cocina
@@ -92,8 +92,8 @@ end
 
 def druids_from_csv(csv_file)
   CSV.foreach(csv_file).filter_map do |row|
-    druid = row.first&.strip&.delete_prefix("\uFEFF")
-    druid unless druid.blank? || druid.casecmp?('druid')
+    druid = row.first # assume druid is in the first column
+    druid unless druid.blank? || druid.casecmp?('druid') # skip header row if exists
   end.uniq
 end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Update `validate-cocina` script to allow user to pass in a specific list of druids to validate against live data.  Helpful if you need to re-run validation against recently remediate objects.  You can pass in the CSV file generated by the `validate-data` script in cocina-models.

If merged, I can update the README in cocina-models.

## How was this change tested? 🤨

On sdr-infra



