### PR TITLE
update reference to new config file in cocina-models

### DIFF
--- a/app/services/cocina/from_marc/identifier.rb
+++ b/app/services/cocina/from_marc/identifier.rb
@@ -39,9 +39,9 @@ module Cocina
         '4' => 'SICI'
       }.freeze
 
-      # See https://github.com/sul-dlss/cocina-models/blob/main/identifier_source_codes.yml
+      # See https://github.com/sul-dlss/cocina-models/blob/main/config/identifier_source_codes.yml
       RECOGNIZED_SOURCE_CODES = YAML.load_file(
-        "#{Gem::Specification.find_by_name('cocina-models').gem_dir}/identifier_source_codes.yml"
+        "#{Gem::Specification.find_by_name('cocina-models').gem_dir}/config/identifier_source_codes.yml"
       ).to_set(&:downcase).freeze
 
       PUBLISHER_NUMBER_TYPES = {


### PR DESCRIPTION
## Why was this change made? 🤔

Goes with https://github.com/sul-dlss/cocina-models/pull/1171

Wait until the new cocina-models release is out, and bump it in DSA, and then merge this.

Note: tests will be fail until we can bump the new cocina-models gem because of the difference in the config path which is fixed here

## How was this change tested? 🤨

Specs