### PR TITLE
Add report for invalid contributor affiliation source codes

### DIFF
--- a/app/reports/invalid_contributor_affiliation_source_codes.rb
+++ b/app/reports/invalid_contributor_affiliation_source_codes.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# objects with values in ..contributor.affiliation.source.code that are not in:
+# https://www.loc.gov/standards/sourcelist/name-title.html
+# https://www.loc.gov/standards/sourcelist/organization.html
+# https://www.loc.gov/standards/sourcelist/standard-identifier.html
+#
+# Invoke via:
+# bin/rails r -e production "InvalidContributorAffiliationSourceCodes.report"
+class InvalidContributorAffiliationSourceCodes
+  # NOTE: Prefer strict JSON querying over lax when using the `.**` operator, per
+  #       https://www.postgresql.org/docs/14/functions-json.html#STRICT-AND-LAX-MODES
+  #
+  # > The .** accessor can lead to surprising results when using the lax mode.
+  # > ... This happens because the .** accessor selects both the segments array
+  # > and each of its elements, while the .HR accessor automatically unwraps
+  # > arrays when using the lax mode. To avoid surprising results, we recommend
+  # > using the .** accessor only in the strict mode.
+  JSON_PATH = 'strict $.**.contributor[*].affiliation[*].source.code'
+
+  VALID_SOURCE_CODES = (
+    InvalidIdentifierSourceCodes::LOC_IDENTIFIER_SOURCE_CODES +
+    InvalidContributorSourceCodes::MARC_NAME_TITLE_SOURCE_CODES +
+    InvalidContributorSourceCodes::MARC_ORG_SOURCE_CODES
+  ).uniq.freeze
+
+  def self.regex
+    @regex ||= "^(?!#{VALID_SOURCE_CODES.map { |code| "#{code}$" }.join('|')})"
+  end
+
+  def self.sql
+    <<~SQL.squish
+      SELECT jsonb_path_query(rov.description, '#{JSON_PATH} ? (@ like_regex "#{regex}")') ->> 0 as value,
+             ro.external_identifier,
+             jsonb_path_query(rov.description, '$.title[0].structuredValue[*] ? (@.type == "main title").value') ->> 0 as structured_title,
+             jsonb_path_query(rov.description, '$.title[0].value') ->> 0 as title,
+             jsonb_path_query(rov.identification, '$.catalogLinks[*] ? (@.catalog == "folio").catalogRecordId') ->> 0 as hrid,
+             jsonb_path_query(rov.structural, '$.isMemberOf') ->> 0 as collection_id,
+             jsonb_path_query(rov.administrative, '$.hasAdminPolicy') ->> 0 as apo
+             FROM repository_objects AS ro, repository_object_versions AS rov
+             WHERE ro.head_version_id = rov.id
+             AND ro.object_type = 'dro'
+             AND jsonb_path_exists(rov.description, '#{JSON_PATH} ? (@ like_regex "#{regex}")')
+    SQL
+  end
+
+  def self.report
+    puts "item_druid,value,title,collection_druid,collection_name,hrid,apo_druid,apo_name\n"
+
+    rows(sql).each { |row| puts row }
+  end
+
+  def self.rows(query)
+    ActiveRecord::Base
+      .connection
+      .execute(query)
+      .to_a
+      .group_by { |row| row['external_identifier'] }
+      .map do |id, rows|
+        collection_druid = rows.first['collection_id']
+        collection_head_version = RepositoryObject.collections.find_by(external_identifier: collection_druid)&.head_version
+        if collection_head_version&.has_cocina?
+          collection_name = CocinaDisplay::CocinaRecord.new(collection_head_version.to_cocina.to_h.with_indifferent_access).display_title
+        end
+
+        apo_druid = rows.first['apo']
+        apo_head_version = RepositoryObject.admin_policies.find_by(external_identifier: apo_druid)&.head_version
+        if apo_head_version&.has_cocina?
+          apo_name = CocinaDisplay::CocinaRecord.new(apo_head_version.to_cocina.to_h.with_indifferent_access).display_title
+        end
+
+        title = (rows.first['structured_title'] || rows.first['title'])&.delete("\n")
+
+        [
+          id,
+          rows.pluck('value').join(';'),
+          title,
+          collection_druid,
+          collection_name,
+          rows.first['hrid'],
+          apo_druid,
+          apo_name
+        ].to_csv
+      end
+  end
+end


### PR DESCRIPTION
# Why was this change made?

Fixes #6050

This commit adds the `InvalidContributorAffiliationSourceCodes` report to identify objects with contributor affiliation source codes not in LOC lists.

# How was this change tested?

CI, ran report in all envs
