### PR TITLE
Prepare for cocina-models schema changes for label and AdminPolicy

### DIFF
--- a/app/reports/data_work_contributor_affiliation.rb
+++ b/app/reports/data_work_contributor_affiliation.rb
@@ -29,7 +29,7 @@ class DataWorkContributorAffiliation
       collection_druid = row['collection_druid']
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
       if collection_head_version&.has_cocina?
-        collection_title = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_title = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
 
       [

--- a/app/reports/data_work_type.rb
+++ b/app/reports/data_work_type.rb
@@ -34,7 +34,7 @@ class DataWorkType
       collection_druid = row['collection_druid']
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
       if collection_head_version&.has_cocina?
-        collection_title = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_title = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
       work_subtypes = JSON.parse(row['work_subtypes'] || '[]').join(',')
       object = RepositoryObject.find_by(external_identifier: druid)

--- a/app/reports/date_encoding_values.rb
+++ b/app/reports/date_encoding_values.rb
@@ -49,7 +49,11 @@ class DateEncodingValues
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         [

--- a/app/reports/date_encoding_values.rb
+++ b/app/reports/date_encoding_values.rb
@@ -46,13 +46,12 @@ class DateEncodingValues
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/descendant_source_code_no_uri.rb
+++ b/app/reports/descendant_source_code_no_uri.rb
@@ -41,7 +41,7 @@ class DescendantSourceCodeNoUri
       collection_druid = row['collection_druid']
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
       if collection_head_version&.has_cocina?
-        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
 
       [

--- a/app/reports/digital_serials.rb
+++ b/app/reports/digital_serials.rb
@@ -34,7 +34,7 @@ class DigitalSerials
       collection_druid = row['collection_id']
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
       if collection_head_version&.has_cocina?
-        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
 
       [

--- a/app/reports/digital_serials_based_on_hrid.rb
+++ b/app/reports/digital_serials_based_on_hrid.rb
@@ -35,7 +35,7 @@ class DigitalSerialsBasedOnHrid
       collection_druid = row['collection_id']
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
       if collection_head_version&.has_cocina?
-        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
 
       [

--- a/app/reports/digital_serials_unreleased.rb
+++ b/app/reports/digital_serials_unreleased.rb
@@ -33,7 +33,7 @@ class DigitalSerialsUnreleased
       collection_druid = row['collection_id']
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
       if collection_head_version&.has_cocina?
-        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
 
       title_part_number_before, title_part_name, title_part_number_after = title_part_label_from(JSON.parse(row['title_part_name_and_number']))

--- a/app/reports/druids_refresh_false.rb
+++ b/app/reports/druids_refresh_false.rb
@@ -29,7 +29,7 @@ class DruidsRefreshFalse
       collection_druid = row['collection_id']
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
       if collection_head_version&.has_cocina?
-        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
 
       [

--- a/app/reports/events_multiple_date_types.rb
+++ b/app/reports/events_multiple_date_types.rb
@@ -47,7 +47,7 @@ class EventsMultipleDateTypes
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
 
         [

--- a/app/reports/invalid_contributor_name_uris.rb
+++ b/app/reports/invalid_contributor_name_uris.rb
@@ -46,7 +46,11 @@ class InvalidContributorNameUris
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         [

--- a/app/reports/invalid_contributor_name_uris.rb
+++ b/app/reports/invalid_contributor_name_uris.rb
@@ -43,13 +43,12 @@ class InvalidContributorNameUris
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_contributor_source_codes.rb
+++ b/app/reports/invalid_contributor_source_codes.rb
@@ -112,7 +112,11 @@ class InvalidContributorSourceCodes
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         [

--- a/app/reports/invalid_contributor_source_codes.rb
+++ b/app/reports/invalid_contributor_source_codes.rb
@@ -109,13 +109,12 @@ class InvalidContributorSourceCodes
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_date_encoding_codes.rb
+++ b/app/reports/invalid_date_encoding_codes.rb
@@ -50,7 +50,11 @@ class InvalidDateEncodingCodes
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         [

--- a/app/reports/invalid_date_encoding_codes.rb
+++ b/app/reports/invalid_date_encoding_codes.rb
@@ -47,13 +47,12 @@ class InvalidDateEncodingCodes
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_doi_uris.rb
+++ b/app/reports/invalid_doi_uris.rb
@@ -45,7 +45,11 @@ class InvalidDoiUris
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         [

--- a/app/reports/invalid_doi_uris.rb
+++ b/app/reports/invalid_doi_uris.rb
@@ -42,13 +42,12 @@ class InvalidDoiUris
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_doi_values.rb
+++ b/app/reports/invalid_doi_values.rb
@@ -46,7 +46,11 @@ class InvalidDoiValues
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         [

--- a/app/reports/invalid_doi_values.rb
+++ b/app/reports/invalid_doi_values.rb
@@ -43,13 +43,12 @@ class InvalidDoiValues
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_edtf_dates.rb
+++ b/app/reports/invalid_edtf_dates.rb
@@ -52,7 +52,7 @@ class InvalidEdtfDates
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
 
         [

--- a/app/reports/invalid_event_location_codes.rb
+++ b/app/reports/invalid_event_location_codes.rb
@@ -81,7 +81,11 @@ class InvalidEventLocationCodes
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         [

--- a/app/reports/invalid_event_location_codes.rb
+++ b/app/reports/invalid_event_location_codes.rb
@@ -78,13 +78,12 @@ class InvalidEventLocationCodes
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_form_source_codes.rb
+++ b/app/reports/invalid_form_source_codes.rb
@@ -104,7 +104,11 @@ class InvalidFormSourceCodes
         collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
       end
       apo_druid = rows.first['apo']
-      apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+      apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+      if apo_head_version&.has_cocina?
+        apo_description = apo_head_version.to_cocina.description
+        apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+      end
       title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
       [

--- a/app/reports/invalid_form_source_codes.rb
+++ b/app/reports/invalid_form_source_codes.rb
@@ -101,13 +101,12 @@ class InvalidFormSourceCodes
       collection_druid = rows.first['collection_id']
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
       if collection_head_version&.has_cocina?
-        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
       apo_druid = rows.first['apo']
       apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
       if apo_head_version&.has_cocina?
-        apo_description = apo_head_version.to_cocina.description
-        apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
       title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_identifier_source_codes.rb
+++ b/app/reports/invalid_identifier_source_codes.rb
@@ -85,7 +85,11 @@ class InvalidIdentifierSourceCodes
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         [

--- a/app/reports/invalid_identifier_source_codes.rb
+++ b/app/reports/invalid_identifier_source_codes.rb
@@ -82,13 +82,12 @@ class InvalidIdentifierSourceCodes
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_iso8601_dates.rb
+++ b/app/reports/invalid_iso8601_dates.rb
@@ -49,7 +49,7 @@ class InvalidIso8601Dates
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
 
         [

--- a/app/reports/invalid_lc_resource_types.rb
+++ b/app/reports/invalid_lc_resource_types.rb
@@ -67,7 +67,11 @@ class InvalidLcResourceTypes
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         [

--- a/app/reports/invalid_lc_resource_types.rb
+++ b/app/reports/invalid_lc_resource_types.rb
@@ -64,13 +64,12 @@ class InvalidLcResourceTypes
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_role_codes.rb
+++ b/app/reports/invalid_role_codes.rb
@@ -60,7 +60,11 @@ class InvalidRoleCodes
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         [

--- a/app/reports/invalid_role_codes.rb
+++ b/app/reports/invalid_role_codes.rb
@@ -57,13 +57,12 @@ class InvalidRoleCodes
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_role_source_codes.rb
+++ b/app/reports/invalid_role_source_codes.rb
@@ -47,7 +47,11 @@ class InvalidRoleSourceCodes
         collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
       end
       apo_druid = rows.first['apo']
-      apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+      apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+      if apo_head_version&.has_cocina?
+        apo_description = apo_head_version.to_cocina.description
+        apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+      end
       title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
       [

--- a/app/reports/invalid_role_source_codes.rb
+++ b/app/reports/invalid_role_source_codes.rb
@@ -44,13 +44,12 @@ class InvalidRoleSourceCodes
       collection_druid = rows.first['collection_id']
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
       if collection_head_version&.has_cocina?
-        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
       apo_druid = rows.first['apo']
       apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
       if apo_head_version&.has_cocina?
-        apo_description = apo_head_version.to_cocina.description
-        apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
       title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_script_code.rb
+++ b/app/reports/invalid_script_code.rb
@@ -82,7 +82,11 @@ class InvalidScriptCode
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         [

--- a/app/reports/invalid_script_code.rb
+++ b/app/reports/invalid_script_code.rb
@@ -79,13 +79,12 @@ class InvalidScriptCode
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_script_source_codes.rb
+++ b/app/reports/invalid_script_source_codes.rb
@@ -53,7 +53,11 @@ class InvalidScriptSourceCodes
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         values = rows.filter_map { |row| row['lang_value'] || row['value_lang_value'] }.uniq

--- a/app/reports/invalid_script_source_codes.rb
+++ b/app/reports/invalid_script_source_codes.rb
@@ -50,13 +50,12 @@ class InvalidScriptSourceCodes
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_subject_encoding_codes.rb
+++ b/app/reports/invalid_subject_encoding_codes.rb
@@ -48,7 +48,11 @@ class InvalidSubjectEncodingCodes
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         [

--- a/app/reports/invalid_subject_encoding_codes.rb
+++ b/app/reports/invalid_subject_encoding_codes.rb
@@ -45,13 +45,12 @@ class InvalidSubjectEncodingCodes
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_subject_non_source_uris.rb
+++ b/app/reports/invalid_subject_non_source_uris.rb
@@ -42,7 +42,7 @@ class InvalidSubjectNonSourceUris
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
 
         [

--- a/app/reports/invalid_subject_source_codes.rb
+++ b/app/reports/invalid_subject_source_codes.rb
@@ -128,7 +128,11 @@ class InvalidSubjectSourceCodes
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         omit_values = rows.filter_map { |row| row['omit_value'] }.uniq

--- a/app/reports/invalid_subject_source_codes.rb
+++ b/app/reports/invalid_subject_source_codes.rb
@@ -125,13 +125,12 @@ class InvalidSubjectSourceCodes
 
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_value_language_code.rb
+++ b/app/reports/invalid_value_language_code.rb
@@ -60,7 +60,11 @@ class InvalidValueLanguageCode
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         [

--- a/app/reports/invalid_value_language_code.rb
+++ b/app/reports/invalid_value_language_code.rb
@@ -57,13 +57,12 @@ class InvalidValueLanguageCode
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_value_script_code.rb
+++ b/app/reports/invalid_value_script_code.rb
@@ -82,7 +82,11 @@ class InvalidValueScriptCode
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         [

--- a/app/reports/invalid_value_script_code.rb
+++ b/app/reports/invalid_value_script_code.rb
@@ -79,13 +79,12 @@ class InvalidValueScriptCode
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/invalid_w3cdtf_dates.rb
+++ b/app/reports/invalid_w3cdtf_dates.rb
@@ -49,7 +49,7 @@ class InvalidW3cdtfDates
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
 
         [

--- a/app/reports/invalid_w3cdtf_event_dates.rb
+++ b/app/reports/invalid_w3cdtf_event_dates.rb
@@ -60,7 +60,7 @@ class InvalidW3cdtfEventDates
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
 
         [

--- a/app/reports/parallel_events.rb
+++ b/app/reports/parallel_events.rb
@@ -42,7 +42,11 @@ class ParallelEvents
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
 
         [
           id,

--- a/app/reports/parallel_events.rb
+++ b/app/reports/parallel_events.rb
@@ -39,13 +39,12 @@ class ParallelEvents
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
 
         [

--- a/app/reports/property_contains_property_collections.rb
+++ b/app/reports/property_contains_property_collections.rb
@@ -39,7 +39,7 @@ class PropertyContainsPropertyCollections
       .map do |row|
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: row['collection_druid'])&.head_version
       if collection_head_version&.has_cocina?
-        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
 
       [

--- a/app/reports/property_events_with_display_label.rb
+++ b/app/reports/property_events_with_display_label.rb
@@ -30,7 +30,7 @@ class PropertyEventsWithDisplayLabel
     sql_result_rows.map do |row|
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: row['collection_druid'])&.head_version
       if collection_head_version&.has_cocina?
-        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
       display_labels = JSON.parse(row['displaylabels']).map { |label| "\"#{label}\"" }.join(';')
 

--- a/app/reports/property_existence_collections.rb
+++ b/app/reports/property_existence_collections.rb
@@ -38,7 +38,7 @@ class PropertyExistenceCollections
       collection_druid = row['collection_druid']
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
       if collection_head_version&.has_cocina?
-        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
 
       [

--- a/app/reports/property_existence_collections_without_hrid.rb
+++ b/app/reports/property_existence_collections_without_hrid.rb
@@ -38,7 +38,7 @@ class PropertyExistenceCollectionsWithoutHrid
       collection_druid = row['collection_druid']
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
       if collection_head_version&.has_cocina?
-        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
 
       [

--- a/app/reports/property_existence_dros.rb
+++ b/app/reports/property_existence_dros.rb
@@ -28,7 +28,7 @@ class PropertyExistenceDros
 
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: row['collection_druid'])&.head_version
       if collection_head_version&.has_cocina?
-        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
 
       puts [

--- a/app/reports/property_existence_dros_without_hrid.rb
+++ b/app/reports/property_existence_dros_without_hrid.rb
@@ -37,7 +37,7 @@ class PropertyExistenceDrosWithoutHrid
 
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: row['collection_druid'])&.head_version
       if collection_head_version&.has_cocina?
-        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
 
       puts [

--- a/app/reports/property_multiple_events.rb
+++ b/app/reports/property_multiple_events.rb
@@ -39,7 +39,7 @@ class PropertyMultipleEvents
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
 
         [

--- a/app/reports/property_nesting_level_collections.rb
+++ b/app/reports/property_nesting_level_collections.rb
@@ -32,7 +32,7 @@ class PropertyNestingLevelCollections
       collection_druid = row['collection_druid']
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
       if collection_head_version&.has_cocina?
-        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
 
       [

--- a/app/reports/property_nesting_level_dros.rb
+++ b/app/reports/property_nesting_level_dros.rb
@@ -33,7 +33,7 @@ class PropertyNestingLevelDros
       collection_druid = row['collection_id']
       collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
       if collection_head_version&.has_cocina?
-        collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+        collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
       end
 
       [

--- a/app/reports/subject_encoding_values.rb
+++ b/app/reports/subject_encoding_values.rb
@@ -49,7 +49,11 @@ class SubjectEncodingValues
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 
         [

--- a/app/reports/subject_encoding_values.rb
+++ b/app/reports/subject_encoding_values.rb
@@ -46,13 +46,12 @@ class SubjectEncodingValues
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
 

--- a/app/reports/subjects_without_types.rb
+++ b/app/reports/subjects_without_types.rb
@@ -53,7 +53,11 @@ class SubjectsWithoutTypes
           collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
         end
         apo_druid = rows.first['apo']
-        apo_name = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version&.label
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_description = apo_head_version.to_cocina.description
+          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+        end
 
         subject_values = rows.flat_map { |row| JSON.parse(row['subject_values']) }.uniq
         structured_values = rows.flat_map { |row| JSON.parse(row['structured_values']) }.uniq

--- a/app/reports/subjects_without_types.rb
+++ b/app/reports/subjects_without_types.rb
@@ -50,13 +50,12 @@ class SubjectsWithoutTypes
         collection_druid = rows.first['collection_id']
         collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
         if collection_head_version&.has_cocina?
-          collection_name = Cocina::Models::Builders::TitleBuilder.build(collection_head_version.to_cocina.description.title)
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
         apo_druid = rows.first['apo']
         apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
         if apo_head_version&.has_cocina?
-          apo_description = apo_head_version.to_cocina.description
-          apo_name = Cocina::Models::Builders::TitleBuilder.build(apo_description.title) if apo_description
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
         end
 
         subject_values = rows.flat_map { |row| JSON.parse(row['subject_values']) }.uniq

--- a/app/services/cocina/serializer.rb
+++ b/app/services/cocina/serializer.rb
@@ -9,7 +9,9 @@ module Cocina
     end
 
     def serialize(cocina_item)
-      super(Cocina::Models.without_metadata(cocina_item).to_h)
+      cocina_object = super(Cocina::Models.without_metadata(cocina_item).to_h)
+      # Remove when label fully gone from cocina-models schema
+      cocina_object.merge({ label: '' })
     end
 
     def deserialize(hash)

--- a/spec/factories/repository_object_versions.rb
+++ b/spec/factories/repository_object_versions.rb
@@ -12,7 +12,6 @@ FactoryBot.define do
     lock { 2 }
     cocina_version { Cocina::Models::VERSION }
     content_type { Cocina::Models::ObjectType.book }
-    label { 'Test DRO' }
     access do
       { view: 'world', download: 'world' }
     end
@@ -21,7 +20,7 @@ FactoryBot.define do
     end
     description do
       {
-        title: [{ value: label }],
+        title: [{ value: 'Test Object' }],
         purl: "https://purl.stanford.edu/#{external_identifier.delete_prefix('druid:')}"
       }
     end
@@ -110,6 +109,12 @@ FactoryBot.define do
         hasAdminPolicy: 'druid:hy787xj5878',
         hasAgreement: 'druid:bb033gt0615',
         accessTemplate: access_template
+      }
+    end
+    description do
+      {
+        title: [{ value: label }],
+        purl: "https://purl.stanford.edu/#{external_identifier.delete_prefix('druid:')}"
       }
     end
     access { nil }

--- a/spec/factories/repository_object_versions.rb
+++ b/spec/factories/repository_object_versions.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
       external_identifier { generate(:unique_druid) }
       is_member_of { [] }
       source_id { "sul:#{SecureRandom.uuid}" }
+      title { 'Test Object' }
     end
     sequence(:version)
     version_description { 'Best version ever' }
@@ -20,7 +21,7 @@ FactoryBot.define do
     end
     description do
       {
-        title: [{ value: 'Test Object' }],
+        title: [{ value: title }],
         purl: "https://purl.stanford.edu/#{external_identifier.delete_prefix('druid:')}"
       }
     end
@@ -101,8 +102,8 @@ FactoryBot.define do
   trait :admin_policy_repository_object_version do
     transient do
       access_template { { view: 'world', download: 'world' } }
+      title { 'Test Admin Policy' }
     end
-    label { 'Test Admin Policy' }
     content_type { Cocina::Models::ObjectType.admin_policy }
     administrative do
       {
@@ -113,7 +114,7 @@ FactoryBot.define do
     end
     description do
       {
-        title: [{ value: label }],
+        title: [{ value: title }],
         purl: "https://purl.stanford.edu/#{external_identifier.delete_prefix('druid:')}"
       }
     end
@@ -126,7 +127,6 @@ FactoryBot.define do
     transient do
       title { 'Test Collection' }
     end
-    label { title }
     content_type { Cocina::Models::ObjectType.collection }
     administrative do
       { hasAdminPolicy: 'druid:hy787xj5878' }

--- a/spec/models/repository_object_spec.rb
+++ b/spec/models/repository_object_spec.rb
@@ -196,10 +196,10 @@ RSpec.describe RepositoryObject do
 
     context 'when based on an earlier version' do
       before do
-        repository_object.head_version.label = 'Version 1'
+        repository_object.head_version.description = { 'title' => [{ 'value' => 'Version 1' }] }
         repository_object.close_version!
         repository_object.open_version!(description: 'Another version')
-        repository_object.head_version.label = 'Version 2'
+        repository_object.head_version.description = { 'title' => [{ 'value' => 'Version 2' }] }
         repository_object.close_version!
       end
 
@@ -212,7 +212,7 @@ RSpec.describe RepositoryObject do
         expect(newly_created_version.version).to eq(3)
         expect(repository_object.head_version).to eq(newly_created_version)
         expect(repository_object.opened_version).to eq(newly_created_version)
-        expect(newly_created_version.label).to eq 'Version 1'
+        expect(newly_created_version.description['title'].first['value']).to eq 'Version 1'
         expect(newly_created_version.closed_at).to be_nil
       end
     end
@@ -263,7 +263,6 @@ RSpec.describe RepositoryObject do
       expect { repository_object.update_opened_version_from(cocina_object:) }
         .to change(repository_object.opened_version, :cocina_version).from(nil).to(Cocina::Models::VERSION)
         .and change(repository_object.opened_version, :content_type).from(nil).to(Cocina::Models::ObjectType.object)
-        .and change(repository_object.opened_version, :label).from(nil).to('')
         .and change(repository_object.opened_version, :access).from(nil).to(instance_of(Hash))
         .and change(repository_object.opened_version, :administrative).from(nil).to(instance_of(Hash))
         .and change(repository_object.opened_version, :description).from(nil).to(instance_of(Hash))

--- a/spec/models/repository_object_version_spec.rb
+++ b/spec/models/repository_object_version_spec.rb
@@ -236,16 +236,6 @@ RSpec.describe RepositoryObjectVersion do
       it { is_expected.to include(cocina_version: Cocina::Models::VERSION) }
       it { is_expected.to include(content_type: Cocina::Models::ObjectType.admin_policy) }
       it { is_expected.to include(description: hash_including(:title)) }
-
-      context 'with no description' do
-        let(:cocina_instance) do
-          # NOTE: The cocina-models factories (as of v0.96.0) don't seem to
-          #       provide a better way to build an APO sans description.
-          Cocina::Models::AdminPolicy.new(build(:admin_policy).to_h.except(:description))
-        end
-
-        it { is_expected.to include(description: nil) }
-      end
     end
   end
 

--- a/spec/requests/indexable_spec.rb
+++ b/spec/requests/indexable_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'Indexable' do
     create(:repository_object, :admin_policy, :with_repository_object_version)
   end
   let(:apo_druid) { apo.external_identifier }
-  let(:label) { 'This is my label' }
   let(:title) { 'This is my title' }
 
   let(:view) { 'world' }
@@ -78,7 +77,7 @@ RSpec.describe 'Indexable' do
         "cocinaVersion": "#{Cocina::Models::VERSION}",
         "externalIdentifier": "#{druid}",
         "type":"#{content_type}",
-        "label":"#{label}","version":1,
+        "version":1,
         "access":{
           "view":"#{view}",
           "download":"#{view}",

--- a/spec/requests/show_user_version_solr_spec.rb
+++ b/spec/requests/show_user_version_solr_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Show single user version' do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(id: object.external_identifier)
-      expect(response.parsed_body).to include(display_title_ss: 'Test DRO')
+      expect(response.parsed_body).to include(display_title_ss: 'Test Object')
     end
   end
 end

--- a/spec/requests/show_version_solr_spec.rb
+++ b/spec/requests/show_version_solr_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe 'Show solr for an object version' do
     before do
       object.head_version.tap do |version|
         version.description['title'] =
-          [{ 'value' => 'Test DRO', 'parallelValue' => [{ 'value' => 'Аԥышәара DRO' }, { 'value' => 'परीक्षण DRO' }] }]
+          [{ 'value' => 'Test Object',
+             'parallelValue' => [{ 'value' => 'Аԥышәара DRO' }, { 'value' => 'परीक्षण DRO' }] }]
         version.save!
       end
     end
@@ -36,7 +37,7 @@ RSpec.describe 'Show solr for an object version' do
 
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include(id: object.external_identifier)
-        expect(response.parsed_body).to include(display_title_ss: 'Test DRO')
+        expect(response.parsed_body).to include(display_title_ss: 'Test Object')
       end
     end
 
@@ -47,7 +48,7 @@ RSpec.describe 'Show solr for an object version' do
 
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include(id: object.external_identifier)
-        expect(response.parsed_body).to include(display_title_ss: 'Test DRO')
+        expect(response.parsed_body).to include(display_title_ss: 'Test Object')
       end
     end
   end
@@ -73,7 +74,7 @@ RSpec.describe 'Show solr for an object version' do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(id: object.external_identifier)
-      expect(response.parsed_body).to include(display_title_ss: 'Test DRO')
+      expect(response.parsed_body).to include(display_title_ss: 'Test Object')
     end
   end
 end

--- a/spec/requests/update_metadata_spec.rb
+++ b/spec/requests/update_metadata_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Update object' do
         "cocinaVersion": "#{Cocina::Models::VERSION}",
         "externalIdentifier": "#{druid}",
         "type":"#{content_type}",
-        "label":"","version":1,
+        "version":1,
         "access":{
           "view":"#{view}",
           "download":"#{view}",
@@ -195,7 +195,7 @@ RSpec.describe 'Update object' do
               "cocinaVersion": "#{Cocina::Models::VERSION}",
               "externalIdentifier": "#{druid}",
               "type":"#{Cocina::Models::ObjectType.image}",
-              "label":"","version":1,
+              "version":1,
               "access":{
                 "view":"#{view}",
                 "download":"world",
@@ -218,7 +218,7 @@ RSpec.describe 'Update object' do
           {
             sourceId: 'googlebooks:999999',
             catalogLinks: [
-              { catalog: 'symphony', catalogRecordId: '8888', refresh: true }
+              { catalog: 'folio', catalogRecordId: 'a8888', refresh: true }
             ]
           }
         end
@@ -443,7 +443,7 @@ RSpec.describe 'Update object' do
                 "cocinaVersion": "#{Cocina::Models::VERSION}",
                 "externalIdentifier": "#{druid}",
                 "type":"#{Cocina::Models::ObjectType.image}",
-                "label":"","version":1,
+                "version":1,
                 "access":{
                   "view":"#{view}",
                   "download":"world",
@@ -493,7 +493,7 @@ RSpec.describe 'Update object' do
                 "cocinaVersion":"#{Cocina::Models::VERSION}",
                 "externalIdentifier": "#{druid}",
                 "type":"#{Cocina::Models::ObjectType.image}",
-                "label":"","version":1,
+                "version":1,
                 "access":{
                   "view":"#{view}",
                   "download":"world",
@@ -522,7 +522,6 @@ RSpec.describe 'Update object' do
       end
 
       context 'when a book is provided' do
-        let(:label) { 'This is my label' }
         let(:title) { 'This is my title' }
         let(:expected) do
           build(:dro, id: druid, type: Cocina::Models::ObjectType.book, title:,
@@ -543,7 +542,7 @@ RSpec.describe 'Update object' do
               "cocinaVersion": "#{Cocina::Models::VERSION}",
               "externalIdentifier": "#{druid}",
               "type":"#{Cocina::Models::ObjectType.book}",
-              "label":"","version":1,
+              "version":1,
               "access":{
                 "view":"world",
                 "download":"world"
@@ -604,7 +603,7 @@ RSpec.describe 'Update object' do
               "cocinaVersion": "#{Cocina::Models::VERSION}",
               "externalIdentifier": "#{druid}",
               "type":"#{Cocina::Models::ObjectType.book}",
-              "label":"","version":1,
+              "version":1,
               "access":{"view":"stanford","download":"stanford",
                 "embargo":{"view":"world","download":"world","releaseDate":"2020-02-29T07:00:00.000+00:00"}
               },
@@ -664,7 +663,7 @@ RSpec.describe 'Update object' do
               "cocinaVersion": "#{Cocina::Models::VERSION}",
               "externalIdentifier": "#{druid}",
               "type":"#{content_type}",
-              "label":"","version":1,
+              "version":1,
               "access":{
                 "view":"#{view}",
                 "download":"#{view}",
@@ -730,7 +729,7 @@ RSpec.describe 'Update object' do
               "cocinaVersion": "#{Cocina::Models::VERSION}",
               "externalIdentifier": "druid:xs123xx8388",
               "type":"#{content_type}",
-              "label":"","version":1,
+              "version":1,
               "access":{
                 "view":"#{view}",
                 "download":"#{view}",
@@ -811,7 +810,7 @@ RSpec.describe 'Update object' do
           "cocinaVersion": "#{Cocina::Models::VERSION}",
           "externalIdentifier": "#{druid}",
           "type":"#{Cocina::Models::ObjectType.collection}",
-          "label":"","version":1,
+          "version":1,
           "access":{},
           "identification":#{identification.to_json},
           "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
@@ -889,7 +888,6 @@ RSpec.describe 'Update object' do
           "cocinaVersion": "#{Cocina::Models::VERSION}",
           "externalIdentifier": "#{druid}",
           "type":"#{Cocina::Models::ObjectType.admin_policy}",
-          "label":"",
           "version":1,
           "administrative":{
             "disseminationWorkflow":"assemblyWF",

--- a/spec/services/cocina/serializer_spec.rb
+++ b/spec/services/cocina/serializer_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Cocina::Serializer do
       {
         'type' => Cocina::Models::ObjectType.object,
         'externalIdentifier' => 'druid:ft609gr4031',
-        'label' => 'SUL Logo for golden_wonder_millet',
         'version' => 1,
         'access' => {
           'view' => 'citation-only',
@@ -78,7 +77,6 @@ RSpec.describe Cocina::Serializer do
       cocinaVersion: Cocina::Models::VERSION,
       type: Cocina::Models::ObjectType.object,
       externalIdentifier: 'druid:ft609gr4031',
-      label: 'SUL Logo for golden_wonder_millet',
       version: 1,
       access: {
         view: 'citation-only',

--- a/spec/services/cocina/serializer_spec.rb
+++ b/spec/services/cocina/serializer_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Cocina::Serializer do
       {
         'type' => Cocina::Models::ObjectType.object,
         'externalIdentifier' => 'druid:ft609gr4031',
+        'label' => '',
         'version' => 1,
         'access' => {
           'view' => 'citation-only',
@@ -78,6 +79,7 @@ RSpec.describe Cocina::Serializer do
       type: Cocina::Models::ObjectType.object,
       externalIdentifier: 'druid:ft609gr4031',
       version: 1,
+      label: '',
       access: {
         view: 'citation-only',
         download: 'none',

--- a/spec/services/cocina/to_datacite/attributes_spec.rb
+++ b/spec/services/cocina/to_datacite/attributes_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Cocina::ToDatacite::Attributes do
   let(:cocina_item) do
     Cocina::Models::DRO.new(externalIdentifier: druid,
                             type: Cocina::Models::ObjectType.object,
-                            label:,
                             version: 1,
                             description: {
                               title: [{ value: title }],
@@ -26,7 +25,6 @@ RSpec.describe Cocina::ToDatacite::Attributes do
   let(:druid) { 'druid:bb666bb1234' }
   let(:doi) { "10.25740/#{druid.split(':').last}" }
   let(:purl) { "https://purl.stanford.edu/#{druid.split(':').last}" }
-  let(:label) { 'label' }
   let(:title) { 'title' }
   let(:apo_druid) { 'druid:pp000pp0000' }
   let(:url) { nil }
@@ -73,7 +71,6 @@ RSpec.describe Cocina::ToDatacite::Attributes do
     let(:cocina_item) do
       Cocina::Models::DRO.new(externalIdentifier: druid,
                               type: Cocina::Models::ObjectType.object,
-                              label:,
                               version: 1,
                               description: {
                                 title: [{ value: title }],
@@ -123,7 +120,6 @@ RSpec.describe Cocina::ToDatacite::Attributes do
     let(:cocina_item) do
       Cocina::Models::DRO.new(externalIdentifier: druid,
                               type: Cocina::Models::ObjectType.object,
-                              label:,
                               version: 1,
                               description: {
                                 contributor: [
@@ -533,7 +529,6 @@ RSpec.describe Cocina::ToDatacite::Attributes do
     let(:cocina_item) do
       Cocina::Models::DRO.new(externalIdentifier: druid,
                               type: Cocina::Models::ObjectType.object,
-                              label:,
                               version: 1,
                               description: {
                                 contributor: [
@@ -847,7 +842,6 @@ RSpec.describe Cocina::ToDatacite::Attributes do
     let(:cocina_item) do
       Cocina::Models::Collection.new(externalIdentifier: druid,
                                      type: Cocina::Models::ObjectType.collection,
-                                     label:,
                                      version: 1,
                                      description: {
                                        title: [{ value: title }],
@@ -869,7 +863,6 @@ RSpec.describe Cocina::ToDatacite::Attributes do
     let(:cocina_item) do
       Cocina::Models::AdminPolicy.new(externalIdentifier: druid,
                                       type: Cocina::Models::ObjectType.admin_policy,
-                                      label:,
                                       version: 1,
                                       description: {
                                         title: [{ value: title }],

--- a/spec/services/cocina/to_datacite/event_dates_spec.rb
+++ b/spec/services/cocina/to_datacite/event_dates_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Cocina::ToDatacite::Event do
   end
   let(:cocina_item) do
     Cocina::Models::DRO.new(type: Cocina::Models::ObjectType.object,
-                            label: 'This is my label',
                             version: 1,
                             administrative: { hasAdminPolicy: 'druid:dd999df4567' },
                             description: cocina_description,

--- a/spec/services/cocina/to_datacite/event_pub_year_spec.rb
+++ b/spec/services/cocina/to_datacite/event_pub_year_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Cocina::ToDatacite::Event do
   end
   let(:cocina_item) do
     Cocina::Models::DRO.new(type: Cocina::Models::ObjectType.object,
-                            label: 'This is my label',
                             version: 1,
                             administrative: { hasAdminPolicy: 'druid:dd999df4567' },
                             description: cocina_description,

--- a/spec/services/cocina/to_xml/content_metadata_generator_spec.rb
+++ b/spec/services/cocina/to_xml/content_metadata_generator_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Cocina::ToXml::ContentMetadataGenerator do
   let(:data) do
     <<~JSON
       { "type":"#{object_type}",
-        "label":"The object label","version":1,"access":{"view":"world","download":"world"},
+        "version":1,"access":{"view":"world","download":"world"},
         "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
         "description":{"title":[{"status":"primary","value":"the object title"}]},
         "identification":{"sourceId":"sul:9999999"},
@@ -688,7 +688,7 @@ RSpec.describe Cocina::ToXml::ContentMetadataGenerator do
       <<~JSON
         { "externalIdentifier":"druid:bc123df5678",
           "type":"#{object_type}",
-          "label":"The object label","version":1,"access":{"view":"world","download":"world"},
+          "version":1,"access":{"view":"world","download":"world"},
           "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
           "description":{
             "title":[{"status":"primary","value":"the object title"}],
@@ -767,7 +767,7 @@ RSpec.describe Cocina::ToXml::ContentMetadataGenerator do
       <<~JSON
         { "externalIdentifier":"druid:bc123df5678",
           "type":"#{object_type}",
-          "label":"The object label","version":1,"access":{"view":"world","download":"world"},
+          "version":1,"access":{"view":"world","download":"world"},
           "administrative":{"hasAdminPolicy":"druid:dd999df4567"},
           "description":{
             "title":[{"status":"primary","value":"the object title"}],
@@ -783,7 +783,6 @@ RSpec.describe Cocina::ToXml::ContentMetadataGenerator do
         externalIdentifier: constituent_druid,
         version: 1,
         type: Cocina::Models::ObjectType.object,
-        label: 'Dummy DRO',
         access: { view: 'world', download: 'world' },
         administrative: { hasAdminPolicy: 'druid:df123cd4567' },
         description: {

--- a/spec/services/update_object_service_spec.rb
+++ b/spec/services/update_object_service_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe UpdateObjectService do
                                     cocinaVersion: '0.0.1',
                                     externalIdentifier: druid,
                                     type: Cocina::Models::ObjectType.book,
-                                    label: 'Changed Test DRO',
                                     version: 1,
                                     description: {
                                       title: [{ value: 'Changed Test DRO' }],
@@ -44,7 +43,7 @@ RSpec.describe UpdateObjectService do
 
         it 'saves to datastore and sends event data to EventFactory' do
           expect(store.update).to be_a Cocina::Models::DROWithMetadata
-          expect(repository_object.reload.head_version.label).to eq 'Changed Test DRO'
+          expect(repository_object.reload.head_version.to_cocina.description.title.first.value).to eq 'Changed Test DRO'
           expect(EventFactory).to have_received(:create).with(
             druid:,
             event_type: 'update',
@@ -64,12 +63,10 @@ RSpec.describe UpdateObjectService do
           Cocina::Models.with_metadata(repository_object.head_version.to_cocina, lock,
                                        created: repository_object.created_at.utc,
                                        modified: repository_object.updated_at.utc)
-                        .new(label: 'new label')
         end
 
         it 'saves to datastore' do
           expect(store.update).to be_a Cocina::Models::DROWithMetadata
-          expect(repository_object.reload.opened_version.label).to eq 'new label'
         end
       end
 
@@ -83,7 +80,6 @@ RSpec.describe UpdateObjectService do
           Cocina::Models.with_metadata(repository_object.head_version.to_cocina, lock,
                                        created: repository_object.created_at.utc,
                                        modified: repository_object.updated_at.utc)
-                        .new(label: 'new label')
         end
 
         it 'saves to datastore' do
@@ -103,7 +99,6 @@ RSpec.describe UpdateObjectService do
           Cocina::Models.with_metadata(repository_object.head_version.to_cocina, lock,
                                        created: repository_object.created_at.utc,
                                        modified: repository_object.updated_at.utc)
-                        .new(label: 'new label')
         end
 
         it 'raises' do
@@ -123,7 +118,6 @@ RSpec.describe UpdateObjectService do
           Cocina::Models.with_metadata(repository_object.head_version.to_cocina, lock,
                                        created: repository_object.head_version.created_at.utc,
                                        modified: repository_object.head_version.updated_at.utc)
-                        .new(label: 'new label')
         end
 
         before do
@@ -148,19 +142,23 @@ RSpec.describe UpdateObjectService do
                                           cocinaVersion: '0.0.1',
                                           externalIdentifier: druid,
                                           type: Cocina::Models::ObjectType.admin_policy,
-                                          label: 'Updated Test Admin Policy',
                                           version: 1,
                                           administrative: {
                                             hasAdminPolicy: 'druid:hy787xj5878',
                                             hasAgreement: 'druid:bb033gt0615',
                                             accessTemplate: { view: 'world', download: 'world' }
+                                          },
+                                          description: {
+                                            title: [{ value: 'Updated Test Admin Policy' }],
+                                            purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
                                           }
                                         })
       end
 
       it 'saves to datastore' do
         expect(store.update).to be_a Cocina::Models::AdminPolicyWithMetadata
-        expect(repository_object.reload.head_version.label).to eq 'Updated Test Admin Policy'
+        expect(repository_object.reload.head_version.to_cocina.description.title.first.value)
+          .to eq 'Updated Test Admin Policy'
       end
     end
 
@@ -174,7 +172,6 @@ RSpec.describe UpdateObjectService do
                                          cocinaVersion: '0.0.1',
                                          externalIdentifier: druid,
                                          type: Cocina::Models::ObjectType.collection,
-                                         label: 'Test Collection',
                                          description: {
                                            title: [{ value: 'Updated title' }],
                                            purl: 'https://purl.stanford.edu/zr174jb7823'

--- a/spec/services/version_service_spec.rb
+++ b/spec/services/version_service_spec.rb
@@ -113,13 +113,18 @@ RSpec.describe VersionService do
 
       before do
         repository_object.open_version!(description: 'A new version')
-        repository_object.head_version.update!(label: 'New version label')
+        repository_object.head_version.update!(
+          description: {
+            'title' => [{ 'value' => 'New version title' }],
+            'purl' => "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
+          }
+        )
         repository_object.close_version!
       end
 
       it 'creates an object version and starts a workflow' do
         expect(open).to be_a(Cocina::Models::DROWithMetadata)
-        expect(open.label).not_to eq 'New version label'
+        expect(open.description.title.first.value).not_to eq 'New version title'
         expect(workflow_state_service).to have_received(:accessioned?)
         expect(workflow_state_service).to have_received(:accessioning?)
         expect(Workflow::Service).to have_received(:create).with(druid:, workflow_name: 'versioningWF', version: '3')


### PR DESCRIPTION
## Why was this change made? 🤔
Changes that will be required in DSA when the next set of cocina-models changes to the schema are released 
(removing label and making description required for AdminPolicy).

Changes to reports are all to remove references to the AdminPolicy label field.
 
OK to merge before the cocina-models release that removes label is deployed. The only further change needed with the cocina-models release is removing the blank label insertion from app/service/serializer.rb

## How was this change tested? 🤨
CI, To be tested with integration tests. 


