### PR TITLE
[HOLD] Remove label field from repository_object_version

### DIFF
--- a/db/migrate/20260729194939_drop_label_from_repository_object_versions.rb
+++ b/db/migrate/20260729194939_drop_label_from_repository_object_versions.rb
@@ -1,0 +1,7 @@
+class DropLabelFromRepositoryObjectVersions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+  
+  def change
+    remove_column :repository_object_versions, :label, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -230,7 +230,6 @@ CREATE TABLE public.repository_object_versions (
     version_description character varying NOT NULL,
     cocina_version character varying,
     content_type character varying,
-    label character varying,
     access jsonb,
     administrative jsonb,
     description jsonb,
@@ -726,6 +725,7 @@ ALTER TABLE ONLY public.repository_objects
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260729194939'),
 ('20260710111258'),
 ('20260218154641'),
 ('20240807210223'),


### PR DESCRIPTION
## Why was this change made? 🤔
Fixes #6302.

HOLD until coordinated with Ops and Andrew. Andrew will need 3-5 days advance notice to communicate to users and will work with Amy to find a good date.

Tentative plan, for @andrewjbtw and @justinlittman (as East Coast FR) to run at a date TBD the week of August 10:

At 5PM Pacific:
- [ ] Pause queues / quiet workers so there is no activity by robots
- [ ] Put up Argo and H3 maintenance pages
- [ ] Merge this PR.
- [ ] Ops to create a database backup. A test run took 8.5 hours, so this will go overnight. 
- [ ] The next morning, deploy DSA, which will run the database migration. 
- [ ] Take down maintenance pages
- [ ] Restart Sidekiq workers

If it doesn't work out to run the week of August 10, find a date when @lwrubel is back in town. 
